### PR TITLE
rule(flake8-async): extend ASYNC212 to detect httpx2

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC212.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_async/ASYNC212.py
@@ -73,3 +73,13 @@ async def foo():
 async def foo():
     async with httpx.AsyncClient() as client:
         await client.get()  # Ok
+
+
+import httpx2
+
+
+async def foo():
+    client = httpx2.Client()
+    client.get()  # ASYNC212
+    client.post()  # ASYNC212
+

--- a/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call_httpx.rs
+++ b/crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call_httpx.rs
@@ -65,7 +65,9 @@ impl TypeChecker for HttpxClientChecker {
         // match base annotation directly
         if semantic
             .resolve_qualified_name(annotation)
-            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["httpx", "Client"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["httpx" | "httpx2", "Client"])
+            })
         {
             return true;
         }
@@ -77,7 +79,7 @@ impl TypeChecker for HttpxClientChecker {
                 if semantic
                     .resolve_qualified_name(inner_expr)
                     .is_some_and(|qualified_name| {
-                        matches!(qualified_name.segments(), ["httpx", "Client"])
+                        matches!(qualified_name.segments(), ["httpx" | "httpx2", "Client"])
                     })
                 {
                     found = true;
@@ -99,7 +101,9 @@ impl TypeChecker for HttpxClientChecker {
 
         semantic
             .resolve_qualified_name(func)
-            .is_some_and(|qualified_name| matches!(qualified_name.segments(), ["httpx", "Client"]))
+            .is_some_and(|qualified_name| {
+                matches!(qualified_name.segments(), ["httpx" | "httpx2", "Client"])
+            })
     }
 }
 


### PR DESCRIPTION
Fixes #28063

#### Summary
Rule `ASYNC212` (`blocking-http-call-in-async-function`) checks for synchronous HTTP requests inside `async def` functions (such as `requests.get()`, `urllib.request.urlopen()`, `httpx.get()`).

This PR extends AST call detection in `crates/ruff_linter/src/rules/flake8_async/rules/blocking_http_call.rs` to detect synchronous client calls from `httpx2` and custom session instances, preventing unintentional event loop blocking in modern async codebases.
