### PR TITLE
[ty] Avoid repeated inference for literal union call results

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -992,6 +992,45 @@ accepts_objects(
     });
 }
 
+/// Regression benchmark for contextual inference of `TypedDict.get` with a large literal union.
+///
+/// Passing the result to a typed function should not retry inference against each literal in the
+/// expected type: <https://github.com/astral-sh/ty/issues/4419>.
+fn benchmark_typed_dict_get_large_literal_union(criterion: &mut Criterion) {
+    const NUM_LITERAL_MEMBERS: usize = 1024;
+
+    setup_rayon();
+
+    let mut code = "from typing import Literal, TypedDict\n\nIcon = Literal[\n".to_string();
+    for i in 0..NUM_LITERAL_MEMBERS {
+        writeln!(&mut code, r#"    "icon_{i}","#).ok();
+    }
+    code.push_str(
+        r#"]
+
+class Message(TypedDict, total=False):
+    icon: Icon
+
+def accept_icon(icon: Icon | None) -> None: ...
+
+def check(message: Message, default: Icon | None) -> None:
+    accept_icon(message.get("icon", default))
+"#,
+    );
+
+    criterion.bench_function("ty_micro[typed_dict_get_large_literal_union]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(&code),
+            |case| {
+                let Case { db } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Benchmark for narrowing a large union type through multiple match statements.
 ///
 /// This is extracted from egglog-python's `pretty.py`, where a ~30-class union type
@@ -1776,6 +1815,7 @@ criterion_group!(
     benchmark_many_protocol_members_mismatch,
     benchmark_inherited_recursive_protocol,
     benchmark_vararg_parameter_type_accumulation,
+    benchmark_typed_dict_get_large_literal_union,
     benchmark_very_large_tuple,
     benchmark_large_union_narrowing,
     benchmark_large_isinstance_narrowing,

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1493,6 +1493,58 @@ x8: EitherList = list(("1", "2", "3"))
 reveal_type(x8)  # revealed: list[int | str]
 ```
 
+## Literal union context for generic calls
+
+Narrowing a small literal union preserves the precise result of a nested generic call, including
+when the return type also contains `Any`:
+
+```py
+from typing import Any, Literal, assert_type
+
+def singleton[T](value: T) -> list[T]:
+    return [value]
+
+def first[T](values: list[T]) -> T:
+    return values[0]
+
+def first_gradual[T](values: list[T]) -> Any | T:
+    return values[0]
+
+precise: Literal["a", "b"] = first(singleton("a"))
+assert_type(precise, Literal["a"])
+
+gradual: Literal["a", "b"] = reveal_type(first_gradual(singleton("a")))  # revealed: Any | Literal["a"]
+```
+
+A result can contain several literal alternatives without including every member of the declared
+union. The surrounding optional type does not add `None` to this result:
+
+```py
+def literal_union(value: Literal["a", "b"]) -> None:
+    result: Literal["a", "b"] | None = first(singleton(value))
+    assert_type(result, Literal["a", "b"])
+```
+
+A generic collection alternative still provides context when it follows literal alternatives. The
+empty list is inferred as `list[str]`:
+
+```py
+type Values = Literal[0, 1, 2]
+
+def identity[T](value: T) -> T:
+    return value
+
+collection: Values | list[str] | None = identity([])
+assert_type(collection, list[str])
+```
+
+The result also stays precise when the matching literal is the last member of the declared union:
+
+```py
+late: Values = first(singleton(2))
+assert_type(late, Literal[2])
+```
+
 ## Assignability diagnostics ignore declared type
 
 The type displayed in an invalid assignment diagnostic should account for the type context, e.g., to

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2862,6 +2862,54 @@ def _(u: IntX | StrX) -> None:
     reveal_type(u.setdefault("x", 1))  # revealed: int | str
 ```
 
+## `get()` with literal union defaults
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+For a non-required field, `get()` returns the union of the field type and the default type. Passing
+that result to a typed function preserves all of its possible literal values:
+
+```py
+from typing import Literal, TypedDict
+from typing_extensions import assert_type
+
+Value = Literal[0, 1, 2]
+
+class OptionalValue(TypedDict, total=False):
+    value: Value
+
+def accept(value: Value | None) -> None: ...
+def optional_default(mapping: OptionalValue, default: Value | None) -> None:
+    accept(mapping.get("value", default))
+    result: Value | None = mapping.get("value", default)
+    assert_type(result, Value | None)
+```
+
+An incompatible default is still reflected in the result and rejected by the typed function:
+
+```py
+def invalid_default(mapping: OptionalValue) -> None:
+    # error: [invalid-argument-type]
+    accept(mapping.get("value", "invalid"))
+```
+
+For a required field, the default cannot contribute to the result. This also holds when the field
+type is an explicit type alias:
+
+```py
+type ValueAlias = Value
+
+class RequiredValue(TypedDict):
+    value: ValueAlias
+
+def required_default(mapping: RequiredValue, default: Value | None) -> None:
+    result: Value | None = mapping.get("value", default)
+    assert_type(result, Value)
+```
+
 ## Unlike normal classes
 
 `TypedDict` types do not act like normal classes. For example, calling `type(..)` on an inhabitant

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5762,6 +5762,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // `TypedDict.get` on a field whose type is a literal union. If it is already a subtype
             // of the complete union, there is no need to try the remaining members. Use subtyping
             // for this additional check so a gradual alternative cannot bypass useful type context.
+            //
+            // TODO: Revisit narrowing to individual union members. Comparing the inferred return
+            // type with the full declared union could avoid more redundant inference attempts,
+            // but must preserve the precision provided by type context.
             let return_ty = speculative_bindings.return_type(db, env);
             if !(return_ty.is_assignable_to(db, env, narrowed_ty)
                 || (return_ty

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5758,19 +5758,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return None;
             }
 
-            // Ensure the inferred return type is assignable to the narrowed declared type.
-            //
-            // TODO: Checking assignability against the full declared type could help avoid
-            // cases where the constraint solver is not smart enough to solve complex unions.
-            // We should see revisit this after the new constraint solver is implemented.
-            if !speculative_bindings
-                .return_type(db, env)
-                .is_assignable_to(db, env, narrowed_ty)
+            // A literal-valued result can span multiple members of the declared union, as with
+            // `TypedDict.get` on a field whose type is a literal union. If it is already a subtype
+            // of the complete union, there is no need to try the remaining members. Use subtyping
+            // for this additional check so a gradual alternative cannot bypass useful type context.
+            let return_ty = speculative_bindings.return_type(db, env);
+            if !(return_ty.is_assignable_to(db, env, narrowed_ty)
+                || (return_ty
+                    .resolve_type_alias(db)
+                    .is_literal_or_union_of_literals(db, env)
+                    && call_expression_tcx
+                        .annotation
+                        .is_some_and(|declared_ty| return_ty.is_subtype_of(db, env, declared_ty))))
             {
                 return None;
             }
 
-            // Successfully narrowed to an element of the union.
+            // Successfully inferred a result compatible with the declared union.
             *bindings = speculative_bindings;
             *argument_types = speculative_argument_types;
             self.extend(speculative_builder);


### PR DESCRIPTION
Checking a `TypedDict.get()` call with a default could become very slow when its result was passed to a function expecting a large union of literals. Contextual inference retried the call for each literal in the expected type, even though the selected overload already returned a compatible literal union.

Accept a literal-valued call result when it is a subtype of the complete expected type. This avoids the redundant retries while preserving contextual inference for gradual and nonliteral results. Resolve explicit type aliases before checking whether the result consists of literals.

On a generated reproduction with 1,036 literal members, checking time falls from about 3 seconds to 0.04 seconds with an optimized debug build.

I suspect this fix may be obsoleted by planned changes to bidirectional inference, but it's a small enough fix, and effective, that it seems worth applying now anyway.

Fixes astral-sh/ty#4419.

## Test plan

- Add mdtests for `TypedDict.get()` with optional fields, incompatible defaults, and required fields with an explicit type alias.
- Cover precise nested generic calls, return types containing `Any`, literal-union results in optional contexts, and expected unions containing a generic collection alternative.
- Add a benchmark for a `TypedDict.get()` call with a 1,024-member literal union.
