### PR TITLE
Lift cargo-fuzz into astral-dev-toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -587,20 +587,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          workspaces: "fuzz -> target"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: "Install Rust toolchain"
-        run: rustup show
-      - name: "Install mold"
-        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-      - name: "Install cargo-binstall"
-        uses: cargo-bins/cargo-binstall@e00d2c94cc0067b77737821097a62d91c0301baa # v1.21.1
-      - name: "Install cargo-fuzz"
-        # Download the latest version from quick install and not the github releases because github releases only has MUSL targets.
-        run: cargo binstall cargo-fuzz --force  --disable-strategies crate-meta-data --no-confirm
-      - run: cargo fuzz build -s none
+          version: "0.12.6"
+      - run: uv run --only-dev cargo fuzz build -s none
 
   fuzz-parser:
     name: "fuzz parser"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -613,6 +613,8 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.6"
+      - name: "Install Rust toolchain"
+        run: rustup show
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ruff-linux-debug

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -587,12 +587,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: "Install Rust toolchain"
-        run: rustup show
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: "fuzz -> target"
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Install Rust toolchain"
+        run: rustup show
       - name: "Install mold"
         uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -587,6 +587,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: "Install Rust toolchain"
+        run: rustup show
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: "fuzz -> target"
@@ -613,8 +615,6 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.6"
-      - name: "Install Rust toolchain"
-        run: rustup show
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ruff-linux-debug

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -587,6 +587,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: "fuzz -> target"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.6"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -591,6 +591,8 @@ jobs:
         with:
           workspaces: "fuzz -> target"
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Install mold"
+        uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.6"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -24,7 +24,7 @@ without it (very unlikely for the fuzzer to generate valid python code from "thi
 Once you have initialised the fuzzers, you can then execute any fuzzer with:
 
 ```bash
-cargo fuzz run -s none name_of_fuzzer -- -timeout=1
+uv run --only-dev cargo fuzz run -s none name_of_fuzzer -- -timeout=1
 ```
 
 > [!NOTE]
@@ -33,10 +33,10 @@ cargo fuzz run -s none name_of_fuzzer -- -timeout=1
 > command, as this architecture does not support fuzzing without a sanitizer.
 >
 > ```shell
-> cargo +nightly fuzz run name_of_fuzzer -- -timeout=1
+> uv run --only-dev cargo +nightly fuzz run name_of_fuzzer -- -timeout=1
 > ```
 
-You can view the names of the available fuzzers with `cargo fuzz list`.
+You can view the names of the available fuzzers with `uv run --only-dev cargo fuzz list`.
 For specific details about how each fuzzer works, please read this document in its entirety.
 
 > [!NOTE]
@@ -53,7 +53,7 @@ triggered with a smaller input.
 `cargo-fuzz` supports this out of the box with:
 
 ```bash
-cargo fuzz tmin -s none name_of_fuzzer artifacts/name_of_fuzzer/crash-...
+uv run --only-dev cargo fuzz tmin -s none name_of_fuzzer artifacts/name_of_fuzzer/crash-...
 ```
 
 From here, you will need to analyse the input and potentially the behaviour of the program.

--- a/fuzz/init-fuzzer.sh
+++ b/fuzz/init-fuzzer.sh
@@ -6,11 +6,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 cd "$SCRIPT_DIR"
 
-if ! cargo fuzz --help >&/dev/null; then
-  echo "Installing cargo-fuzz..."
-  cargo install --git https://github.com/rust-fuzz/cargo-fuzz.git --rev bf2fc668dafda5295aa6fd01825ee67b885f0f2b
-fi
-
 if [ ! -d corpus/common ]; then
   mkdir -p corpus/common
 
@@ -44,9 +39,9 @@ if [ ! -d corpus/common ]; then
 
   echo "Minifying the corpus dataset..."
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    cargo +nightly fuzz cmin ruff_fix_validity corpus/common -- -timeout=5
+    uv run --only-dev cargo +nightly fuzz cmin ruff_fix_validity corpus/common -- -timeout=5
   else
-    cargo fuzz cmin -s none ruff_fix_validity corpus/common -- -timeout=5
+    uv run --only-dev cargo fuzz cmin -s none ruff_fix_validity corpus/common -- -timeout=5
   fi
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ exclude = [
 
 [dependency-groups]
 dev = [
+    "astral-dev-toolchain-cargo-fuzz>=0.13.2",
     "astral-dev-toolchain-cargo-shear>=1.13.4",
     "astral-dev-toolchain-hyperfine>=1.20.0",
     "prek==0.4.12",
@@ -128,6 +129,7 @@ exclude-newer = "P7D"
 [tool.uv.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [tool.uv.dependency-groups]
 dev = { requires-python = ">=3.12" }

--- a/scripts/add_plugin.py.lock
+++ b/scripts/add_plugin.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/add_rule.py.lock
+++ b/scripts/add_rule.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/build_ruff_pgo.py.lock
+++ b/scripts/build_ruff_pgo.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/bump-workspace-crate-versions.py.lock
+++ b/scripts/bump-workspace-crate-versions.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/check_docs_formatted.py.lock
+++ b/scripts/check_docs_formatted.py.lock
@@ -9,6 +9,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]
 requirements = [{ name = "ruff" }]

--- a/scripts/collect_ty_ecosystem_run_metadata.py.lock
+++ b/scripts/collect_ty_ecosystem_run_metadata.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/conformance.py.lock
+++ b/scripts/conformance.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/ecosystem_all_check.py.lock
+++ b/scripts/ecosystem_all_check.py.lock
@@ -9,6 +9,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]
 requirements = [{ name = "tqdm" }]

--- a/scripts/generate-crate-readmes.py.lock
+++ b/scripts/generate-crate-readmes.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/generate_builtin_modules.py.lock
+++ b/scripts/generate_builtin_modules.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/generate_known_standard_library.py.lock
+++ b/scripts/generate_known_standard_library.py.lock
@@ -9,6 +9,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]
 requirements = [{ name = "stdlibs" }]

--- a/scripts/generate_mkdocs.py.lock
+++ b/scripts/generate_mkdocs.py.lock
@@ -9,6 +9,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]
 requirements = [

--- a/scripts/memory_report.py.lock
+++ b/scripts/memory_report.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/publish-crates.py.lock
+++ b/scripts/publish-crates.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/setup-crates-io-publish.py.lock
+++ b/scripts/setup-crates-io-publish.py.lock
@@ -9,6 +9,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]
 requirements = [{ name = "httpx" }]

--- a/scripts/setup_primer_project.py.lock
+++ b/scripts/setup_primer_project.py.lock
@@ -9,6 +9,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]
 requirements = [{ name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer" }]

--- a/scripts/transform_readme.py.lock
+++ b/scripts/transform_readme.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/update_ambiguous_characters.py.lock
+++ b/scripts/update_ambiguous_characters.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/scripts/update_schemastore.py.lock
+++ b/scripts/update_schemastore.py.lock
@@ -9,3 +9,4 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ exclude-newer-span = "P7D"
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]
 build-constraints = [
@@ -78,6 +79,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4b/cd5d66b9f87e773bc71344a368b9472987e33514e6627e28342b9c3e7c43/anysqlite-0.0.5.tar.gz", hash = "sha256:9dfcf87baf6b93426ad1d9118088c41dbf24ef01b445eea4a5d486bac2755cce", size = 3432, upload-time = "2023-10-02T13:49:25.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/31/349eae2bc9d9331dd8951684cf94528d91efaa71129dc30822ac111dfc66/anysqlite-0.0.5-py3-none-any.whl", hash = "sha256:cb345dc4f76f6b37f768d7a0b3e9cf5c700dfcb7a6356af8ab46a11f666edbe7", size = 3907, upload-time = "2023-10-02T13:49:26.943Z" },
+]
+
+[[package]]
+name = "astral-dev-toolchain-cargo-fuzz"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/1a/64ee8361d5f96236a8b9e91e42745529c1585d2049f221416085b0d0840c/astral_dev_toolchain_cargo_fuzz-0.13.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ae22e17a288f4b815e509095cc15f3bacd42b3342f50106f85bbdff87f651cd4", size = 918577, upload-time = "2026-08-31T16:45:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/84/673b1cd197cbff3de46eb8950bd4504f31c11059bf00f64e6ccd5d529cd9/astral_dev_toolchain_cargo_fuzz-0.13.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:802ad95a41270a09fb6285889bedd132590a21512547b89f3a1c82a6918797e1", size = 894396, upload-time = "2026-08-31T16:45:36.308Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/40/cf98874e2b0614da6fe3cb4eeff9f4520ce149036398798bb9c8d7ed7c79/astral_dev_toolchain_cargo_fuzz-0.13.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25b65340d3f18c4b18b8f7e54855b64c53e6526864b192d32a189b59ded41198", size = 835209, upload-time = "2026-08-31T16:45:37.689Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b6/1ab2d25e68fe1d743adbbd6ec1e20af7411ec8b18dcd7fbce16a61ef3f31/astral_dev_toolchain_cargo_fuzz-0.13.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:612108f626b6ee0e5d63b1a0e257c89c13abffbd8fff539ccbffb7205b33093f", size = 882948, upload-time = "2026-08-31T16:45:38.972Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d2/a2a182b716dd695d138945446b03bfcd0378928f246f514afceac676d5a4/astral_dev_toolchain_cargo_fuzz-0.13.2-py3-none-win_amd64.whl", hash = "sha256:8c617c6162bea2c77fcce21c07279bd2f2a93e1b5243dabdc5e85c61f66a45fe", size = 763904, upload-time = "2026-08-31T16:45:40.552Z" },
+    { url = "https://files.pythonhosted.org/packages/19/9d/e823bd76ae1ae5dd69c4a77c45fbc01c9745a49075a19bb3aa97b75e2652/astral_dev_toolchain_cargo_fuzz-0.13.2-py3-none-win_arm64.whl", hash = "sha256:efda924de1a449026d6b6baa7a52c92638f539965951db86a71b3e79804afae5", size = 732469, upload-time = "2026-08-31T16:45:42.026Z" },
 ]
 
 [[package]]
@@ -1531,6 +1545,7 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "astral-dev-toolchain-cargo-fuzz", marker = "python_full_version >= '3.12'" },
     { name = "astral-dev-toolchain-cargo-shear", marker = "python_full_version >= '3.12'" },
     { name = "astral-dev-toolchain-hyperfine", marker = "python_full_version >= '3.12'" },
     { name = "prek", marker = "python_full_version >= '3.12'" },
@@ -1569,6 +1584,7 @@ typeshed-formatting = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "astral-dev-toolchain-cargo-fuzz", marker = "python_full_version >= '3.12'", specifier = ">=0.13.2" },
     { name = "astral-dev-toolchain-cargo-shear", marker = "python_full_version >= '3.12'", specifier = ">=1.13.4" },
     { name = "astral-dev-toolchain-hyperfine", marker = "python_full_version >= '3.12'", specifier = ">=1.20.0" },
     { name = "prek", marker = "python_full_version >= '3.12'", specifier = "==0.4.12" },


### PR DESCRIPTION

## Summary

Continues #28197 by lifting `cargo-fuzz` into the dev toolchain.

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

NFC, internal only. I confirmed that `./init-fuzzer.sh` still runs as expected. I'm less positive about the CI changes.

<!-- How was it tested? -->
