### PR TITLE
[ty] Make playground configuration discovery explicit

### DIFF
--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -932,10 +932,12 @@ mod tests {
     use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf, TestSystem};
     use ruff_db::testing::assert_function_query_was_not_run_by_name;
     use ruff_python_trivia::textwrap::dedent;
+    use ruff_ranged_value::ValueSource;
     use ty_module_resolver::list_modules;
     use ty_python_semantic::Db as _;
 
     use crate::db::testing::TestDb;
+    use crate::metadata::Options;
     use crate::watch::ChangeEvent;
     use crate::{Db, ProjectDatabase, ProjectMetadata, UseUv};
 
@@ -1005,6 +1007,82 @@ mod tests {
         fs.write_file_all(&script, ordinary)?;
         db.apply_changes(&[ChangeEvent::file_content_changed(script)]);
         assert_eq!(db.check().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn fixed_options_ignore_configuration_during_rescans() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let fs = system.memory_file_system().clone();
+        let root = SystemPathBuf::from("/project");
+        let main = root.join("main.py");
+        let user_configuration = SystemPathBuf::from("/config");
+        system
+            .in_memory()
+            .set_user_configuration_directory(Some(user_configuration.clone()));
+        fs.write_file_all(&main, "import nonexistent\nx: int = 'not an int'\n")?;
+
+        let options =
+            Options::from_toml_str("[rules]\nunresolved-import = 'ignore'\n", ValueSource::Cli)?;
+        let metadata = ProjectMetadata::from_fixed_options(options, root.clone());
+        let mut db = ProjectDatabase::fallible(metadata, system)?;
+        assert_eq!(db.check().len(), 1);
+
+        // Rescans synchronize files without loading project, ancestor, or user configuration.
+        for configuration in [
+            root.join("ty.toml"),
+            SystemPathBuf::from("/ty.toml"),
+            user_configuration.join("ty/ty.toml"),
+        ] {
+            fs.write_file_all(&configuration, "[rules]\ninvalid-assignment = 'ignore'\n")?;
+            db.apply_changes(&[ChangeEvent::Rescan]);
+            assert_eq!(db.project().root(&db), root.as_path());
+            let diagnostics = db.check();
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
+            fs.remove_file(&configuration)?;
+        }
+
+        // Fixed configuration still permits ordinary source changes to invalidate diagnostics.
+        fs.write_file_all(&main, "import nonexistent\nx: int = 1\n")?;
+        db.apply_changes(&[ChangeEvent::file_content_changed(main)]);
+        assert!(db.check().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_configuration_reloads_only_the_selected_file() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let fs = system.memory_file_system().clone();
+        let root = SystemPathBuf::from("/project");
+        let selected = SystemPathBuf::from("/config/selected.toml");
+        let ambient = root.join("ty.toml");
+        fs.write_files_all([
+            (root.join("main.py"), "x: int = 'not an int'\n"),
+            (selected.clone(), "[rules]\ninvalid-assignment = 'ignore'\n"),
+            (ambient.clone(), "[rules]\ninvalid-assignment = 'error'\n"),
+        ])?;
+        let metadata = ProjectMetadata::from_config_file(selected.clone(), &root, &system)?;
+        let mut db = ProjectDatabase::fallible(metadata, system)?;
+        assert!(db.check().is_empty());
+
+        // Ambient configuration is ignored, including after a full filesystem rescan.
+        fs.write_file_all(&ambient, "[rules]\ninvalid-assignment = 'warn'\n")?;
+        let changes = db.apply_changes(&[ChangeEvent::file_content_changed(ambient)]);
+        assert!(!changes.project_changed());
+        assert!(db.check().is_empty());
+        db.apply_changes(&[ChangeEvent::Rescan]);
+        assert!(db.check().is_empty());
+
+        fs.write_file_all(&selected, "[rules]\ninvalid-assignment = 'error'\n")?;
+        let changes = db.apply_changes(&[ChangeEvent::file_content_changed(selected)]);
+        assert!(changes.project_changed());
+        assert_eq!(db.project().root(&db), root.as_path());
+        let diagnostics = db.check();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].id().as_str(), "invalid-assignment");
 
         Ok(())
     }

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -1025,7 +1025,7 @@ mod tests {
 
         let options =
             Options::from_toml_str("[rules]\nunresolved-import = 'ignore'\n", ValueSource::Cli)?;
-        let metadata = ProjectMetadata::from_fixed_options(options, root.clone());
+        let metadata = ProjectMetadata::from_fixed_options(options, &root);
         let mut db = ProjectDatabase::fallible(metadata, system)?;
         assert_eq!(db.check().len(), 1);
 

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -345,7 +345,7 @@ impl ProjectDatabase {
                 .unwrap_or(&project_root);
             let metadata = project.metadata(self);
             if metadata.use_uv().workspace_discovery_enabled()
-                && metadata.config_file_override().is_none()
+                && metadata.uses_configuration_discovery()
             {
                 result.project_sync_path = Some(path.to_path_buf());
             } else {
@@ -448,7 +448,7 @@ struct ConfigurationPaths {
 impl ConfigurationPaths {
     fn from_metadata(metadata: &ProjectMetadata) -> Self {
         Self {
-            normal_discovery: metadata.config_file_override().is_none(),
+            normal_discovery: metadata.uses_configuration_discovery(),
             extra: metadata
                 .extra_configuration_paths()
                 .map(SystemPath::to_path_buf)

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -117,7 +117,7 @@ pub struct Project {
 
     /// Diagnostics that were generated when resolving the project settings.
     #[returns(deref)]
-    settings_diagnostics: Vec<OptionDiagnostic>,
+    pub settings_diagnostics: Vec<OptionDiagnostic>,
 
     /// The mode in which the project should be checked.
     ///

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -496,6 +496,11 @@ impl ProjectMetadata {
         }
     }
 
+    /// Replaces all higher-precedence options previously applied to this project.
+    pub fn replace_override_options(&mut self, options: Options) {
+        self.override_options = Some(Box::new(options));
+    }
+
     pub(crate) fn environment(&self) -> &ProjectEnvironment {
         &self.environment
     }

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -96,18 +96,11 @@ impl ProjectMetadata {
     ///
     /// Project, user, and inline script configuration are ignored, including after file
     /// changes and rescans. Options can be replaced with [`Self::replace_override_options`].
-    pub fn from_fixed_options(options: Options, root: SystemPathBuf) -> Self {
+    pub fn from_fixed_options(options: Options, root: &SystemPath) -> Self {
         Self {
-            name: ProjectName::new(root.file_name().unwrap_or("root")),
-            root,
-            options: Options::default(),
-            uv_workspace_options: None,
             override_options: Some(Box::new(options)),
-            user_configuration: None,
-            fallback_options: None,
             configuration_source: ConfigurationSource::Fixed,
-            environment: ProjectEnvironment::default(),
-            use_uv: UseUv::Off,
+            ..Self::new(root.file_name().unwrap_or("root"), root.to_path_buf())
         }
     }
 

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -42,9 +42,8 @@ pub struct ProjectMetadata {
     override_options: Option<Box<Options>>,
 
     /// The raw (unmerged, unresolved) options from the project's configuration.
-    /// When [`Self::config_file_override`] is `None`, then these are the options from the
-    /// project's `ty.toml` or `pyproject.toml`. The options come from
-    /// the file specified by [`Self::config_file_override`] if it is `Some` (e.g. when using `--config-file <path>`).
+    /// These come from discovery or an explicit configuration file, and are empty when
+    /// the caller supplies fixed options through [`Self::from_fixed_options`].
     options: Options,
 
     /// The Python version and interpreter path derived from uv workspace metadata.
@@ -64,12 +63,10 @@ pub struct ProjectMetadata {
     #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
     fallback_options: Option<Box<Options>>,
 
-    /// The explicit configuration file that replaces normal project discovery.
-    ///
-    /// Can be specified using `--config-file <path>`. When `Some`, [`Self::options`] were loaded from this file
-    /// instead of from the project's `pyproject.toml` or `ty.toml` file.
-    #[cfg_attr(test, serde(skip_serializing_if = "Option::is_none"))]
-    config_file_override: Option<SystemPathBuf>,
+    /// Determines whether configuration is discovered, loaded from an explicit file, or
+    /// supplied entirely by the caller. This policy is preserved when files change.
+    #[cfg_attr(test, serde(skip_serializing_if = "ConfigurationSource::is_discovery"))]
+    configuration_source: ConfigurationSource,
 
     #[cfg_attr(test, serde(skip))]
     environment: ProjectEnvironment,
@@ -89,7 +86,26 @@ impl ProjectMetadata {
             override_options: None,
             user_configuration: None,
             fallback_options: None,
-            config_file_override: None,
+            configuration_source: ConfigurationSource::Discovery,
+            environment: ProjectEnvironment::default(),
+            use_uv: UseUv::Off,
+        }
+    }
+
+    /// Creates a project whose options are supplied entirely by the caller.
+    ///
+    /// Project, user, and inline script configuration are ignored, including after file
+    /// changes and rescans. Options can be replaced with [`Self::replace_override_options`].
+    pub fn from_fixed_options(options: Options, root: SystemPathBuf) -> Self {
+        Self {
+            name: ProjectName::new(root.file_name().unwrap_or("root")),
+            root,
+            options: Options::default(),
+            uv_workspace_options: None,
+            override_options: Some(Box::new(options)),
+            user_configuration: None,
+            fallback_options: None,
+            configuration_source: ConfigurationSource::Fixed,
             environment: ProjectEnvironment::default(),
             use_uv: UseUv::Off,
         }
@@ -129,7 +145,7 @@ impl ProjectMetadata {
             override_options: None,
             user_configuration: None,
             fallback_options: None,
-            config_file_override: Some(path),
+            configuration_source: ConfigurationSource::File(path),
             environment: ProjectEnvironment::default(),
             use_uv,
         })
@@ -177,7 +193,7 @@ impl ProjectMetadata {
             override_options: None,
             user_configuration: None,
             fallback_options: None,
-            config_file_override: None,
+            configuration_source: ConfigurationSource::Discovery,
             environment: ProjectEnvironment::default(),
             use_uv: UseUv::Off,
         })
@@ -423,16 +439,19 @@ impl ProjectMetadata {
         path: &SystemPath,
         environment: ProjectEnvironment,
     ) -> Result<Self, ProjectMetadataError> {
-        let mut metadata = if let Some(config_file) = self.config_file_override() {
-            Self::from_config_file_with_uv(
-                config_file.to_path_buf(),
+        let mut metadata = match &self.configuration_source {
+            ConfigurationSource::Discovery => {
+                Self::discover_with_uv_workspace(path, system, environment)?
+                    .with_use_uv(self.use_uv)
+            }
+            ConfigurationSource::File(config_file) => Self::from_config_file_with_uv(
+                config_file.clone(),
                 self.root(),
                 system,
                 self.use_uv,
             )?
-            .with_environment(environment)
-        } else {
-            Self::discover_with_uv_workspace(path, system, environment)?.with_use_uv(self.use_uv)
+            .with_environment(environment),
+            ConfigurationSource::Fixed => return Ok(self.clone()),
         };
 
         metadata.override_options.clone_from(&self.override_options);
@@ -463,7 +482,19 @@ impl ProjectMetadata {
 
     /// Returns the explicit configuration file that replaces normal project discovery, if any.
     pub(crate) fn config_file_override(&self) -> Option<&SystemPath> {
-        self.config_file_override.as_deref()
+        match &self.configuration_source {
+            ConfigurationSource::File(path) => Some(path),
+            ConfigurationSource::Discovery | ConfigurationSource::Fixed => None,
+        }
+    }
+
+    /// Returns whether configuration files and inline script metadata can supply options.
+    pub fn uses_configuration_files(&self) -> bool {
+        !matches!(self.configuration_source, ConfigurationSource::Fixed)
+    }
+
+    pub(crate) fn uses_configuration_discovery(&self) -> bool {
+        self.configuration_source.is_discovery()
     }
 
     /// Returns configuration paths outside normal project discovery that should be watched.
@@ -582,6 +613,10 @@ impl ProjectMetadata {
         &mut self,
         system: &dyn System,
     ) -> Result<(), ConfigurationFileError> {
+        if !self.uses_configuration_files() {
+            return Ok(());
+        }
+
         self.user_configuration = None;
 
         if let Some(user) = ConfigurationFile::user(system)? {
@@ -622,6 +657,20 @@ impl ProjectMetadata {
             metadata: self,
             options,
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
+#[cfg_attr(test, derive(serde::Serialize))]
+enum ConfigurationSource {
+    Discovery,
+    File(SystemPathBuf),
+    Fixed,
+}
+
+impl ConfigurationSource {
+    fn is_discovery(&self) -> bool {
+        matches!(self, Self::Discovery)
     }
 }
 

--- a/crates/ty_project/src/script.rs
+++ b/crates/ty_project/src/script.rs
@@ -100,6 +100,11 @@ pub(crate) fn script(db: &dyn Db, file: File) -> Option<Script<'_>> {
         return None;
     }
 
+    let project_metadata = db.project().metadata(db);
+    if !project_metadata.uses_configuration_files() {
+        return None;
+    }
+
     let mut diagnostics = ScriptConfigurationDiagnostics::default();
     let metadata = parse_script_metadata(file, tag, &mut diagnostics);
     let environment = script_environment(db, file);
@@ -115,8 +120,6 @@ pub(crate) fn script(db: &dyn Db, file: File) -> Option<Script<'_>> {
         .and_then(|path| path.parent())
         .unwrap_or_else(|| db.system().current_directory());
     let context = OptionsContext::Script(configuration_root);
-
-    let project_metadata = db.project().metadata(db);
 
     let options = resolve_script_options(
         project_metadata,

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -115,27 +115,24 @@ pub struct Workspace {
 
 #[wasm_bindgen]
 impl Workspace {
+    /// Creates a workspace with defaults that can be overridden by configuration files.
     #[wasm_bindgen(constructor)]
     pub fn new(
         root: &str,
         position_encoding: PositionEncoding,
-        options: JsValue,
+        default_options: JsValue,
     ) -> Result<Workspace, Error> {
-        let options = Options::deserialize_with(
+        let default_options = Options::deserialize_with(
             ValueSource::Cli,
-            serde_wasm_bindgen::Deserializer::from(options),
+            serde_wasm_bindgen::Deserializer::from(default_options),
         )
         .map_err(into_error)?;
 
         let system = WasmSystem::new(SystemPath::new(root));
 
-        let project = ProjectMetadata::from_options(
-            options,
-            SystemPathBuf::from(root),
-            None,
-            &FallibleStrategy,
-        )
-        .map_err(into_error)?;
+        let mut project =
+            ProjectMetadata::discover(SystemPath::new(root), &system).map_err(into_error)?;
+        project.apply_fallback_options(default_options);
 
         let mut db = ProjectDatabase::fallible(project, system.clone()).map_err(into_error)?;
 
@@ -150,6 +147,7 @@ impl Workspace {
         })
     }
 
+    /// Replaces the explicit options, which take precedence over configuration files and defaults.
     #[wasm_bindgen(js_name = "updateOptions")]
     pub fn update_options(&mut self, options: JsValue) -> Result<(), Error> {
         let options = Options::deserialize_with(
@@ -158,36 +156,50 @@ impl Workspace {
         )
         .map_err(into_error)?;
 
-        let project = ProjectMetadata::from_options(
-            options,
-            self.db.project().root(&self.db).to_path_buf(),
-            None,
-            &FallibleStrategy,
-        )
-        .map_err(into_error)?;
+        let mut project = self.db.project().metadata(&self.db).clone();
+        project.replace_override_options(options);
 
-        let merged_options = project.to_merged_options();
-        let (program_settings, program_settings_diagnostics) = merged_options
-            .to_program_settings(&self.system, self.db.vendored(), &FallibleStrategy)
-            .map_err(into_error)?;
-        self.db
-            .project()
-            .update_program(&mut self.db, program_settings);
+        let settings = (|| {
+            let merged_options = project.to_merged_options();
+            let (program_settings, program_settings_diagnostics) = merged_options
+                .to_program_settings(&self.system, self.db.vendored(), &FallibleStrategy)
+                .map_err(into_error)?;
 
-        let (settings, mut settings_diagnostics) = merged_options
-            .to_settings(&self.db, &FallibleStrategy)
-            .map_err(into_error)?;
-        settings_diagnostics.extend(
-            program_settings_diagnostics
-                .into_iter()
-                .map(|diagnostic| diagnostic.into_diagnostic(&self.db)),
-        );
+            let (settings, mut settings_diagnostics) = merged_options
+                .to_settings(&self.db, &FallibleStrategy)
+                .map_err(into_error)?;
+            settings_diagnostics.extend(
+                program_settings_diagnostics
+                    .into_iter()
+                    .map(|diagnostic| diagnostic.into_diagnostic(&self.db)),
+            );
 
-        self.db
-            .project()
-            .reload(&mut self.db, project, Some(settings), settings_diagnostics);
+            Ok((program_settings, settings, settings_diagnostics))
+        })();
 
-        Ok(())
+        match settings {
+            Ok((program_settings, settings, settings_diagnostics)) => {
+                self.db
+                    .project()
+                    .update_program(&mut self.db, program_settings);
+                self.db.project().reload(
+                    &mut self.db,
+                    project,
+                    Some(settings),
+                    settings_diagnostics,
+                );
+                Ok(())
+            }
+            Err(error) => {
+                // Remember the parsed JSON options even if TOML settings are invalid. Repairing
+                // the TOML must not restore an override that was removed in the meantime.
+                let diagnostics = self.db.project().settings_diagnostics(&self.db).to_vec();
+                self.db
+                    .project()
+                    .reload(&mut self.db, project, None, diagnostics);
+                Err(error)
+            }
+        }
     }
 
     #[wasm_bindgen(js_name = "openFile")]

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -113,31 +113,15 @@ pub struct Workspace {
     system: WasmSystem,
 }
 
-#[wasm_bindgen]
 impl Workspace {
-    /// Creates a workspace with defaults that can be overridden by configuration files.
-    #[wasm_bindgen(constructor)]
-    pub fn new(
-        root: &str,
+    fn from_metadata(
+        project: ProjectMetadata,
         position_encoding: PositionEncoding,
-        default_options: JsValue,
-    ) -> Result<Workspace, Error> {
-        let default_options = Options::deserialize_with(
-            ValueSource::Cli,
-            serde_wasm_bindgen::Deserializer::from(default_options),
-        )
-        .map_err(into_error)?;
-
-        let system = WasmSystem::new(SystemPath::new(root));
-
-        let mut project =
-            ProjectMetadata::discover(SystemPath::new(root), &system).map_err(into_error)?;
-        project.apply_fallback_options(default_options);
-
+    ) -> Result<Self, Error> {
+        let system = WasmSystem::new(project.root());
         let mut db = ProjectDatabase::fallible(project, system.clone()).map_err(into_error)?;
 
-        // By default, it will check all files in the project but we only want to check the open
-        // files in the playground.
+        // A workspace checks the files explicitly opened by its caller.
         db.set_check_mode(CheckMode::OpenFiles);
 
         Ok(Self {
@@ -146,18 +130,51 @@ impl Workspace {
             system,
         })
     }
+}
 
-    /// Replaces the explicit options, which take precedence over configuration files and defaults.
+#[wasm_bindgen]
+impl Workspace {
+    /// Creates a workspace with caller-supplied options.
+    ///
+    /// Configuration files and inline script metadata are ignored. Use `updateOptions`
+    /// to replace these options, or `discover` to create a workspace that loads configuration.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        root: &str,
+        position_encoding: PositionEncoding,
+        options: JsValue,
+    ) -> Result<Workspace, Error> {
+        let project = ProjectMetadata::from_fixed_options(
+            deserialize_options(options)?,
+            SystemPathBuf::from(root),
+        );
+        Self::from_metadata(project, position_encoding)
+    }
+
+    /// Creates a workspace that discovers configuration as files are opened and changed.
+    ///
+    /// Configuration files and inline script metadata take precedence over `default_options`.
+    /// Options supplied through `updateOptions` take precedence over both.
+    pub fn discover(
+        root: &str,
+        position_encoding: PositionEncoding,
+        default_options: JsValue,
+    ) -> Result<Workspace, Error> {
+        let root = SystemPath::new(root);
+        // The filesystem is initially empty. Discovery starts when configuration files are opened.
+        let mut project =
+            ProjectMetadata::new(root.file_name().unwrap_or("root"), root.to_path_buf());
+        project.apply_fallback_options(deserialize_options(default_options)?);
+        Self::from_metadata(project, position_encoding)
+    }
+
+    /// Replaces the caller-supplied options.
+    ///
+    /// In a workspace created with `discover`, these override configuration files and defaults.
     #[wasm_bindgen(js_name = "updateOptions")]
     pub fn update_options(&mut self, options: JsValue) -> Result<(), Error> {
-        let options = Options::deserialize_with(
-            ValueSource::Cli,
-            serde_wasm_bindgen::Deserializer::from(options),
-        )
-        .map_err(into_error)?;
-
         let mut project = self.db.project().metadata(&self.db).clone();
-        project.replace_override_options(options);
+        project.replace_override_options(deserialize_options(options)?);
 
         let settings = (|| {
             let merged_options = project.to_merged_options();
@@ -190,8 +207,8 @@ impl Workspace {
                 );
                 Ok(())
             }
-            Err(error) => {
-                // Remember the parsed JSON options even if TOML settings are invalid. Repairing
+            Err(error) if project.uses_configuration_files() => {
+                // Remember the explicit options even if TOML settings are invalid. Repairing
                 // the TOML must not restore an override that was removed in the meantime.
                 let diagnostics = self.db.project().settings_diagnostics(&self.db).to_vec();
                 self.db
@@ -199,6 +216,7 @@ impl Workspace {
                     .reload(&mut self.db, project, None, diagnostics);
                 Err(error)
             }
+            Err(error) => Err(error),
         }
     }
 
@@ -835,6 +853,14 @@ impl Workspace {
             path: vendored_path.to_path_buf().into(),
         })
     }
+}
+
+fn deserialize_options(options: JsValue) -> Result<Options, Error> {
+    Options::deserialize_with(
+        ValueSource::Cli,
+        serde_wasm_bindgen::Deserializer::from(options),
+    )
+    .map_err(into_error)
 }
 
 pub(crate) fn into_error<E: std::fmt::Display>(err: E) -> Error {

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -146,7 +146,7 @@ impl Workspace {
     ) -> Result<Workspace, Error> {
         let project = ProjectMetadata::from_fixed_options(
             deserialize_options(options)?,
-            SystemPathBuf::from(root),
+            SystemPath::new(root),
         );
         Self::from_metadata(project, position_encoding)
     }

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -1,6 +1,8 @@
 #![cfg(target_arch = "wasm32")]
 
-use ty_wasm::{DiagnosticTag, Position, PositionEncoding, SubDiagnosticSeverity, Workspace};
+use ty_wasm::{
+    DiagnosticTag, FileHandle, Position, PositionEncoding, SubDiagnosticSeverity, Workspace,
+};
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[wasm_bindgen_test]
@@ -59,6 +61,190 @@ fn check() {
         sub_diagnostics
             .iter()
             .all(|sub_diagnostic| sub_diagnostic.annotations.is_empty())
+    );
+}
+
+#[wasm_bindgen_test]
+fn restored_pyproject_preserves_defaults() {
+    ty_wasm::before_main();
+
+    let mut workspace = Workspace::new(
+        "/",
+        PositionEncoding::Utf32,
+        js_sys::JSON::parse(
+            r#"{
+                "environment": {"python-version": "3.14"},
+                "rules": {"undefined-reveal": "ignore"}
+            }"#,
+        )
+        .unwrap(),
+    )
+    .expect("Workspace to be created");
+    let file = workspace
+        .open_file(
+            "main.py",
+            "import sys\nreveal_type(sys.version_info.minor)\n",
+        )
+        .expect("File to be opened");
+    let pyproject = workspace
+        .open_file("pyproject.toml", "[project]\nrequires-python = '>=3.11'\n")
+        .expect("Configuration to be opened");
+
+    // Restoring a workspace without ty.json clears explicit options after opening its files.
+    workspace
+        .update_options(js_sys::JSON::parse("{}").unwrap())
+        .expect("Options to be updated");
+    assert_python_version(&workspace, &file, 11);
+
+    // A whitespace edit preserves both the configured version and unrelated defaults.
+    workspace
+        .update_file(&pyproject, "[project]\nrequires-python = '>=3.11'\n\n")
+        .expect("Configuration to be updated");
+    assert_python_version(&workspace, &file, 11);
+
+    workspace
+        .update_file(&pyproject, "[project]\nrequires-python = '>=3.12'\n")
+        .expect("Configuration to be updated");
+    assert_python_version(&workspace, &file, 12);
+
+    // Removing configuration restores the fallback version.
+    workspace
+        .close_file(pyproject)
+        .expect("Configuration to be removed");
+    assert_python_version(&workspace, &file, 14);
+}
+
+#[wasm_bindgen_test]
+fn explicit_options_override_configuration() {
+    ty_wasm::before_main();
+
+    // JSON options have the same precedence regardless of the restored file order.
+    for options_first in [true, false] {
+        let mut workspace = Workspace::new(
+            "/",
+            PositionEncoding::Utf32,
+            js_sys::JSON::parse(
+                r#"{
+                    "environment": {"python-version": "3.14"},
+                    "rules": {"undefined-reveal": "ignore"}
+                }"#,
+            )
+            .unwrap(),
+        )
+        .expect("Workspace to be created");
+        let file = workspace
+            .open_file(
+                "main.py",
+                "import sys\nreveal_type(sys.version_info.minor)\n",
+            )
+            .expect("File to be opened");
+        let options =
+            js_sys::JSON::parse(r#"{"environment": {"python-version": "3.10"}}"#).unwrap();
+        if options_first {
+            workspace
+                .update_options(options.clone())
+                .expect("Options to be updated");
+        }
+        let configuration = workspace
+            .open_file("ty.toml", "[environment]\npython-version = '3.11'\n")
+            .expect("Configuration to be opened");
+        if !options_first {
+            workspace
+                .update_options(options)
+                .expect("Options to be updated");
+        }
+        assert_python_version(&workspace, &file, 10);
+
+        // Editing TOML cannot replace an explicit JSON option.
+        workspace
+            .update_file(&configuration, "[environment]\npython-version = '3.12'\n")
+            .expect("Configuration to be updated");
+        assert_python_version(&workspace, &file, 10);
+
+        workspace
+            .update_options(
+                js_sys::JSON::parse(r#"{"environment": {"python-version": "3.13"}}"#).unwrap(),
+            )
+            .expect("Options to be updated");
+        assert_python_version(&workspace, &file, 13);
+
+        // Clearing JSON options reveals the current TOML value, not an older override.
+        workspace
+            .update_options(js_sys::JSON::parse("{}").unwrap())
+            .expect("Options to be updated");
+        assert_python_version(&workspace, &file, 12);
+    }
+}
+
+#[wasm_bindgen_test]
+fn explicit_options_update_with_invalid_configuration() {
+    ty_wasm::before_main();
+
+    for (invalid_toml, syntax_error) in [
+        ("[environment]\npython-version = ", true),
+        ("[analysis]\nallowed-unresolved-imports = ['']\n", false),
+    ] {
+        let mut workspace = Workspace::new(
+            "/",
+            PositionEncoding::Utf32,
+            js_sys::JSON::parse(
+                r#"{
+                    "environment": {"python-version": "3.14"},
+                    "rules": {"undefined-reveal": "ignore"}
+                }"#,
+            )
+            .unwrap(),
+        )
+        .expect("Workspace to be created");
+        let file = workspace
+            .open_file(
+                "main.py",
+                "import sys\nreveal_type(sys.version_info.minor)\n",
+            )
+            .expect("File to be opened");
+        let configuration = workspace
+            .open_file("ty.toml", invalid_toml)
+            .expect("Configuration to be opened");
+
+        // JSON options survive configuration errors, even if the update reports invalid settings.
+        let updated = workspace.update_options(
+            js_sys::JSON::parse(r#"{"environment": {"python-version": "3.10"}}"#).unwrap(),
+        );
+        if syntax_error {
+            // Syntax errors retain the last valid settings, allowing the update to succeed.
+            updated.expect("Options to be updated");
+            assert_python_version(&workspace, &file, 10);
+        }
+
+        workspace
+            .update_file(&configuration, "[environment]\npython-version = '3.11'\n")
+            .expect("Configuration to be repaired");
+        assert_python_version(&workspace, &file, 10);
+
+        // Clearing JSON options while TOML is invalid also persists through its repair.
+        workspace
+            .update_file(&configuration, invalid_toml)
+            .expect("Configuration to be updated");
+        let cleared = workspace.update_options(js_sys::JSON::parse("{}").unwrap());
+        if syntax_error {
+            cleared.expect("Options to be cleared");
+        }
+        workspace
+            .update_file(&configuration, "[environment]\npython-version = '3.12'\n")
+            .expect("Configuration to be repaired");
+        assert_python_version(&workspace, &file, 12);
+    }
+}
+
+#[track_caller]
+fn assert_python_version(workspace: &Workspace, file: &FileHandle, minor: u8) {
+    let diagnostics = workspace.check_file(file).expect("Check to succeed");
+    // In particular, the fallback suppression of undefined-reveal still applies.
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].id(), "revealed-type");
+    assert_eq!(
+        diagnostics[0].message(),
+        format!("Revealed type: `Literal[{minor}]`").as_str()
     );
 }
 

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -65,10 +65,136 @@ fn check() {
 }
 
 #[wasm_bindgen_test]
-fn restored_pyproject_preserves_defaults() {
+fn fixed_options_ignore_configuration_files() {
+    ty_wasm::before_main();
+
+    for (name, contents) in [
+        ("ty.toml", "[environment]\npython-version = '3.11'\n"),
+        ("pyproject.toml", "[project]\nrequires-python = '>=3.11'\n"),
+    ] {
+        let mut workspace = Workspace::new(
+            "/",
+            PositionEncoding::Utf32,
+            js_sys::JSON::parse(
+                r#"{
+                    "environment": {"python-version": "3.10"},
+                    "rules": {"undefined-reveal": "ignore"}
+                }"#,
+            )
+            .unwrap(),
+        )
+        .expect("Workspace to be created");
+        let file = workspace
+            .open_file(
+                "main.py",
+                "import sys\nreveal_type(sys.version_info.minor)\n",
+            )
+            .expect("File to be opened");
+
+        let configuration = workspace
+            .open_file(name, contents)
+            .expect("Configuration to be opened");
+        assert_python_version(&workspace, &file, 10);
+
+        workspace
+            .update_file(&configuration, &contents.replace("3.11", "3.12"))
+            .expect("Configuration to be updated");
+        assert_python_version(&workspace, &file, 10);
+
+        workspace
+            .close_file(configuration)
+            .expect("Configuration to be removed");
+        assert_python_version(&workspace, &file, 10);
+    }
+}
+
+#[wasm_bindgen_test]
+fn fixed_options_replace_constructor_options() {
     ty_wasm::before_main();
 
     let mut workspace = Workspace::new(
+        "/",
+        PositionEncoding::Utf32,
+        js_sys::JSON::parse(
+            r#"{
+                "environment": {"python-version": "3.10"},
+                "rules": {"undefined-reveal": "ignore"}
+            }"#,
+        )
+        .unwrap(),
+    )
+    .expect("Workspace to be created");
+    let file = workspace
+        .open_file(
+            "main.py",
+            "import sys\nreveal_type(sys.version_info.minor)\n",
+        )
+        .expect("File to be opened");
+    assert_python_version(&workspace, &file, 10);
+
+    // A failed update leaves both the program and diagnostic settings unchanged.
+    let invalid = workspace.update_options(
+        js_sys::JSON::parse(
+            r#"{
+                "environment": {"python-version": "3.11"},
+                "analysis": {"allowed-unresolved-imports": [""]}
+            }"#,
+        )
+        .unwrap(),
+    );
+    assert!(invalid.is_err());
+    assert_python_version(&workspace, &file, 10);
+
+    // Omitting the Python version restores ty's default, not the constructor option.
+    workspace
+        .update_options(
+            js_sys::JSON::parse(r#"{"rules": {"undefined-reveal": "ignore"}}"#).unwrap(),
+        )
+        .expect("Options to be updated");
+    assert_python_version(&workspace, &file, 14);
+}
+
+#[wasm_bindgen_test]
+fn fixed_options_ignore_script_metadata() {
+    ty_wasm::before_main();
+
+    let mut workspace = Workspace::new(
+        "/",
+        PositionEncoding::Utf32,
+        js_sys::JSON::parse(
+            r#"{
+                "environment": {"python-version": "3.10"},
+                "rules": {"undefined-reveal": "ignore"}
+            }"#,
+        )
+        .unwrap(),
+    )
+    .expect("Workspace to be created");
+    let file = workspace
+        .open_file(
+            "main.py",
+            "# /// script\n# requires-python = '>=3.11'\n# ///\n\
+             import sys\nreveal_type(sys.version_info.minor)\n",
+        )
+        .expect("File to be opened");
+    assert_python_version(&workspace, &file, 10);
+
+    // Malformed inline configuration is also just a comment in fixed-options mode.
+    workspace
+        .update_file(
+            &file,
+            "# /// script\n# requires-python =\n# ///\n\
+             import sys\nreveal_type(sys.version_info.minor)\n",
+        )
+        .expect("File to be updated");
+    assert_python_version(&workspace, &file, 10);
+}
+
+#[wasm_bindgen_test]
+fn restored_pyproject_preserves_defaults() {
+    ty_wasm::before_main();
+
+    let mut workspace = Workspace::discover(
         "/",
         PositionEncoding::Utf32,
         js_sys::JSON::parse(
@@ -120,7 +246,7 @@ fn explicit_options_override_configuration() {
 
     // JSON options have the same precedence regardless of the restored file order.
     for options_first in [true, false] {
-        let mut workspace = Workspace::new(
+        let mut workspace = Workspace::discover(
             "/",
             PositionEncoding::Utf32,
             js_sys::JSON::parse(
@@ -184,7 +310,7 @@ fn explicit_options_update_with_invalid_configuration() {
         ("[environment]\npython-version = ", true),
         ("[analysis]\nallowed-unresolved-imports = ['']\n", false),
     ] {
-        let mut workspace = Workspace::new(
+        let mut workspace = Workspace::discover(
             "/",
             PositionEncoding::Utf32,
             js_sys::JSON::parse(
@@ -239,7 +365,7 @@ fn explicit_options_update_with_invalid_configuration() {
 #[track_caller]
 fn assert_python_version(workspace: &Workspace, file: &FileHandle, minor: u8) {
     let diagnostics = workspace.check_file(file).expect("Check to succeed");
-    // In particular, the fallback suppression of undefined-reveal still applies.
+    // In particular, the configured suppression of undefined-reveal still applies.
     assert_eq!(diagnostics.len(), 1);
     assert_eq!(diagnostics[0].id(), "revealed-type");
     assert_eq!(

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -3,6 +3,7 @@
 use ty_wasm::{
     DiagnosticTag, FileHandle, Position, PositionEncoding, SubDiagnosticSeverity, Workspace,
 };
+use wasm_bindgen::JsValue;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[wasm_bindgen_test]
@@ -72,18 +73,9 @@ fn fixed_options_ignore_configuration_files() {
         ("ty.toml", "[environment]\npython-version = '3.11'\n"),
         ("pyproject.toml", "[project]\nrequires-python = '>=3.11'\n"),
     ] {
-        let mut workspace = Workspace::new(
-            "/",
-            PositionEncoding::Utf32,
-            js_sys::JSON::parse(
-                r#"{
-                    "environment": {"python-version": "3.10"},
-                    "rules": {"undefined-reveal": "ignore"}
-                }"#,
-            )
-            .unwrap(),
-        )
-        .expect("Workspace to be created");
+        let mut workspace =
+            Workspace::new("/", PositionEncoding::Utf32, python_version_options(10))
+                .expect("Workspace to be created");
         let file = workspace
             .open_file(
                 "main.py",
@@ -112,18 +104,8 @@ fn fixed_options_ignore_configuration_files() {
 fn fixed_options_replace_constructor_options() {
     ty_wasm::before_main();
 
-    let mut workspace = Workspace::new(
-        "/",
-        PositionEncoding::Utf32,
-        js_sys::JSON::parse(
-            r#"{
-                "environment": {"python-version": "3.10"},
-                "rules": {"undefined-reveal": "ignore"}
-            }"#,
-        )
-        .unwrap(),
-    )
-    .expect("Workspace to be created");
+    let mut workspace = Workspace::new("/", PositionEncoding::Utf32, python_version_options(10))
+        .expect("Workspace to be created");
     let file = workspace
         .open_file(
             "main.py",
@@ -158,18 +140,8 @@ fn fixed_options_replace_constructor_options() {
 fn fixed_options_ignore_script_metadata() {
     ty_wasm::before_main();
 
-    let mut workspace = Workspace::new(
-        "/",
-        PositionEncoding::Utf32,
-        js_sys::JSON::parse(
-            r#"{
-                "environment": {"python-version": "3.10"},
-                "rules": {"undefined-reveal": "ignore"}
-            }"#,
-        )
-        .unwrap(),
-    )
-    .expect("Workspace to be created");
+    let mut workspace = Workspace::new("/", PositionEncoding::Utf32, python_version_options(10))
+        .expect("Workspace to be created");
     let file = workspace
         .open_file(
             "main.py",
@@ -194,18 +166,9 @@ fn fixed_options_ignore_script_metadata() {
 fn restored_pyproject_preserves_defaults() {
     ty_wasm::before_main();
 
-    let mut workspace = Workspace::discover(
-        "/",
-        PositionEncoding::Utf32,
-        js_sys::JSON::parse(
-            r#"{
-                "environment": {"python-version": "3.14"},
-                "rules": {"undefined-reveal": "ignore"}
-            }"#,
-        )
-        .unwrap(),
-    )
-    .expect("Workspace to be created");
+    let mut workspace =
+        Workspace::discover("/", PositionEncoding::Utf32, python_version_options(14))
+            .expect("Workspace to be created");
     let file = workspace
         .open_file(
             "main.py",
@@ -246,18 +209,9 @@ fn explicit_options_override_configuration() {
 
     // JSON options have the same precedence regardless of the restored file order.
     for options_first in [true, false] {
-        let mut workspace = Workspace::discover(
-            "/",
-            PositionEncoding::Utf32,
-            js_sys::JSON::parse(
-                r#"{
-                    "environment": {"python-version": "3.14"},
-                    "rules": {"undefined-reveal": "ignore"}
-                }"#,
-            )
-            .unwrap(),
-        )
-        .expect("Workspace to be created");
+        let mut workspace =
+            Workspace::discover("/", PositionEncoding::Utf32, python_version_options(14))
+                .expect("Workspace to be created");
         let file = workspace
             .open_file(
                 "main.py",
@@ -310,18 +264,9 @@ fn explicit_options_update_with_invalid_configuration() {
         ("[environment]\npython-version = ", true),
         ("[analysis]\nallowed-unresolved-imports = ['']\n", false),
     ] {
-        let mut workspace = Workspace::discover(
-            "/",
-            PositionEncoding::Utf32,
-            js_sys::JSON::parse(
-                r#"{
-                    "environment": {"python-version": "3.14"},
-                    "rules": {"undefined-reveal": "ignore"}
-                }"#,
-            )
-            .unwrap(),
-        )
-        .expect("Workspace to be created");
+        let mut workspace =
+            Workspace::discover("/", PositionEncoding::Utf32, python_version_options(14))
+                .expect("Workspace to be created");
         let file = workspace
             .open_file(
                 "main.py",
@@ -360,6 +305,16 @@ fn explicit_options_update_with_invalid_configuration() {
             .expect("Configuration to be repaired");
         assert_python_version(&workspace, &file, 12);
     }
+}
+
+fn python_version_options(minor: u8) -> JsValue {
+    js_sys::JSON::parse(&format!(
+        r#"{{
+            "environment": {{"python-version": "3.{minor}"}},
+            "rules": {{"undefined-reveal": "ignore"}}
+        }}"#,
+    ))
+    .unwrap()
 }
 
 #[track_caller]

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -45,7 +45,11 @@ export default function Playground() {
   if (sessionPromiseRef.current == null) {
     sessionPromiseRef.current = startPlayground().then((fetched) => {
       setVersion(fetched.version);
-      const workspace = new Workspace("/", PositionEncoding.Utf16, {});
+      const workspace = new Workspace(
+        "/",
+        PositionEncoding.Utf16,
+        JSON.parse(DEFAULT_SETTINGS),
+      );
       const session = new PlaygroundSession(
         fetched.monaco,
         workspace,
@@ -634,7 +638,7 @@ function updateOptions(
   content: string | null,
   setError: (error: string | null) => void,
 ) {
-  content = content ?? DEFAULT_SETTINGS;
+  content = content ?? "{}";
 
   try {
     const settings = JSON.parse(content);

--- a/playground/ty/src/Playground.tsx
+++ b/playground/ty/src/Playground.tsx
@@ -45,7 +45,7 @@ export default function Playground() {
   if (sessionPromiseRef.current == null) {
     sessionPromiseRef.current = startPlayground().then((fetched) => {
       setVersion(fetched.version);
-      const workspace = new Workspace(
+      const workspace = Workspace.discover(
         "/",
         PositionEncoding.Utf16,
         JSON.parse(DEFAULT_SETTINGS),


### PR DESCRIPTION
Restoring a playground containing `pyproject.toml` or `ty.toml` could replace its configuration with the playground defaults until the TOML file was edited. The playground now opts into `Workspace.discover`, which keeps defaults, discovered configuration, and explicit `ty.json` overrides separate so restoration and subsequent edits use consistent precedence.

`Workspace.new` uses fixed caller-supplied options and ignores project, user, and inline script configuration, including after rescans. `updateOptions` replaces those options, and failed updates leave the last valid settings unchanged. In discovery mode, parsed JSON updates are retained across configuration errors so repairing TOML cannot restore an override that was removed while configuration was invalid.

Fixes astral-sh/ty#4428.

## Test plan

WASM API tests cover fixed-option replacement and failed updates, ignored TOML and inline script configuration, restored Python versions, TOML edits and deletion, JSON precedence in either loading order, and recovery from malformed TOML and invalid settings. Project tests cover fixed options across rescans and ordinary source edits, plus reloading an explicitly selected configuration file while ignoring ambient TOML.
