### PR TITLE
[ty] Fix auto-completion panic involving bare declarations

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -6672,6 +6672,49 @@ from sys import (
     }
 
     #[test]
+    fn from_import_with_bare_annotation() {
+        let builder = CursorTest::builder()
+            .source("module.py", "declared: int\nvalue = 1")
+            .source("main.py", "from module import val<CURSOR>")
+            .completion_test_builder();
+
+        builder.build().contains("value");
+    }
+
+    #[test]
+    fn from_import_with_separate_annotation_and_assignment() {
+        let builder = CursorTest::builder()
+            .source("module.py", "value: int\nvalue = 1")
+            .source("main.py", "from module import val<CURSOR>")
+            .completion_test_builder();
+
+        let test = builder.build();
+        assert!(
+            test.completions()
+                .iter()
+                .any(|completion| completion.name == "value" && !completion.is_type_check_only)
+        );
+    }
+
+    #[test]
+    fn from_import_with_type_checking_annotation() {
+        let builder = CursorTest::builder()
+            .source(
+                "module.py",
+                "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    value: int",
+            )
+            .source("main.py", "from module import val<CURSOR>")
+            .completion_test_builder();
+
+        let test = builder.build();
+        assert!(
+            test.completions()
+                .iter()
+                .any(|completion| completion.name == "value" && completion.is_type_check_only)
+        );
+    }
+
+    #[test]
     fn from_import_unknown_in_module() {
         let builder = completion_test_builder(
             "\

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -15,8 +15,8 @@ use crate::reachability::{
 };
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
-    UnionBuilder, UnionType, binding_type, exists_at_runtime, inferred_declaration,
-    is_discarded_dict_key_assignment,
+    UnionBuilder, UnionType, binding_type, inferred_declaration, is_discarded_dict_key_assignment,
+    may_exist_at_runtime,
 };
 use crate::{Db, FxIndexSet, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
@@ -694,7 +694,7 @@ fn builtins_symbol_impl<'db>(
         if matches!(visibility, BuiltinVisibility::RuntimeOnly)
             && let Place::Defined(defined) = found_symbol.place
             && let Some(definition) = defined.provenance.definition()
-            && !exists_at_runtime(db, definition)
+            && !may_exist_at_runtime(db, definition)
         {
             return None;
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -236,7 +236,7 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
     inference.binding_type(definition)
 }
 
-/// Returns whether a definition represents a value that exists at runtime.
+/// Returns whether a definition may represent a value that exists at runtime.
 ///
 /// Type-checking-only decorators and guards never represent runtime values. Private type-variable
 /// declarations, explicit aliases, and unambiguous typing aliases in stub files are also
@@ -249,8 +249,26 @@ pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) ->
 /// _runtime_callback = callbacks[0]  # Runtime value.
 /// ```
 #[salsa::tracked(returns(copy))]
-pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
+pub(crate) fn may_exist_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db>) -> bool {
     let file = definition.program_file(db);
+    let parsed = parsed_module(db, file.python_file(db));
+    let module = parsed.load(db);
+
+    // Definitions inside an `if TYPE_CHECKING` block are never available at runtime.
+    if semantic_index(db, file).is_in_type_checking_block(
+        definition.file_scope(db),
+        definition.full_range(db, &module).range(),
+    ) {
+        return false;
+    }
+
+    // A bare annotation can describe a value initialized elsewhere, but inference only records
+    // its declared type. Treat it as a possible runtime value without requesting a binding type.
+    let is_stub = file.file(db).is_stub(db);
+    if !definition.kind(db).category(is_stub, &module).is_binding() {
+        return true;
+    }
+
     let inference = infer_definition_types(db, definition);
     let ty = inference.binding_type(definition);
 
@@ -263,19 +281,8 @@ pub(crate) fn exists_at_runtime<'db>(db: &'db dyn Db, definition: Definition<'db
         return false;
     }
 
-    let parsed = parsed_module(db, file.python_file(db));
-    let module = parsed.load(db);
-
-    // Definitions inside an `if TYPE_CHECKING` block are never available at runtime.
-    if semantic_index(db, file).is_in_type_checking_block(
-        definition.file_scope(db),
-        definition.full_range(db, &module).range(),
-    ) {
-        return false;
-    }
-
     // The remaining heuristics only apply to stub definitions.
-    if !file.file(db).is_stub(db) {
+    if !is_stub {
         return true;
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -262,8 +262,9 @@ pub(crate) fn may_exist_at_runtime<'db>(db: &'db dyn Db, definition: Definition<
         return false;
     }
 
-    // A bare annotation can describe a value initialized elsewhere, but inference only records
-    // its declared type. Treat it as a possible runtime value without requesting a binding type.
+    // A declaration (without binding) can describe a value initialized elsewhere, but inference
+    // only records its declared type. Treat it as a possible runtime value without requesting a
+    // binding type.
     let is_stub = file.file(db).is_stub(db);
     if !definition.kind(db).category(is_stub, &module).is_binding() {
         return true;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -263,8 +263,8 @@ pub(crate) fn may_exist_at_runtime<'db>(db: &'db dyn Db, definition: Definition<
     }
 
     // A declaration (without binding) can describe a value initialized elsewhere, but inference
-    // only records its declared type. Treat it as a possible runtime value without requesting a
-    // binding type.
+    // only records its declared type. Treat it as a possible runtime value without querying the
+    // type of its binding.
     let is_stub = file.file(db).is_stub(db);
     if !definition.kind(db).category(is_stub, &module).is_binding() {
         return true;

--- a/crates/ty_python_semantic/src/types/dedicated/pytest.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest.rs
@@ -69,7 +69,7 @@ use crate::types::infer::{function_known_decorators, infer_definition_types, ori
 use crate::types::signatures::Parameter as SignatureParameter;
 use crate::types::{
     ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, Type, definition_expression_type,
-    exists_at_runtime, extract_fixed_length_iterable_element_types,
+    extract_fixed_length_iterable_element_types, may_exist_at_runtime,
 };
 use crate::{Db, FxIndexMap, FxIndexSet};
 
@@ -871,7 +871,7 @@ fn is_available_definition_in_scope<'db>(
             .use_def_map(scope)
             .end_of_scope_bindings(definition.place(db)),
     );
-    resolution.definitions().contains(&definition) && exists_at_runtime(db, definition)
+    resolution.definitions().contains(&definition) && may_exist_at_runtime(db, definition)
 }
 
 /// A class hierarchy or scope searched when resolving a fixture request.
@@ -943,7 +943,7 @@ fn class_attribute_exists_at_runtime<'db>(
 ) -> bool {
     definitions
         .iter()
-        .any(|definition| exists_at_runtime(db, *definition))
+        .any(|definition| may_exist_at_runtime(db, *definition))
 }
 
 /// Resolves a request against the fixture exposures in `search_scope`.
@@ -1161,7 +1161,7 @@ fn exposures_contributed_by_definition<'db>(
     ) {
         return Vec::new();
     }
-    if !exists_at_runtime(db, definition) {
+    if !may_exist_at_runtime(db, definition) {
         return Vec::new();
     }
 

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -20,7 +20,7 @@ use crate::{
     types::{
         ClassBase, ClassLiteral, KnownClass, ProgramEnvironment, StaticClassLiteral,
         SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
-        exists_at_runtime, function::FunctionType, infer_definition_types,
+        function::FunctionType, infer_definition_types, may_exist_at_runtime,
     },
 };
 use ty_python_core::{
@@ -453,7 +453,7 @@ impl<'db> AllMembers<'db> {
                         is_type_check_only: defined
                             .provenance
                             .definition()
-                            .is_some_and(|definition| !exists_at_runtime(db, definition)),
+                            .is_some_and(|definition| !may_exist_at_runtime(db, definition)),
                     });
                 }
 


### PR DESCRIPTION
## Summary

Requesting completion after `val` in `from module import val` previously panicked when `module.py` contained a declaration without a right hand side value, even for an unrelated name:

```python
declared: int
value = 1
```

closes https://github.com/astral-sh/ty/issues/4423.

## Test Plan

- Three regression tests for the original bug and related issues