### PR TITLE
fix: don't infer `NoReturn` when a context manager swallows the exception

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_annotations/auto_return_type.py
@@ -325,3 +325,39 @@ class Class:
 # Test case: function that raises other exceptions should still get NoReturn
 def func():
     raise ValueError
+
+
+# Test cases for context managers that swallow exceptions: the function returns `None`, even
+# though every statement in the `with` body raises
+def func():
+    import pytest
+
+    with pytest.raises(ValueError):
+        raise ValueError
+
+
+def func():
+    import contextlib
+
+    with contextlib.suppress(ValueError):
+        raise ValueError
+
+
+class Class:
+    def method(self):
+        with self.assertRaises(ValueError):
+            raise ValueError
+
+
+# The `return` is also conditional, since the exception can be swallowed before it runs
+def func():
+    import contextlib
+
+    with contextlib.suppress(ValueError):
+        return 1
+
+
+# Test case: a context manager that isn't known to swallow exceptions still gets NoReturn
+def func():
+    with open("file") as f:
+        raise ValueError(f)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_return/RET504.py
@@ -461,3 +461,23 @@ def f():
     x = (1
               )
     return x
+
+
+# `pytest.raises` and `unittest`'s `assertRaises` can also swallow an exception, so the
+# assignment in the body may not have run by the time the `with` statement exits
+import pytest
+
+
+def foo():
+    x = 2
+    with pytest.raises(Exception):
+        x = x + 1
+    return x
+
+
+class Class:
+    def method(self):
+        x = 2
+        with self.assertRaises(Exception):
+            x = x + 1
+        return x

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type.snap
@@ -763,3 +763,95 @@ help: Add return type annotation: `Never`
 327 |     raise ValueError
     |
 note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:332:5
+    |
+330 | # Test cases for context managers that swallow exceptions: the function returns `None`, even
+331 | # though every statement in the `with` body raises
+332 | def func():
+    |     ^^^^
+333 |     import pytest
+    |
+help: Add return type annotation: `None`
+    |
+331 | # though every statement in the `with` body raises
+    - def func():
+332 + def func() -> None:
+333 |     import pytest
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:339:5
+    |
+339 | def func():
+    |     ^^^^
+340 |     import contextlib
+    |
+help: Add return type annotation: `None`
+    |
+338 |
+    - def func():
+339 + def func() -> None:
+340 |     import contextlib
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `method`
+   --> auto_return_type.py:347:9
+    |
+346 | class Class:
+347 |     def method(self):
+    |         ^^^^^^
+348 |         with self.assertRaises(ValueError):
+349 |             raise ValueError
+    |
+help: Add return type annotation: `None`
+    |
+346 | class Class:
+    -     def method(self):
+347 +     def method(self) -> None:
+348 |         with self.assertRaises(ValueError):
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:353:5
+    |
+352 | # The `return` is also conditional, since the exception can be swallowed before it runs
+353 | def func():
+    |     ^^^^
+354 |     import contextlib
+    |
+help: Add return type annotation: `int | None`
+    |
+352 | # The `return` is also conditional, since the exception can be swallowed before it runs
+    - def func():
+353 + def func() -> int | None:
+354 |     import contextlib
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:361:5
+    |
+360 | # Test case: a context manager that isn't known to swallow exceptions still gets NoReturn
+361 | def func():
+    |     ^^^^
+362 |     with open("file") as f:
+363 |         raise ValueError(f)
+    |
+help: Add return type annotation: `Never`
+    |
+216 |
+    - from typing import overload
+217 + from typing import overload, Never
+218 |
+--------------------------------------------------------------------------------
+360 | # Test case: a context manager that isn't known to swallow exceptions still gets NoReturn
+    - def func():
+361 + def func() -> Never:
+362 |     with open("file") as f:
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
+++ b/crates/ruff_linter/src/rules/flake8_annotations/snapshots/ruff_linter__rules__flake8_annotations__tests__auto_return_type_py38.snap
@@ -823,3 +823,100 @@ help: Add return type annotation: `NoReturn`
 327 |     raise ValueError
     |
 note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:332:5
+    |
+330 | # Test cases for context managers that swallow exceptions: the function returns `None`, even
+331 | # though every statement in the `with` body raises
+332 | def func():
+    |     ^^^^
+333 |     import pytest
+    |
+help: Add return type annotation: `None`
+    |
+331 | # though every statement in the `with` body raises
+    - def func():
+332 + def func() -> None:
+333 |     import pytest
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:339:5
+    |
+339 | def func():
+    |     ^^^^
+340 |     import contextlib
+    |
+help: Add return type annotation: `None`
+    |
+338 |
+    - def func():
+339 + def func() -> None:
+340 |     import contextlib
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `method`
+   --> auto_return_type.py:347:9
+    |
+346 | class Class:
+347 |     def method(self):
+    |         ^^^^^^
+348 |         with self.assertRaises(ValueError):
+349 |             raise ValueError
+    |
+help: Add return type annotation: `None`
+    |
+346 | class Class:
+    -     def method(self):
+347 +     def method(self) -> None:
+348 |         with self.assertRaises(ValueError):
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:353:5
+    |
+352 | # The `return` is also conditional, since the exception can be swallowed before it runs
+353 | def func():
+    |     ^^^^
+354 |     import contextlib
+    |
+help: Add return type annotation: `Optional[int]`
+    |
+216 |
+    - from typing import overload
+217 + from typing import overload, Optional
+218 |
+--------------------------------------------------------------------------------
+352 | # The `return` is also conditional, since the exception can be swallowed before it runs
+    - def func():
+353 + def func() -> Optional[int]:
+354 |     import contextlib
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+ANN201 [*] Missing return type annotation for public function `func`
+   --> auto_return_type.py:361:5
+    |
+360 | # Test case: a context manager that isn't known to swallow exceptions still gets NoReturn
+361 | def func():
+    |     ^^^^
+362 |     with open("file") as f:
+363 |         raise ValueError(f)
+    |
+help: Add return type annotation: `NoReturn`
+    |
+216 |
+    - from typing import overload
+217 + from typing import overload, NoReturn
+218 |
+--------------------------------------------------------------------------------
+360 | # Test case: a context manager that isn't known to swallow exceptions still gets NoReturn
+    - def func():
+361 + def func() -> NoReturn:
+362 |     with open("file") as f:
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__unnecessary-assign_RET504.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_return/snapshots/ruff_linter__rules__flake8_return__tests__unnecessary-assign_RET504.py.snap
@@ -257,5 +257,6 @@ help: Remove unnecessary assignment
 461 +     return (1
 462 |               )
     -     return x
+463 |
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_return/visitor.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/visitor.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashSet;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_semantic::SemanticModel;
+use ruff_python_semantic::analyze::context_manager::may_suppress_exceptions;
 use ruff_text_size::{Ranged, TextRange};
 
 #[derive(Default)]
@@ -232,19 +233,5 @@ impl<'a> Visitor<'a> for ReturnVisitor<'_, 'a> {
 ///     return data
 /// ```
 pub(crate) fn has_conditional_body(with: &ast::StmtWith, semantic: &SemanticModel) -> bool {
-    with.items.iter().any(|item| {
-        let ast::WithItem {
-            context_expr: Expr::Call(ast::ExprCall { func, .. }),
-            ..
-        } = item
-        else {
-            return false;
-        };
-        if let Some(qualified_name) = semantic.resolve_qualified_name(func) {
-            if qualified_name.segments() == ["contextlib", "suppress"] {
-                return true;
-            }
-        }
-        false
-    })
+    may_suppress_exceptions(with, semantic)
 }

--- a/crates/ruff_python_semantic/src/analyze/context_manager.rs
+++ b/crates/ruff_python_semantic/src/analyze/context_manager.rs
@@ -1,0 +1,47 @@
+use ruff_python_ast::{self as ast, Expr};
+
+use crate::SemanticModel;
+
+/// Returns `true` if any of the `with` statement's context managers may swallow an exception
+/// raised in its body, letting execution resume after the `with` statement.
+///
+/// A context manager suppresses an exception by returning a truthy value from `__exit__`. We
+/// can't know that in general, since `__exit__` is usually defined in another module, so we
+/// recognize the handful of context managers that are widely used for exactly that purpose:
+///
+/// ```python
+/// def func():
+///     with pytest.raises(ValueError):
+///         raise ValueError("boom")
+///     # `pytest.raises` swallowed the exception, so we get here.
+/// ```
+pub fn may_suppress_exceptions(with: &ast::StmtWith, semantic: &SemanticModel) -> bool {
+    with.items.iter().any(|item| {
+        let Expr::Call(ast::ExprCall { func, .. }) = &item.context_expr else {
+            return false;
+        };
+
+        if semantic
+            .resolve_qualified_name(func)
+            .is_some_and(|qualified_name| {
+                matches!(
+                    qualified_name.segments(),
+                    ["contextlib", "suppress"] | ["pytest", "raises"]
+                )
+            })
+        {
+            return true;
+        }
+
+        // `unittest`'s `assertRaises` helpers are called on a `TestCase` instance (typically
+        // `self`), which we can't resolve, so match on the method name alone.
+        matches!(
+            func.as_ref(),
+            Expr::Attribute(ast::ExprAttribute { attr, .. })
+                if matches!(
+                    attr.as_str(),
+                    "assertRaises" | "assertRaisesRegex" | "assertRaisesRegexp" | "failUnlessRaises"
+                )
+        )
+    })
+}

--- a/crates/ruff_python_semantic/src/analyze/mod.rs
+++ b/crates/ruff_python_semantic/src/analyze/mod.rs
@@ -1,4 +1,5 @@
 pub mod class;
+pub mod context_manager;
 pub mod function_type;
 pub mod imports;
 pub mod logging;

--- a/crates/ruff_python_semantic/src/analyze/terminal.rs
+++ b/crates/ruff_python_semantic/src/analyze/terminal.rs
@@ -372,7 +372,8 @@ fn sometimes_breaks(stmts: &[Stmt], semantic: &SemanticModel) -> bool {
     false
 }
 
-/// Returns `true` if the body may break via a `break` statement.
+/// Returns `true` if the body always breaks via a `break` statement, i.e., if it reaches a
+/// top-level `break` before any `return` or `raise`.
 fn always_breaks(stmts: &[Stmt]) -> bool {
     for stmt in stmts {
         match stmt {

--- a/crates/ruff_python_semantic/src/analyze/terminal.rs
+++ b/crates/ruff_python_semantic/src/analyze/terminal.rs
@@ -154,16 +154,11 @@ impl Terminal {
                     let body_terminal = Self::from_body(&with_stmt.body, semantic);
 
                     if may_suppress_exceptions(with_stmt, semantic) {
-                        // The context manager can swallow an exception raised anywhere in the
-                        // body, in which case execution resumes after the `with` statement. So,
-                        // as for a `try` block, the body tells us nothing about how the function
-                        // ends, beyond the fact that it can return:
-                        // ```python
-                        // def func():
-                        //     with pytest.raises(ValueError):
-                        //         raise ValueError("boom")
-                        //     # We get here, so the function doesn't always raise.
-                        // ```
+                        // Execution resumes after the `with` statement once the exception is
+                        // swallowed, so the body never proves that the function always raises.
+                        // A `return` in the body proves only that the function *can* return:
+                        // `with suppress(ValueError): return int(value)` falls through to an
+                        // implicit `return None` whenever `int(value)` raises.
                         if body_terminal.has_any_return() {
                             terminal = terminal.and_then(Terminal::ConditionalReturn);
                         }

--- a/crates/ruff_python_semantic/src/analyze/terminal.rs
+++ b/crates/ruff_python_semantic/src/analyze/terminal.rs
@@ -1,6 +1,7 @@
 use ruff_python_ast::helpers::map_callable;
 use ruff_python_ast::{self as ast, ExceptHandler, Stmt};
 
+use crate::analyze::context_manager::may_suppress_exceptions;
 use crate::model::SemanticModel;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -149,8 +150,26 @@ impl Terminal {
                         );
                     }
                 }
-                Stmt::With(ast::StmtWith { body, .. }) => {
-                    terminal = terminal.and_then(Self::from_body(body, semantic));
+                Stmt::With(with_stmt) => {
+                    let body_terminal = Self::from_body(&with_stmt.body, semantic);
+
+                    if may_suppress_exceptions(with_stmt, semantic) {
+                        // The context manager can swallow an exception raised anywhere in the
+                        // body, in which case execution resumes after the `with` statement. So,
+                        // as for a `try` block, the body tells us nothing about how the function
+                        // ends, beyond the fact that it can return:
+                        // ```python
+                        // def func():
+                        //     with pytest.raises(ValueError):
+                        //         raise ValueError("boom")
+                        //     # We get here, so the function doesn't always raise.
+                        // ```
+                        if body_terminal.has_any_return() {
+                            terminal = terminal.and_then(Terminal::ConditionalReturn);
+                        }
+                    } else {
+                        terminal = terminal.and_then(body_terminal);
+                    }
                 }
                 Stmt::Return(_) => {
                     terminal = terminal.and_then(Terminal::RaiseOrReturn);


### PR DESCRIPTION
## Summary

Create a ``may_suppress_exceptions`` helper to take into account `pytest.raises`, ``contextlib.suppress,`` and unittest's `assertRaises`  error suppressing behavior. ``flake8_return::has_conditional_body`` already handled contextlib.suppress.

Fixes #15975

## Test Plan

Added a functional test for the 3 context manager each in a class and in a function if possible (not for unittest TestCase class)

Drafting to see the result of the ecosystem run.