### PR TITLE
[ty] Fix cached classmethods on generic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -563,6 +563,86 @@ reveal_type(Explicit.class_method.__func__)  # revealed: Wrapper
 reveal_type(Explicit.class_method.__call__(1))  # revealed: int
 ```
 
+## Generic inference for method wrappers
+
+When a generic function returns a mutable container, inference can widen literal types in its
+argument. A method wrapper remains assignable to the inferred type when its callable's return type
+widens from a string literal to `str`.
+
+```py
+def as_list[T](value: T) -> list[T]:
+    return [value]
+
+reveal_type(as_list(classmethod(lambda cls: ""))[0].__func__(object))  # revealed: str
+reveal_type(as_list(staticmethod(lambda: ""))[0]())  # revealed: str
+```
+
+## Type relations between method wrappers
+
+Wrappers of the same kind preserve the type relationships between their wrapped callables. A
+callable returning `str` can be used where one returning `object` is expected, but the reverse is
+not safe. The wrapper types overlap because they can contain the same callable.
+
+```py
+from typing import Callable
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_assignable_to, is_disjoint_from, is_subtype_of
+
+def _(str_fn: Callable[[object], str], object_fn: Callable[[object], object]):
+    str_class = classmethod(str_fn)
+    object_class = classmethod(object_fn)
+    str_static = staticmethod(str_fn)
+    object_static = staticmethod(object_fn)
+
+    static_assert(is_subtype_of(TypeOf[str_class], TypeOf[object_class]))
+    static_assert(not is_assignable_to(TypeOf[object_class], TypeOf[str_class]))
+    static_assert(not is_disjoint_from(TypeOf[str_class], TypeOf[object_class]))
+
+    static_assert(is_subtype_of(TypeOf[str_static], TypeOf[object_static]))
+    static_assert(not is_assignable_to(TypeOf[object_static], TypeOf[str_static]))
+    static_assert(not is_disjoint_from(TypeOf[str_static], TypeOf[object_static]))
+```
+
+A classmethod and a staticmethod are distinct descriptor types, even if they wrap the same callable.
+
+```py
+    static_assert(not is_assignable_to(TypeOf[str_class], TypeOf[str_static]))
+    static_assert(not is_assignable_to(TypeOf[str_static], TypeOf[str_class]))
+    static_assert(is_disjoint_from(TypeOf[str_class], TypeOf[str_static]))
+```
+
+The wrapped object's attributes also matter. Sharing a call signature does not make a base-class
+instance assignable to a subclass that provides additional attributes.
+
+```py
+class Base:
+    def __call__(self, cls: object) -> str:
+        return ""
+
+class Derived(Base):
+    extra: int
+
+def _(base: Base, derived: Derived):
+    base_method = classmethod(base)
+    derived_method = classmethod(derived)
+
+    static_assert(is_subtype_of(TypeOf[derived_method], TypeOf[base_method]))
+    static_assert(not is_assignable_to(TypeOf[base_method], TypeOf[derived_method]))
+    static_assert(not is_disjoint_from(TypeOf[base_method], TypeOf[derived_method]))
+```
+
+Descriptors wrapping distinct function objects are disjoint, even when those functions have the same
+signature.
+
+```py
+def first(cls: object) -> None: ...
+def second(cls: object) -> None: ...
+
+first_method = classmethod(first)
+second_method = classmethod(second)
+static_assert(is_disjoint_from(TypeOf[first_method], TypeOf[second_method]))
+```
+
 ## Decorators returning a different function
 
 An inner decorator can replace a method with a function defined elsewhere. The outer `classmethod`

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -424,8 +424,8 @@ C().f2(1)
 
 ## Decorators returning unions of callables
 
-Each alternative returned by a callable decorator retains the method's binding behavior.
-`staticmethod` and `classmethod` accept these alternatives even when their signatures differ.
+A decorator can return a union of callables with different signatures. `staticmethod` accepts the
+union and leaves each signature unchanged.
 
 ```py
 from collections.abc import Callable
@@ -433,29 +433,41 @@ from collections.abc import Callable
 def static_decorator(function: object) -> Callable[[int], int] | Callable[[int, str], str]:
     raise NotImplementedError
 
-type ClassCallable = Callable[[type, int], int]
-type ClassCallables = ClassCallable | Callable[[type, int, str], str]
-
-def class_decorator(function: object) -> ClassCallables:
-    raise NotImplementedError
-
 class C:
     @staticmethod
     @static_decorator
     def static() -> None: ...
+
+reveal_type(C.static)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+reveal_type(C().static)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+```
+
+`classmethod` binds the first parameter of each alternative to the class. This also works when the
+union is expressed through a type alias.
+
+```py
+type ClassCallables = Callable[[type, int], int] | Callable[[type, int, str], str]
+
+def class_decorator(function: object) -> ClassCallables:
+    raise NotImplementedError
+
+class D:
     @classmethod
     @class_decorator
     def class_method(cls) -> None: ...
 
-reveal_type(C.static)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
-reveal_type(C().static)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
-reveal_type(C.class_method)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
-reveal_type(C().class_method)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+reveal_type(D.class_method)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+reveal_type(D().class_method)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
 ```
 
-An alternative that is not callable still causes an error when applying `staticmethod`.
+## Decorators returning a possibly non-callable value
+
+A decorator might return a non-callable value. We report an error when `staticmethod` is applied to
+such a return type.
 
 ```py
+from collections.abc import Callable
+
 def maybe_callable(function: object) -> Callable[[], int] | int:
     raise NotImplementedError
 
@@ -468,17 +480,16 @@ class Invalid:
 
 ## Callable wrappers retain attributes and overloads
 
-`staticmethod` returns the wrapped callable unchanged on attribute access. `classmethod` binds the
-class argument, preserving the callable's overloads and forwarding access to its attributes.
+An object returned by a decorator can have attributes and an overloaded `__call__` method. Here,
+`Wrapper` exposes a `reset` method and returns its second argument, with overloads for `int` and
+`str`.
 
 ```py
 from collections.abc import Callable
 from typing import overload
 
 class Wrapper:
-    def __init__(self, function: Callable[..., object]) -> None:
-        self.function = function
-
+    def __init__(self, function: Callable[..., object]) -> None: ...
     def reset(self) -> None: ...
     @overload
     def __call__(self, receiver: object, value: int) -> int: ...
@@ -486,34 +497,39 @@ class Wrapper:
     def __call__(self, receiver: object, value: str) -> str: ...
     def __call__(self, receiver: object, value: int | str) -> int | str:
         return value
+```
 
+Accessing a staticmethod through a class or instance returns the wrapper unchanged. Its attributes
+remain accessible, and each call uses the matching overload's return type.
+
+```py
 class C:
     @staticmethod
     @Wrapper
     def static(receiver: object, value: int | str) -> int | str:
         return value
 
+C.static.reset()
+reveal_type(C.static(None, 1))  # revealed: int
+reveal_type(C().static(None, "a"))  # revealed: str
+```
+
+Accessing a classmethod supplies the class as the wrapper's first argument. The bound method also
+exposes the wrapper's attributes and preserves its overloads.
+
+```py
+class D:
     @classmethod
     @Wrapper
     def class_method(cls, value: int | str) -> int | str:
         return value
 
-C.static.reset()
-C().static.reset()
-reveal_type(C.static(None, 1))  # revealed: int
-reveal_type(C().static(None, "a"))  # revealed: str
-
-C.class_method.reset()
-C().class_method.reset()
-reveal_type(C.class_method(1))  # revealed: int
-reveal_type(C().class_method("a"))  # revealed: str
-
-static: Callable[[object, int], int] = C.static
-class_method: Callable[[int], int] = C.class_method
+D().class_method.reset()
+reveal_type(D.class_method(1))  # revealed: int
+reveal_type(D().class_method("a"))  # revealed: str
 ```
 
-Explicit constructor calls preserve the same attributes and overloads as decorator syntax. A bound
-classmethod exposes its receiver and the original callable through `__self__` and `__func__`.
+Calling `staticmethod` and `classmethod` explicitly has the same effect as using them as decorators.
 
 ```py
 class Explicit:
@@ -526,19 +542,32 @@ reveal_type(Explicit.static(None, 1))  # revealed: int
 reveal_type(Explicit().static(None, "a"))  # revealed: str
 reveal_type(Explicit.class_method(1))  # revealed: int
 reveal_type(Explicit().class_method("a"))  # revealed: str
-reveal_type(Explicit.class_method.__call__(1))  # revealed: int
-reveal_type(Explicit.class_method.__self__)  # revealed: <class 'Explicit'>
-reveal_type(Explicit.class_method.__func__)  # revealed: Wrapper
-class_method = Explicit.class_method
 
 # error: [no-matching-overload]
 Explicit.class_method(None)
 ```
 
+A bound classmethod is assignable to a `Callable` whose signature matches one of its overloads after
+the class argument has been supplied.
+
+```py
+method: Callable[[int], int] = Explicit.class_method
+```
+
+The bound method's `__self__` attribute identifies the class, and `__func__` exposes the wrapper.
+Calling `__call__` explicitly also supplies the class argument.
+
+```py
+reveal_type(Explicit.class_method.__self__)  # revealed: <class 'Explicit'>
+reveal_type(Explicit.class_method.__func__)  # revealed: Wrapper
+reveal_type(Explicit.class_method.__call__(1))  # revealed: int
+```
+
 ## Decorators returning a different function
 
-An inner decorator can return a function that was defined elsewhere. The outer method decorator
-determines how that replacement function binds, independently of the original function's decorators.
+An inner decorator can replace a method with a function defined elsewhere. The outer `classmethod`
+decorator binds that replacement function to the class, even though the replacement's own definition
+has no decorators.
 
 ```py
 def replacement(cls: type, value: int) -> int:
@@ -550,12 +579,13 @@ class C:
     def method(cls, value: int) -> int:
         return value
 
-    assigned = classmethod(replacement)
-
 reveal_type(C.method(1))  # revealed: int
 reveal_type(C().method(1))  # revealed: int
-reveal_type(C.assigned(1))  # revealed: int
-reveal_type(C().assigned(1))  # revealed: int
+```
+
+The bound method's `__func__` refers to the replacement function.
+
+```py
 reveal_type(C.method.__func__)  # revealed: def replacement(cls: type, value: int) -> int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -422,6 +422,50 @@ C.f2(1)
 C().f2(1)
 ```
 
+## Decorators returning unions of callables
+
+Each alternative returned by a callable decorator retains the method's binding behavior.
+`staticmethod` and `classmethod` accept these alternatives even when their signatures differ.
+
+```py
+from collections.abc import Callable
+
+def static_decorator(function: object) -> Callable[[int], int] | Callable[[int, str], str]:
+    raise NotImplementedError
+
+type ClassCallable = Callable[[type, int], int]
+type ClassCallables = ClassCallable | Callable[[type, int, str], str]
+
+def class_decorator(function: object) -> ClassCallables:
+    raise NotImplementedError
+
+class C:
+    @staticmethod
+    @static_decorator
+    def static() -> None: ...
+    @classmethod
+    @class_decorator
+    def class_method(cls) -> None: ...
+
+reveal_type(C.static)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+reveal_type(C().static)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+reveal_type(C.class_method)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+reveal_type(C().class_method)  # revealed: ((int, /) -> int) | ((int, str, /) -> str)
+```
+
+An alternative that is not callable still causes an error when applying `staticmethod`.
+
+```py
+def maybe_callable(function: object) -> Callable[[], int] | int:
+    raise NotImplementedError
+
+class Invalid:
+    # error: [invalid-argument-type]
+    @staticmethod
+    @maybe_callable
+    def method() -> None: ...
+```
+
 ## Callable wrappers retain attributes and overloads
 
 `staticmethod` returns the wrapped callable unchanged on attribute access. `classmethod` binds the

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -422,6 +422,52 @@ C.f2(1)
 C().f2(1)
 ```
 
+## Callable wrappers retain attributes and overloads
+
+`staticmethod` returns the wrapped callable unchanged on attribute access. `classmethod` binds the
+class argument, preserving the callable's overloads and forwarding access to its attributes.
+
+```py
+from collections.abc import Callable
+from typing import overload
+
+class Wrapper:
+    def __init__(self, function: Callable[..., object]) -> None:
+        self.function = function
+
+    def reset(self) -> None: ...
+    @overload
+    def __call__(self, receiver: object, value: int) -> int: ...
+    @overload
+    def __call__(self, receiver: object, value: str) -> str: ...
+    def __call__(self, receiver: object, value: int | str) -> int | str:
+        return value
+
+class C:
+    @staticmethod
+    @Wrapper
+    def static(receiver: object, value: int | str) -> int | str:
+        return value
+
+    @classmethod
+    @Wrapper
+    def class_method(cls, value: int | str) -> int | str:
+        return value
+
+C.static.reset()
+C().static.reset()
+reveal_type(C.static(None, 1))  # revealed: int
+reveal_type(C().static(None, "a"))  # revealed: str
+
+C.class_method.reset()
+C().class_method.reset()
+reveal_type(C.class_method(1))  # revealed: int
+reveal_type(C().class_method("a"))  # revealed: str
+
+static: Callable[[object, int], int] = C.static
+class_method: Callable[[int], int] = C.class_method
+```
+
 ## Types are not bound-method descriptors
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -512,6 +512,53 @@ static: Callable[[object, int], int] = C.static
 class_method: Callable[[int], int] = C.class_method
 ```
 
+Explicit constructor calls preserve the same attributes and overloads as decorator syntax. A bound
+classmethod exposes its receiver and the original callable through `__self__` and `__func__`.
+
+```py
+class Explicit:
+    static = staticmethod(C.static)
+    class_method = classmethod(C.static)
+
+Explicit.static.reset()
+Explicit().class_method.reset()
+reveal_type(Explicit.static(None, 1))  # revealed: int
+reveal_type(Explicit().static(None, "a"))  # revealed: str
+reveal_type(Explicit.class_method(1))  # revealed: int
+reveal_type(Explicit().class_method("a"))  # revealed: str
+reveal_type(Explicit.class_method.__call__(1))  # revealed: int
+reveal_type(Explicit.class_method.__self__)  # revealed: <class 'Explicit'>
+reveal_type(Explicit.class_method.__func__)  # revealed: Wrapper
+class_method = Explicit.class_method
+
+# error: [no-matching-overload]
+Explicit.class_method(None)
+```
+
+## Decorators returning a different function
+
+An inner decorator can return a function that was defined elsewhere. The outer method decorator
+determines how that replacement function binds, independently of the original function's decorators.
+
+```py
+def replacement(cls: type, value: int) -> int:
+    return value
+
+class C:
+    @classmethod
+    @(lambda original: replacement)
+    def method(cls, value: int) -> int:
+        return value
+
+    assigned = classmethod(replacement)
+
+reveal_type(C.method(1))  # revealed: int
+reveal_type(C().method(1))  # revealed: int
+reveal_type(C.assigned(1))  # revealed: int
+reveal_type(C().assigned(1))  # revealed: int
+reveal_type(C.method.__func__)  # revealed: def replacement(cls: type, value: int) -> int
+```
+
 ## Types are not bound-method descriptors
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -601,11 +601,7 @@ def _(str_fn: Callable[[object], str], object_fn: Callable[[object], object]):
     static_assert(is_subtype_of(TypeOf[str_static], TypeOf[object_static]))
     static_assert(not is_assignable_to(TypeOf[object_static], TypeOf[str_static]))
     static_assert(not is_disjoint_from(TypeOf[str_static], TypeOf[object_static]))
-```
-
-A classmethod and a staticmethod are distinct descriptor types, even if they wrap the same callable.
-
-```py
+    # Classmethods and staticmethods are distinct descriptor types, even with the same callable.
     static_assert(not is_assignable_to(TypeOf[str_class], TypeOf[str_static]))
     static_assert(not is_assignable_to(TypeOf[str_static], TypeOf[str_class]))
     static_assert(is_disjoint_from(TypeOf[str_class], TypeOf[str_static]))
@@ -650,12 +646,17 @@ decorator binds that replacement function to the class, even though the replacem
 has no decorators.
 
 ```py
+from ty_extensions._internal import TypeOf
+
 def replacement(cls: type, value: int) -> int:
     return value
 
+def replace_method(original: object) -> TypeOf[replacement]:
+    return replacement
+
 class C:
     @classmethod
-    @(lambda original: replacement)
+    @replace_method
     def method(cls, value: int) -> int:
         return value
 

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -999,28 +999,27 @@ A.bar(x=10)
 
 ### Staticmethods wrapping lambdas
 
-A `staticmethod` wrapping a lambda retains the descriptor's own attributes. Its `__get__` method can
-be called explicitly to retrieve the lambda.
+A staticmethod can wrap a lambda. Access through a class or instance returns the lambda, including
+its function attributes, without binding an instance to its first parameter.
 
 ```py
 wrapper = staticmethod(lambda x: str(x))
 
-wrapper.__get__(None, object)(1)
-wrapper.__get__(object())(1)
-reveal_type(wrapper.__func__(1))  # revealed: str
-reveal_type(wrapper.__wrapped__(1))  # revealed: str
-```
-
-Access through a class or instance returns the original function, including its attributes, without
-binding the instance to the lambda's first parameter.
-
-```py
 class C:
     f = wrapper
 
 reveal_type(C.f(1))  # revealed: str
 reveal_type(C().f(1))  # revealed: str
 reveal_type(C.f.__code__)  # revealed: CodeType
+```
+
+The `staticmethod` object exposes the lambda through `__func__` and `__wrapped__`. Its `__get__`
+method can also be called explicitly.
+
+```py
+reveal_type(wrapper.__func__(1))  # revealed: str
+reveal_type(wrapper.__wrapped__(1))  # revealed: str
+wrapper.__get__(None, object)(1)
 ```
 
 ### Accessing the staticmethod as a static member

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -997,6 +997,32 @@ A.bar(5)
 A.bar(x=10)
 ```
 
+### Staticmethods wrapping lambdas
+
+A `staticmethod` wrapping a lambda retains the descriptor's own attributes. Its `__get__` method can
+be called explicitly to retrieve the lambda.
+
+```py
+wrapper = staticmethod(lambda x: str(x))
+
+wrapper.__get__(None, object)(1)
+wrapper.__get__(object())(1)
+reveal_type(wrapper.__func__(1))  # revealed: str
+reveal_type(wrapper.__wrapped__(1))  # revealed: str
+```
+
+Access through a class or instance returns the original function, including its attributes, without
+binding the instance to the lambda's first parameter.
+
+```py
+class C:
+    f = wrapper
+
+reveal_type(C.f(1))  # revealed: str
+reveal_type(C().f(1))  # revealed: str
+reveal_type(C.f.__code__)  # revealed: CodeType
+```
+
 ### Accessing the staticmethod as a static member
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -192,6 +192,30 @@ def compare(left: TypeOf[Left(C()).method], right: TypeOf[Right(C()).method]) ->
     reveal_type(left is right)  # revealed: bool
 ```
 
+## Identity of descriptors wrapping callable objects
+
+Classmethod and staticmethod descriptors are distinct kinds of objects, even when they wrap the same
+callable. Bound classmethods can also wrap callable instances instead of Python functions.
+
+```py
+class CallableObject:
+    def __call__(self, *args: object) -> int:
+        return 0
+
+wrapped = CallableObject()
+static = staticmethod(wrapped)
+class_method = classmethod(wrapped)
+
+reveal_type(static is static)  # revealed: bool
+reveal_type(class_method is class_method)  # revealed: bool
+reveal_type(static is class_method)  # revealed: Literal[False]
+
+class C:
+    method = class_method
+
+reveal_type(C.method is C.method)  # revealed: bool
+```
+
 ## Identity of properties, saved method wrappers, and partials
 
 If a generic class defines a property `prop`, specializing that class changes the static signatures

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1553,10 +1553,27 @@ class Box(Generic[T]):
     def configured(cls) -> "Box[T]":
         return cls()
 
+    @staticmethod
+    @lru_cache
+    def identity(value: T) -> T:
+        return value
+
 reveal_type(Box.make())  # revealed: Box[Unknown]
 reveal_type(Box[int].make())  # revealed: Box[int]
 reveal_type(Box.configured())  # revealed: Box[Unknown]
 reveal_type(Box[int].configured())  # revealed: Box[int]
+```
+
+The cache-management methods remain accessible on the wrapped callable.
+
+```py
+Box.make.cache_clear()
+Box[int].make.cache_clear()
+reveal_type(Box.make.cache_info().hits)  # revealed: int
+reveal_type(Box[int]().configured.cache_info().misses)  # revealed: int
+Box[int].identity.cache_clear()
+reveal_type(Box[int].identity.cache_info().hits)  # revealed: int
+reveal_type(Box[int].identity(1))  # revealed: int
 ```
 
 ## Metaclass descriptors shadow generic instance attributes

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1470,6 +1470,95 @@ reveal_type(DescriptorOrInt[str].value)  # revealed: int
 DescriptorOrInt[int].value = 1
 ```
 
+## Decorated methods on generic classes
+
+Wrapping a generic method in a callable object does not remove the descriptor behavior supplied by
+`classmethod` or `staticmethod`. Both remain accessible through the class and its generic aliases.
+Decorators returning `Callable` also preserve the classmethod binding.
+
+```py
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+class Wrapper(Generic[R]):
+    def __init__(self, function: Callable[..., R]) -> None:
+        self.function = function
+
+    def __call__(self, argument: object) -> R:
+        return self.function(argument)
+
+def preserve_return(function: Callable[..., R]) -> Callable[..., R]:
+    return function
+
+class Box(Generic[T]):
+    @classmethod
+    @Wrapper
+    def make(cls) -> "Box[T]":
+        return cls()
+
+    @staticmethod
+    @Wrapper
+    def identity(value: T) -> T:
+        return value
+
+    @preserve_return
+    @classmethod
+    def preserved(cls) -> "Box[T]":
+        return cls()
+
+reveal_type(Box.make())  # revealed: Box[Unknown]
+reveal_type(Box[int].make())  # revealed: Box[int]
+Box.identity(1)
+reveal_type(Box[int].identity(1))  # revealed: int
+reveal_type(Box.preserved())  # revealed: Box[Unknown]
+reveal_type(Box[int].preserved())  # revealed: Box[int]
+```
+
+A callable instance attribute whose type depends on the class's type parameter is still restricted.
+Neither a `Callable` annotation nor the wrapper's `__call__` method supplies descriptor behavior.
+
+```py
+class Callables(Generic[T]):
+    function: Callable[[], T]
+    wrapper: Wrapper[T]
+
+# error: [invalid-attribute-access]
+Callables[int].function()
+# error: [invalid-attribute-access]
+Callables[int].wrapper(1)
+```
+
+## Cached classmethods
+
+`functools.lru_cache` can wrap a generic classmethod's implementation without preventing class
+access. This works both with the decorator's defaults and with explicit cache options.
+
+```py
+from functools import lru_cache
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    @classmethod
+    @lru_cache
+    def make(cls) -> "Box[T]":
+        return cls()
+
+    @classmethod
+    @lru_cache(maxsize=128, typed=True)
+    def configured(cls) -> "Box[T]":
+        return cls()
+
+reveal_type(Box.make())  # revealed: Box[Unknown]
+reveal_type(Box[int].make())  # revealed: Box[int]
+reveal_type(Box.configured())  # revealed: Box[Unknown]
+reveal_type(Box[int].configured())  # revealed: Box[int]
+```
+
 ## Metaclass descriptors shadow generic instance attributes
 
 A data descriptor on the metaclass governs class access even when instances have an attribute of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1316,6 +1316,26 @@ node.label = 2
 reveal_type(Node[int](1).label)  # revealed: int
 ```
 
+Callable instance attributes follow the same restriction. Neither a `Callable` annotation nor a
+`__call__` method makes an attribute a descriptor.
+
+```py
+from collections.abc import Callable
+
+class CallableObject(Generic[T]):
+    def __call__(self) -> T:
+        raise NotImplementedError
+
+class Callables(Generic[T]):
+    function: Callable[[], T]
+    instance: CallableObject[T]
+
+# error: [invalid-attribute-access]
+Callables[int].function
+# error: [invalid-attribute-access]
+Callables[int].instance
+```
+
 ## Class attributes independent of type variables
 
 Generic classes can expose class variables, ordinary attributes whose types do not depend on their
@@ -1472,9 +1492,8 @@ DescriptorOrInt[int].value = 1
 
 ## Decorated methods on generic classes
 
-Wrapping a generic method in a callable object does not remove the descriptor behavior supplied by
-`classmethod` or `staticmethod`. Both remain accessible through the class and its generic aliases.
-Decorators returning `Callable` also preserve the classmethod binding.
+A decorator can wrap a method in a callable object whose type depends on the enclosing class's type
+parameter. This wrapper preserves the function's return type but has no `__get__` method of its own.
 
 ```py
 from collections.abc import Callable
@@ -1489,52 +1508,65 @@ class Wrapper(Generic[R]):
 
     def __call__(self, argument: object) -> R:
         return self.function(argument)
+```
 
-def preserve_return(function: Callable[..., R]) -> Callable[..., R]:
-    return function
+An outer `classmethod` supplies descriptor behavior, making the method accessible through the
+generic class. The method's return type uses any type argument supplied to the class.
 
+```py
 class Box(Generic[T]):
     @classmethod
     @Wrapper
     def make(cls) -> "Box[T]":
         return cls()
 
+Box.make()
+reveal_type(Box[int].make())  # revealed: Box[int]
+```
+
+A `staticmethod` also permits access through the generic class, without supplying a class or
+instance argument to the wrapper.
+
+```py
+class C(Generic[T]):
     @staticmethod
     @Wrapper
     def identity(value: T) -> T:
         return value
 
-    @preserve_return
-    @classmethod
-    def preserved(cls) -> "Box[T]":
-        return cls()
-
-reveal_type(Box.make())  # revealed: Box[Unknown]
-reveal_type(Box[int].make())  # revealed: Box[int]
-Box.identity(1)
-reveal_type(Box[int].identity(1))  # revealed: int
-reveal_type(Box.preserved())  # revealed: Box[Unknown]
-reveal_type(Box[int].preserved())  # revealed: Box[int]
+C.identity(1)
+reveal_type(C[int].identity(1))  # revealed: int
 ```
 
-A callable instance attribute whose type depends on the class's type parameter is still restricted.
-Neither a `Callable` annotation nor the wrapper's `__call__` method supplies descriptor behavior.
+## Decorators returning `Callable` on generic classes
+
+We retain classmethod binding when an outer decorator returns a `Callable`. The method remains
+accessible through the generic class and uses any supplied type argument in its return type.
 
 ```py
-class Callables(Generic[T]):
-    function: Callable[[], T]
-    wrapper: Wrapper[T]
+from collections.abc import Callable
+from typing import Generic, TypeVar
 
-# error: [invalid-attribute-access]
-Callables[int].function()
-# error: [invalid-attribute-access]
-Callables[int].wrapper(1)
+T = TypeVar("T")
+R = TypeVar("R")
+
+def preserve_return(function: Callable[..., R]) -> Callable[..., R]:
+    return function
+
+class Box(Generic[T]):
+    @preserve_return
+    @classmethod
+    def make(cls) -> "Box[T]":
+        return cls()
+
+Box.make()
+reveal_type(Box[int].make())  # revealed: Box[int]
 ```
 
 ## Cached classmethods
 
-`functools.lru_cache` can wrap a generic classmethod's implementation without preventing class
-access. This works both with the decorator's defaults and with explicit cache options.
+`functools.lru_cache` returns a callable wrapper. An outer `classmethod` makes it accessible through
+the generic class, and the cached method retains its return type.
 
 ```py
 from functools import lru_cache
@@ -1548,32 +1580,15 @@ class Box(Generic[T]):
     def make(cls) -> "Box[T]":
         return cls()
 
-    @classmethod
-    @lru_cache(maxsize=128, typed=True)
-    def configured(cls) -> "Box[T]":
-        return cls()
-
-    @staticmethod
-    @lru_cache
-    def identity(value: T) -> T:
-        return value
-
-reveal_type(Box.make())  # revealed: Box[Unknown]
+Box.make()
 reveal_type(Box[int].make())  # revealed: Box[int]
-reveal_type(Box.configured())  # revealed: Box[Unknown]
-reveal_type(Box[int].configured())  # revealed: Box[int]
 ```
 
-The cache-management methods remain accessible on the wrapped callable.
+The cache's `cache_clear` and `cache_info` methods remain accessible through the bound classmethod.
 
 ```py
 Box.make.cache_clear()
-Box[int].make.cache_clear()
-reveal_type(Box.make.cache_info().hits)  # revealed: int
-reveal_type(Box[int]().configured.cache_info().misses)  # revealed: int
-Box[int].identity.cache_clear()
-reveal_type(Box[int].identity.cache_info().hits)  # revealed: int
-reveal_type(Box[int].identity(1))  # revealed: int
+Box[int].make.cache_info()
 ```
 
 ## Metaclass descriptors shadow generic instance attributes

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1520,7 +1520,7 @@ class Box(Generic[T]):
     def make(cls) -> "Box[T]":
         return cls()
 
-Box.make()
+reveal_type(Box.make())  # revealed: Box[Unknown]
 reveal_type(Box[int].make())  # revealed: Box[int]
 ```
 
@@ -1534,7 +1534,7 @@ class C(Generic[T]):
     def identity(value: T) -> T:
         return value
 
-C.identity(1)
+reveal_type(C.identity(1))  # revealed: Unknown
 reveal_type(C[int].identity(1))  # revealed: int
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -1415,5 +1415,44 @@ class Ok1[T, *Ts]: ...
 class Ok3[*Ts]: ...
 ```
 
+## Decorated methods on generic classes
+
+A decorator can wrap a method in a callable object that retains its return type. An outer
+`classmethod` supplies the class argument and permits access through the generic class.
+
+```py
+from collections.abc import Callable
+
+class Wrapper[R]:
+    def __init__(self, function: Callable[..., R]) -> None:
+        self.function = function
+
+    def __call__(self, argument: object) -> R:
+        return self.function(argument)
+
+class Box[T]:
+    @classmethod
+    @Wrapper
+    def make(cls) -> "Box[T]":
+        return cls()
+
+reveal_type(Box.make())  # revealed: Box[Unknown]
+reveal_type(Box[int].make())  # revealed: Box[int]
+```
+
+A `staticmethod` permits access without supplying a receiver. The wrapper's parameter accepts
+`object`, so an unspecialized class does not infer its type argument from the call's argument.
+
+```py
+class C[T]:
+    @staticmethod
+    @Wrapper
+    def identity(value: T) -> T:
+        return value
+
+reveal_type(C.identity(1))  # revealed: Unknown
+reveal_type(C[int].identity(1))  # revealed: int
+```
+
 [crtp]: https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 [f-bound]: https://en.wikipedia.org/wiki/Bounded_quantification#F-bounded_quantification

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -142,8 +142,8 @@ reveal_type(foo3.takes_self_or_int(1))  # revealed: int
 
 ## Cached classmethod implementations
 
-Caching an overloaded classmethod's implementation preserves its method binding. The implementation
-remains callable for overload validation, and callers retain the overload-specific return types.
+An overloaded classmethod can cache its implementation with `lru_cache`. Each call uses the return
+type of its matching overload.
 
 ```py
 from functools import lru_cache

--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -140,6 +140,31 @@ reveal_type(foo3.takes_self_or_int(foo3))  # revealed: Foo3
 reveal_type(foo3.takes_self_or_int(1))  # revealed: int
 ```
 
+## Cached classmethod implementations
+
+Caching an overloaded classmethod's implementation preserves its method binding. The implementation
+remains callable for overload validation, and callers retain the overload-specific return types.
+
+```py
+from functools import lru_cache
+from typing import overload
+
+class Cached:
+    @overload
+    @classmethod
+    def identity(cls, value: int) -> int: ...
+    @overload
+    @classmethod
+    def identity(cls, value: str) -> str: ...
+    @classmethod
+    @lru_cache
+    def identity(cls, value: int | str) -> int | str:
+        return value
+
+reveal_type(Cached.identity(1))  # revealed: int
+reveal_type(Cached.identity("value"))  # revealed: str
+```
+
 ## Explicit receiver annotations
 
 Binding a method filters overloads that explicitly annotate `self` with a type that cannot accept

--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -422,6 +422,23 @@ info: `Pattern` instances are always truthy because `Pattern` cannot be subclass
     | |______________________________^ `Pattern` defined here
 ```
 
+## Classmethods wrapping callable objects
+
+A bound classmethod is always truthy even when it wraps a callable instance instead of a Python
+function. Testing the method does not call the wrapped object.
+
+```py
+class CallableObject:
+    def __call__(self, cls: type[object]) -> bool:
+        return False
+
+class C:
+    method = classmethod(CallableObject())
+
+if C.method:  # error: [redundant-condition] "Object of type `MethodType[CallableObject]` is always truthy"
+    pass
+```
+
 ## Enum instances
 
 An enum with members is implicitly final, so its instances are always truthy if the enum defines

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4427,7 +4427,7 @@ impl<'db> Type<'db> {
                     );
                 }
                 Type::BoundMethod(method) => {
-                    collect(db, Type::FunctionLiteral(method.function(db)), functions);
+                    collect(db, method.func(db), functions);
                 }
                 Type::Union(union) => {
                     for element in union.elements(db) {
@@ -8839,7 +8839,7 @@ impl<'db> Type<'db> {
 
             let signatures = match self {
                 Type::FunctionLiteral(function) => function_signatures(function),
-                Type::BoundMethod(method) => function_signatures(method.function(db)),
+                Type::BoundMethod(method) => method.function(db).and_then(function_signatures),
                 Type::Callable(callable) => Some(callable.signatures(db)),
                 _ => None,
             };
@@ -10207,7 +10207,13 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
                 } else {
                     // A callable object's type does not include the additional receiver bound
                     // by classmethod, which is also exposed through `__self__`.
-                    variance.join(method_type.self_instance(db).variance_of(db, env, typevar))
+                    VarianceTerm::join(
+                        db,
+                        [
+                            variance,
+                            method_type.self_instance(db).variance_of(db, env, typevar),
+                        ],
+                    )
                 }
             }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -44,7 +44,7 @@ pub(crate) use self::infer::{
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
-use self::known_instance::{MethodWrapper, MethodWrapperKind};
+use self::known_instance::MethodWrapperKind;
 pub(crate) use self::match_pattern::{
     ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
     definite_match_pattern_type, definite_match_pattern_type_for_subject,
@@ -4586,15 +4586,9 @@ impl<'db> Type<'db> {
                 Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
                     let return_type = match wrapper.kind(db) {
                         MethodWrapperKind::Staticmethod => wrapper.wrapped(db),
-                        MethodWrapperKind::Classmethod => Type::KnownInstance(
-                            KnownInstanceType::MethodWrapper(MethodWrapper::new(
-                                db,
-                                wrapper.wrapped(db),
-                                wrapper.descriptor(db),
-                                MethodWrapperKind::BoundClassmethod(owner),
-                            )),
+                        MethodWrapperKind::Classmethod => Type::BoundMethod(
+                            BoundMethodType::from_callable(db, wrapper.wrapped(db), owner, owner),
                         ),
-                        MethodWrapperKind::BoundClassmethod(_) => ty,
                     };
                     return Ok(Some(DescriptorGetResult {
                         return_type,
@@ -5733,41 +5727,22 @@ impl<'db> Type<'db> {
                 {
                     Place::bound(wrapper).into()
                 }
-                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
-                    match (wrapper.kind(db), name_str) {
-                        (_, "__func__")
-                        | (
-                            MethodWrapperKind::Staticmethod | MethodWrapperKind::Classmethod,
-                            "__wrapped__",
-                        ) => Place::bound(wrapper.wrapped(db)).into(),
-                        (MethodWrapperKind::BoundClassmethod(receiver), "__self__") => {
-                            Place::bound(receiver).into()
-                        }
-                        (_, "__call__") if let Some(callables) = wrapper.callables(db, env) => {
-                            Place::bound(callables.into_type(db, env)).into()
-                        }
-                        (kind, _) => {
-                            let result = wrapper
-                                .instance_fallback(db, env)
-                                .member_lookup_with_policy_and_receiver(
-                                    db, env, name_str, policy, receiver,
-                                );
-                            if matches!(kind, MethodWrapperKind::BoundClassmethod(_)) {
-                                member_lookup_or_fall_back_to(db, env, result, || {
-                                    wrapper.wrapped(db).member_lookup_with_policy_and_receiver(
-                                        db, env, name_str, policy, None,
-                                    )
-                                })
-                            } else {
-                                result
-                            }
-                        }
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => match name_str {
+                    "__func__" | "__wrapped__" => Place::bound(wrapper.wrapped(db)).into(),
+                    "__call__" if let Some(callables) = wrapper.callables(db, env) => {
+                        Place::bound(callables.into_type(db, env)).into()
                     }
-                }
+                    _ => wrapper
+                        .instance_fallback(db, env)
+                        .member_lookup_with_policy_and_receiver(
+                            db, env, name_str, policy, receiver,
+                        ),
+                },
                 Type::BoundMethod(bound_method) => match name_str {
                     "__self__" => Place::bound(bound_method.self_instance(db)).into(),
-                    "__func__" => {
-                        Place::bound(Type::FunctionLiteral(bound_method.function(db))).into()
+                    "__func__" => Place::bound(bound_method.func(db)).into(),
+                    "__call__" if let Some(callables) = bound_method.callables(db, env) => {
+                        Place::bound(callables.into_type(db, env)).into()
                     }
                     _ => {
                         let result = KnownClass::MethodType
@@ -5780,7 +5755,8 @@ impl<'db> Type<'db> {
                             // it will be looked up on the underlying function object. This
                             // changes the lookup object, so do not forward the bound-method
                             // receiver.
-                            Type::FunctionLiteral(bound_method.function(db))
+                            bound_method
+                                .func(db)
                                 .member_lookup_with_policy_and_receiver(
                                     db, env, name_str, policy, None,
                                 )
@@ -6352,7 +6328,17 @@ impl<'db> Type<'db> {
             }
 
             Type::BoundMethod(bound_method) => {
-                let signature = bound_method.function(db).signature(db);
+                let Some(function) = bound_method.function(db) else {
+                    return bound_method.callables(db, env).map_or_else(
+                        || CallableBinding::not_callable(self).into(),
+                        |callables| {
+                            callables
+                                .into_type(db, env)
+                                .bindings_impl(db, env, recursion_guard)
+                        },
+                    );
+                };
+                let signature = function.signature(db);
                 let self_instance = bound_method.self_instance(db);
                 let signature_receiver = bound_method.signature_receiver(db);
                 // Class-based protocol member lookup has already specialized the method for this
@@ -6970,6 +6956,25 @@ impl<'db> Type<'db> {
                     .into(),
                 )
             }
+
+            // Keep the argument's full type in `MethodWrapper` instead of inferring one shared
+            // ParamSpec and return type, which would lose attributes and overload correlations.
+            KnownClass::Classmethod | KnownClass::Staticmethod => Some(
+                Binding::single(
+                    self,
+                    Signature::new(
+                        Parameters::standard([Parameter::positional_only(Some(Name::new_static(
+                            "f",
+                        )))
+                        .with_annotated_type(Type::single_callable(
+                            db,
+                            Signature::new(Parameters::gradual_form(), Type::object()),
+                        ))]),
+                        Type::unknown(),
+                    ),
+                )
+                .into(),
+            ),
 
             KnownClass::Property => {
                 let getter_signature = Signature::new(
@@ -8941,11 +8946,16 @@ impl<'db> Type<'db> {
                 }
             }),
 
-            Type::BoundMethod(method) => Type::BoundMethod(BoundMethodType::new(
+            Type::BoundMethod(method) => Type::BoundMethod(BoundMethodType::from_callable(
                 db,
-                method
-                    .function(db)
-                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                match method.func(db) {
+                    // The method retains its function identity even when types in the signature
+                    // are promoted. Promoting the function itself would erase its attributes.
+                    Type::FunctionLiteral(function) => Type::FunctionLiteral(
+                        function.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    ),
+                    func => func.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                },
                 method
                     .self_instance(db)
                     .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -9357,7 +9367,7 @@ impl<'db> Type<'db> {
                     typevars,
                     visitor,
                 );
-                method.function(db).find_legacy_typevars_impl(
+                method.func(db).find_legacy_typevars_impl(
                     db,
                     env,
                     binding_context,
@@ -9538,15 +9548,6 @@ impl<'db> Type<'db> {
                         typevars,
                         visitor,
                     );
-                    if let MethodWrapperKind::BoundClassmethod(receiver) = wrapper.kind(db) {
-                        receiver.find_legacy_typevars_impl(
-                            db,
-                            env,
-                            binding_context,
-                            typevars,
-                            visitor,
-                        );
-                    }
                 }
                 KnownInstanceType::SubscriptedProtocol(_)
                 | KnownInstanceType::SubscriptedGeneric(_)
@@ -9753,9 +9754,7 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
     ) -> Option<TypeDefinition<'db>> {
         match self {
-            Self::BoundMethod(method) => {
-                Some(TypeDefinition::Function(method.function(db).definition(db)))
-            }
+            Self::BoundMethod(method) => method.func(db).definition(db, env),
             Self::FunctionLiteral(function) => {
                 Some(TypeDefinition::Function(function.definition(db)))
             }
@@ -9913,7 +9912,7 @@ impl<'db> Type<'db> {
             Type::FunctionLiteral(function) => Some(function.parameter_span(db, parameter_index)),
             Type::BoundMethod(bound_method) => Some(
                 bound_method
-                    .function(db)
+                    .function(db)?
                     .parameter_span(db, parameter_index),
             ),
             _ => None,
@@ -9940,7 +9939,7 @@ impl<'db> Type<'db> {
     fn function_spans(&self, db: &'db dyn Db) -> Option<FunctionSpans> {
         match self {
             Type::FunctionLiteral(function) => Some(function.spans(db)),
-            Type::BoundMethod(bound_method) => Some(bound_method.function(db).spans(db)),
+            Type::BoundMethod(bound_method) => Some(bound_method.function(db)?.spans(db)),
             _ => None,
         }
     }
@@ -10202,7 +10201,14 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
 
             Type::BoundMethod(method_type) => {
                 // TODO: do we need to replace self?
-                method_type.function(db).variance_of(db, typevar)
+                let variance = method_type.func(db).variance_of(db, env, typevar);
+                if method_type.function(db).is_some() {
+                    variance
+                } else {
+                    // A callable object's type does not include the additional receiver bound
+                    // by classmethod, which is also exposed through `__self__`.
+                    variance.join(method_type.self_instance(db).variance_of(db, env, typevar))
+                }
             }
 
             Type::NominalInstance(nominal_instance_type) => {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -44,6 +44,7 @@ pub(crate) use self::infer::{
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
+use self::known_instance::{MethodWrapper, MethodWrapperKind};
 pub(crate) use self::match_pattern::{
     ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
     definite_match_pattern_type, definite_match_pattern_type_for_subject,
@@ -4582,6 +4583,24 @@ impl<'db> Type<'db> {
             }
 
             match ty {
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
+                    let return_type = match wrapper.kind(db) {
+                        MethodWrapperKind::Staticmethod => wrapper.wrapped(db),
+                        MethodWrapperKind::Classmethod => Type::KnownInstance(
+                            KnownInstanceType::MethodWrapper(MethodWrapper::new(
+                                db,
+                                wrapper.wrapped(db),
+                                wrapper.descriptor(db),
+                                MethodWrapperKind::BoundClassmethod(owner),
+                            )),
+                        ),
+                        MethodWrapperKind::BoundClassmethod(_) => ty,
+                    };
+                    return Ok(Some(DescriptorGetResult {
+                        return_type,
+                        kind: AttributeKind::NormalOrNonDataDescriptor,
+                    }));
+                }
                 Type::Callable(callable) if callable.is_staticmethod_like(db) => {
                     // For "staticmethod-like" callables, model the behavior of `staticmethod.__get__`.
                     // The underlying function is returned as-is, without binding self.
@@ -5714,6 +5733,37 @@ impl<'db> Type<'db> {
                 {
                     Place::bound(wrapper).into()
                 }
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
+                    match (wrapper.kind(db), name_str) {
+                        (_, "__func__")
+                        | (
+                            MethodWrapperKind::Staticmethod | MethodWrapperKind::Classmethod,
+                            "__wrapped__",
+                        ) => Place::bound(wrapper.wrapped(db)).into(),
+                        (MethodWrapperKind::BoundClassmethod(receiver), "__self__") => {
+                            Place::bound(receiver).into()
+                        }
+                        (_, "__call__") if let Some(callables) = wrapper.callables(db, env) => {
+                            Place::bound(callables.into_type(db, env)).into()
+                        }
+                        (kind, _) => {
+                            let result = wrapper
+                                .instance_fallback(db, env)
+                                .member_lookup_with_policy_and_receiver(
+                                    db, env, name_str, policy, receiver,
+                                );
+                            if matches!(kind, MethodWrapperKind::BoundClassmethod(_)) {
+                                member_lookup_or_fall_back_to(db, env, result, || {
+                                    wrapper.wrapped(db).member_lookup_with_policy_and_receiver(
+                                        db, env, name_str, policy, None,
+                                    )
+                                })
+                            } else {
+                                result
+                            }
+                        }
+                    }
+                }
                 Type::BoundMethod(bound_method) => match name_str {
                     "__self__" => Place::bound(bound_method.self_instance(db)).into(),
                     "__func__" => {
@@ -6726,6 +6776,17 @@ impl<'db> Type<'db> {
                 KnownInstanceType::FunctoolsPartial(partial)
                 | KnownInstanceType::FunctoolsPartialCall(partial),
             ) => Type::Callable(partial.partial(db)).bindings_impl(db, env, recursion_guard),
+
+            Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
+                wrapper.callables(db, env).map_or_else(
+                    || CallableBinding::not_callable(self).into(),
+                    |callables| {
+                        callables
+                            .into_type(db, env)
+                            .bindings_impl(db, env, recursion_guard)
+                    },
+                )
+            }
 
             Type::KnownInstance(known_instance) => known_instance
                 .instance_fallback(db, env)
@@ -8221,6 +8282,7 @@ impl<'db> Type<'db> {
                 }
                 KnownInstanceType::FunctoolsPartial(_)
                 | KnownInstanceType::FunctoolsPartialCall(_)
+                | KnownInstanceType::MethodWrapper(_)
                 | KnownInstanceType::Range { .. } => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                         *self, scope_id
@@ -9467,6 +9529,24 @@ impl<'db> Type<'db> {
                         typevars,
                         visitor,
                     );
+                }
+                KnownInstanceType::MethodWrapper(wrapper) => {
+                    wrapper.wrapped(db).find_legacy_typevars_impl(
+                        db,
+                        env,
+                        binding_context,
+                        typevars,
+                        visitor,
+                    );
+                    if let MethodWrapperKind::BoundClassmethod(receiver) = wrapper.kind(db) {
+                        receiver.find_legacy_typevars_impl(
+                            db,
+                            env,
+                            binding_context,
+                            typevars,
+                            visitor,
+                        );
+                    }
                 }
                 KnownInstanceType::SubscriptedProtocol(_)
                 | KnownInstanceType::SubscriptedGeneric(_)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5313,6 +5313,14 @@ impl<'db> Type<'db> {
             _ => std::slice::from_ref(&ty),
         };
         alternatives.iter().any(|ty| {
+            // Synthesized methods bind through `try_call_dunder_get` without necessarily
+            // exposing a `__get__` member on their meta-type.
+            if let Type::Callable(callable) = ty
+                && callable.is_method_like(db)
+            {
+                return false;
+            }
+
             // Descriptors define their own class-access behavior, but do not exempt other
             // alternatives in a union from the restriction on generic instance storage.
             ty.class_member(db, env, "__get__").is_undefined()

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4554,15 +4554,15 @@ impl<'db> CallableBinding<'db> {
         &self,
         db: &'db dyn Db,
     ) -> impl Iterator<Item = OverloadLiteral<'db>> + Clone {
-        if let Type::Callable(callable) = self.signature_type {
+        let signature_type = match self.signature_type {
+            Type::BoundMethod(bound) => bound.func(db),
+            ty => ty,
+        };
+        if let Type::Callable(callable) = signature_type {
             return Either::Left(callable.deprecated(db).into_iter());
         }
-        let function = match self.signature_type {
-            Type::FunctionLiteral(function) => Some(function),
-            Type::BoundMethod(bound) => Some(bound.function(db)),
-            _ => None,
-        };
-        let (overloads, implementation) = function
+        let (overloads, implementation) = signature_type
+            .as_function_literal()
             .map(|function| function.overloads_and_implementation(db))
             .unwrap_or_default();
         if let Some(implementation) =

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -54,7 +54,9 @@ use crate::types::generics::{
     GenericContext, Specialization, SpecializationBuilder, SpecializationError, TypeVarInference,
 };
 use crate::types::infer::original_class_type;
-use crate::types::known_instance::{FieldInstance, InternedConstraintSetSolution};
+use crate::types::known_instance::{
+    FieldInstance, InternedConstraintSetSolution, MethodWrapper, MethodWrapperKind,
+};
 use crate::types::signatures::{
     CallableSignature, Parameter, ParameterDisplayName, ParameterKind, Parameters, ParametersKind,
     PartialApplication, PartialSignatureApplication,
@@ -1980,9 +1982,10 @@ impl<'db> Bindings<'db> {
                     Type::BoundMethod(bound_method)
                         if let Type::PropertyInstance(property) =
                             bound_method.self_instance(db)
-                            && is_property_method(db, env, bound_method.function(db)) =>
+                            && let Some(function) = bound_method.function(db)
+                            && is_property_method(db, env, function) =>
                     {
-                        match bound_method.function(db).name(db).as_str() {
+                        match function.name(db).as_str() {
                             "setter" => {
                                 if let [Some(_), Some(setter)] = overload.parameter_types() {
                                     overload.set_return_type(Type::PropertyInstance(
@@ -2351,9 +2354,11 @@ impl<'db> Bindings<'db> {
                                         signature_generic_context(function.signature(db))
                                     }
 
-                                    Type::BoundMethod(bound_method) => signature_generic_context(
-                                        bound_method.function(db).signature(db),
-                                    ),
+                                    Type::BoundMethod(bound_method) => {
+                                        bound_method.function(db).and_then(|function| {
+                                            signature_generic_context(function.signature(db))
+                                        })
+                                    }
 
                                     Type::Callable(callable) => {
                                         signature_generic_context(callable.signatures(db))
@@ -3251,6 +3256,17 @@ impl<'db> Bindings<'db> {
                         Some(KnownClass::Type) if overload_index == 0 => {
                             if let [Some(arg)] = overload.parameter_types() {
                                 overload.set_return_type(arg.dunder_class(db, env));
+                            }
+                        }
+
+                        Some(class @ (KnownClass::Classmethod | KnownClass::Staticmethod)) => {
+                            if let [Some(wrapped)] = overload.parameter_types() {
+                                let kind = match class {
+                                    KnownClass::Classmethod => MethodWrapperKind::Classmethod,
+                                    _ => MethodWrapperKind::Staticmethod,
+                                };
+                                overload
+                                    .set_return_type(MethodWrapper::wrap(db, env, *wrapped, kind));
                             }
                         }
 
@@ -4679,10 +4695,9 @@ impl<'db> CallableBinding<'db> {
                 // [1]: https://github.com/astral-sh/ty/issues/274#issuecomment-2881856028
                 let function_type_and_kind = match self.signature_type {
                     Type::FunctionLiteral(function) => Some((FunctionKind::Function, function)),
-                    Type::BoundMethod(bound_method) => Some((
-                        FunctionKind::BoundMethod,
-                        bound_method.function(context.db()),
-                    )),
+                    Type::BoundMethod(bound_method) => bound_method
+                        .function(context.db())
+                        .map(|function| (FunctionKind::BoundMethod, function)),
                     Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(
                         function,
                     )) => Some((FunctionKind::MethodWrapper, function)),
@@ -5953,7 +5968,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         let callable = argument_bindings.single_item()?.callable();
                         let (function, is_bound_method) = match callable.signature_type {
                             Type::FunctionLiteral(function) => (function, false),
-                            Type::BoundMethod(method) => (method.function(db), true),
+                            Type::BoundMethod(method) => (method.function(db)?, true),
                             _ => return None,
                         };
                         let source_binding = callable
@@ -8602,7 +8617,7 @@ impl<'db> CallableDescription<'db> {
     ) -> Option<ClassLiteral<'db>> {
         let function = match callable_type {
             Type::FunctionLiteral(function) => function,
-            Type::BoundMethod(method) => method.function(db),
+            Type::BoundMethod(method) => method.function(db)?,
             Type::ClassLiteral(class) => return Some(class),
             _ => return None,
         };
@@ -8680,7 +8695,7 @@ impl<'db> CallableDescription<'db> {
                 })
             }
             Type::BoundMethod(bound_method) => Some({
-                let function = bound_method.function(db);
+                let function = bound_method.function(db)?;
                 let kind = if function.name(db) == "__init__" {
                     None
                 } else {

--- a/crates/ty_python_semantic/src/types/call/bind/property.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/property.rs
@@ -20,7 +20,7 @@ impl<'db> Bindings<'db> {
                 continue;
             }
             let function = match constructor.callable().callable_type {
-                Type::BoundMethod(method) => method.function(db),
+                Type::BoundMethod(method) if let Some(function) = method.function(db) => function,
                 Type::FunctionLiteral(function) => function,
                 _ => continue,
             };

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -288,6 +288,10 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::FunctoolsPartialCall(partial),
             ) => Some(CallableTypes::one(partial.partial(db))),
 
+            Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
+                wrapper.callables(db, env)
+            }
+
             Type::Intersection(intersection) => intersection
                 .finite_alternative_union(db, env)
                 .and_then(|alternatives| {

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -113,13 +113,13 @@ impl<'db> Type<'db> {
                 Some(CallableTypes::one(function_literal.into_callable_type(db)))
             }
             Type::BoundMethod(bound_method)
-                if context.is_recursive_reference(db, bound_method.function(db)) =>
+                if bound_method
+                    .function(db)
+                    .is_some_and(|function| context.is_recursive_reference(db, function)) =>
             {
                 Some(CallableTypes::one(CallableType::bottom(db)))
             }
-            Type::BoundMethod(bound_method) => {
-                Some(CallableTypes::one(bound_method.into_callable_type(db)))
-            }
+            Type::BoundMethod(bound_method) => bound_method.callables(db, env),
 
             Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
                 let call_symbol = self

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1458,7 +1458,7 @@ impl<'db> ClassType<'db> {
             match ty {
                 Type::FunctionLiteral(function) => function.as_abstract_method(db, defining_class),
                 Type::BoundMethod(method) => {
-                    method.function(db).as_abstract_method(db, defining_class)
+                    type_as_abstract_method(db, method.func(db), defining_class)
                 }
                 Type::PropertyInstance(property) => {
                     // A property is abstract if any of its accessors is abstract.
@@ -2400,6 +2400,7 @@ impl<'db> ClassType<'db> {
             ty: Type::BoundMethod(metaclass_dunder_call_function),
             ..
         }) = metaclass_dunder_call_function_symbol
+            && let Some(function) = metaclass_dunder_call_function.function(db)
         {
             // TODO: this intentionally diverges from step 1 in
             // https://typing.python.org/en/latest/spec/constructors.html#converting-a-constructor-to-callable
@@ -2414,10 +2415,13 @@ impl<'db> ClassType<'db> {
             let is_actual_enum = enum_metadata(db, self.class_literal(db)).is_some();
             if !is_actual_enum {
                 let callable = if receiver == lookup_type {
-                    metaclass_dunder_call_function.into_callable_type(db)
+                    function.into_bound_callable(
+                        db,
+                        metaclass_dunder_call_function.signature_receiver(db),
+                        metaclass_dunder_call_function.typing_self_type(db),
+                    )
                 } else {
-                    metaclass_dunder_call_function
-                        .into_callable_type_with_receiver(db, env, receiver, receiver)
+                    function.into_bound_callable_with_receiver(db, env, receiver, receiver)
                 };
                 return CallableTypes::one(callable);
             }
@@ -2562,11 +2566,11 @@ impl<'db> ClassType<'db> {
                         new_function =
                             new_function.with_inherited_generic_context(db, class_generic_context);
                     }
-                    CallableTypes::one(
-                        new_function
-                            .into_bound_method_type(db, instance_type)
-                            .into_callable_type(db),
-                    )
+                    CallableTypes::one(new_function.into_bound_callable(
+                        db,
+                        instance_type,
+                        instance_type,
+                    ))
                 } else {
                     // Fallback if no `object.__new__` is found.
                     CallableTypes::one(CallableType::single(

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -253,6 +253,7 @@ impl<'db> ClassBase<'db> {
                 | KnownInstanceType::Sentinel(_)
                 | KnownInstanceType::Range { .. }
                 | KnownInstanceType::FunctoolsPartial(_)
+                | KnownInstanceType::MethodWrapper(_)
                 | KnownInstanceType::FunctoolsPartialCall(_) => None,
                 KnownInstanceType::TypeGenericAlias(_) => Self::try_from_type(
                     db,

--- a/crates/ty_python_semantic/src/types/dedicated/pytest/collection.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest/collection.rs
@@ -186,7 +186,7 @@ pub(crate) fn pytest_test_for_binding<'db>(
     } else {
         let function = match binding_value_type(db, binding) {
             Type::FunctionLiteral(function) => function,
-            Type::BoundMethod(method) => method.function(db),
+            Type::BoundMethod(method) => method.function(db)?,
             _ => return None,
         };
         test_function_definition(db, function)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2566,7 +2566,7 @@ pub(super) fn report_dynamic_function_decorator_return<'db>(
 
     let decorator_function = match decorator_binding.signature_type {
         Type::FunctionLiteral(function) => function,
-        Type::BoundMethod(method) => method.function(db),
+        Type::BoundMethod(method) if let Some(function) = method.function(db) => function,
         _ => return,
     };
 
@@ -5014,7 +5014,7 @@ pub(super) fn report_invalid_method_override<'db>(
 
                 let superclass_function_span = match superclass_type {
                     Type::FunctionLiteral(function) => Some(signature_span(function)),
-                    Type::BoundMethod(method) => Some(signature_span(method.function(db))),
+                    Type::BoundMethod(method) => method.function(db).map(signature_span),
                     _ => None,
                 };
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1233,10 +1233,21 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'_, 'db> {
                 .display_with(db, self.env, self.settings.clone())
                 .fmt_detailed(f),
             Type::BoundMethod(bound_method) => {
-                let function = bound_method.function(db);
+                let Some(function) = bound_method.function(db) else {
+                    f.set_invalid_type_annotation();
+                    write!(
+                        f,
+                        "MethodType[{}]",
+                        bound_method
+                            .func(db)
+                            .display_with(db, self.env, self.settings.clone())
+                    )?;
+                    return Ok(());
+                };
                 let self_ty = bound_method.self_instance(db);
                 let receiver_ty = bound_method.signature_receiver(db);
-                let bound_signatures = bound_method.bound_signatures(db);
+                let bound_signatures =
+                    function.bound_signatures(db, receiver_ty, bound_method.typing_self_type(db));
 
                 match bound_signatures.overloads.as_slice() {
                     [signature] => {

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3831,6 +3831,13 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
             KnownInstanceType::FunctoolsPartialCall(partial) => Type::Callable(partial.partial(db))
                 .display_with(db, self.env, DisplaySettings::default().singleline())
                 .fmt_detailed(f),
+            KnownInstanceType::MethodWrapper(wrapper) => {
+                f.set_invalid_type_annotation();
+                f.write_str(wrapper.class(db).name(self.env.python_version(db)))?;
+                f.write_char('[')?;
+                wrapper.wrapped(db).display(db, self.env).fmt_detailed(f)?;
+                f.write_char(']')
+            }
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1664,15 +1664,22 @@ impl<'db> FunctionType<'db> {
     }
 
     /// Bind this function's signatures to a receiver while preserving overload selection and `Self`.
+    #[salsa::tracked(
+        returns(copy),
+        cycle_initial=|db, _, _, _, _| CallableType::bottom(db),
+        heap_size=ruff_memory_usage::heap_size
+    )]
     pub(crate) fn into_bound_callable(
         self,
         db: &'db dyn Db,
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
     ) -> CallableType<'db> {
+        let env = ProgramEnvironment::from_scope(self.literal(db).last_definition.body_scope(db));
+
         CallableType::new(
             db,
-            self.bound_signatures(db, receiver_type, typing_self_type),
+            self.bound_signatures_with_receiver(db, &env, receiver_type, typing_self_type),
             CallableTypeKind::FunctionLike,
         )
     }
@@ -1692,16 +1699,15 @@ impl<'db> FunctionType<'db> {
         )
     }
 
-    #[salsa::tracked(returns(ref), cycle_initial=|_, _, _, _, _| CallableSignature::bottom(), heap_size=ruff_memory_usage::heap_size)]
+    /// Shares the signatures retained in the function's interned bound callable.
     pub(crate) fn bound_signatures(
         self,
         db: &'db dyn Db,
         receiver_type: Type<'db>,
         typing_self_type: Type<'db>,
-    ) -> CallableSignature<'db> {
-        let env = ProgramEnvironment::from_scope(self.literal(db).last_definition.body_scope(db));
-
-        self.bound_signatures_with_receiver(db, &env, receiver_type, typing_self_type)
+    ) -> &'db CallableSignature<'db> {
+        self.into_bound_callable(db, receiver_type, typing_self_type)
+            .signatures(db)
     }
 
     fn bound_signatures_with_receiver(

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -92,11 +92,11 @@ use crate::types::tuple::TupleSpec;
 use crate::types::variance::{VarianceInferable, VarianceOrigin, VarianceTerm};
 use crate::types::visitor::non_any_dynamic_content;
 use crate::types::{
-    ApplyTypeMappingVisitor, BoundMethodType, BoundTypeVarIdentity, BoundTypeVarInstance,
-    CallableType, ClassBase, ClassLiteral, ClassType, FindLegacyTypeVarsVisitor,
-    IntersectionBuilder, KnownClass, KnownInstanceType, SpecialFormType, SubclassOfInner,
-    SubclassOfType, Truthiness, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
-    UnionBuilder, UnionType, binding_type, definition_expression_type, walk_signature,
+    ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, CallableType, ClassBase,
+    ClassLiteral, ClassType, FindLegacyTypeVarsVisitor, IntersectionBuilder, KnownClass,
+    KnownInstanceType, SpecialFormType, SubclassOfInner, SubclassOfType, Truthiness, Type,
+    TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionBuilder, UnionType, binding_type,
+    definition_expression_type, walk_signature,
 };
 use crate::{Db, FxIndexMap, FxOrderSet, ProgramEnvironment};
 use ty_python_core::ast_ids::HasScopedUseId;
@@ -1663,13 +1663,94 @@ impl<'db> FunctionType<'db> {
         CallableType::new(db, self.signature(db), self.callable_type_kind(db))
     }
 
-    /// Convert the `FunctionType` into a [`BoundMethodType`].
-    pub(crate) fn into_bound_method_type(
+    /// Bind this function's signatures to a receiver while preserving overload selection and `Self`.
+    pub(crate) fn into_bound_callable(
         self,
         db: &'db dyn Db,
-        self_instance: Type<'db>,
-    ) -> BoundMethodType<'db> {
-        BoundMethodType::new(db, self, self_instance, self_instance)
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> CallableType<'db> {
+        CallableType::new(
+            db,
+            self.bound_signatures(db, receiver_type, typing_self_type),
+            CallableTypeKind::FunctionLike,
+        )
+    }
+
+    /// Bind this function using the caller's environment and separate receiver and `Self` types.
+    pub(crate) fn into_bound_callable_with_receiver(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> CallableType<'db> {
+        CallableType::new(
+            db,
+            self.bound_signatures_with_receiver(db, env, receiver_type, typing_self_type),
+            CallableTypeKind::FunctionLike,
+        )
+    }
+
+    #[salsa::tracked(returns(ref), cycle_initial=|_, _, _, _, _| CallableSignature::bottom(), heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn bound_signatures(
+        self,
+        db: &'db dyn Db,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> CallableSignature<'db> {
+        let env = ProgramEnvironment::from_scope(self.literal(db).last_definition.body_scope(db));
+
+        self.bound_signatures_with_receiver(db, &env, receiver_type, typing_self_type)
+    }
+
+    fn bound_signatures_with_receiver(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> CallableSignature<'db> {
+        let function_signature = self.signature(db);
+
+        let [signature] = function_signature.overloads.as_slice() else {
+            if !function_signature
+                .overloads
+                .iter()
+                .any(Signature::has_explicit_positional_receiver_annotation)
+            {
+                return CallableSignature::from_overloads(function_signature.overloads.iter().map(
+                    |signature| {
+                        signature.bind_self_with_receiver(
+                            db,
+                            env,
+                            Some(receiver_type),
+                            Some(typing_self_type),
+                        )
+                    },
+                ));
+            }
+
+            return CallableSignature::from_overloads(
+                function_signature
+                    .overloads
+                    .iter()
+                    .filter_map(|signature| {
+                        signature.bind_self_if_compatible(db, env, receiver_type, typing_self_type)
+                    })
+                    .flat_map(|signature| signature.overloads),
+            );
+        };
+
+        let specialized = if signature.has_receiver_determined_method_typevar(db, env) {
+            signature.specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
+        } else {
+            None
+        };
+
+        specialized
+            .unwrap_or_else(|| CallableSignature::single(signature.clone()))
+            .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type))
     }
 
     pub(crate) fn find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9368,8 +9368,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Check for unsound calls to abstract classmethods/staticmethods on class objects
         match callable_type {
-            Type::BoundMethod(bound_method) => {
-                let function = bound_method.function(self.db());
+            Type::BoundMethod(bound_method) if let Some(function) = bound_method.function(db) => {
                 if let Some(class) = bound_method.self_instance(self.db()).to_class_type(db) {
                     if function.is_classmethod(self.db())
                         && function.as_abstract_method(self.db(), class).is_some()
@@ -10150,7 +10149,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Next handle functions
         let function = match ty {
             Type::FunctionLiteral(function) => function,
-            Type::BoundMethod(bound) => bound.function(self.db()),
+            Type::BoundMethod(bound) if let Some(function) = bound.function(self.db()) => function,
             Type::Callable(callable) => {
                 self.report_deprecated_functions(ranged, callable.deprecated(self.db()));
                 return;

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -29,6 +29,7 @@ use crate::{
             infer_function_default_types, infer_statement_types, nearest_enclosing_function,
             original_class_type,
         },
+        known_instance::{MethodWrapper, MethodWrapperKind},
         relation::TypeRelation,
         signatures::{ReturnCallableTypeVarScope, function_signature_expression_type},
         tuple::{TupleSpecBuilder, TupleType},
@@ -606,6 +607,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 continue;
             }
 
+            let wrapped_ty = inferred_ty;
             if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) = decorator_ty {
                 match inferred_ty {
                     Type::FunctionLiteral(function) => {
@@ -629,6 +631,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 decorator_node,
                 (!is_decorated_overload_implementation).then_some(function),
             );
+
+            if FunctionDecorators::from_decorator_type(db, *decorator_ty)
+                .intersects(FunctionDecorators::CLASSMETHOD | FunctionDecorators::STATICMETHOD)
+                && let Type::NominalInstance(instance) = inferred_ty
+            {
+                let kind = if instance.has_known_class(db, KnownClass::Classmethod) {
+                    Some(MethodWrapperKind::Classmethod)
+                } else if instance.has_known_class(db, KnownClass::Staticmethod) {
+                    Some(MethodWrapperKind::Staticmethod)
+                } else {
+                    None
+                };
+                if let Some(kind) = kind {
+                    // Keep the wrapped object as well as the nominal descriptor: the latter
+                    // exposes only `Callable[P, R]`, losing attributes and overload correlations.
+                    inferred_ty = Type::KnownInstance(KnownInstanceType::MethodWrapper(
+                        MethodWrapper::new(db, wrapped_ty, inferred_ty, kind),
+                    ));
+                }
+            }
         }
 
         if is_decorated_overload_implementation {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -593,16 +593,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
-            // Function types and overload signatures retain these decorators as binding metadata.
-            // If an inner decorator returned another object, construct the descriptor normally.
+            // Function types, overload signatures, and method-like callables already retain
+            // binding metadata. Check every callable alternative: a decorator can return a
+            // union whose signatures cannot be represented by a single ParamSpec.
             if FunctionDecorators::from_decorator_type(db, *decorator_ty)
                 .intersects(FunctionDecorators::CLASSMETHOD | FunctionDecorators::STATICMETHOD)
                 && (is_decorated_overload_implementation
                     || is_decorated_overload
                     || matches!(inferred_ty, Type::FunctionLiteral(_))
                     || inferred_ty
-                        .as_callable()
-                        .is_some_and(|callable| callable.is_method_like(db)))
+                        .try_upcast_to_callable(db, self.program_environment())
+                        .is_some_and(|callables| {
+                            callables.iter().all(|callable| callable.is_method_like(db))
+                        }))
             {
                 continue;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -470,7 +470,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
                 _ => {}
             }
-            if !decorator_function_decorator.is_empty() {
+            if !decorator_function_decorator.is_empty()
+                && !decorator_function_decorator
+                    .intersects(FunctionDecorators::CLASSMETHOD | FunctionDecorators::STATICMETHOD)
+            {
                 continue;
             }
 
@@ -543,10 +546,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
         let function_literal = FunctionLiteral::new(db, overload_literal);
         let function_type = FunctionType::new(db, function_literal, None);
-        let is_decorated_overload_implementation = !decorator_types_and_nodes.is_empty()
-            && function_literal.has_separate_implementation(db);
-        let is_decorated_overload =
-            !decorator_types_and_nodes.is_empty() && overload_literal.is_overload(db);
+        let has_custom_decorators = decorator_types_and_nodes
+            .iter()
+            .any(|(ty, _)| FunctionDecorators::from_decorator_type(db, *ty).is_empty());
+        let is_decorated_overload_implementation =
+            has_custom_decorators && function_literal.has_separate_implementation(db);
+        let is_decorated_overload = has_custom_decorators && overload_literal.is_overload(db);
 
         let mut inferred_ty = Type::FunctionLiteral(
             if is_decorated_overload_implementation || is_decorated_overload {
@@ -587,6 +592,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
+            // Function types and overload signatures retain these decorators as binding metadata.
+            // If an inner decorator returned another object, construct the descriptor normally.
+            if FunctionDecorators::from_decorator_type(db, *decorator_ty)
+                .intersects(FunctionDecorators::CLASSMETHOD | FunctionDecorators::STATICMETHOD)
+                && (is_decorated_overload_implementation
+                    || is_decorated_overload
+                    || matches!(inferred_ty, Type::FunctionLiteral(_))
+                    || inferred_ty
+                        .as_callable()
+                        .is_some_and(|callable| callable.is_method_like(db)))
+            {
+                continue;
+            }
+
             if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) = decorator_ty {
                 match inferred_ty {
                     Type::FunctionLiteral(function) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -29,7 +29,6 @@ use crate::{
             infer_function_default_types, infer_statement_types, nearest_enclosing_function,
             original_class_type,
         },
-        known_instance::{MethodWrapper, MethodWrapperKind},
         relation::TypeRelation,
         signatures::{ReturnCallableTypeVarScope, function_signature_expression_type},
         tuple::{TupleSpecBuilder, TupleType},
@@ -593,24 +592,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
-            // Function types, overload signatures, and method-like callables already retain
-            // binding metadata. Check every callable alternative: a decorator can return a
-            // union whose signatures cannot be represented by a single ParamSpec.
-            if FunctionDecorators::from_decorator_type(db, *decorator_ty)
-                .intersects(FunctionDecorators::CLASSMETHOD | FunctionDecorators::STATICMETHOD)
-                && (is_decorated_overload_implementation
-                    || is_decorated_overload
-                    || matches!(inferred_ty, Type::FunctionLiteral(_))
-                    || inferred_ty
-                        .try_upcast_to_callable(db, self.program_environment())
-                        .is_some_and(|callables| {
-                            callables.iter().all(|callable| callable.is_method_like(db))
-                        }))
-            {
-                continue;
-            }
-
-            let wrapped_ty = inferred_ty;
             if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) = decorator_ty {
                 match inferred_ty {
                     Type::FunctionLiteral(function) => {
@@ -634,29 +615,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 decorator_node,
                 (!is_decorated_overload_implementation).then_some(function),
             );
-
-            if FunctionDecorators::from_decorator_type(db, *decorator_ty)
-                .intersects(FunctionDecorators::CLASSMETHOD | FunctionDecorators::STATICMETHOD)
-                && let Type::NominalInstance(instance) = inferred_ty
-            {
-                let kind = if instance.has_known_class(db, KnownClass::Classmethod) {
-                    Some(MethodWrapperKind::Classmethod)
-                } else if instance.has_known_class(db, KnownClass::Staticmethod) {
-                    Some(MethodWrapperKind::Staticmethod)
-                } else {
-                    None
-                };
-                if let Some(kind) = kind {
-                    // Keep the wrapped object as well as the nominal descriptor: the latter
-                    // exposes only `Callable[P, R]`, losing attributes and overload correlations.
-                    inferred_ty = Type::KnownInstance(KnownInstanceType::MethodWrapper(
-                        MethodWrapper::new(db, wrapped_ty, inferred_ty, kind),
-                    ));
-                }
-            }
         }
 
         if is_decorated_overload_implementation {
+            // Overloads describe the exposed function. The implementation check compares the
+            // unbound callable, before classmethod or staticmethod descriptor binding.
+            let implementation_ty = match inferred_ty {
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
+                    wrapper.wrapped(db)
+                }
+                _ => inferred_ty,
+            };
             let last_definition = match inferred_ty {
                 Type::FunctionLiteral(function) => Some(function.literal(db).last_definition),
                 Type::Callable(callable) => callable.deprecated(db),
@@ -671,7 +640,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 function_type
             };
-            let implementation_callables = inferred_ty
+            let implementation_callables = implementation_ty
                 .try_upcast_to_callable(db, self.program_environment())
                 .map_or_else(Box::default, |callables| {
                     callables.iter().copied().collect()

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -212,10 +212,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     function.signature(db),
                     function.name(db),
                 )),
-                Type::BoundMethod(method) => {
-                    let function = method.function(db);
+                Type::BoundMethod(method) if let Some(function) = method.function(db) => {
                     Some(FunctionInfo::Method(
-                        method.bound_signatures(db),
+                        function.bound_signatures(
+                            db,
+                            method.signature_receiver(db),
+                            method.typing_self_type(db),
+                        ),
                         CallableDescription::defining_class(db, *test_type)
                             .map(|class| {
                                 Cow::Owned(format!("{}.{}", class.name(db), function.name(db)))

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1914,6 +1914,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     Type::unknown()
                 }
+                KnownInstanceType::MethodWrapper(wrapper) => {
+                    if !self.in_string_annotation() {
+                        self.infer_expression(&subscript.slice, TypeContext::default());
+                    }
+                    if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
+                        builder.into_diagnostic(format_args!(
+                            "`{}` instances cannot be specialized",
+                            wrapper.class(db).name(env.python_version(db)),
+                        ));
+                    }
+                    Type::unknown()
+                }
                 KnownInstanceType::Range { .. } => {
                     if !self.in_string_annotation() {
                         self.infer_expression(&subscript.slice, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -13,7 +13,7 @@ use crate::types::cyclic::CycleDetector;
 use crate::types::equality::{
     ComparisonSoundnessPolicy, TupleEqualityEvaluator, equality_truthiness, inequality_truthiness,
 };
-use crate::types::known_instance::{FunctoolsPartialInstance, InternedType};
+use crate::types::known_instance::{FunctoolsPartialInstance, InternedType, MethodWrapper};
 use crate::types::tuple::{Tuple, TupleSpec};
 use crate::types::{
     BoundMethodType, CallableType, DynamicType, FunctionType, IntersectionBuilder,
@@ -313,9 +313,9 @@ impl<'db> Type<'db> {
                     unspecialized_function(db, function),
                 )),
                 Type::BoundMethod(method) => visit_type(db, ty, visitor, || {
-                    UpcastResult::unstable(Type::BoundMethod(BoundMethodType::new(
+                    UpcastResult::unstable(Type::BoundMethod(BoundMethodType::from_callable(
                         db,
-                        unspecialized_function(db, method.function(db)),
+                        upcast(db, env, method.func(db), visitor).ty,
                         upcast(db, env, method.self_instance(db), visitor).ty,
                         method.signature_receiver(db),
                     )))
@@ -376,6 +376,17 @@ impl<'db> Type<'db> {
                         db, env, property, visitor,
                     )))
                 }),
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
+                    visit_type(db, ty, visitor, || {
+                        UpcastResult::unstable(Type::KnownInstance(
+                            KnownInstanceType::MethodWrapper(MethodWrapper::new(
+                                db,
+                                upcast(db, env, wrapper.wrapped(db), visitor).ty,
+                                wrapper.kind(db),
+                            )),
+                        ))
+                    })
+                }
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
                     UpcastResult::unstable(
                         upcast_partial(db, env, partial)

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -9,7 +9,7 @@ use crate::{
         ClassType, GenericContext, InferenceFlags, InvalidTypeExpressionError, KnownClass,
         PromotionKind, PromotionMode, StringLiteralType, Type, TypeAliasType, TypeContext,
         TypeMapping, TypeVarNonce, UnionBuilder, VarianceTerm,
-        callable::{CallableTypeKind, CallableTypes},
+        callable::CallableTypes,
         class::NamedTupleSpec,
         constraints::{OwnedConstraintSet, TypeVarSolution},
         dedicated::pydantic::ConfigBoolean,
@@ -95,8 +95,9 @@ pub enum MethodWrapperKind {
 }
 
 impl<'db> MethodWrapper<'db> {
-    /// Construct a method descriptor, retaining precise function and callable representations
-    /// where they already encode descriptor binding.
+    /// Construct a method descriptor, retaining function and callable representations that
+    /// already encode the matching descriptor binding. Other callables need a separate wrapper
+    /// to expose the descriptor's own attributes.
     pub(super) fn wrap(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
@@ -118,14 +119,14 @@ impl<'db> MethodWrapper<'db> {
             {
                 wrapped
             }
-            Type::Callable(callable) => Type::Callable(CallableType::new(
-                db,
-                callable.signatures(db),
-                match kind {
-                    MethodWrapperKind::Classmethod => CallableTypeKind::ClassMethodLike,
-                    MethodWrapperKind::Staticmethod => CallableTypeKind::StaticMethodLike,
-                },
-            )),
+            Type::Callable(callable)
+                if match kind {
+                    MethodWrapperKind::Classmethod => callable.is_classmethod_like(db),
+                    MethodWrapperKind::Staticmethod => callable.is_staticmethod_like(db),
+                } =>
+            {
+                wrapped
+            }
             Type::Union(union) => union.map(db, env, |element| Self::wrap(db, env, *element, kind)),
             Type::TypeAlias(alias) => Self::wrap(db, env, alias.value_type(db), kind),
             _ => Type::KnownInstance(KnownInstanceType::MethodWrapper(Self::new(

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -9,10 +9,11 @@ use crate::{
         ClassType, GenericContext, InferenceFlags, InvalidTypeExpressionError, KnownClass,
         PromotionKind, PromotionMode, StringLiteralType, Type, TypeAliasType, TypeContext,
         TypeMapping, TypeVarNonce, UnionBuilder, VarianceTerm,
-        callable::CallableTypes,
+        callable::{CallableTypeKind, CallableTypes},
         class::NamedTupleSpec,
         constraints::{OwnedConstraintSet, TypeVarSolution},
         dedicated::pydantic::ConfigBoolean,
+        function::FunctionDecorators,
         generics::{Specialization, walk_generic_context},
         newtype::NewType,
         typevar::TypeVarInstance,
@@ -72,7 +73,7 @@ pub struct FunctoolsPartialInstance<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for FunctoolsPartialInstance<'_> {}
 
-/// A method descriptor that retains the object returned by an inner decorator.
+/// A classmethod or staticmethod descriptor that retains the complete wrapped callable.
 ///
 /// The nominal `classmethod[T, P, R]` and `staticmethod[P, R]` types expose only a
 /// callable signature, which cannot preserve the wrapped object's attributes or
@@ -81,28 +82,62 @@ impl get_size2::GetSize for FunctoolsPartialInstance<'_> {}
 pub struct MethodWrapper<'db> {
     #[returns(copy)]
     pub(super) wrapped: Type<'db>,
-    /// The constructor's nominal result, used for the descriptor's own members.
     #[returns(copy)]
-    pub(super) descriptor: Type<'db>,
-    #[returns(copy)]
-    pub(super) kind: MethodWrapperKind<'db>,
+    pub(super) kind: MethodWrapperKind,
 }
 
 impl get_size2::GetSize for MethodWrapper<'_> {}
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-pub enum MethodWrapperKind<'db> {
+pub enum MethodWrapperKind {
     Staticmethod,
     Classmethod,
-    BoundClassmethod(Type<'db>),
 }
 
 impl<'db> MethodWrapper<'db> {
+    /// Construct a method descriptor, retaining precise function and callable representations
+    /// where they already encode descriptor binding.
+    pub(super) fn wrap(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        wrapped: Type<'db>,
+        kind: MethodWrapperKind,
+    ) -> Type<'db> {
+        match wrapped {
+            // Function definitions already record built-in method decorators, including their
+            // consistency across overloads. Keep that representation for overload validation.
+            // A replacement function without this metadata needs its own descriptor.
+            Type::FunctionLiteral(function)
+                if function.has_known_decorator(
+                    db,
+                    match kind {
+                        MethodWrapperKind::Classmethod => FunctionDecorators::CLASSMETHOD,
+                        MethodWrapperKind::Staticmethod => FunctionDecorators::STATICMETHOD,
+                    },
+                ) =>
+            {
+                wrapped
+            }
+            Type::Callable(callable) => Type::Callable(CallableType::new(
+                db,
+                callable.signatures(db),
+                match kind {
+                    MethodWrapperKind::Classmethod => CallableTypeKind::ClassMethodLike,
+                    MethodWrapperKind::Staticmethod => CallableTypeKind::StaticMethodLike,
+                },
+            )),
+            Type::Union(union) => union.map(db, env, |element| Self::wrap(db, env, *element, kind)),
+            Type::TypeAlias(alias) => Self::wrap(db, env, alias.value_type(db), kind),
+            _ => Type::KnownInstance(KnownInstanceType::MethodWrapper(Self::new(
+                db, wrapped, kind,
+            ))),
+        }
+    }
+
     pub(super) fn class(self, db: &'db dyn Db) -> KnownClass {
         match self.kind(db) {
             MethodWrapperKind::Staticmethod => KnownClass::Staticmethod,
             MethodWrapperKind::Classmethod => KnownClass::Classmethod,
-            MethodWrapperKind::BoundClassmethod(_) => KnownClass::MethodType,
         }
     }
 
@@ -111,10 +146,7 @@ impl<'db> MethodWrapper<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
-        match self.kind(db) {
-            MethodWrapperKind::Staticmethod | MethodWrapperKind::Classmethod => self.descriptor(db),
-            MethodWrapperKind::BoundClassmethod(_) => KnownClass::MethodType.to_instance(db, env),
-        }
+        self.class(db).to_instance(db, env)
     }
 
     pub(super) fn callables(
@@ -125,12 +157,6 @@ impl<'db> MethodWrapper<'db> {
         match self.kind(db) {
             MethodWrapperKind::Staticmethod => self.wrapped(db).try_upcast_to_callable(db, env),
             MethodWrapperKind::Classmethod => None,
-            MethodWrapperKind::BoundClassmethod(receiver) => self
-                .wrapped(db)
-                .try_upcast_to_callable(db, env)
-                .map(|callables| {
-                    callables.map(|callable| callable.bind_self(db, env, Some(receiver)))
-                }),
         }
     }
 
@@ -141,19 +167,11 @@ impl<'db> MethodWrapper<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
-        let kind = match self.kind(db) {
-            MethodWrapperKind::BoundClassmethod(receiver) => MethodWrapperKind::BoundClassmethod(
-                receiver.recursive_type_normalized_impl(db, env, div, nested)?,
-            ),
-            kind => kind,
-        };
         Some(Self::new(
             db,
             self.wrapped(db)
                 .recursive_type_normalized_impl(db, env, div, nested)?,
-            self.descriptor(db)
-                .recursive_type_normalized_impl(db, env, div, nested)?,
-            kind,
+            self.kind(db),
         ))
     }
 
@@ -164,19 +182,11 @@ impl<'db> MethodWrapper<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'_, 'db>,
     ) -> Self {
-        let kind = match self.kind(db) {
-            MethodWrapperKind::BoundClassmethod(receiver) => MethodWrapperKind::BoundClassmethod(
-                receiver.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            ),
-            kind => kind,
-        };
         Self::new(
             db,
             self.wrapped(db)
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            self.descriptor(db)
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            kind,
+            self.kind(db),
         )
     }
 }
@@ -343,10 +353,6 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
         }
         KnownInstanceType::MethodWrapper(wrapper) => {
             visitor.visit_type(db, wrapper.wrapped(db));
-            visitor.visit_type(db, wrapper.descriptor(db));
-            if let MethodWrapperKind::BoundClassmethod(receiver) = wrapper.kind(db) {
-                visitor.visit_type(db, receiver);
-            }
         }
     }
 }
@@ -363,12 +369,7 @@ impl<'db> VarianceInferable<'db> for KnownInstanceType<'db> {
                 type_alias.raw_value_type(db).variance_of(db, env, typevar)
             }
             KnownInstanceType::MethodWrapper(wrapper) => {
-                let variance = wrapper.wrapped(db).variance_of(db, env, typevar);
-                if let MethodWrapperKind::BoundClassmethod(receiver) = wrapper.kind(db) {
-                    variance.join(receiver.variance_of(db, env, typevar))
-                } else {
-                    variance
-                }
+                wrapper.wrapped(db).variance_of(db, env, typevar)
             }
             _ => VarianceTerm::BIVARIANT,
         }

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -9,6 +9,7 @@ use crate::{
         ClassType, GenericContext, InferenceFlags, InvalidTypeExpressionError, KnownClass,
         PromotionKind, PromotionMode, StringLiteralType, Type, TypeAliasType, TypeContext,
         TypeMapping, TypeVarNonce, UnionBuilder, VarianceTerm,
+        callable::CallableTypes,
         class::NamedTupleSpec,
         constraints::{OwnedConstraintSet, TypeVarSolution},
         dedicated::pydantic::ConfigBoolean,
@@ -70,6 +71,115 @@ pub struct FunctoolsPartialInstance<'db> {
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for FunctoolsPartialInstance<'_> {}
+
+/// A method descriptor that retains the object returned by an inner decorator.
+///
+/// The nominal `classmethod[T, P, R]` and `staticmethod[P, R]` types expose only a
+/// callable signature, which cannot preserve the wrapped object's attributes or
+/// correlations between its overloads.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct MethodWrapper<'db> {
+    #[returns(copy)]
+    pub(super) wrapped: Type<'db>,
+    /// The constructor's nominal result, used for the descriptor's own members.
+    #[returns(copy)]
+    pub(super) descriptor: Type<'db>,
+    #[returns(copy)]
+    pub(super) kind: MethodWrapperKind<'db>,
+}
+
+impl get_size2::GetSize for MethodWrapper<'_> {}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub enum MethodWrapperKind<'db> {
+    Staticmethod,
+    Classmethod,
+    BoundClassmethod(Type<'db>),
+}
+
+impl<'db> MethodWrapper<'db> {
+    pub(super) fn class(self, db: &'db dyn Db) -> KnownClass {
+        match self.kind(db) {
+            MethodWrapperKind::Staticmethod => KnownClass::Staticmethod,
+            MethodWrapperKind::Classmethod => KnownClass::Classmethod,
+            MethodWrapperKind::BoundClassmethod(_) => KnownClass::MethodType,
+        }
+    }
+
+    pub(super) fn instance_fallback(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Type<'db> {
+        match self.kind(db) {
+            MethodWrapperKind::Staticmethod | MethodWrapperKind::Classmethod => self.descriptor(db),
+            MethodWrapperKind::BoundClassmethod(_) => KnownClass::MethodType.to_instance(db, env),
+        }
+    }
+
+    pub(super) fn callables(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<CallableTypes<'db>> {
+        match self.kind(db) {
+            MethodWrapperKind::Staticmethod => self.wrapped(db).try_upcast_to_callable(db, env),
+            MethodWrapperKind::Classmethod => None,
+            MethodWrapperKind::BoundClassmethod(receiver) => self
+                .wrapped(db)
+                .try_upcast_to_callable(db, env)
+                .map(|callables| {
+                    callables.map(|callable| callable.bind_self(db, env, Some(receiver)))
+                }),
+        }
+    }
+
+    fn recursive_type_normalized_impl(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        let kind = match self.kind(db) {
+            MethodWrapperKind::BoundClassmethod(receiver) => MethodWrapperKind::BoundClassmethod(
+                receiver.recursive_type_normalized_impl(db, env, div, nested)?,
+            ),
+            kind => kind,
+        };
+        Some(Self::new(
+            db,
+            self.wrapped(db)
+                .recursive_type_normalized_impl(db, env, div, nested)?,
+            self.descriptor(db)
+                .recursive_type_normalized_impl(db, env, div, nested)?,
+            kind,
+        ))
+    }
+
+    fn apply_type_mapping_impl(
+        self,
+        db: &'db dyn Db,
+        type_mapping: &TypeMapping<'_, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'_, 'db>,
+    ) -> Self {
+        let kind = match self.kind(db) {
+            MethodWrapperKind::BoundClassmethod(receiver) => MethodWrapperKind::BoundClassmethod(
+                receiver.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            ),
+            kind => kind,
+        };
+        Self::new(
+            db,
+            self.wrapped(db)
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            self.descriptor(db)
+                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            kind,
+        )
+    }
+}
 
 /// Singleton types that are heavily special-cased by ty. Despite its name,
 /// quite a different type to [`super::NominalInstanceType`].
@@ -160,6 +270,9 @@ pub enum KnownInstanceType<'db> {
 
     /// The bound `__call__` attribute of a precise `functools.partial(...)` result.
     FunctoolsPartialCall(FunctoolsPartialInstance<'db>),
+
+    /// A class or static method wrapping a decorated callable, or its bound method.
+    MethodWrapper(MethodWrapper<'db>),
 }
 
 pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
@@ -228,6 +341,13 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
         | KnownInstanceType::FunctoolsPartialCall(partial) => {
             visitor.visit_callable_type(db, partial.partial(db));
         }
+        KnownInstanceType::MethodWrapper(wrapper) => {
+            visitor.visit_type(db, wrapper.wrapped(db));
+            visitor.visit_type(db, wrapper.descriptor(db));
+            if let MethodWrapperKind::BoundClassmethod(receiver) = wrapper.kind(db) {
+                visitor.visit_type(db, receiver);
+            }
+        }
     }
 }
 
@@ -241,6 +361,14 @@ impl<'db> VarianceInferable<'db> for KnownInstanceType<'db> {
         match self {
             KnownInstanceType::TypeAliasType(type_alias) => {
                 type_alias.raw_value_type(db).variance_of(db, env, typevar)
+            }
+            KnownInstanceType::MethodWrapper(wrapper) => {
+                let variance = wrapper.wrapped(db).variance_of(db, env, typevar);
+                if let MethodWrapperKind::BoundClassmethod(receiver) = wrapper.kind(db) {
+                    variance.join(receiver.variance_of(db, env, typevar))
+                } else {
+                    variance
+                }
             }
             _ => VarianceTerm::BIVARIANT,
         }
@@ -303,6 +431,9 @@ impl<'db> KnownInstanceType<'db> {
             Self::FunctoolsPartialCall(partial) => partial
                 .recursive_type_normalized_impl(db, env, div, nested)
                 .map(Self::FunctoolsPartialCall),
+            Self::MethodWrapper(wrapper) => wrapper
+                .recursive_type_normalized_impl(db, env, div, nested)
+                .map(Self::MethodWrapper),
         }
     }
 
@@ -338,6 +469,7 @@ impl<'db> KnownInstanceType<'db> {
             Self::FunctoolsPartial(_) => KnownClass::FunctoolsPartial,
             Self::Range { .. } => KnownClass::Range,
             Self::FunctoolsPartialCall(_) => KnownClass::MethodWrapperType,
+            Self::MethodWrapper(wrapper) => wrapper.class(db),
         }
     }
 
@@ -355,7 +487,11 @@ impl<'db> KnownInstanceType<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
-        self.class(db).to_instance(db, env)
+        if let Self::MethodWrapper(wrapper) = self {
+            wrapper.instance_fallback(db, env)
+        } else {
+            self.class(db).to_instance(db, env)
+        }
     }
 
     /// Return the type denoted by this retained runtime type-expression object.
@@ -462,6 +598,11 @@ impl<'db> KnownInstanceType<'db> {
             KnownInstanceType::Callable(callable_type) => {
                 Type::KnownInstance(KnownInstanceType::Callable(
                     callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                ))
+            }
+            KnownInstanceType::MethodWrapper(wrapper) => {
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(
+                    wrapper.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
             KnownInstanceType::FunctoolsPartial(partial) => {

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -119,6 +119,8 @@ impl<'db> MethodWrapper<'db> {
             {
                 wrapped
             }
+            // These callables already encode the matching descriptor behavior in their kind,
+            // so they do not need another method wrapper.
             Type::Callable(callable)
                 if match kind {
                     MethodWrapperKind::Classmethod => callable.is_classmethod_like(db),

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -869,7 +869,7 @@ pub(super) fn extract_underlying_functions<'db>(
 ) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
     match ty {
         Type::FunctionLiteral(function) => smallvec::smallvec_inline![function],
-        Type::BoundMethod(method) => smallvec::smallvec_inline![method.function(db)],
+        Type::BoundMethod(method) => extract_underlying_functions(db, method.func(db)),
         Type::PropertyInstance(property) => property.getter(db).map_or_else(
             || smallvec::smallvec![],
             |getter| extract_underlying_functions(db, getter),

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -166,10 +166,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 self.check_type_pair(db, source.self_instance(db), target.self_instance(db))
             })
             .and(db, self.constraints, || {
-                self.check_callable_signature_pair(
+                let (Some(source), Some(target)) = (
+                    source.callables(db, self.env),
+                    target.callables(db, self.env),
+                ) else {
+                    return self.never();
+                };
+                self.check_type_pair(
                     db,
-                    source.bound_signatures(db),
-                    target.bound_signatures(db),
+                    source.into_type(db, self.env),
+                    target.into_type(db, self.env),
                 )
             })
     }

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -5,11 +5,10 @@ use ruff_python_ast::name::Name;
 use crate::{
     Db,
     types::{
-        CallableType, KnownClass, LiteralValueType, LiteralValueTypeKind, Parameter, Parameters,
+        CallableTypes, KnownClass, LiteralValueType, LiteralValueTypeKind, Parameter, Parameters,
         PropertyInstanceType, Signature, StringLiteralType, Type, TypeFormType, UnionType,
-        callable::CallableTypeKind, constraints::ConstraintSet, function::FunctionType,
-        known_instance::InternedConstraintSet, relation::TypeRelationChecker,
-        signatures::CallableSignature, visitor,
+        constraints::ConstraintSet, function::FunctionType, known_instance::InternedConstraintSet,
+        relation::TypeRelationChecker, visitor,
     },
 };
 
@@ -17,12 +16,12 @@ use crate::{
 /// on an instance of a class. For example, the expression `Path("a.txt").touch` creates
 /// a bound method object that represents the `Path.touch` method which is bound to the
 /// instance `Path("a.txt")`.
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, constructor=from_callable, heap_size=ruff_memory_usage::heap_size)]
 pub struct BoundMethodType<'db> {
-    /// The function that is being bound. Corresponds to the `__func__` attribute on a
-    /// bound method object
+    /// The callable being bound, exposed as `__func__`. A classmethod can bind a callable
+    /// instance as well as a Python function.
     #[returns(copy)]
-    pub(crate) function: FunctionType<'db>,
+    pub(crate) func: Type<'db>,
     /// The instance on which this method has been called. Corresponds to the `__self__`
     /// attribute on a bound method object
     #[returns(copy)]
@@ -46,20 +45,40 @@ pub(super) fn walk_bound_method_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>
     method: BoundMethodType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_function_type(db, method.function(db));
+    visitor.visit_type(db, method.func(db));
     visitor.visit_type(db, method.self_instance(db));
     visitor.visit_type(db, method.signature_receiver(db));
 }
 
 #[salsa::tracked]
 impl<'db> BoundMethodType<'db> {
+    pub(crate) fn new(
+        db: &'db dyn Db,
+        function: FunctionType<'db>,
+        self_instance: Type<'db>,
+        signature_receiver: Type<'db>,
+    ) -> Self {
+        Self::from_callable(
+            db,
+            Type::FunctionLiteral(function),
+            self_instance,
+            signature_receiver,
+        )
+    }
+
+    /// Returns the underlying Python function, when the bound callable has a function definition.
+    pub(crate) fn function(self, db: &'db dyn Db) -> Option<FunctionType<'db>> {
+        self.func(db).as_function_literal()
+    }
+
     /// Returns the type that replaces any `typing.Self` annotations in the bound method signature.
     /// This is normally the bound-instance type (the type of `self` or `cls`), but if the bound method is
     /// a `@classmethod`, then it should be an instance of that bound-instance type.
     pub(crate) fn typing_self_type(self, db: &'db dyn Db) -> Type<'db> {
         let mut self_instance = self.self_instance(db);
-        let function = self.function(db);
-        if function.is_classmethod(db) {
+        if let Some(function) = self.function(db)
+            && function.is_classmethod(db)
+        {
             let env =
                 ProgramEnvironment::from_scope(function.literal(db).last_definition.body_scope(db));
             self_instance = self_instance
@@ -74,9 +93,9 @@ impl<'db> BoundMethodType<'db> {
         db: &'db dyn Db,
         mut f: impl FnMut(Type<'db>) -> Type<'db>,
     ) -> Self {
-        Self::new(
+        Self::from_callable(
             db,
-            self.function(db),
+            self.func(db),
             f(self.self_instance(db)),
             f(self.signature_receiver(db)),
         )
@@ -88,95 +107,29 @@ impl<'db> BoundMethodType<'db> {
         self_instance: Type<'db>,
         signature_receiver: Type<'db>,
     ) -> Self {
-        Self::new(db, self.function(db), self_instance, signature_receiver)
+        Self::from_callable(db, self.func(db), self_instance, signature_receiver)
     }
 
-    #[salsa::tracked(
-        returns(copy),
-        cycle_initial=|db, _, _| CallableType::bottom(db),
-        heap_size=ruff_memory_usage::heap_size
-    )]
-    pub(crate) fn into_callable_type(self, db: &'db dyn Db) -> CallableType<'db> {
-        let function = self.function(db);
-        let env =
-            ProgramEnvironment::from_scope(function.literal(db).last_definition.body_scope(db));
-        let typing_self_type = self.typing_self_type(db);
-        let receiver_type = self.signature_receiver(db);
-
-        CallableType::new(
-            db,
-            self.bound_signatures_with_receiver(db, &env, receiver_type, typing_self_type),
-            CallableTypeKind::FunctionLike,
-        )
-    }
-
-    /// Converts this bound method into a callable using separate runtime-receiver and `Self` types.
-    pub(crate) fn into_callable_type_with_receiver(
+    pub(crate) fn callables(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        receiver_type: Type<'db>,
-        typing_self_type: Type<'db>,
-    ) -> CallableType<'db> {
-        CallableType::new(
-            db,
-            self.bound_signatures_with_receiver(db, env, receiver_type, typing_self_type),
-            CallableTypeKind::FunctionLike,
-        )
-    }
-
-    /// Shares the signatures retained in the method's interned callable.
-    pub(crate) fn bound_signatures(self, db: &'db dyn Db) -> &'db CallableSignature<'db> {
-        self.into_callable_type(db).signatures(db)
-    }
-
-    fn bound_signatures_with_receiver(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        receiver_type: Type<'db>,
-        typing_self_type: Type<'db>,
-    ) -> CallableSignature<'db> {
-        let function_signature = self.function(db).signature(db);
-
-        let [signature] = function_signature.overloads.as_slice() else {
-            if !function_signature
-                .overloads
-                .iter()
-                .any(Signature::has_explicit_positional_receiver_annotation)
-            {
-                return CallableSignature::from_overloads(function_signature.overloads.iter().map(
-                    |signature| {
-                        signature.bind_self_with_receiver(
-                            db,
-                            env,
-                            Some(receiver_type),
-                            Some(typing_self_type),
-                        )
-                    },
-                ));
-            }
-
-            return CallableSignature::from_overloads(
-                function_signature
-                    .overloads
-                    .iter()
-                    .filter_map(|signature| {
-                        signature.bind_self_if_compatible(db, env, receiver_type, typing_self_type)
-                    })
-                    .flat_map(|signature| signature.overloads),
-            );
-        };
-
-        let specialized = if signature.has_receiver_determined_method_typevar(db, env) {
-            signature.specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
+    ) -> Option<CallableTypes<'db>> {
+        if let Some(function) = self.function(db) {
+            Some(CallableTypes::one(function.into_bound_callable(
+                db,
+                self.signature_receiver(db),
+                self.typing_self_type(db),
+            )))
         } else {
-            None
-        };
-
-        specialized
-            .unwrap_or_else(|| CallableSignature::single(signature.clone()))
-            .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type))
+            self.func(db)
+                .try_upcast_to_callable(db, env)
+                .map(|callables| {
+                    callables.map(|callable| {
+                        callable.bind_self(db, env, Some(self.signature_receiver(db)))
+                    })
+                })
+        }
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -186,9 +139,9 @@ impl<'db> BoundMethodType<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
-        Some(Self::new(
+        Some(Self::from_callable(
             db,
-            self.function(db)
+            self.func(db)
                 .recursive_type_normalized_impl(db, env, div, nested)?,
             self.self_instance(db)
                 .recursive_type_normalized_impl(db, env, div, true)?,
@@ -208,7 +161,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // The receiver exposed by `__self__` is an already-captured value, so it is covariant.
         // However, `Self` can also appear in the remaining parameters, where binding the
         // receiver must still preserve ordinary callable contravariance.
-        self.check_function_pair(db, source.function(db), target.function(db))
+        self.check_type_pair(db, source.func(db), target.func(db))
             .and(db, self.constraints, || {
                 self.check_type_pair(db, source.self_instance(db), target.self_instance(db))
             })

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1012,8 +1012,11 @@ fn method_override_types<'db>(
     superclass_type: Type<'db>,
 ) -> Option<(Type<'db>, Type<'db>)> {
     let (subclass_type, superclass_type) = match (subclass_type, superclass_type) {
-        (Type::BoundMethod(subclass_method), Type::BoundMethod(superclass_method)) => {
-            let superclass_signature = superclass_method.function(db).signature(db);
+        (Type::BoundMethod(subclass_method), Type::BoundMethod(superclass_method))
+            if let Some(subclass_function) = subclass_method.function(db)
+                && let Some(superclass_function) = superclass_method.function(db) =>
+        {
+            let superclass_signature = superclass_function.signature(db);
             let explicit_receiver = match superclass_signature.overloads.as_slice() {
                 [signature] => signature
                     .parameters()
@@ -1040,13 +1043,13 @@ fn method_override_types<'db>(
             // Both signatures describe calls on the subclass. In particular, inherited `Self`
             // annotations refer to the subclass even when the receiver is implicitly annotated.
             (
-                Type::Callable(subclass_method.into_callable_type_with_receiver(
+                Type::Callable(subclass_function.into_bound_callable_with_receiver(
                     db,
                     env,
                     receiver,
                     typing_self_type,
                 )),
-                Type::Callable(superclass_method.into_callable_type_with_receiver(
+                Type::Callable(superclass_function.into_bound_callable_with_receiver(
                     db,
                     env,
                     receiver,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3880,8 +3880,15 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // A `BoundMethod` type includes instances of the same method bound to a
             // subtype/subclass of the self type.
             (Type::BoundMethod(a), Type::BoundMethod(b)) => {
-                let a_function = a.function(db);
-                let b_function = b.function(db);
+                let (Some(a_function), Some(b_function)) = (a.function(db), b.function(db)) else {
+                    return nontrivial_check(self, || {
+                        self.check_type_pair(db, a.func(db), b.func(db)).or(
+                            db,
+                            self.constraints,
+                            || self.check_type_pair(db, a.self_instance(db), b.self_instance(db)),
+                        )
+                    });
+                };
                 if a_function.name(db) != b_function.name(db) {
                     // We typically ask about `BoundMethod` disjointness when we're looking at a
                     // method call on an intersection type like `A & B`. In that case, the same

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1859,6 +1859,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
+            // The read-only `__func__` and `__wrapped__` attributes expose the complete wrapped
+            // object, so its attributes matter here as well as its call signature.
+            (
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(source_wrapper)),
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(target_wrapper)),
+            ) if source_wrapper.kind(db) == target_wrapper.kind(db) => {
+                self.with_recursion_guard(db, source, target, || {
+                    self.check_type_pair(db, source_wrapper.wrapped(db), target_wrapper.wrapped(db))
+                })
+            }
+
             (
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_partial)),
@@ -3456,6 +3467,17 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 self.constraints,
                 !left_sentinel.is_same_sentinel(db, right_sentinel),
             ),
+
+            // Distinct wrapper types can describe the same descriptor when their wrapped types
+            // overlap; they do not necessarily represent distinct objects.
+            (
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(left_wrapper)),
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(right_wrapper)),
+            ) if left_wrapper.kind(db) == right_wrapper.kind(db) => nontrivial_check(self, || {
+                self.with_recursion_guard(db, left, right, || {
+                    self.check_type_pair(db, left_wrapper.wrapped(db), right_wrapper.wrapped(db))
+                })
+            }),
 
             // These types are disjoint whenever their represented objects differ.
             (


### PR DESCRIPTION
## Summary

We now allow cached classmethods to be accessed through generic classes:

```python
from functools import lru_cache
from typing import Generic, TypeVar

T = TypeVar("T")

class Box(Generic[T]):
    @classmethod
    @lru_cache
    def make(cls) -> "Box[T]":
        return cls()

Box.make()  # Previously: invalid-attribute-access.
```

Previously, we recorded `classmethod` and `staticmethod` on the original function type, but lost that binding information when another decorator (`lru-cache`) returned a callable object. We now preserve the complete wrapped callable when constructing these descriptors and use the existing bound-method representation to bind the class argument. (This also retains wrapper attributes such as `cache_clear` and overload-specific return types.)

Closes https://github.com/astral-sh/ty/issues/4431.
