### PR TITLE
[ty] Fix loop-header cycle initialization build failure

### DIFF
--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1547,7 +1547,7 @@ fn loop_header_reachability_impl<'db>(
             // Assignment validity can depend on this header, so avoid inferring it while
             // initializing a cycle.
             DefinitionState::Defined(def)
-                if is_cycle_initial || !is_discarded_dict_key_assignment(db, def) =>
+                if cycle_initial_cache.is_some() || !is_discarded_dict_key_assignment(db, def) =>
             {
                 debug_assert_ne!(
                     def, definition,


### PR DESCRIPTION
`main` fails to compile after #28044 because a loop-header match guard still references the removed `is_cycle_initial` parameter. Check `cycle_initial_cache.is_some()` instead, preserving the guard that skips dictionary-assignment inference during cycle initialization.

## Test plan

Workspace compilation passes for all targets and features. The existing `for`, `while`, and dictionary mdtests pass, covering nested loop deletions and accepted, rejected, and setter-backed dictionary assignments across loop iterations.
