### PR TITLE
[ty] Stabilize condition truthiness during cyclic inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/while_loop.md
@@ -469,6 +469,90 @@ while random():
     reveal_type(y)  # revealed: Literal[1, 2]
 ```
 
+### Loop increments guarded by chained comparisons converge
+
+A negated comparison chain validates an increment before the loop updates its offset. Inference
+converges even though the guard depends on the value added to the loop variable.
+
+```py
+def advance(data: bytes, offset: int) -> None:
+    while offset < len(data):
+        byte = data[offset]
+        if byte == 0:
+            return
+        step = byte & 15
+        if not 1 <= step <= 8:
+            raise ValueError
+        offset += step
+        # TODO: The offset should retain its `int` type.
+        reveal_type(offset)  # revealed: int | Unknown
+```
+
+### Loop updates guarded by compound conditions converge
+
+Type checks and a negated comparison chain validate a record's size before advancing the offset.
+Combining these checks with `or` preserves the integer type of the updated offset.
+
+```py
+def read_record(offset: int) -> tuple[int | None, int | None]:
+    return 1, 1
+
+def read_records(offset: int, end: int) -> None:
+    while offset < end:
+        value, size = read_record(offset)
+        if not isinstance(value, int) or not isinstance(size, int) or not 0 <= size <= end - offset:
+            raise ValueError
+        offset += size
+        reveal_type(offset)  # revealed: int
+```
+
+### Worklists guarded by chained comparisons converge
+
+A chained comparison guards both extending a worklist and inserting into a set. The set's inferred
+element type remains `str` as entries are added and queued for later loop iterations.
+
+```py
+def visit(start: str, height: int) -> None:
+    columns = "abc"
+    column = columns.index(start[0])
+    row = int(start[1:]) - 1
+    visited = {start}
+    pending = [(column, row)]
+    while pending:
+        current_column, current_row = pending.pop()
+        for x, y in ((current_column, current_row - 1),):
+            if not 0 <= y < height:
+                continue
+            visited.add(f"{columns[x]}{y + 1}")
+            pending.append((x, y))
+            reveal_type(visited)  # revealed: set[str]
+```
+
+### Conditional attribute updates converge
+
+Each batch depends on an instance attribute that is updated from the last item in the batch. The
+condition and the attribute's type depend on each other across loop iterations. Inference converges,
+and the condition narrows the assigned value to a non-empty `str`.
+
+```py
+class Inventory:
+    after: str | None
+
+    def next_batch(self, after: object) -> "list[Inventory]":
+        return []
+
+    def iterate(self):
+        while True:
+            item = None
+            batch = self.next_batch(self.after)
+            assert batch
+            for item in batch:
+                pass
+            if item and item.after:
+                self.after = item.after
+                reveal_type(self.after)  # revealed: str & ~AlwaysFalsy
+```
+
 ### Monotonic widening can keep stale loopback bindings reachable
 
 ```py

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1862,6 +1862,17 @@ pub(crate) fn analyze_condition_expression(
 #[salsa::tracked(
     returns(copy),
     cycle_initial = |_, _, _| Truthiness::Ambiguous,
+    cycle_fn = |_, cycle: &salsa::Cycle, previous: &Truthiness, result: Truthiness, _| {
+        // A condition can control whether one of its own inputs is reachable. Expression inference
+        // can lose its previous result when it ceases to be a cycle head, so its type widening alone
+        // does not ensure that the condition's truthiness converges. Delay widening here to avoid
+        // retaining imprecise results from the first few iterations.
+        if cycle.iteration() > crate::TAINTED_CYCLES && *previous != result {
+            Truthiness::Ambiguous
+        } else {
+            result
+        }
+    },
     heap_size = get_size2::GetSize::get_heap_size
 )]
 fn analyze_condition<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Truthiness {


### PR DESCRIPTION
Fix cycle-iteration panics in loops whose conditions depend on bindings that those same conditions make reachable. Expression inference can lose its previous result when its role in a cycle changes, allowing condition truthiness to keep oscillating.

Add delayed widening to `analyze_condition`: after the initial cycle iterations, conflicting truthiness results become `Ambiguous`. This gives condition analysis its own convergence rule while allowing early results to become more precise.

Fixes astral-sh/ty#4427.
Fixes astral-sh/ty#4429.

## Test plan

Add regression mdtests for conditional attribute writeback, byte-offset increments guarded by comparison chains, combined type-and-range checks, and guarded worklist/set updates. Each example reproduces a cycle-iteration panic without the recovery callback. The tests also check retained narrowing and collection element types; the byte-offset case records a remaining `int | Unknown` precision limitation with a TODO.
