### PR TITLE
[ty] Add an unused-dependency rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4815,6 +4815,7 @@ dependencies = [
  "ordermap",
  "parking_lot",
  "pep440_rs",
+ "pep508_rs",
  "rayon",
  "regex",
  "regex-automata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ path-absolutize = { version = "4.0.0" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
 pep440_rs = { version = "0.7.1" }
+pep508_rs = { version = "0.9.2" }
 pretty_assertions = "1.3.0"
 proc-macro2 = { version = "1.0.79" }
 pyproject-toml = { version = "0.13.4" }

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -6020,6 +6020,73 @@ async def main() -> None:
     await fetch_data()  # OK
 ```
 
+## `unused-dependency`
+
+<small>
+Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.76">0.0.76</a> ·
+<a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-dependency%22" target="_blank">Related issues</a> ·
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Fdependency.rs#L20" target="_blank">View source</a>
+</small>
+
+
+**What it does**
+
+
+Checks for declared dependencies that are not imported by a project or PEP 723 script.
+
+The package name need not match its import name. For example, importing `PIL` counts as using the
+`pillow` dependency.
+
+**Why is this bad?**
+
+
+An unused dependency adds installation time and can impose unnecessary version constraints. Remove
+the declaration if the dependency is no longer needed.
+
+**Rule status**
+
+
+This rule is disabled by default. Enable it with `--warn unused-dependency` or set
+`unused-dependency = "warn"` in the `rules` table of your ty configuration.
+
+It requires uv dependency metadata, including module ownership. Enable uv workspace integration with
+`TY_UV=1`, or script integration with `TY_UV=scripts`. Project checks use an existing, synchronized
+environment; ty synchronizes PEP 723 script environments automatically.
+
+The rule checks `project.dependencies`, `project.optional-dependencies`, and PEP 723 script
+dependencies. Dependency groups, conditional requirements, and distributions with no known
+importable modules are not checked.
+
+**Known limitations**
+
+
+Project checks require a complete scan of the project directory. Checking an individual file or
+subdirectory, or configuring `src.include` or a nonempty `src.exclude`, does not report unused
+project dependencies. Script checks include imports in local modules reached from the script, using
+the script's own environment and declarations.
+
+Imports in nested scopes, stub files, and `TYPE_CHECKING` blocks count as use. Literal calls to
+`importlib.import_module` and `__import__` also count. If a recognized dynamic import has an unknown
+module name, the rule does not report unused dependencies for that project or script.
+
+Some dependencies are used without imports, for example through command-line tools or plugin
+discovery. Their absence from the import inventory does not prove they can be removed. Review these
+uses before removing a dependency, or disable the rule for projects that rely on them.
+
+**Example**
+
+
+For a project with these dependencies:
+
+```toml
+[project]
+dependencies = ["requests", "flask"]
+```
+
+If the project imports `requests` but never imports `flask`, ty reports the `flask` declaration.
+Remove it if the project no longer uses Flask.
+
 ## `unused-ignore-comment`
 
 <small>

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -44,6 +44,7 @@ notify = { workspace = true }
 ordermap = { workspace = true, features = ["serde"] }
 parking_lot = { workspace = true }
 pep440_rs = { workspace = true, features = ["version-ranges"] }
+pep508_rs = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 regex-automata = { workspace = true }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -618,6 +618,13 @@ impl SemanticDb for ProjectDatabase {
             .as_deref()
     }
 
+    fn unused_dependency_diagnostics(&self, file: File) -> &[Diagnostic] {
+        if Script::for_file(self, file).is_none() {
+            return &[];
+        }
+        crate::dependency::script_dependency_diagnostics(self, file)
+    }
+
     fn verbose(&self) -> bool {
         self.project().verbose(self)
     }
@@ -891,6 +898,13 @@ pub(crate) mod testing {
                 .as_ref()
                 .ok()?
                 .as_deref()
+        }
+
+        fn unused_dependency_diagnostics(&self, file: File) -> &[Diagnostic] {
+            if Script::for_file(self, file).is_none() {
+                return &[];
+            }
+            crate::dependency::script_dependency_diagnostics(self, file)
         }
 
         fn verbose(&self) -> bool {

--- a/crates/ty_project/src/dependency.rs
+++ b/crates/ty_project/src/dependency.rs
@@ -1,0 +1,318 @@
+//! Checks dependency declarations against imports in their project or standalone script.
+
+use std::collections::BTreeSet;
+
+use compact_str::CompactString;
+use pep508_rs::PackageName;
+use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
+use ruff_db::files::{File, system_path_to_file};
+use ruff_db::system::SystemPath;
+use rustc_hash::FxHashSet;
+use ty_module_resolver::{ImportingFile, resolve_real_module};
+use ty_python_core::ProgramFile;
+use ty_python_semantic::dependency::{
+    DependencyMetadata, DependencyProject, DependencyProjectKind, UNUSED_DEPENDENCY,
+    imported_modules,
+};
+use ty_python_semantic::lint::LintId;
+
+use crate::script::{Script, script_tag};
+use crate::{Db, Project};
+
+mod declarations;
+
+#[cfg(test)]
+mod tests;
+
+use declarations::{DependencyDeclaration, declarations};
+
+/// Checks declarations in fully included workspace members, including imports in unopened files.
+///
+/// These diagnostics belong to `pyproject.toml`, so document diagnostics for individual Python
+/// files cannot deliver them. Both the command line and language server report them separately.
+pub fn project_dependency_diagnostics(db: &dyn Db) -> &[Diagnostic] {
+    let project = db.project();
+    if project.metadata(db).uv_workspace().is_none() {
+        return &[];
+    }
+    check_project_dependencies(db, project)
+}
+
+#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
+fn check_project_dependencies(db: &dyn Db, project: Project) -> Box<[Diagnostic]> {
+    let Ok(Some(metadata)) = project.dependency_metadata(db) else {
+        return Box::default();
+    };
+    project_diagnostics(db, metadata)
+}
+
+fn project_diagnostics(db: &dyn Db, metadata: &DependencyMetadata) -> Box<[Diagnostic]> {
+    let project = db.project();
+    if project
+        .metadata(db)
+        .to_merged_options()
+        .options()
+        .src
+        .as_ref()
+        .is_some_and(|src| {
+            src.include.is_some()
+                || src
+                    .exclude
+                    .as_ref()
+                    .is_some_and(|patterns| !patterns.is_empty())
+        })
+    {
+        // Source filters describe the files to type-check, not every file that can use a
+        // project's dependencies. Imports outside that selection can keep a dependency in use.
+        return Box::default();
+    }
+    let mut indexed = None;
+    let mut diagnostics = Vec::new();
+    for member in &metadata.projects {
+        if member.kind != DependencyProjectKind::Project
+            || !project
+                .included_paths_or_root(db)
+                .iter()
+                .any(|path| member.path.starts_with(path))
+        {
+            // A check of `src/` or a single file cannot establish that a dependency is unused by
+            // the containing project. Selecting a complete workspace member is sufficient.
+            continue;
+        }
+
+        let Ok(file) = system_path_to_file(db, member.path.join("pyproject.toml")) else {
+            continue;
+        };
+        let Some(severity) = db
+            .rule_selection(file)
+            .severity(LintId::of(&UNUSED_DEPENDENCY))
+        else {
+            continue;
+        };
+        let Some(declarations) = declarations(db, file, DependencyProjectKind::Project) else {
+            continue;
+        };
+        if declarations.is_empty() {
+            continue;
+        }
+
+        let indexed = indexed.get_or_insert_with(|| project.files(db));
+        if !indexed.diagnostics().is_empty() {
+            // A failed directory walk can hide an import that uses any declared dependency.
+            return Box::default();
+        }
+
+        let files = indexed
+            .iter()
+            .chain(project.open_files(db).iter().copied())
+            .filter(|file| {
+                file.path(db).as_system_path().is_some_and(|path| {
+                    containing_project(metadata, path).is_some_and(|owner| owner == member)
+                }) && script_tag(db, *file).is_none()
+            })
+            .map(|file| project.program(db).program_file(db, file));
+        let Some(used) = used_dependencies(db, metadata, files, Some(member)) else {
+            continue;
+        };
+        diagnostics.extend(unused_declarations(
+            metadata,
+            member,
+            declarations,
+            &used,
+            file,
+            severity,
+        ));
+    }
+
+    diagnostics.into_boxed_slice()
+}
+
+/// Checks one script before semantic diagnostics apply the script's suppression comments.
+#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
+pub(crate) fn script_dependency_diagnostics(db: &dyn Db, file: File) -> Box<[Diagnostic]> {
+    let Some(script) = Script::for_file(db, file) else {
+        return Box::default();
+    };
+    if !script.has_valid_settings(db)
+        || !db
+            .rule_selection(file)
+            .is_enabled(LintId::of(&UNUSED_DEPENDENCY))
+    {
+        return Box::default();
+    }
+    let Ok(Some(metadata)) = script.dependency_metadata(db) else {
+        return Box::default();
+    };
+    script_diagnostics(db, script, metadata)
+}
+
+fn script_diagnostics(
+    db: &dyn Db,
+    script: Script<'_>,
+    metadata: &DependencyMetadata,
+) -> Box<[Diagnostic]> {
+    let file = script.file(db);
+    let Some(severity) = db
+        .rule_selection(file)
+        .severity(LintId::of(&UNUSED_DEPENDENCY))
+    else {
+        return Box::default();
+    };
+    let Some(declarations) = declarations(db, file, DependencyProjectKind::Script) else {
+        return Box::default();
+    };
+    let Some(project) = metadata.projects.iter().find(|project| {
+        project.kind == DependencyProjectKind::Script
+            && file.path(db).as_system_path() == Some(project.path.as_path())
+    }) else {
+        return Box::default();
+    };
+    let Some(used) = used_dependencies(
+        db,
+        metadata,
+        [script.program(db).program_file(db, file)],
+        None,
+    ) else {
+        return Box::default();
+    };
+
+    unused_declarations(metadata, project, declarations, &used, file, severity)
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+fn containing_project<'a>(
+    metadata: &'a DependencyMetadata,
+    path: &SystemPath,
+) -> Option<&'a DependencyProject> {
+    metadata
+        .projects
+        .iter()
+        .filter(|project| {
+            project.kind == DependencyProjectKind::Project && path.starts_with(&project.path)
+        })
+        .max_by_key(|project| project.path.as_str().len())
+}
+
+/// Includes local helpers in the caller's environment. Their own script metadata, if present,
+/// does not describe the environment in which an importing script executes them.
+fn used_dependencies<'db>(
+    db: &'db dyn Db,
+    metadata: &DependencyMetadata,
+    files: impl IntoIterator<Item = ProgramFile<'db>>,
+    member: Option<&DependencyProject>,
+) -> Option<BTreeSet<CompactString>> {
+    let mut pending: Vec<_> = files.into_iter().collect();
+    let mut visited = FxHashSet::default();
+    let mut used = BTreeSet::new();
+
+    while let Some(file) = pending.pop() {
+        if !visited.insert(file.file(db)) {
+            continue;
+        }
+        let imports = imported_modules(db, file);
+        if imports.incomplete {
+            return None;
+        }
+        metadata.record_used_dependencies(db, file, imports, &mut used);
+
+        let local_modules = imports.modules.iter().flat_map(|module| {
+            [
+                Some(*module),
+                resolve_real_module(
+                    db,
+                    ImportingFile::File(file.file(db), file.resolver_environment(db)),
+                    module.name(db),
+                ),
+            ]
+            .into_iter()
+            .flatten()
+        });
+        for module in local_modules {
+            if !module.search_path(db).is_some_and(|path| {
+                !path.is_standard_library() && !path.is_site_packages() && !path.is_editable()
+            }) {
+                continue;
+            }
+            let Some(imported_file) = module.file(db) else {
+                continue;
+            };
+            let Some(path) = imported_file.path(db).as_system_path() else {
+                continue;
+            };
+            if let Some(member) = member
+                && containing_project(metadata, path).is_some_and(|owner| owner != member)
+            {
+                continue;
+            }
+            if metadata.distributions.iter().any(|(id, distribution)| {
+                member.and_then(|member| member.distribution.as_ref()) != Some(id)
+                    && distribution
+                        .editable_path
+                        .as_ref()
+                        .is_some_and(|root| path.starts_with(root))
+            }) {
+                // Workspace members and other editable dependencies supply their own imports.
+                // Looking inside them would make their transitive dependencies appear used here.
+                continue;
+            }
+            pending.push(file.program(db).program_file(db, imported_file));
+        }
+    }
+
+    Some(used)
+}
+
+fn unused_declarations<'a>(
+    metadata: &'a DependencyMetadata,
+    project: &'a DependencyProject,
+    declarations: &'a [DependencyDeclaration],
+    used: &'a BTreeSet<CompactString>,
+    file: File,
+    severity: Severity,
+) -> impl Iterator<Item = Diagnostic> + 'a {
+    declarations.iter().filter_map(move |declaration| {
+        let mut has_known_modules = false;
+        for id in &project.dependencies {
+            let Some(distribution) = metadata.distributions.get(id) else {
+                continue;
+            };
+            if !distribution
+                .name
+                .parse::<PackageName>()
+                .is_ok_and(|name| name.as_ref() == declaration.name.as_str())
+            {
+                continue;
+            }
+            if used.contains(id) {
+                return None;
+            }
+            has_known_modules |= metadata
+                .module_owners
+                .values()
+                .any(|owners| owners.contains(id));
+        }
+        if !has_known_modules {
+            // Import analysis says nothing about packages that only provide commands, plugins,
+            // or resources, or about dependencies absent from the synchronized environment.
+            return None;
+        }
+
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::Lint(UNUSED_DEPENDENCY.name()),
+            severity,
+            format_args!(
+                "Dependency `{}` is declared but never imported",
+                declaration.name
+            ),
+        );
+        diagnostic.annotate(Annotation::primary(
+            Span::from(file).with_range(declaration.range),
+        ));
+        diagnostic.set_documentation_url(Some(format!(
+            "https://ty.dev/rules#{}",
+            UNUSED_DEPENDENCY.name()
+        )));
+        Some(diagnostic)
+    })
+}

--- a/crates/ty_project/src/dependency/declarations.rs
+++ b/crates/ty_project/src/dependency/declarations.rs
@@ -1,0 +1,149 @@
+use std::collections::BTreeMap;
+
+use compact_str::CompactString;
+use pep508_rs::Requirement;
+use ruff_db::files::File;
+use ruff_db::source::source_text;
+use ruff_python_ast::script::ScriptSourceMap;
+use ruff_text_size::{TextRange, TextSize};
+use serde::Deserialize;
+use toml::Spanned;
+use ty_python_semantic::dependency::DependencyProjectKind;
+
+use crate::Db;
+use crate::script::script_tag;
+
+/// A dependency declaration that can be checked without evaluating environment markers.
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
+pub(super) struct DependencyDeclaration {
+    pub(super) name: CompactString,
+    pub(super) range: TextRange,
+}
+
+/// Returns unconditional runtime and optional dependency declarations with their source locations.
+///
+/// Invalid metadata is not evidence that a dependency is unused. Dependency groups and build
+/// requirements are excluded because they commonly provide tools rather than imported modules.
+pub(super) fn declarations(
+    db: &dyn Db,
+    file: File,
+    kind: DependencyProjectKind,
+) -> Option<&[DependencyDeclaration]> {
+    match kind {
+        DependencyProjectKind::Project => project_declarations(db, file),
+        DependencyProjectKind::Script => script_declarations(db, file),
+    }
+}
+
+#[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]
+fn project_declarations(db: &dyn Db, file: File) -> Option<Box<[DependencyDeclaration]>> {
+    let source = source_text(db, file);
+    if source.read_error().is_some() {
+        return None;
+    }
+
+    parse_project(source.as_str())
+}
+
+fn parse_project(source: &str) -> Option<Box<[DependencyDeclaration]>> {
+    let metadata: ProjectMetadata = toml::from_str(source).ok()?;
+    let project = metadata.project.unwrap_or_default();
+    let requirements = project
+        .dependencies
+        .into_iter()
+        .chain(project.optional_dependencies.into_values().flatten());
+    parse_requirements(requirements, None)
+}
+
+#[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]
+fn script_declarations(db: &dyn Db, file: File) -> Option<Box<[DependencyDeclaration]>> {
+    let tag = script_tag(db, file)?;
+    let metadata: ScriptMetadata = toml::from_str(tag.metadata()).ok()?;
+    parse_requirements(metadata.dependencies, Some(tag.source_map()))
+}
+
+fn parse_requirements(
+    requirements: impl IntoIterator<Item = Spanned<String>>,
+    source_map: Option<&ScriptSourceMap>,
+) -> Option<Box<[DependencyDeclaration]>> {
+    let mut declarations = Vec::new();
+    for requirement in requirements {
+        let parsed: Requirement = requirement.get_ref().parse().ok()?;
+        // The dependency graph covers every supported environment. An installed distribution can
+        // satisfy another declaration even when this declaration's marker does not apply.
+        if !parsed.marker.is_true() {
+            continue;
+        }
+
+        let span = requirement.span();
+        let range = TextRange::new(
+            TextSize::try_from(span.start).ok()?,
+            TextSize::try_from(span.end).ok()?,
+        );
+        declarations.push(DependencyDeclaration {
+            name: CompactString::new(parsed.name.as_ref()),
+            range: source_map.map_or(range, |source_map| source_map.map_range(range)),
+        });
+    }
+
+    declarations.sort_unstable_by_key(|declaration| declaration.range.start());
+    Some(declarations.into_boxed_slice())
+}
+
+#[derive(Deserialize)]
+struct ProjectMetadata {
+    project: Option<ProjectDependencies>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct ProjectDependencies {
+    #[serde(default)]
+    dependencies: Vec<Spanned<String>>,
+    #[serde(default)]
+    optional_dependencies: BTreeMap<String, Vec<Spanned<String>>>,
+}
+
+#[derive(Deserialize)]
+struct ScriptMetadata {
+    #[serde(default)]
+    dependencies: Vec<Spanned<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Context;
+    use ruff_python_ast::script::ScriptTag;
+
+    use super::{ScriptMetadata, parse_project, parse_requirements};
+
+    #[test]
+    fn script_declaration_ranges() -> anyhow::Result<()> {
+        let source = "# café\r\n# /// script\r\n# dependencies = [\r\n#     'Some_Package',\r\n#     \"other-package>=2\",\r\n# ]\r\n# ///\r\n";
+        let tag = ScriptTag::parse(source.as_bytes()).context("expected valid script metadata")?;
+        let metadata: ScriptMetadata = toml::from_str(tag.metadata())?;
+        let declarations = parse_requirements(metadata.dependencies, Some(tag.source_map()))
+            .context("expected valid requirements")?;
+        assert_eq!(
+            declarations
+                .iter()
+                .map(|declaration| (declaration.name.as_str(), &source[declaration.range]))
+                .collect::<Vec<_>>(),
+            [
+                ("some-package", "'Some_Package'"),
+                ("other-package", r#""other-package>=2""#),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_metadata_is_not_checked() {
+        for source in [
+            "[project",
+            "[project]\ndependencies = ['valid', 'invalid requirement']",
+        ] {
+            assert!(parse_project(source).is_none(), "{source}");
+        }
+    }
+}

--- a/crates/ty_project/src/dependency/tests.rs
+++ b/crates/ty_project/src/dependency/tests.rs
@@ -1,0 +1,402 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::Context;
+use compact_str::CompactString;
+use ruff_db::Db as _;
+use ruff_db::diagnostic::{Diagnostic, Severity, UnifiedFile};
+use ruff_db::files::{File, system_path_to_file};
+use ruff_db::source::source_text;
+use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPathBuf};
+use ruff_ranged_value::ValueSource;
+use ty_module_resolver::{ModuleName, SearchPathSettings};
+use ty_python_core::program::FallibleStrategy;
+use ty_python_semantic::dependency::{
+    DependencyDistribution, DependencyMetadata, DependencyProject, DependencyProjectKind,
+};
+
+use crate::db::testing::TestDb;
+use crate::metadata::options::Options;
+use crate::script::Script;
+use crate::{Db as _, ProjectMetadata};
+
+use super::{project_diagnostics, script_diagnostics};
+
+fn database(rule: &str, modules: &[&str]) -> anyhow::Result<TestDb> {
+    let options = format!("[rules]\nunused-dependency = '{rule}'");
+    database_with_options(&options, modules, ValueSource::Cli)
+}
+
+fn database_with_options(
+    options: &str,
+    modules: &[&str],
+    source: ValueSource,
+) -> anyhow::Result<TestDb> {
+    let root = SystemPathBuf::from("/project");
+    let mut metadata = ProjectMetadata::new("app", root.clone());
+    metadata.apply_override_options(Options::from_toml_str(options, source)?);
+    let mut db = TestDb::new(metadata);
+    for module in modules {
+        db.write_file(format!("/site-packages/{module}.py"), "")?;
+    }
+    db.memory_file_system()
+        .create_directory_all("/site-packages")?;
+    let mut paths = SearchPathSettings::new(vec![root]);
+    paths.site_packages_paths = vec![SystemPathBuf::from("/site-packages")];
+    let project = db.project();
+    let mut settings = project.program_settings(&db).clone();
+    settings.search_paths = paths.to_search_paths(db.system(), db.vendored(), &FallibleStrategy)?;
+    project.update_program(&mut db, settings);
+    Ok(db)
+}
+
+fn metadata(
+    projects: &[(&str, DependencyProjectKind, &[&str])],
+) -> anyhow::Result<DependencyMetadata> {
+    let mut distributions = BTreeMap::new();
+    let mut module_owners = BTreeMap::new();
+    let mut dependency_projects = Vec::new();
+    for (path, kind, dependencies) in projects {
+        let mut ids = BTreeSet::new();
+        for name in *dependencies {
+            let id = CompactString::from(format!("distribution:{name}"));
+            distributions.insert(
+                id.clone(),
+                DependencyDistribution {
+                    name: CompactString::new(name),
+                    editable_path: None,
+                },
+            );
+            module_owners.insert(
+                ModuleName::new(&name.replace('-', "_")).context("valid module name")?,
+                vec![id.clone()].into_boxed_slice(),
+            );
+            ids.insert(id);
+        }
+        dependency_projects.push(DependencyProject {
+            path: SystemPathBuf::from(*path),
+            kind: *kind,
+            distribution: None,
+            dependencies: ids,
+            group_dependencies: BTreeSet::new(),
+        });
+    }
+    Ok(DependencyMetadata {
+        projects: dependency_projects.into_boxed_slice(),
+        distributions,
+        module_owners,
+    })
+}
+
+fn declarations(
+    db: &TestDb,
+    diagnostics: &[Diagnostic],
+) -> anyhow::Result<Vec<(SystemPathBuf, String)>> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| {
+            assert_eq!(diagnostic.id().as_str(), "unused-dependency");
+            let span = diagnostic.primary_span().context("declaration span")?;
+            let UnifiedFile::Ty(file) = span.file() else {
+                anyhow::bail!("expected a ty file");
+            };
+            let range = span.range().context("declaration range")?;
+            Ok((
+                file.path(db)
+                    .as_system_path()
+                    .context("declaration path")?
+                    .to_path_buf(),
+                source_text(db, *file)[range].to_owned(),
+            ))
+        })
+        .collect()
+}
+
+fn script<'db>(db: &'db TestDb, path: &str) -> anyhow::Result<Script<'db>> {
+    let file = system_path_to_file(db, path)?;
+    Ok(script_with_project_program(db, file))
+}
+
+#[salsa::tracked(returns(copy))]
+fn script_with_project_program(db: &dyn crate::Db, file: File) -> Script<'_> {
+    let project = db.project();
+    Script::new(
+        db,
+        file,
+        project.settings(db).clone(),
+        project.program(db),
+        project.program_settings(db).python_version.clone(),
+        true,
+        Box::default(),
+    )
+}
+
+#[test]
+fn declaration_file_rule_override() -> anyhow::Result<()> {
+    let mut db = database_with_options(
+        "[rules]\nunused-dependency = 'error'\n\n[[overrides]]\ninclude = ['pyproject.toml']\n[overrides.rules]\nunused-dependency = 'ignore'\n",
+        &["unused_lib"],
+        ValueSource::File(SystemPathBuf::from("/project/ty.toml").into()),
+    )?;
+    db.write_file(
+        "/project/pyproject.toml",
+        "[project]\ndependencies = ['unused-lib']\n",
+    )?;
+    db.write_file("/project/main.py", "")?;
+    let metadata = metadata(&[("/project", DependencyProjectKind::Project, &["unused-lib"])])?;
+    assert!(project_diagnostics(&db, &metadata).is_empty());
+    Ok(())
+}
+
+#[test]
+fn unopened_file_import_counts_for_project() -> anyhow::Result<()> {
+    let mut db = database("warn", &["used_lib"])?;
+    db.write_file(
+        "/project/pyproject.toml",
+        "[project]\ndependencies = ['used-lib']\n",
+    )?;
+    db.write_file("/project/main.py", "")?;
+    db.write_file("/project/worker.py", "import used_lib\n")?;
+    let main = system_path_to_file(&db, "/project/main.py")?;
+    db.project().open_file(&mut db, main);
+    let metadata = metadata(&[("/project", DependencyProjectKind::Project, &["used-lib"])])?;
+    assert!(project_diagnostics(&db, &metadata).is_empty());
+
+    db.write_file("/project/worker.py", "")?;
+    assert_eq!(project_diagnostics(&db, &metadata).len(), 1);
+    Ok(())
+}
+
+#[test]
+fn local_module_shadowing_does_not_use_installed_distribution() -> anyhow::Result<()> {
+    let mut db = database("warn", &["shared_lib"])?;
+    db.write_file(
+        "/project/pyproject.toml",
+        "[project]\ndependencies = ['shared-lib']\n",
+    )?;
+    db.write_file("/project/main.py", "import shared_lib\n")?;
+    db.write_file("/project/shared_lib.py", "")?;
+    let metadata = metadata(&[("/project", DependencyProjectKind::Project, &["shared-lib"])])?;
+    assert_eq!(
+        declarations(&db, &project_diagnostics(&db, &metadata))?,
+        [("/project/pyproject.toml".into(), "'shared-lib'".into())]
+    );
+    Ok(())
+}
+
+#[test]
+fn stub_only_dependencies_without_module_ownership_are_skipped() -> anyhow::Result<()> {
+    let mut db = database("warn", &["shared_lib"])?;
+    db.write_file("/site-packages/shared_lib-stubs/__init__.pyi", "")?;
+    db.write_file(
+        "/project/pyproject.toml",
+        "[project]\ndependencies = ['shared-lib', 'shared-lib-stubs']\n",
+    )?;
+    db.write_file("/project/main.py", "import shared_lib\n")?;
+    let mut metadata = metadata(&[(
+        "/project",
+        DependencyProjectKind::Project,
+        &["shared-lib", "shared-lib-stubs"],
+    )])?;
+    metadata.module_owners.clear();
+    metadata.module_owners.insert(
+        ModuleName::new("shared_lib").context("valid module name")?,
+        vec![CompactString::new("distribution:shared-lib")].into_boxed_slice(),
+    );
+    assert!(project_diagnostics(&db, &metadata).is_empty());
+
+    db.write_file("/project/main.py", "")?;
+    assert_eq!(
+        declarations(&db, &project_diagnostics(&db, &metadata))?,
+        [("/project/pyproject.toml".into(), "'shared-lib'".into())]
+    );
+    Ok(())
+}
+
+#[test]
+fn namespace_import_credits_all_owners_but_child_import_is_specific() -> anyhow::Result<()> {
+    let mut db = database("warn", &[])?;
+    db.write_file("/site-packages/shared/a.py", "")?;
+    db.write_file("/site-packages/shared/b.py", "")?;
+    db.write_file(
+        "/project/pyproject.toml",
+        "[project]\ndependencies = ['a-lib', 'b-lib']\n",
+    )?;
+    db.write_file("/project/main.py", "import shared\n")?;
+    let mut metadata = metadata(&[(
+        "/project",
+        DependencyProjectKind::Project,
+        &["a-lib", "b-lib"],
+    )])?;
+    metadata.module_owners.clear();
+    for (module, owners) in [
+        ("shared", &["a-lib", "b-lib"][..]),
+        ("shared.a", &["a-lib"][..]),
+        ("shared.b", &["b-lib"][..]),
+    ] {
+        metadata.module_owners.insert(
+            ModuleName::new(module).context("valid module name")?,
+            owners
+                .iter()
+                .map(|name| CompactString::from(format!("distribution:{name}")))
+                .collect(),
+        );
+    }
+    assert!(project_diagnostics(&db, &metadata).is_empty());
+
+    db.write_file("/project/main.py", "import shared.a\n")?;
+    assert_eq!(
+        declarations(&db, &project_diagnostics(&db, &metadata))?,
+        [("/project/pyproject.toml".into(), "'b-lib'".into())]
+    );
+    Ok(())
+}
+
+#[test]
+fn runtime_and_optional_declarations_exclude_groups_and_markers() -> anyhow::Result<()> {
+    let mut db = database(
+        "error",
+        &["unused_lib", "optional_lib", "conditional_lib", "dev_tool"],
+    )?;
+    db.write_file(
+        "/project/pyproject.toml",
+        "[project]\ndependencies = ['Unused.Lib>=1', \"conditional-lib; python_version >= '3.0'\"]\n\n[project.optional-dependencies]\nfeature = ['optional-lib']\n\n[dependency-groups]\ndev = ['dev-tool', 'unused-lib']\n\n[build-system]\nrequires = ['unused-lib']\n",
+    )?;
+    db.write_file("/project/main.py", "")?;
+    let mut metadata = metadata(&[(
+        "/project",
+        DependencyProjectKind::Project,
+        &["unused-lib", "optional-lib", "conditional-lib", "dev-tool"],
+    )])?;
+    let member = &mut metadata.projects[0];
+    member.dependencies.remove("distribution:dev-tool");
+    member
+        .group_dependencies
+        .insert(CompactString::new("distribution:dev-tool"));
+    let diagnostics = project_diagnostics(&db, &metadata);
+    assert_eq!(
+        declarations(&db, &diagnostics)?,
+        [
+            ("/project/pyproject.toml".into(), "'Unused.Lib>=1'".into()),
+            ("/project/pyproject.toml".into(), "'optional-lib'".into()),
+        ]
+    );
+    assert_eq!(diagnostics[0].severity(), Severity::Error);
+    Ok(())
+}
+
+#[test]
+fn custom_source_filters_do_not_prove_unused_dependencies() -> anyhow::Result<()> {
+    for filter in ["include = ['src']", "exclude = ['worker.py']"] {
+        let options = format!("[rules]\nunused-dependency = 'warn'\n[src]\n{filter}\n");
+        let mut db = database_with_options(
+            &options,
+            &["used_lib"],
+            ValueSource::File(SystemPathBuf::from("/project/ty.toml").into()),
+        )?;
+        db.write_file(
+            "/project/pyproject.toml",
+            "[project]\ndependencies = ['used-lib']\n",
+        )?;
+        db.write_file("/project/src/main.py", "")?;
+        db.write_file("/project/worker.py", "import used_lib\n")?;
+        let worker = system_path_to_file(&db, "/project/worker.py")?;
+        assert!(!db.project().files(&db).contains(worker));
+        let project_metadata =
+            metadata(&[("/project", DependencyProjectKind::Project, &["used-lib"])])?;
+        assert!(project_diagnostics(&db, &project_metadata).is_empty());
+    }
+    Ok(())
+}
+
+#[test]
+fn complete_member_check_and_import_isolation() -> anyhow::Result<()> {
+    let mut db = database("warn", &["shared_lib"])?;
+    for member in ["a", "b"] {
+        db.write_file(
+            format!("/project/{member}/pyproject.toml"),
+            "[project]\ndependencies = ['shared-lib']\n",
+        )?;
+    }
+    db.write_file("/project/a/main.py", "import b.main\n")?;
+    db.write_file("/project/b/main.py", "import shared_lib\n")?;
+    db.write_file(
+        "/project/a/script.py",
+        "# /// script\n# dependencies = ['shared-lib']\n# ///\nimport shared_lib\n",
+    )?;
+    let metadata = metadata(&[
+        (
+            "/project/a",
+            DependencyProjectKind::Project,
+            &["shared-lib"],
+        ),
+        (
+            "/project/b",
+            DependencyProjectKind::Project,
+            &["shared-lib"],
+        ),
+    ])?;
+    assert_eq!(
+        declarations(&db, &project_diagnostics(&db, &metadata))?,
+        [("/project/a/pyproject.toml".into(), "'shared-lib'".into())]
+    );
+
+    db.project()
+        .set_included_paths(&mut db, vec![SystemPathBuf::from("/project/a")]);
+    assert_eq!(
+        declarations(&db, &project_diagnostics(&db, &metadata))?,
+        [("/project/a/pyproject.toml".into(), "'shared-lib'".into())]
+    );
+    db.project()
+        .set_included_paths(&mut db, vec![SystemPathBuf::from("/project/a/main.py")]);
+    assert!(project_diagnostics(&db, &metadata).is_empty());
+    Ok(())
+}
+
+#[test]
+fn incomplete_project_analysis_does_not_report_unused_dependencies() -> anyhow::Result<()> {
+    let mut db = database("warn", &["unused_lib"])?;
+    db.write_file(
+        "/project/pyproject.toml",
+        "[project]\ndependencies = ['unused-lib']\n",
+    )?;
+    db.write_file("/project/main.py", "def incomplete(\n")?;
+    let metadata = metadata(&[("/project", DependencyProjectKind::Project, &["unused-lib"])])?;
+    assert!(project_diagnostics(&db, &metadata).is_empty());
+
+    db.write_file("/project/main.py", "")?;
+    assert_eq!(project_diagnostics(&db, &metadata).len(), 1);
+    let file = system_path_to_file(&db, "/project/main.py")?;
+    db.memory_file_system().remove_file("/project/main.py")?;
+    file.sync(&mut db);
+    assert!(project_diagnostics(&db, &metadata).is_empty());
+    Ok(())
+}
+
+#[test]
+fn script_reachable_helpers_cycles_and_edits() -> anyhow::Result<()> {
+    let mut db = database("warn", &["used_lib"])?;
+    db.write_file(
+        "/project/script.py",
+        "# /// script\n# dependencies = ['used-lib']\n# ///\nimport helper\n",
+    )?;
+    db.write_file("/project/helper.pyi", "")?;
+    db.write_file("/project/helper.py", "import other\n")?;
+    db.write_file("/project/other.py", "import helper\nimport used_lib\n")?;
+    db.write_file("/project/unrelated.py", "import used_lib\n")?;
+    let metadata = metadata(&[(
+        "/project/script.py",
+        DependencyProjectKind::Script,
+        &["used-lib"],
+    )])?;
+    assert!(script_diagnostics(&db, script(&db, "/project/script.py")?, &metadata).is_empty());
+
+    db.write_file("/project/other.py", "import helper\n")?;
+    assert_eq!(
+        declarations(
+            &db,
+            &script_diagnostics(&db, script(&db, "/project/script.py")?, &metadata)
+        )?,
+        [("/project/script.py".into(), "'used-lib'".into())]
+    );
+    Ok(())
+}

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -38,6 +38,7 @@ use uv::DependencyMetadataError;
 pub use uv::{ScriptEnvironmentAvailability, UseUv, UvEnvironments, UvSyncChanges};
 
 mod db;
+pub mod dependency;
 mod files;
 pub mod glob;
 pub mod metadata;
@@ -501,6 +502,7 @@ impl Project {
         reporter.set_files(files.len());
 
         diagnostics.extend_from_slice(files.diagnostics());
+        diagnostics.extend_from_slice(dependency::project_dependency_diagnostics(db));
 
         reporter.report_diagnostics(db, diagnostics);
 

--- a/crates/ty_python_semantic/resources/lint_docs/unused-dependency.md
+++ b/crates/ty_python_semantic/resources/lint_docs/unused-dependency.md
@@ -1,0 +1,51 @@
+## What it does
+
+Checks for declared dependencies that are not imported by a project or PEP 723 script.
+
+The package name need not match its import name. For example, importing `PIL` counts as using the
+`pillow` dependency.
+
+## Why is this bad?
+
+An unused dependency adds installation time and can impose unnecessary version constraints. Remove
+the declaration if the dependency is no longer needed.
+
+## Rule status
+
+This rule is disabled by default. Enable it with `--warn unused-dependency` or set
+`unused-dependency = "warn"` in the `rules` table of your ty configuration.
+
+It requires uv dependency metadata, including module ownership. Enable uv workspace integration with
+`TY_UV=1`, or script integration with `TY_UV=scripts`. Project checks use an existing, synchronized
+environment; ty synchronizes PEP 723 script environments automatically.
+
+The rule checks `project.dependencies`, `project.optional-dependencies`, and PEP 723 script
+dependencies. Dependency groups, conditional requirements, and distributions with no known
+importable modules are not checked.
+
+## Known limitations
+
+Project checks require a complete scan of the project directory. Checking an individual file or
+subdirectory, or configuring `src.include` or a nonempty `src.exclude`, does not report unused
+project dependencies. Script checks include imports in local modules reached from the script, using
+the script's own environment and declarations.
+
+Imports in nested scopes, stub files, and `TYPE_CHECKING` blocks count as use. Literal calls to
+`importlib.import_module` and `__import__` also count. If a recognized dynamic import has an unknown
+module name, the rule does not report unused dependencies for that project or script.
+
+Some dependencies are used without imports, for example through command-line tools or plugin
+discovery. Their absence from the import inventory does not prove they can be removed. Review these
+uses before removing a dependency, or disable the rule for projects that rely on them.
+
+## Example
+
+For a project with these dependencies:
+
+```toml
+[project]
+dependencies = ["requests", "flask"]
+```
+
+If the project imports `requests` but never imports `flask`, ty reports the `flask` declaration.
+Remove it if the project no longer uses Flask.

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -26,6 +26,14 @@ pub trait Db: PythonCoreDb {
     /// Returns the package manager's dependency information for this file.
     fn dependency_metadata(&self, file: File) -> Option<&DependencyMetadata>;
 
+    /// Dependency diagnostics attached to this Python file's inline metadata.
+    ///
+    /// Project implementations compute these from the script's declarations and local imports.
+    /// They are incorporated before checking suppressions, alongside ordinary Python diagnostics.
+    fn unused_dependency_diagnostics(&self, _file: File) -> &[Diagnostic] {
+        &[]
+    }
+
     /// Whether ty is running with logging verbosity INFO or higher (`-v` or more).
     fn verbose(&self) -> bool;
 

--- a/crates/ty_python_semantic/src/dependency.rs
+++ b/crates/ty_python_semantic/src/dependency.rs
@@ -10,6 +10,21 @@ use ty_module_resolver::{
 use ty_python_core::ProgramFile;
 
 use crate::Db;
+use crate::declare_lint;
+use crate::lint::{Level, LintStatus};
+
+mod imports;
+
+pub use imports::{ImportedModules, imported_modules};
+
+declare_lint! {
+    #[doc = include_str!("../resources/lint_docs/unused-dependency.md")]
+    pub static UNUSED_DEPENDENCY = {
+        summary: "detects declared dependencies that are not imported",
+        status: LintStatus::stable("0.0.76"),
+        default_level: Level::Ignore,
+    }
+}
 
 /// Returns the missing dependency for this import, if one can be identified.
 ///
@@ -39,6 +54,66 @@ pub struct DependencyMetadata {
 }
 
 impl DependencyMetadata {
+    /// Record the distributions used by a file's imports.
+    ///
+    /// Module ownership describes runtime distributions, so also resolve the implementation when
+    /// type checking selected a stub. Ambiguous namespace ownership counts as use: it does not
+    /// establish that any owner is unused.
+    pub fn record_used_dependencies(
+        &self,
+        db: &dyn Db,
+        file: ProgramFile<'_>,
+        imports: &ImportedModules<'_>,
+        used: &mut BTreeSet<CompactString>,
+    ) {
+        for module in imports.modules.iter().copied() {
+            self.record_module_owners(db, module, used);
+            if let Some(runtime) = resolve_real_module(
+                db,
+                ImportingFile::File(file.file(db), file.resolver_environment(db)),
+                module.name(db),
+            ) {
+                self.record_module_owners(db, runtime, used);
+            }
+        }
+
+        // Import resolution can fail for native extensions or unavailable stubs. The package
+        // manager can still identify their distribution from the imported module's name.
+        for name in &imports.unresolved {
+            self.record_named_module_owners(name, used);
+        }
+    }
+
+    fn record_module_owners(
+        &self,
+        db: &dyn Db,
+        module: Module<'_>,
+        used: &mut BTreeSet<CompactString>,
+    ) {
+        if let Some(owner) = self.owner(db, module) {
+            used.insert(owner.clone());
+            return;
+        }
+
+        if module.search_path(db).is_none_or(|path| {
+            path.is_site_packages()
+                || path.is_editable()
+                || (path.is_standard_library()
+                    && module.name(db).first_component() == "typing_extensions")
+        }) {
+            self.record_named_module_owners(module.name(db), used);
+        }
+    }
+
+    fn record_named_module_owners(&self, name: &ModuleName, used: &mut BTreeSet<CompactString>) {
+        if let Some(owners) = name
+            .ancestors()
+            .find_map(|name| self.module_owners.get(&name))
+        {
+            used.extend(owners.iter().cloned());
+        }
+    }
+
     /// Check whether `importing_file` is allowed to import `imported_module`.
     ///
     /// Use the script's own declarations or the nearest containing project's declarations.

--- a/crates/ty_python_semantic/src/dependency/imports.rs
+++ b/crates/ty_python_semantic/src/dependency/imports.rs
@@ -1,0 +1,271 @@
+use ruff_db::parsed::parsed_module;
+use ruff_db::source::source_text;
+use ruff_python_ast as ast;
+use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
+use ty_module_resolver::{ImportingFile, Module, ModuleName, resolve_module};
+use ty_python_core::{ProgramFile, SemanticIndex, semantic_index};
+
+use crate::types::{KnownFunction, Type, infer_definition_types};
+use crate::{Db, FxIndexSet, HasType, SemanticModel};
+
+/// The modules imported anywhere in one file, including imports used only for typing.
+#[derive(Debug, Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+pub struct ImportedModules<'db> {
+    pub modules: Box<[Module<'db>]>,
+    /// Imports whose names are known but whose modules could not be resolved.
+    pub unresolved: Box<[ModuleName]>,
+    /// Whether an unreadable file, invalid syntax, or dynamic import prevents complete analysis.
+    pub incomplete: bool,
+}
+
+/// Collect imports separately from inference results, so ordinary type inference does not retain
+/// dependency-usage sets. The result changes only when the file's imported modules change.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+pub fn imported_modules<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> ImportedModules<'db> {
+    if source_text(db, file.file(db)).read_error().is_some() {
+        return ImportedModules {
+            incomplete: true,
+            ..ImportedModules::default()
+        };
+    }
+
+    let parsed = parsed_module(db, file.python_file(db)).load(db);
+    if !parsed.errors().is_empty() {
+        return ImportedModules {
+            incomplete: true,
+            ..ImportedModules::default()
+        };
+    }
+
+    let mut collector = ImportCollector {
+        model: SemanticModel::new(db, file),
+        index: semantic_index(db, file),
+        modules: FxIndexSet::default(),
+        unresolved: FxIndexSet::default(),
+        incomplete: false,
+    };
+    collector.visit_body(parsed.suite());
+    ImportedModules {
+        modules: collector.modules.into_iter().collect(),
+        unresolved: collector.unresolved.into_iter().collect(),
+        incomplete: collector.incomplete,
+    }
+}
+
+struct ImportCollector<'db> {
+    model: SemanticModel<'db>,
+    index: &'db SemanticIndex<'db>,
+    modules: FxIndexSet<Module<'db>>,
+    unresolved: FxIndexSet<ModuleName>,
+    incomplete: bool,
+}
+
+impl<'db> ImportCollector<'db> {
+    fn resolve(&mut self, name: &ModuleName, include_namespace: bool) -> Option<Module<'db>> {
+        let db = self.model.db();
+        let importing_file = ImportingFile::File(
+            self.model.file(),
+            self.model.program_file().resolver_environment(db),
+        );
+        let module = resolve_module(db, importing_file, name);
+        if let Some(module) = module {
+            if include_namespace || module.search_path(db).is_some() {
+                self.modules.insert(module);
+            }
+        } else {
+            self.unresolved.insert(name.clone());
+        }
+
+        // Importing a child also executes its parent packages. This matters for local package
+        // initializers and for namespace packages whose children have different distributions.
+        for parent in name.ancestors().skip(1) {
+            if let Some(parent) = resolve_module(db, importing_file, &parent)
+                && parent.search_path(db).is_some()
+            {
+                self.modules.insert(parent);
+            }
+        }
+        module
+    }
+
+    fn import_from(&mut self, import: &ast::StmtImportFrom) {
+        let db = self.model.db();
+        let importing_file = ImportingFile::File(
+            self.model.file(),
+            self.model.program_file().resolver_environment(db),
+        );
+        let Ok(name) = ModuleName::from_import_statement(db, importing_file, import) else {
+            self.incomplete = true;
+            return;
+        };
+        let Some(parent) = self.resolve(&name, false) else {
+            return;
+        };
+
+        for alias in &import.names {
+            if &alias.name == "*" {
+                self.modules.insert(parent);
+                continue;
+            }
+            let Some(definitions) = self.index.try_definitions(ast::AnyNodeRef::Alias(alias))
+            else {
+                self.incomplete = true;
+                continue;
+            };
+            let mut found_child = false;
+            for definition in definitions {
+                // Follow the same attribute-versus-submodule decision as import inference.
+                // A value re-exported from another distribution does not directly import it.
+                for ty in infer_definition_types(db, *definition).declaration_types() {
+                    if let Type::ModuleLiteral(literal) = ty.inner_type()
+                        && let child = literal.module(db)
+                        && let child_name = child.name(db)
+                        && child_name.parent().as_ref() == Some(parent.name(db))
+                        && child_name.components().next_back() == Some(alias.name.as_str())
+                    {
+                        self.modules.insert(child);
+                        found_child = true;
+                    }
+                }
+            }
+            if !found_child {
+                self.modules.insert(parent);
+            }
+        }
+    }
+
+    fn dynamic_import(&mut self, call: &ast::ExprCall) {
+        // Import functions can be aliased, so use the callee's inferred identity rather than its
+        // spelling. An unknown module name means we cannot prove any dependency is unused.
+        let Some(Type::FunctionLiteral(function)) = call.func.inferred_type(&self.model) else {
+            return;
+        };
+        if !matches!(
+            function.known(self.model.db()),
+            Some(KnownFunction::DunderImport | KnownFunction::ImportModule)
+        ) {
+            return;
+        }
+
+        if let [ast::Expr::StringLiteral(name)] = call.arguments.args.as_ref()
+            && call.arguments.keywords.is_empty()
+            && let Some(name) = ModuleName::new(name.value.to_str())
+        {
+            self.resolve(&name, true);
+        } else {
+            self.incomplete = true;
+        }
+    }
+}
+
+impl<'ast> Visitor<'ast> for ImportCollector<'_> {
+    fn visit_stmt(&mut self, stmt: &'ast ast::Stmt) {
+        match stmt {
+            ast::Stmt::Import(import) => {
+                for alias in &import.names {
+                    if let Some(name) = ModuleName::new(&alias.name) {
+                        self.resolve(&name, true);
+                    }
+                }
+            }
+            ast::Stmt::ImportFrom(import) => self.import_from(import),
+            _ => walk_stmt(self, stmt),
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &'ast ast::Expr) {
+        if let ast::Expr::Call(call) = expr {
+            self.dynamic_import(call);
+        }
+        walk_expr(self, expr);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::DbWithWritableSystem as _;
+
+    use crate::Db;
+    use crate::db::tests::TestDbBuilder;
+
+    use super::imported_modules;
+
+    #[test]
+    fn import_sites_across_scopes() -> anyhow::Result<()> {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/main.py",
+                "from typing import TYPE_CHECKING\n\
+                 from package import exported\n\
+                 from namespace import child\n\
+                 from empty import *\n\
+                 if TYPE_CHECKING:\n    import typing_only\n\
+                 def inner():\n    import package.child\n",
+            )
+            .with_file("/src/package/__init__.py", "import unrelated as exported\n")
+            .with_file("/src/package/exported.py", "")
+            .with_file("/src/package/child.py", "")
+            .with_file("/src/unrelated.py", "")
+            .with_file("/src/namespace/child.py", "")
+            .with_file("/src/empty.py", "")
+            .with_file("/src/typing_only.py", "")
+            .build()?;
+        let file = system_path_to_file(&db, "/src/main.py")?;
+        let imports = imported_modules(&db, db.program_file(file));
+        assert!(!imports.incomplete);
+        assert!(imports.unresolved.is_empty());
+        let names: Vec<_> = imports
+            .modules
+            .iter()
+            .map(|module| module.name(&db).as_str())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "typing",
+                "package",
+                "namespace.child",
+                "empty",
+                "typing_only",
+                "package.child"
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_import_identity_and_invalidation() -> anyhow::Result<()> {
+        let mut db = TestDbBuilder::new()
+            .with_file(
+                "/src/main.py",
+                "from importlib import import_module as load\nload('external')\n",
+            )
+            .with_file("/src/external.py", "")
+            .build()?;
+        let file = system_path_to_file(&db, "/src/main.py")?;
+        let imports = imported_modules(&db, db.program_file(file));
+        assert!(!imports.incomplete);
+        assert!(
+            imports
+                .modules
+                .iter()
+                .any(|module| module.name(&db) == "external")
+        );
+
+        db.write_file(
+            "/src/main.py",
+            "from importlib import import_module as load\ndef run(name: str):\n    load(name)\n",
+        )?;
+        assert!(imported_modules(&db, db.program_file(file)).incomplete);
+
+        db.write_file(
+            "/src/main.py",
+            "def load(name: str):\n    pass\nload('external')\n",
+        )?;
+        let imports = imported_modules(&db, db.program_file(file));
+        assert!(!imports.incomplete);
+        assert!(imports.modules.is_empty());
+        Ok(())
+    }
+}

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -90,6 +90,7 @@ pub fn default_lint_registry() -> &'static LintRegistry {
 /// Register all known semantic lints.
 fn register_lints(registry: &mut LintRegistryBuilder) {
     types::register_lints(registry);
+    registry.register_lint(&dependency::UNUSED_DEPENDENCY);
     registry.register_lint(&UNUSED_IGNORE_COMMENT);
     registry.register_lint(&UNUSED_TYPE_IGNORE_COMMENT);
     registry.register_lint(&IGNORE_COMMENT_UNKNOWN_RULE);

--- a/crates/ty_python_semantic/src/lint.rs
+++ b/crates/ty_python_semantic/src/lint.rs
@@ -603,7 +603,7 @@ impl RuleSelection {
     }
 
     /// Returns the configured severity for the lint with the given id or `None` if the lint is disabled.
-    pub(crate) fn severity(&self, lint: LintId) -> Option<Severity> {
+    pub fn severity(&self, lint: LintId) -> Option<Severity> {
         self.lints.get(&lint).map(|(severity, _)| *severity)
     }
 
@@ -612,7 +612,7 @@ impl RuleSelection {
     }
 
     /// Returns `true` if the `lint` is enabled.
-    pub(crate) fn is_enabled(&self, lint: LintId) -> bool {
+    pub fn is_enabled(&self, lint: LintId) -> bool {
         self.severity(lint).is_some()
     }
 

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -145,6 +145,20 @@ pub(crate) fn check_suppressions(
 ) -> Vec<Diagnostic> {
     let mut context = CheckSuppressionsContext::new(db, file, diagnostics);
 
+    for diagnostic in db.unused_dependency_diagnostics(file.file(db)) {
+        let Some(range) = diagnostic.primary_span().and_then(|span| span.range()) else {
+            continue;
+        };
+        if let Some(suppression) = context
+            .suppressions
+            .find_suppression(range, LintId::of(&crate::dependency::UNUSED_DEPENDENCY))
+        {
+            context.diagnostics.borrow_mut().mark_used(suppression.id());
+        } else {
+            context.diagnostics.borrow_mut().push(diagnostic.clone());
+        }
+    }
+
     check_unknown_rule(&mut context);
     check_invalid_suppression(&mut context);
     check_blanket_suppressions(&mut context);

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -82,9 +82,10 @@ use crate::types::diagnostic::{
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
 pub(crate) use crate::types::equality::{ComparisonSoundnessPolicy, equality_truthiness};
+pub(crate) use crate::types::function::KnownFunction;
 use crate::types::function::{
     DataclassTransformerFlags, DataclassTransformerParams, FunctionDecorators, FunctionSpans,
-    FunctionType, KnownFunction, OverloadLiteral,
+    FunctionType, OverloadLiteral,
 };
 pub(crate) use crate::types::generics::GenericContext;
 use crate::types::generics::{ApplySpecialization, Specialization, bind_typevar};

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1651,7 +1651,9 @@ impl<'db> DefinitionInference<'db> {
         self.types.declarations(owner)
     }
 
-    fn declaration_types(&self) -> impl ExactSizeIterator<Item = TypeAndQualifiers<'db>> {
+    pub(crate) fn declaration_types(
+        &self,
+    ) -> impl ExactSizeIterator<Item = TypeAndQualifiers<'db>> {
         self.types.declaration_types()
     }
 

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -23,9 +23,7 @@ mod script_progress;
 
 use crate::session::client::Client;
 pub(crate) use api::Error;
-pub(crate) use api::{
-    publish_all_document_diagnostics, publish_diagnostics_if_needed, publish_settings_diagnostics,
-};
+pub(crate) use api::{publish_all_document_diagnostics, publish_diagnostics_if_needed};
 pub(crate) use lazy_work_done_progress::LazyWorkDoneProgress;
 pub(crate) use main_loop::{
     Action, ConnectionSender, Event, MainLoopReceiver, MainLoopSender, SendRequest,

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -18,8 +18,9 @@ mod type_hierarchy;
 use self::traits::{NotificationHandler, RequestHandler};
 use super::{Result, schedule::BackgroundSchedule};
 use crate::session::client::Client;
+pub(super) use diagnostics::project_diagnostics_task;
 pub(crate) use diagnostics::{
-    publish_all_document_diagnostics, publish_diagnostics_if_needed, publish_settings_diagnostics,
+    ProjectDiagnosticsResult, publish_all_document_diagnostics, publish_diagnostics_if_needed,
 };
 use ruff_db::panic::PanicError;
 

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::hash::{DefaultHasher, Hash as _, Hasher as _};
+use std::panic::AssertUnwindSafe;
 
 use lsp_types::{Code, PublishDiagnosticsNotification};
 use lsp_types::{
@@ -23,10 +24,12 @@ use ty_project::{Db as _, ProjectDatabase};
 
 use crate::capabilities::ResolvedClientCapabilities;
 use crate::document::{FileRangeExt, ToRangeExt};
+use crate::server::Action;
+use crate::server::schedule::{BackgroundSchedule, Task};
 use crate::session::client::Client;
 use crate::session::{DocumentHandle, GlobalSettings};
 use crate::system::{AnySystemPath, file_to_uri};
-use crate::{DIAGNOSTIC_NAME, Db, DiagnosticMode};
+use crate::{DIAGNOSTIC_NAME, Db};
 use crate::{PositionEncoding, Session};
 
 #[derive(Debug)]
@@ -239,7 +242,9 @@ pub(crate) fn publish_diagnostics_if_needed(
 /// Publishes the diagnostics for the given document snapshot using the [publish diagnostics
 /// notification].
 pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, client: &Client) {
-    if session.global_settings().diagnostic_mode().is_off() {
+    if session.global_settings().diagnostic_mode().is_off()
+        || session.has_project_diagnostics(document.uri())
+    {
         return;
     }
 
@@ -287,106 +292,132 @@ pub(super) fn publish_diagnostics(document: &DocumentHandle, session: &Session, 
     }
 }
 
-/// Publishes settings diagnostics for all the project at the given path
-/// using the [publish diagnostics notification].
+/// Computes diagnostics for files that clients do not request document diagnostics for.
 ///
-/// [publish diagnostics notification]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics
-pub(crate) fn publish_settings_diagnostics(
-    session: &mut Session,
-    client: &Client,
-    path: SystemPathBuf,
-) {
-    // Don't publish settings diagnostics for workspace that are already doing full diagnostics.
-    //
-    // Note we DO NOT respect the fact that clients support pulls because these are
-    // files they *specifically* won't pull diagnostics from us for, because we don't
-    // claim to be an LSP for them.
-    match session.global_settings().diagnostic_mode() {
-        DiagnosticMode::Workspace | DiagnosticMode::Off => {
+/// Dependency diagnostics can change when any Python file changes, even when the manifest
+/// is closed. Their project-wide import inventory must be computed on a background worker.
+pub(in crate::server) fn project_diagnostics_task() -> Task {
+    Task::background(BackgroundSchedule::Worker, |session| {
+        let revision = session.revision();
+        let encoding = session.position_encoding();
+        let capabilities = session.client_capabilities();
+        let settings = session.global_settings().clone();
+        // The snapshots are discarded on unwinding and never reused afterward.
+        let projects = AssertUnwindSafe(session.project_snapshots());
+
+        Box::new(move |client| {
+            let result = ruff_db::panic::catch_unwind(|| {
+                let projects = projects;
+                let mut project_diagnostics = Vec::with_capacity(projects.len());
+                // Drop each completed snapshot before checking the next project. An edit cancels
+                // projects in this order and would otherwise wait for an earlier snapshot.
+                for (root, db) in projects.0 {
+                    let mut diagnostics_by_uri: FxHashMap<Uri, Vec<Diagnostic>> =
+                        FxHashMap::default();
+
+                    // Workspace diagnostics already include these diagnostics. Empty results also
+                    // clear previously pushed diagnostics when the diagnostic mode changes.
+                    if settings.diagnostic_mode().is_open_files_only() {
+                        let diagnostics = db.project().check_settings(&db);
+                        for diagnostic in diagnostics
+                            .iter()
+                            .chain(ty_project::dependency::project_dependency_diagnostics(&db))
+                        {
+                            let Some(span) = diagnostic.primary_span() else {
+                                continue;
+                            };
+                            let Some(uri) = file_to_uri(&db, span.expect_ty_file()) else {
+                                continue;
+                            };
+                            if let Some((_, diagnostic)) = to_lsp_diagnostic(
+                                &db,
+                                diagnostic,
+                                encoding,
+                                capabilities,
+                                &settings,
+                            ) {
+                                diagnostics_by_uri.entry(uri).or_default().push(diagnostic);
+                            }
+                        }
+                    }
+
+                    project_diagnostics.push((root, diagnostics_by_uri));
+                }
+                ProjectDiagnostics {
+                    revision,
+                    projects: project_diagnostics,
+                }
+            });
+            // All snapshots are now released, including on cancellation. Sending an action can
+            // block on the bounded main-loop queue, so it must not retain a database snapshot.
+
+            let result = match result {
+                Ok(diagnostics) => ProjectDiagnosticsResult::Completed(diagnostics),
+                Err(error) if error.payload.downcast_ref::<salsa::Cancelled>().is_some() => {
+                    ProjectDiagnosticsResult::Cancelled
+                }
+                Err(error) => {
+                    tracing::error!("Failed to compute project diagnostics: {error}");
+                    ProjectDiagnosticsResult::Failed
+                }
+            };
+            client.queue_action(Action::ProjectDiagnosticsFinished(result));
+        })
+    })
+}
+
+#[derive(Debug)]
+pub(crate) enum ProjectDiagnosticsResult {
+    Completed(ProjectDiagnostics),
+    Cancelled,
+    Failed,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProjectDiagnostics {
+    revision: u64,
+    projects: Vec<(SystemPathBuf, FxHashMap<Uri, Vec<Diagnostic>>)>,
+}
+
+impl ProjectDiagnostics {
+    pub(crate) fn publish(self, session: &mut Session, client: &Client) {
+        // Conversion runs in the background, so source or settings may have changed since then.
+        if self.revision != session.revision() {
             return;
         }
-        DiagnosticMode::OpenFilesOnly => {}
-    }
 
-    let session_encoding = session.position_encoding();
-    let client_capabilities = session.client_capabilities();
+        for (root, diagnostics_by_uri) in self.projects {
+            let state = session.project_state_mut(&AnySystemPath::System(root));
+            let mut previous =
+                std::mem::replace(&mut state.pushed_project_diagnostics, diagnostics_by_uri);
 
-    let project_path = AnySystemPath::System(path);
-
-    let (mut diagnostics_by_uri, old_untracked) = {
-        let state = session.project_state_mut(&project_path);
-        let db = &state.db;
-        let project = db.project();
-        let settings_diagnostics = project.check_settings(db);
-
-        // We need to send diagnostics if we have non-empty ones, or we have ones to clear.
-        // These will both almost always be empty so this function will almost always be a no-op.
-        if settings_diagnostics.is_empty()
-            && state.untracked_files_with_pushed_diagnostics.is_empty()
-        {
-            return;
-        }
-
-        // Group diagnostics by URI
-        let mut diagnostics_by_uri: FxHashMap<Uri, Vec<_>> = FxHashMap::default();
-        for diagnostic in settings_diagnostics {
-            if let Some(span) = diagnostic.primary_span() {
-                let file = span.expect_ty_file();
-                let Some(uri) = file_to_uri(db, file) else {
-                    tracing::debug!("Failed to convert file to URI at {}", file.path(db));
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "diagnostic notifications for distinct document URIs are independent"
+            )]
+            for (uri, diagnostics) in &state.pushed_project_diagnostics {
+                if previous.remove(uri).as_ref() == Some(diagnostics) {
                     continue;
-                };
-                diagnostics_by_uri.entry(uri).or_default().push(diagnostic);
+                }
+                client.send_notification::<PublishDiagnosticsNotification>(
+                    PublishDiagnosticsParams {
+                        uri: uri.clone(),
+                        diagnostics: diagnostics.clone(),
+                        version: None,
+                    },
+                );
+            }
+
+            for uri in previous.into_keys() {
+                client.send_notification::<PublishDiagnosticsNotification>(
+                    PublishDiagnosticsParams {
+                        uri,
+                        diagnostics: Vec::new(),
+                        version: None,
+                    },
+                );
             }
         }
-
-        // Record the URIs we're sending non-empty diagnostics for, so we know to clear them
-        // the next time we publish settings diagnostics!
-        let old_untracked = std::mem::replace(
-            &mut state.untracked_files_with_pushed_diagnostics,
-            diagnostics_by_uri.keys().cloned().collect(),
-        );
-
-        (diagnostics_by_uri, old_untracked)
-    };
-
-    // Add empty diagnostics for any files that had diagnostics before but don't now.
-    // This will clear them (either the file is no longer relevant to us or fixed!)
-    for uri in old_untracked {
-        diagnostics_by_uri.entry(uri).or_default();
-    }
-
-    let db = session.project_db(&project_path);
-    let global_settings = session.global_settings();
-
-    // Send the settings diagnostics!
-    #[expect(
-        clippy::iter_over_hash_type,
-        reason = "diagnostic notifications for distinct document URIs are independent"
-    )]
-    for (uri, file_diagnostics) in diagnostics_by_uri {
-        // Convert diagnostics to LSP format
-        let lsp_diagnostics = file_diagnostics
-            .into_iter()
-            .filter_map(|diagnostic| {
-                Some(
-                    to_lsp_diagnostic(
-                        db,
-                        &diagnostic,
-                        session_encoding,
-                        client_capabilities,
-                        global_settings,
-                    )?
-                    .1,
-                )
-            })
-            .collect::<Vec<_>>();
-
-        client.send_notification::<PublishDiagnosticsNotification>(PublishDiagnosticsParams {
-            uri,
-            diagnostics: lsp_diagnostics,
-            version: None,
-        });
     }
 }
 

--- a/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/ty_server/src/server/api/notifications/did_change_watched_files.rs
@@ -1,8 +1,6 @@
 use crate::document::DocumentKey;
 use crate::server::Result;
-use crate::server::api::diagnostics::{
-    publish_all_document_diagnostics, publish_settings_diagnostics,
-};
+use crate::server::api::diagnostics::publish_all_document_diagnostics;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::session::Session;
 use crate::session::client::Client;
@@ -78,8 +76,7 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
         for root in roots {
             tracing::debug!("Applying changes to `{root}`");
 
-            session.apply_changes(client, &AnySystemPath::System(root.clone()), &changes);
-            publish_settings_diagnostics(session, client, root);
+            session.apply_changes(client, &AnySystemPath::System(root), &changes);
         }
 
         if client_capabilities.supports_workspace_diagnostic_refresh() {

--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -14,12 +14,16 @@ pub(crate) type MainLoopReceiver = crossbeam::channel::Receiver<Event>;
 
 impl Server {
     pub(super) fn main_loop(&mut self) -> crate::Result<()> {
-        self.initialize(&Client::new(
+        let client = Client::new(
             self.main_loop_sender.clone(),
             self.connection.sender.clone(),
-        ));
+        );
+        self.initialize(&client);
 
         let mut scheduler = Scheduler::new(self.worker_threads);
+        let mut project_diagnostics_revision = Some(self.session.revision());
+        let mut project_diagnostics_in_flight = true;
+        scheduler.dispatch(api::project_diagnostics_task(), &mut self.session, client);
 
         while let Ok(next_event) = self.next_event() {
             let Some(next_event) = next_event else {
@@ -97,7 +101,7 @@ impl Server {
                         }
                     };
 
-                    scheduler.dispatch(task, &mut self.session, client);
+                    scheduler.dispatch(task, &mut self.session, client.clone());
                 }
                 Event::Action(action) => match action {
                     Action::SendResponse(response) => {
@@ -129,7 +133,7 @@ impl Server {
                             .is_pending(&request.id)
                         {
                             let task = api::request(request);
-                            scheduler.dispatch(task, &mut self.session, client);
+                            scheduler.dispatch(task, &mut self.session, client.clone());
                         } else {
                             tracing::debug!(
                                 "Request {}/{} was cancelled, not retrying",
@@ -156,10 +160,33 @@ impl Server {
                         // paths into account.
                         // self.try_register_file_watcher(&client);
                     }
+                    Action::ProjectDiagnosticsFinished(result) => {
+                        project_diagnostics_in_flight = false;
+                        match result {
+                            api::ProjectDiagnosticsResult::Completed(diagnostics) => {
+                                diagnostics.publish(&mut self.session, &client);
+                            }
+                            api::ProjectDiagnosticsResult::Cancelled => {
+                                project_diagnostics_revision = None;
+                            }
+                            api::ProjectDiagnosticsResult::Failed => {}
+                        }
+                    }
                 },
                 Event::PollUvEnvironments { project_root } => {
                     self.session.poll_uv_sync(&client, &project_root);
                 }
+            }
+
+            // A queued result still counts as in flight: deferred document notifications can
+            // otherwise fill the action queue while later worker tasks retain database snapshots.
+            // The next edit would wait for a queued snapshot whose worker cannot make progress.
+            if !project_diagnostics_in_flight
+                && project_diagnostics_revision != Some(self.session.revision())
+            {
+                project_diagnostics_revision = Some(self.session.revision());
+                project_diagnostics_in_flight = true;
+                scheduler.dispatch(api::project_diagnostics_task(), &mut self.session, client);
             }
         }
 
@@ -215,6 +242,9 @@ pub(crate) enum Action {
     /// Initialize the workspace after the server received
     /// the options from the client.
     InitializeWorkspaces(Vec<(Uri, ClientOptions)>),
+
+    /// Complete the outstanding project query before scheduling another snapshot.
+    ProjectDiagnosticsFinished(api::ProjectDiagnosticsResult),
 }
 
 #[derive(Debug)]

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -22,6 +22,7 @@ use ruff_db::Db;
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_python_ast::PySourceType;
+use rustc_hash::FxHashMap;
 use ty_combine::Combine;
 use ty_project::metadata::Options;
 use ty_project::watch::ChangeEvent;
@@ -41,7 +42,7 @@ use crate::db::Db as _;
 use crate::document::{DocumentKey, DocumentVersion, LanguageId, NotebookDocument};
 use crate::server::{
     Action, LazyWorkDoneProgress, ScriptProgress, publish_all_document_diagnostics,
-    publish_diagnostics_if_needed, publish_settings_diagnostics,
+    publish_diagnostics_if_needed,
 };
 use crate::session::client::Client;
 use crate::session::index::Document;
@@ -126,7 +127,7 @@ pub(crate) struct Session {
 
 /// LSP State for a Project
 pub(crate) struct ProjectState {
-    /// Files that we have outstanding otherwise-untracked pushed diagnostics for.
+    /// The latest pushed diagnostics for otherwise-untracked project files.
     ///
     /// In `CheckMode::OpenFiles` we still read some files that the client hasn't
     /// told us to open. Notably settings files like `pyproject.toml`. In this
@@ -136,10 +137,9 @@ pub(crate) struct ProjectState {
     ///
     /// However diagnostics for those files include things like "you typo'd your
     /// configuration for the LSP itself", so it's really important that we tell
-    /// the user about them! So we remember which ones we have emitted diagnostics
-    /// for so that we can clear the diagnostics for all of them before we go
-    /// to update any of them.
-    pub(crate) untracked_files_with_pushed_diagnostics: Vec<Uri>,
+    /// the user about them! Remembering their diagnostics lets us clear resolved issues
+    /// without repeatedly publishing unchanged diagnostics after Python source edits.
+    pub(crate) pushed_project_diagnostics: FxHashMap<Uri, Vec<lsp_types::Diagnostic>>,
 
     // Note: This field should be last to ensure the `db` gets dropped last.
     // The db drop order matters because we call `Arc::into_inner` on some Arc's
@@ -307,10 +307,6 @@ impl Session {
             return;
         }
 
-        if changes.project.is_some() {
-            publish_settings_diagnostics(self, client, project_root.to_path_buf());
-        }
-
         self.bump_revision();
 
         self.resume_suspended_workspace_diagnostic_request(client);
@@ -395,6 +391,18 @@ impl Session {
     /// any change to the document states (but also when the open workspaces change etc.).
     fn bump_revision(&mut self) {
         self.revision += 1;
+    }
+
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    /// Snapshots each project together with the workspace root that identifies its state.
+    pub(crate) fn project_snapshots(&self) -> Vec<(SystemPathBuf, ProjectDatabase)> {
+        self.projects
+            .iter()
+            .map(|(root, state)| (root.clone(), state.db.clone()))
+            .collect()
     }
 
     /// The LSP specification doesn't allow configuration requests during initialization,
@@ -688,6 +696,7 @@ impl Session {
         }
 
         self.register_capabilities(client);
+        self.bump_revision();
     }
 
     /// Initializes a single workspace folder with the given URI
@@ -822,7 +831,7 @@ impl Session {
         // Carry forward diagnostic state if any exists
         let previous = self.projects.remove(&root);
         let untracked = previous
-            .map(|state| state.untracked_files_with_pushed_diagnostics)
+            .map(|state| state.pushed_project_diagnostics)
             .unwrap_or_default();
         let scripts: Vec<_> = db.project().script_files(&db).iter().collect();
         Self::synchronize_closed_scripts(
@@ -836,11 +845,9 @@ impl Session {
             root.clone(),
             ProjectState {
                 db,
-                untracked_files_with_pushed_diagnostics: untracked,
+                pushed_project_diagnostics: untracked,
             },
         );
-
-        publish_settings_diagnostics(self, client, root);
     }
 
     /// Adds an uninitialized workspace to this session.
@@ -1009,7 +1016,7 @@ impl Session {
         // Remove the associated project database.
         if let Some(project_state) = self.projects.remove(&workspace_path) {
             // Clear diagnostics for any files that had pushed diagnostics in this project.
-            for file_uri in project_state.untracked_files_with_pushed_diagnostics {
+            for file_uri in project_state.pushed_project_diagnostics.into_keys() {
                 self.clear_diagnostics(client, &file_uri);
             }
         }
@@ -1038,11 +1045,21 @@ impl Session {
     }
 
     pub(crate) fn clear_diagnostics_if_needed(&self, document: &DocumentHandle, client: &Client) {
+        if self.has_project_diagnostics(document.uri()) {
+            return;
+        }
         if self.client_capabilities().supports_pull_diagnostics() && !document.is_cell_or_notebook()
         {
             return;
         }
         self.clear_diagnostics(client, document.uri());
+    }
+
+    /// These diagnostics remain owned by the project query even if their document is opened.
+    pub(crate) fn has_project_diagnostics(&self, uri: &Uri) -> bool {
+        self.projects
+            .values()
+            .any(|state| state.pushed_project_diagnostics.contains_key(uri))
     }
 
     /// Clears the diagnostics for the document identified by `uri`.

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -8,7 +8,7 @@ use lsp_types::{
     TextDocumentContentChangePartial, TextDocumentContentChangeWholeDocument, TextDocumentItem,
     Uri,
 };
-use ruff_db::system::{SystemPath, SystemVirtualPath};
+use ruff_db::system::{SystemPath, SystemPathBuf, SystemVirtualPath};
 use ty_server::ClientOptions;
 
 use crate::notebook::NotebookBuilder;
@@ -34,6 +34,65 @@ def foo() -> str:
     let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
 
     insta::assert_debug_snapshot!(diagnostics);
+
+    Ok(())
+}
+
+#[test]
+fn deferred_opens_complete_with_one_worker() -> Result<()> {
+    let mut builder = TestServerBuilder::new()?.with_workspace(SystemPath::new("src"), None)?;
+    let paths = (0..80)
+        .map(|index| SystemPathBuf::from(format!("src/file_{index}.py")))
+        .collect::<Vec<_>>();
+    for path in &paths {
+        builder = builder.with_file(path, "value = 1\n")?;
+    }
+    let mut server = builder.build();
+
+    // Editors can open many documents before workspace settings arrive. With a single worker,
+    // processing those deferred notifications must still leave later requests able to run.
+    for path in &paths {
+        server.open_text_document(path, "value = 1\n", 1);
+    }
+    let mut server = server.wait_until_workspaces_are_initialized();
+    server.document_diagnostic_request(&paths[0], None);
+
+    Ok(())
+}
+
+#[test]
+fn opening_and_closing_manifest_preserves_project_diagnostics() -> Result<()> {
+    let manifest = SystemPath::new("src/pyproject.toml");
+    let source = "[tool.ty.rules]\nunknown-rule = \"warn\"\n";
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(SystemPath::new("src"), None)?
+        .with_file(manifest, source)?
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let initial = server.await_notification::<PublishDiagnosticsNotification>();
+    assert_eq!(initial.uri, server.file_uri(manifest));
+    assert!(!initial.diagnostics.is_empty());
+
+    // A manifest's diagnostics belong to the project, including while it is open as TOML.
+    server.send_notification::<DidOpenTextDocumentNotification>(DidOpenTextDocumentParams {
+        text_document: TextDocumentItem {
+            uri: server.file_uri(manifest),
+            language_id: LanguageKind::new("toml"),
+            version: 1,
+            text: source.to_string(),
+        },
+    });
+    // Closing the document preserves its project diagnostic until the configuration is fixed.
+    server.close_text_document(manifest);
+    assert!(
+        server
+            .try_await_notification::<PublishDiagnosticsNotification>(Some(Duration::from_millis(
+                100,
+            )))
+            .is_err()
+    );
 
     Ok(())
 }
@@ -964,6 +1023,8 @@ mod uv_metadata {
     use std::process::Command;
 
     use anyhow::Result;
+    #[cfg(feature = "test-uv")]
+    use lsp_types::TextDocumentContentChangeWholeDocument;
     use lsp_types::{Code, PublishDiagnosticsNotification};
     use ruff_db::system::SystemPath;
     use serde_json::json;
@@ -1020,12 +1081,74 @@ package = "invalid"
 
         server.assert_work_done_progress("Refreshing example metadata")?;
 
-        // The existing warning is republished while the refresh is pending, then cleared.
-        assert_eq!(
-            server.collect_publish_diagnostic_notifications(1),
-            diagnostics
-        );
+        // The unchanged warning stays visible until the completed refresh clears it.
         assert!(server.collect_publish_diagnostic_notifications(1)[&event.uri].is_empty());
+        Ok(())
+    }
+
+    #[cfg(feature = "test-uv")]
+    #[test]
+    fn unused_dependency_updates_closed_manifest_after_python_edits() -> Result<()> {
+        let main = SystemPath::new("src/main.py");
+        let manifest = SystemPath::new("src/pyproject.toml");
+        let builder = TestServerBuilder::new()?
+            .with_workspace(SystemPath::new("src"), None)?
+            .with_file(
+                manifest,
+                r#"
+[project]
+name = "example"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["attrs==25.4.0"]
+
+[tool.ty.rules]
+unused-dependency = "warn"
+"#,
+            )?
+            .with_file(main, "pass\n")?
+            .with_real_uv(UseUv::On)?;
+
+        let output = Command::new("uv")
+            .current_dir(builder.file_path("src"))
+            .args(["sync"])
+            .output()?;
+        anyhow::ensure!(
+            output.status.success(),
+            "uv sync failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let mut server = builder.build().wait_until_workspaces_are_initialized();
+        let diagnostic = server.await_notification::<PublishDiagnosticsNotification>();
+        assert_eq!(diagnostic.uri, server.file_uri(manifest));
+        assert_eq!(diagnostic.diagnostics.len(), 1);
+        assert_eq!(
+            diagnostic.diagnostics[0].code,
+            Some(Code::String("unused-dependency".into()))
+        );
+
+        // The manifest remains closed, and default pull diagnostics never requests it.
+        // The import in an unsaved Python document still clears its dependency diagnostic.
+        server.open_text_document(main, "import attrs\n", 1);
+        let cleared = server.await_notification::<PublishDiagnosticsNotification>();
+        assert_eq!(cleared.uri, server.file_uri(manifest));
+        assert!(cleared.diagnostics.is_empty());
+
+        server.change_text_document(
+            main,
+            vec![
+                TextDocumentContentChangeWholeDocument {
+                    text: "pass\n".to_string(),
+                }
+                .into(),
+            ],
+            2,
+        );
+        let restored = server.await_notification::<PublishDiagnosticsNotification>();
+        assert_eq!(restored.uri, diagnostic.uri);
+        assert_eq!(restored.diagnostics, diagnostic.diagnostics);
+
         Ok(())
     }
 

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -1614,6 +1614,16 @@
             }
           ]
         },
+        "unused-dependency": {
+          "title": "detects declared dependencies that are not imported",
+          "description": "## What it does\n\nChecks for declared dependencies that are not imported by a project or PEP 723 script.\n\nThe package name need not match its import name. For example, importing `PIL` counts as using the\n`pillow` dependency.\n\n## Why is this bad?\n\nAn unused dependency adds installation time and can impose unnecessary version constraints. Remove\nthe declaration if the dependency is no longer needed.\n\n## Rule status\n\nThis rule is disabled by default. Enable it with `--warn unused-dependency` or set\n`unused-dependency = \"warn\"` in the `rules` table of your ty configuration.\n\nIt requires uv dependency metadata, including module ownership. Enable uv workspace integration with\n`TY_UV=1`, or script integration with `TY_UV=scripts`. Project checks use an existing, synchronized\nenvironment; ty synchronizes PEP 723 script environments automatically.\n\nThe rule checks `project.dependencies`, `project.optional-dependencies`, and PEP 723 script\ndependencies. Dependency groups, conditional requirements, and distributions with no known\nimportable modules are not checked.\n\n## Known limitations\n\nProject checks require a complete scan of the project directory. Checking an individual file or\nsubdirectory, or configuring `src.include` or a nonempty `src.exclude`, does not report unused\nproject dependencies. Script checks include imports in local modules reached from the script, using\nthe script's own environment and declarations.\n\nImports in nested scopes, stub files, and `TYPE_CHECKING` blocks count as use. Literal calls to\n`importlib.import_module` and `__import__` also count. If a recognized dynamic import has an unknown\nmodule name, the rule does not report unused dependencies for that project or script.\n\nSome dependencies are used without imports, for example through command-line tools or plugin\ndiscovery. Their absence from the import inventory does not prove they can be removed. Review these\nuses before removing a dependency, or disable the rule for projects that rely on them.\n\n## Example\n\nFor a project with these dependencies:\n\n```toml\n[project]\ndependencies = [\"requests\", \"flask\"]\n```\n\nIf the project imports `requests` but never imports `flask`, ty reports the `flask` declaration.\nRemove it if the project no longer uses Flask.",
+          "default": "ignore",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "unused-ignore-comment": {
           "title": "detects unused `ty: ignore` comments",
           "description": "## What it does\n\nChecks for `ty: ignore` directives that are no longer applicable.\n\n## Why is this bad?\n\nA `ty: ignore` directive that no longer matches any diagnostic violations is likely included by\nmistake, and should be removed to avoid confusion.\n\n## Examples\n\n```py\n# error\na = 20 / 2  # ty: ignore[division-by-zero]\n```\n\nUse instead:\n\n```py\na = 20 / 2\n```\n\n## Options\n\nSet\n[`analysis.respect-type-ignore-comments`](https://docs.astral.sh/ty/reference/configuration/#respect-type-ignore-comments)\nto `false` to prevent this rule from reporting unused `type: ignore` comments.",


### PR DESCRIPTION
Dependencies can remain declared after their last import is removed. Add an opt-in `unused-dependency` rule that uses uv’s module ownership metadata to report these declarations in `pyproject.toml` and PEP 723 scripts.

Project checks include unopened files across complete workspace members. Script checks follow reachable local helpers in the script’s environment and respect suppression comments. In editors, Python source changes update diagnostics on closed manifests through a background project check.

Enable the rule with `--warn unused-dependency` and uv integration. It checks unconditional runtime and optional declarations, skipping dependency groups, unknown module ownership, and incomplete project scans. Dependencies used through command-line tools or plugin discovery can still be reported.

The schema and rule documentation are regenerated. `pep508_rs`, already present transitively, becomes a direct dependency of `ty_project` for parsing requirements.
