### PR TITLE
fix(pyupgrade): preserve parentheses safety in UP040 type alias rewriting

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
@@ -56,6 +56,10 @@ x: int = 1
 T = typing.TypeVar["T"]
 Decorator: TypeAlias = typing.Callable[[T], T]
 
+# Tuple type alias without parentheses
+TupleAlias: TypeAlias = int, str
+
+
 
 from typing import TypeVar, Annotated, TypeAliasType
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -276,13 +276,23 @@ fn create_diagnostic(
     let tokens = checker.tokens();
     let comment_ranges = checker.comment_ranges();
 
-    let range_with_parentheses =
-        parenthesized_range(value.into(), stmt.into(), tokens).unwrap_or(value.range());
+    let (range_with_parentheses, is_parenthesized) =
+        if let Some(range) = parenthesized_range(value.into(), stmt.into(), tokens) {
+            (range, true)
+        } else {
+            (value.range(), false)
+        };
+
+    let formatted_value = if value.is_tuple_expr() && !is_parenthesized {
+        format!("({})", &source[range_with_parentheses])
+    } else {
+        source[range_with_parentheses].to_string()
+    };
 
     let content = format!(
         "type {name}{type_params} = {value}",
         type_params = DisplayTypeVars { type_vars, source },
-        value = &source[range_with_parentheses]
+        value = formatted_value
     );
     let edit = Edit::range_replacement(content, stmt.range());
 


### PR DESCRIPTION
Preserves parentheses when rewriting tuple type aliases to PEP 695 `type` statements in UP040.