### PR TITLE
[`ruff`] Avoid false positive when `pytest.raises` is used in a `with` statement (`RUF061`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF061_deprecated_call.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF061_deprecated_call.py
@@ -12,6 +12,14 @@ def test_ok():
         raise_deprecation_warning("")
 
 
+def test_ok_positional_args():
+    with pytest.deprecated_call("oops"):
+        pass
+
+    with pytest.deprecated_call("oops") as warninfo:
+        pass
+
+
 def test_error_trivial():
     pytest.deprecated_call(raise_deprecation_warning, "deprecated")
 

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF061_raises.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF061_raises.py
@@ -15,6 +15,25 @@ def test_ok_as():
         raise ValueError
 
 
+def test_ok_positional_args():
+    with pytest.raises(ValueError, "oops"):
+        pass
+
+    with pytest.raises(ValueError, "oops") as excinfo:
+        pass
+
+    with (
+        pytest.raises(ValueError, "oops"),
+        pytest.raises(TypeError, "bar"),
+    ):
+        pass
+
+
+def test_error_nested_in_with():
+    with pytest.raises(ValueError, "oops"):
+        pytest.raises(ZeroDivisionError, func, 1, b=0)
+
+
 def test_error_trivial():
     pytest.raises(ZeroDivisionError, func, 1, b=0)
 

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF061_warns.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF061_warns.py
@@ -12,6 +12,14 @@ def test_ok():
         raise_user_warning("")
 
 
+def test_ok_positional_args():
+    with pytest.warns(UserWarning, "oops"):
+        pass
+
+    with pytest.warns(UserWarning, "oops") as warninfo:
+        pass
+
+
 def test_error_trivial():
     pytest.warns(UserWarning, raise_user_warning, "warning")
 

--- a/crates/ruff_linter/src/rules/ruff/rules/legacy_form_pytest_raises.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/legacy_form_pytest_raises.rs
@@ -133,6 +133,15 @@ pub(crate) fn legacy_raises_warns_deprecated_call(checker: &Checker, call: &ast:
         return;
     }
 
+    if let Stmt::With(ast::StmtWith { items, .. }) = semantic.current_statement() {
+        if items
+            .iter()
+            .any(|item| item.context_expr.as_call_expr() == Some(call))
+        {
+            return;
+        }
+    }
+
     let mut diagnostic =
         checker.report_diagnostic(LegacyFormPytestRaises { context_type }, call.range());
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__legacy-form-pytest-raises_RUF061_deprecated_call.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__legacy-form-pytest-raises_RUF061_deprecated_call.py.snap
@@ -2,50 +2,50 @@
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF061 [*] Use context-manager form of `pytest.deprecated_call()`
-  --> RUF061_deprecated_call.py:16:5
+  --> RUF061_deprecated_call.py:24:5
    |
-15 | def test_error_trivial():
-16 |     pytest.deprecated_call(raise_deprecation_warning, "deprecated")
+23 | def test_error_trivial():
+24 |     pytest.deprecated_call(raise_deprecation_warning, "deprecated")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.deprecated_call()` as a context-manager
    |
-15 | def test_error_trivial():
+23 | def test_error_trivial():
    -     pytest.deprecated_call(raise_deprecation_warning, "deprecated")
-16 +     with pytest.deprecated_call():
-17 +         raise_deprecation_warning("deprecated")
-18 |
+24 +     with pytest.deprecated_call():
+25 +         raise_deprecation_warning("deprecated")
+26 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.deprecated_call()`
-  --> RUF061_deprecated_call.py:20:9
+  --> RUF061_deprecated_call.py:28:9
    |
-19 | def test_error_assign():
-20 |     s = pytest.deprecated_call(raise_deprecation_warning, "deprecated")
+27 | def test_error_assign():
+28 |     s = pytest.deprecated_call(raise_deprecation_warning, "deprecated")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-21 |     print(s)
+29 |     print(s)
    |
 help: Use `pytest.deprecated_call()` as a context-manager
    |
-19 | def test_error_assign():
+27 | def test_error_assign():
    -     s = pytest.deprecated_call(raise_deprecation_warning, "deprecated")
-20 +     with pytest.deprecated_call():
-21 +         s = raise_deprecation_warning("deprecated")
-22 |     print(s)
+28 +     with pytest.deprecated_call():
+29 +         s = raise_deprecation_warning("deprecated")
+30 |     print(s)
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.deprecated_call()`
-  --> RUF061_deprecated_call.py:25:5
+  --> RUF061_deprecated_call.py:33:5
    |
-24 | def test_error_lambda():
-25 |     pytest.deprecated_call(lambda: warnings.warn("", DeprecationWarning))
+32 | def test_error_lambda():
+33 |     pytest.deprecated_call(lambda: warnings.warn("", DeprecationWarning))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.deprecated_call()` as a context-manager
    |
-24 | def test_error_lambda():
+32 | def test_error_lambda():
    -     pytest.deprecated_call(lambda: warnings.warn("", DeprecationWarning))
-25 +     with pytest.deprecated_call():
-26 +         (lambda: warnings.warn("", DeprecationWarning))()
+33 +     with pytest.deprecated_call():
+34 +         (lambda: warnings.warn("", DeprecationWarning))()
    |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__legacy-form-pytest-raises_RUF061_raises.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__legacy-form-pytest-raises_RUF061_raises.py.snap
@@ -2,98 +2,115 @@
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF061 [*] Use context-manager form of `pytest.raises()`
-  --> RUF061_raises.py:19:5
+  --> RUF061_raises.py:34:9
    |
-18 | def test_error_trivial():
-19 |     pytest.raises(ZeroDivisionError, func, 1, b=0)
+32 | def test_error_nested_in_with():
+33 |     with pytest.raises(ValueError, "oops"):
+34 |         pytest.raises(ZeroDivisionError, func, 1, b=0)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Use `pytest.raises()` as a context-manager
+   |
+33 |     with pytest.raises(ValueError, "oops"):
+   -         pytest.raises(ZeroDivisionError, func, 1, b=0)
+34 +         with pytest.raises(ZeroDivisionError):
+35 +             func(1, b=0)
+36 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF061 [*] Use context-manager form of `pytest.raises()`
+  --> RUF061_raises.py:38:5
+   |
+37 | def test_error_trivial():
+38 |     pytest.raises(ZeroDivisionError, func, 1, b=0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.raises()` as a context-manager
    |
-18 | def test_error_trivial():
+37 | def test_error_trivial():
    -     pytest.raises(ZeroDivisionError, func, 1, b=0)
-19 +     with pytest.raises(ZeroDivisionError):
-20 +         func(1, b=0)
-21 |
+38 +     with pytest.raises(ZeroDivisionError):
+39 +         func(1, b=0)
+40 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.raises()`
-  --> RUF061_raises.py:23:5
+  --> RUF061_raises.py:42:5
    |
-22 | def test_error_match():
-23 |     pytest.raises(ZeroDivisionError, func, 1, b=0).match("division by zero")
+41 | def test_error_match():
+42 |     pytest.raises(ZeroDivisionError, func, 1, b=0).match("division by zero")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.raises()` as a context-manager
    |
-22 | def test_error_match():
+41 | def test_error_match():
    -     pytest.raises(ZeroDivisionError, func, 1, b=0).match("division by zero")
-23 +     with pytest.raises(ZeroDivisionError, match="division by zero"):
-24 +         func(1, b=0)
-25 |
+42 +     with pytest.raises(ZeroDivisionError, match="division by zero"):
+43 +         func(1, b=0)
+44 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.raises()`
-  --> RUF061_raises.py:27:15
+  --> RUF061_raises.py:46:15
    |
-26 | def test_error_assign():
-27 |     excinfo = pytest.raises(ZeroDivisionError, func, 1, b=0)
+45 | def test_error_assign():
+46 |     excinfo = pytest.raises(ZeroDivisionError, func, 1, b=0)
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.raises()` as a context-manager
    |
-26 | def test_error_assign():
+45 | def test_error_assign():
    -     excinfo = pytest.raises(ZeroDivisionError, func, 1, b=0)
-27 +     with pytest.raises(ZeroDivisionError) as excinfo:
-28 +         func(1, b=0)
-29 |
+46 +     with pytest.raises(ZeroDivisionError) as excinfo:
+47 +         func(1, b=0)
+48 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.raises()`
-  --> RUF061_raises.py:31:5
+  --> RUF061_raises.py:50:5
    |
-30 | def test_error_kwargs():
-31 |     pytest.raises(func=func, expected_exception=ZeroDivisionError)
+49 | def test_error_kwargs():
+50 |     pytest.raises(func=func, expected_exception=ZeroDivisionError)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.raises()` as a context-manager
    |
-30 | def test_error_kwargs():
+49 | def test_error_kwargs():
    -     pytest.raises(func=func, expected_exception=ZeroDivisionError)
-31 +     with pytest.raises(ZeroDivisionError):
-32 +         func()
-33 |
+50 +     with pytest.raises(ZeroDivisionError):
+51 +         func()
+52 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.raises()`
-  --> RUF061_raises.py:35:15
+  --> RUF061_raises.py:54:15
    |
-34 | def test_error_multi_statement():
-35 |     excinfo = pytest.raises(ValueError, int, "hello")
+53 | def test_error_multi_statement():
+54 |     excinfo = pytest.raises(ValueError, int, "hello")
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-36 |     assert excinfo.match("^invalid literal")
+55 |     assert excinfo.match("^invalid literal")
    |
 help: Use `pytest.raises()` as a context-manager
    |
-34 | def test_error_multi_statement():
+53 | def test_error_multi_statement():
    -     excinfo = pytest.raises(ValueError, int, "hello")
-35 +     with pytest.raises(ValueError) as excinfo:
-36 +         int("hello")
-37 |     assert excinfo.match("^invalid literal")
+54 +     with pytest.raises(ValueError) as excinfo:
+55 +         int("hello")
+56 |     assert excinfo.match("^invalid literal")
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.raises()`
-  --> RUF061_raises.py:40:5
+  --> RUF061_raises.py:59:5
    |
-39 | def test_error_lambda():
-40 |     pytest.raises(ZeroDivisionError, lambda: 1 / 0)
+58 | def test_error_lambda():
+59 |     pytest.raises(ZeroDivisionError, lambda: 1 / 0)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.raises()` as a context-manager
    |
-39 | def test_error_lambda():
+58 | def test_error_lambda():
    -     pytest.raises(ZeroDivisionError, lambda: 1 / 0)
-40 +     with pytest.raises(ZeroDivisionError):
-41 +         (lambda: 1 / 0)()
+59 +     with pytest.raises(ZeroDivisionError):
+60 +         (lambda: 1 / 0)()
    |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__legacy-form-pytest-raises_RUF061_warns.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__legacy-form-pytest-raises_RUF061_warns.py.snap
@@ -2,50 +2,50 @@
 source: crates/ruff_linter/src/rules/ruff/mod.rs
 ---
 RUF061 [*] Use context-manager form of `pytest.warns()`
-  --> RUF061_warns.py:16:5
+  --> RUF061_warns.py:24:5
    |
-15 | def test_error_trivial():
-16 |     pytest.warns(UserWarning, raise_user_warning, "warning")
+23 | def test_error_trivial():
+24 |     pytest.warns(UserWarning, raise_user_warning, "warning")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.warns()` as a context-manager
    |
-15 | def test_error_trivial():
+23 | def test_error_trivial():
    -     pytest.warns(UserWarning, raise_user_warning, "warning")
-16 +     with pytest.warns(UserWarning):
-17 +         raise_user_warning("warning")
-18 |
+24 +     with pytest.warns(UserWarning):
+25 +         raise_user_warning("warning")
+26 |
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.warns()`
-  --> RUF061_warns.py:20:9
+  --> RUF061_warns.py:28:9
    |
-19 | def test_error_assign():
-20 |     s = pytest.warns(UserWarning, raise_user_warning, "warning")
+27 | def test_error_assign():
+28 |     s = pytest.warns(UserWarning, raise_user_warning, "warning")
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-21 |     print(s)
+29 |     print(s)
    |
 help: Use `pytest.warns()` as a context-manager
    |
-19 | def test_error_assign():
+27 | def test_error_assign():
    -     s = pytest.warns(UserWarning, raise_user_warning, "warning")
-20 +     with pytest.warns(UserWarning):
-21 +         s = raise_user_warning("warning")
-22 |     print(s)
+28 +     with pytest.warns(UserWarning):
+29 +         s = raise_user_warning("warning")
+30 |     print(s)
    |
 note: This is an unsafe fix and may change runtime behavior
 
 RUF061 [*] Use context-manager form of `pytest.warns()`
-  --> RUF061_warns.py:25:5
+  --> RUF061_warns.py:33:5
    |
-24 | def test_error_lambda():
-25 |     pytest.warns(UserWarning, lambda: warnings.warn("", UserWarning))
+32 | def test_error_lambda():
+33 |     pytest.warns(UserWarning, lambda: warnings.warn("", UserWarning))
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: Use `pytest.warns()` as a context-manager
    |
-24 | def test_error_lambda():
+32 | def test_error_lambda():
    -     pytest.warns(UserWarning, lambda: warnings.warn("", UserWarning))
-25 +     with pytest.warns(UserWarning):
-26 +         (lambda: warnings.warn("", UserWarning))()
+33 +     with pytest.warns(UserWarning):
+34 +         (lambda: warnings.warn("", UserWarning))()
    |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Closes #28146.

Avoids false-positive `RUF061` violations when `pytest.raises(...)`, `pytest.warns(...)`, or `pytest.deprecated_call(...)` is already used as the context expression in a `with` (or `async with`) statement.

Previously, passing additional positional arguments (such as `with pytest.raises(ValueError, "oops"):`) caused `find_argument("func", 1)` to match the second positional argument as the deprecated callable parameter, triggering `RUF061` on code that was already using context-manager syntax.

## Test Plan

- Updated `RUF061_raises.py`, `RUF061_warns.py`, and `RUF061_deprecated_call.py` with test cases covering extra positional arguments in `with` statements and nested calls within `with` bodies.
- Updated snapshots via `INSTA_UPDATE=always cargo test -p ruff_linter`.
- Verified `cargo fmt --check` and `cargo clippy -p ruff_linter --all-targets`.
