### PR TITLE
[ty] Preserve uncertain branches during quantification

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/constraint_set_ordering.md
@@ -362,8 +362,8 @@ def get_value(value: GetValue[ConstrainedValue]) -> ConstrainedValue:
     raise NotImplementedError
 
 def typed_dict_union(value: ValueA | ValueB) -> None:
-    # TODO: sometimes: revealed object
-    # revealed: int
+    # TODO: revealed int
+    # revealed: object
     reveal_type(get_value(value))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -3254,7 +3254,9 @@ def _(value: AnyExtraItems | OtherAnyExtraItems) -> None:
     reveal_type(get_bounded_mapping(value))  # revealed: Any
 ```
 
-Rejected common-constraint probes must not affect fallback protocol inference:
+Rejected common-constraint probes must not affect fallback protocol inference. Both mappings below
+contain an `int`, so inference should select the `int` constraint. It currently selects the broader
+`object` constraint instead:
 
 ```py
 from typing import Literal, Protocol, TypeVar, TypedDict
@@ -3275,7 +3277,8 @@ def get_value(value: GetValue[ConstrainedValue]) -> ConstrainedValue:
 
 def takes_str(value: str) -> None: ...
 def _(value: ValueA | ValueB) -> None:
-    reveal_type(get_value(value))  # revealed: int
+    # TODO: revealed int
+    reveal_type(get_value(value))  # revealed: object
     takes_str(get_value(value))  # error: [invalid-argument-type]
 ```
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3267,15 +3267,6 @@ impl NodeId {
         a_and_b.or(storage, not_a_and_not_b)
     }
 
-    /// Returns the `if-then-else` of three BDDs: when `self` evaluates to `true`, it returns what
-    /// `then_node` evaluates to; otherwise it returns what `else_node` evaluates to.
-    fn ite(self, storage: &mut ConstraintSetStorage<'_>, then_node: Self, else_node: Self) -> Self {
-        let if_true = self.and(storage, then_node);
-        let negated = self.negate(storage);
-        let if_false = negated.and(storage, else_node);
-        if_true.or(storage, if_false)
-    }
-
     /// Returns the TDD `if-then-else` of four BDDs: when `self` evaluates to `true`, it returns
     /// what `then_node` evaluates to; when `self` evaluates to `false`, it returns what
     /// `else_node` evaluates to; and `uncertain_node` is included regardless of `self`'s value.
@@ -4879,23 +4870,16 @@ impl InteriorNode {
             ) -> ControlFlow<Self::Break, Self::Result> {
                 let (disposition, constraint) = interior;
                 match disposition {
-                    // If we are keeping this node, absorb the uncertain branch into both the true
-                    // and false branches before constructing the ITE, matching TDD semantics: when
-                    // the constraint holds the result is C ∨ U, and when it doesn't the result is
-                    // D ∨ U.
-                    //
-                    // NB: We cannot use `Node::new` here, because the recursive calls might introduce new
-                    // derived constraints into the result, and those constraints might appear before this
-                    // one in the BDD ordering.
+                    // Preserve the uncertain branch when rebuilding the node. Recursive calls
+                    // can introduce derived constraints earlier in the variable ordering, so
+                    // use `ite_uncertain` rather than constructing a node directly.
                     Disposition::Keep => {
                         let (guard, guard_source_order) =
                             Node::new_constraint(storage, *constraint);
                         let (if_true, if_true_source_order) = if_true;
                         let (if_uncertain, if_uncertain_source_order) = if_uncertain;
                         let (if_false, if_false_source_order) = if_false;
-                        let if_true = if_true.or(storage, if_uncertain);
-                        let if_false = if_false.or(storage, if_uncertain);
-                        let node = guard.ite(storage, if_true, if_false);
+                        let node = guard.ite_uncertain(storage, if_true, if_uncertain, if_false);
                         let left_source_order =
                             storage.ordered_source_order(guard_source_order, if_true_source_order);
                         let right_source_order = storage
@@ -6903,7 +6887,7 @@ class E: ...
     }
 
     #[test]
-    fn constraint_ordering_changes_nested_transitive_solutions() {
+    fn constraint_ordering_preserves_nested_transitive_solutions() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -6949,19 +6933,15 @@ class E: ...
                     .and(storage, list_int_t)
                     .or(storage, bytes_v)
             },
-            // TODO: All permutations should produce the first result. TDD traversal currently
-            // leaks irrelevant positive constraints onto the `V = bytes` alternative.
+            // The unrelated `V = bytes` alternative must not pick up bindings for `T` or `U`.
             [
                 "never=false always=false merged=[T=list[int], U=int, V=bytes] paths=[T=list[int], U=int; V=bytes]",
-                "never=false always=false merged=[T=list[int], U=int, V=bytes] paths=[T=list[int], U=int; T=list[int], V=bytes; V=bytes]",
-                "never=false always=false merged=[T=list[int], U=int, V=bytes] paths=[T=list[int], U=int; U=int, V=bytes; V=bytes]",
-                "never=false always=false merged=[T=list[int] | list[U], U=int, V=bytes] paths=[T=list[int], U=int; T=list[U], V=bytes; V=bytes]",
             ],
         );
     }
 
     #[test]
-    fn constraint_ordering_changes_negated_alternative_solutions() {
+    fn constraint_ordering_preserves_negated_alternative_solutions() {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -6999,13 +6979,9 @@ class E: ...
                     .negate(storage)
                     .or(storage, bytes_u)
             },
-            // TODO: All permutations should produce the first result. A satisfied alternative
-            // should not infer `T` from unrelated positive decisions made earlier in a BDD path.
-            [
-                "never=false always=false merged=[U=bytes] paths=[; U=bytes]",
-                "never=false always=false merged=[T=str, U=bytes] paths=[; T=str, U=bytes; U=bytes]",
-                "never=false always=false merged=[T=int, U=bytes] paths=[; T=int, U=bytes; U=bytes]",
-            ],
+            // A satisfied alternative must not infer `T` from unrelated positive decisions
+            // made earlier in a TDD path.
+            ["never=false always=false merged=[U=bytes] paths=[; U=bytes]"],
         );
     }
 


### PR DESCRIPTION
Quantification distributes a constraint node's uncertain branch into its true and false branches when rebuilding retained nodes. Although this preserves the Boolean result, it can introduce irrelevant positive constraints into solution paths and make inferred solutions depend on constraint ordering.

Rebuild these nodes with the existing TDD-aware `ite_uncertain` helper so that the uncertain branch is preserved, and remove the now-unused binary `ite` helper. This follows up on #28042.

Two constraint-ordering unit tests now produce the same expected solutions for every permutation. The existing TypedDict protocol-inference case also becomes stable, but consistently selects the broader `object` constraint instead of alternating between `int` and `object`; the mdtests document that remaining inference limitation.

Overall this significantly reduces wobble (total wobbling tests go from 36 to 23); unfortunately in some cases visible in mdtests that resolves the wobble in the wrong direction for the normal constraint ordering, but those look like cases where we need an orthogonal fix.

## Test plan

Strengthen the existing permutation tests for nested transitive constraints and negated alternatives to reject irrelevant bindings. Update the two existing TypedDict mdtest assertions to document the stable result; no new mdtest scenarios are added.

The semantic suite passes. A comparison against the base revision across nine constraint orders finds no new wobbling assertion sites or checker panics, with wobbling sites decreasing from 36 to 23. The descriptor mdtests also pass for both revisions under all masks from 0 through 31 and reversed ordering.
