### PR TITLE
[pydoclint] Recognize adjacent structured docstring sections (DOC102)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC102_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC102_google.py
@@ -262,3 +262,14 @@ def add_numbers(b):
         int: The sum of the two numbers.
     """
     return a + b
+
+# OK - https://github.com/astral-sh/ruff/issues/20984
+def documented_return_after_unpunctuated_parameter(bar: int) -> bool:
+    """Do something.
+
+    Args:
+        bar: some argument
+    Returns:
+        bool: some return value
+    """
+    return bar > 0

--- a/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydoclint/DOC201_google.py
@@ -214,3 +214,25 @@ class Spam:
     def __new__(cls) -> 'Spam':
         """New!!"""
         return cls()
+
+# OK - https://github.com/astral-sh/ruff/issues/20984
+def documented_return_after_unpunctuated_parameter(bar: int) -> bool:
+    """Do something.
+
+    Args:
+        bar: some argument
+    Returns:
+        bool: some return value
+    """
+    return bar > 0
+
+# OK - Google argument aliases should not swallow an adjacent Returns section.
+def documented_return_after_keyword_args(**kwargs) -> bool:
+    """Do something.
+
+    Keyword Args:
+        option: some argument
+    Returns:
+        bool: some return value
+    """
+    return True

--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/sections.py
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/sections.py
@@ -630,3 +630,36 @@ def another_valid_google_style_docstring(a: str) -> str:
 
     """
     return a
+
+def canonical_section_name_in_examples():
+    """Don't treat canonical-looking example content as a section.
+
+    Examples:
+        Here is some example text
+    Returns:
+        this is literal example content
+
+    """
+
+def google_argument_alias_followed_by_returns():
+    """Recognize Returns after a Google argument-section alias.
+
+    Keyword Args:
+        option: some argument
+    Returns:
+        bool: some return value
+
+    """
+
+
+def singular_return_followed_by_raises():
+    """Recognize supported singular section aliases.
+
+    Args:
+        value: some argument.
+    Return:
+        bool: some return value
+    Raises:
+        ValueError: bad value
+
+    """

--- a/crates/ruff_linter/src/docstrings/sections.rs
+++ b/crates/ruff_linter/src/docstrings/sections.rs
@@ -474,6 +474,39 @@ fn is_docstring_section(
         return true;
     }
 
+    let verbatim = &line[TextRange::at(indent_size, section_name_size)];
+
+    // Structured peer sections are unambiguous even when the preceding item description
+    // doesn't end in punctuation. Keep the paragraph heuristic for free-form sections
+    // like `Examples`, where section-looking content may be literal example output.
+    let is_structured_peer_transition = previous_section.is_some_and(|previous_section| {
+        previous_section.indent_size == indent_size
+            && section_kind.as_str() == verbatim
+            && matches!(
+                (previous_section.kind, section_kind),
+                (
+                    SectionKind::Args
+                        | SectionKind::Arguments
+                        | SectionKind::KeywordArgs
+                        | SectionKind::KeywordArguments
+                        | SectionKind::OtherArgs
+                        | SectionKind::OtherArguments
+                        | SectionKind::Parameters,
+                    SectionKind::Return
+                        | SectionKind::Returns
+                        | SectionKind::Yield
+                        | SectionKind::Yields
+                        | SectionKind::Raises
+                ) | (
+                    SectionKind::Return
+                        | SectionKind::Returns
+                        | SectionKind::Yield
+                        | SectionKind::Yields,
+                    SectionKind::Raises
+                )
+            )
+    });
+
     // Determine whether the previous line looks like the end of a paragraph.
     let previous_line_looks_like_end_of_paragraph = previous_line.is_none_or(|previous_line| {
         let previous_line = previous_line.trim();
@@ -482,7 +515,7 @@ fn is_docstring_section(
             .any(|char| previous_line.ends_with(char));
         previous_line_ends_with_punctuation || previous_line.is_empty()
     });
-    if !previous_line_looks_like_end_of_paragraph {
+    if !is_structured_peer_transition && !previous_line_looks_like_end_of_paragraph {
         return false;
     }
 
@@ -509,8 +542,6 @@ fn is_docstring_section(
     // However, if the header is an _exact_ match (like `Returns:`, as opposed to `returns:`), then
     // continue to treat it as a section header.
     if let Some(previous_section) = previous_section {
-        let verbatim = &line[TextRange::at(indent_size, section_name_size)];
-
         // If the section is more deeply indented, assume it's a subsection, as in:
         // ```python
         // def func(args: tuple[int]):

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__no-blank-line-after-section_sections.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__no-blank-line-after-section_sections.py.snap
@@ -34,3 +34,54 @@ help: Add blank line after "Returns"
 227 +
 228 |     Raises:
     |
+
+D410 [*] Missing blank line after section ("Keyword Args")
+   --> sections.py:647:5
+    |
+645 |     """Recognize Returns after a Google argument-section alias.
+646 |
+647 |     Keyword Args:
+    |     ^^^^^^^^^^^^
+648 |         option: some argument
+649 |     Returns:
+    |
+help: Add blank line after "Keyword Args"
+    |
+648 |         option: some argument
+649 +
+650 |     Returns:
+    |
+
+D410 [*] Missing blank line after section ("Args")
+   --> sections.py:658:5
+    |
+656 |     """Recognize supported singular section aliases.
+657 |
+658 |     Args:
+    |     ^^^^
+659 |         value: some argument.
+660 |     Return:
+    |
+help: Add blank line after "Args"
+    |
+659 |         value: some argument.
+660 +
+661 |     Return:
+    |
+
+D410 [*] Missing blank line after section ("Return")
+   --> sections.py:660:5
+    |
+658 |     Args:
+659 |         value: some argument.
+660 |     Return:
+    |     ^^^^^^
+661 |         bool: some return value
+662 |     Raises:
+    |
+help: Add blank line after "Return"
+    |
+661 |         bool: some return value
+662 +
+663 |     Raises:
+    |

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__no-blank-line-before-section_sections.py.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__no-blank-line-before-section_sections.py.snap
@@ -48,3 +48,52 @@ help: Add blank line before "Raises"
 227 +
 228 |     Raises:
     |
+
+D411 [*] Missing blank line before section ("Returns")
+   --> sections.py:649:5
+    |
+647 |     Keyword Args:
+648 |         option: some argument
+649 |     Returns:
+    |     ^^^^^^^
+650 |         bool: some return value
+    |
+help: Add blank line before "Returns"
+    |
+648 |         option: some argument
+649 +
+650 |     Returns:
+    |
+
+D411 [*] Missing blank line before section ("Return")
+   --> sections.py:660:5
+    |
+658 |     Args:
+659 |         value: some argument.
+660 |     Return:
+    |     ^^^^^^
+661 |         bool: some return value
+662 |     Raises:
+    |
+help: Add blank line before "Return"
+    |
+659 |         value: some argument.
+660 +
+661 |     Return:
+    |
+
+D411 [*] Missing blank line before section ("Raises")
+   --> sections.py:662:5
+    |
+660 |     Return:
+661 |         bool: some return value
+662 |     Raises:
+    |     ^^^^^^
+663 |         ValueError: bad value
+    |
+help: Add blank line before "Raises"
+    |
+661 |         bool: some return value
+662 +
+663 |     Raises:
+    |


### PR DESCRIPTION
Ruff was treating Returns: like it was still part of Args: when the two sections were right next to each other. That made it throw DOC102 and DOC201 errors even though the Returns: section was there.
I changed the section detection so Ruff can tell when Returns: is actually a new section. I also added tests for that and for a few similar section names.
CI passed.