### PR TITLE
[ty] Preserve union return types in intersection dunder calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/binary/instances.md
+++ b/crates/ty_python_semantic/resources/mdtest/binary/instances.md
@@ -217,6 +217,36 @@ class C(B): ...
 reveal_type(A() + C())  # revealed: Literal["right", "left"]
 ```
 
+## Conditional reflected methods on intersection operands
+
+A conditionally defined reflected method can have multiple return types. Excluding an unrelated
+class from the right operand preserves those alternatives, along with the left operand's result when
+its regular method takes precedence.
+
+```py
+def enabled() -> bool:
+    return True
+
+class Base:
+    def __add__(self, other) -> bytes:
+        return b"left"
+
+class Child(Base):
+    if enabled():
+        def __radd__(self, other) -> str:
+            return "right"
+
+    else:
+        def __radd__(self, other) -> int:
+            return 42
+
+class Excluded: ...
+
+def add(left: Base, right: Child):
+    if not isinstance(right, Excluded):
+        reveal_type(left + right)  # revealed: str | int | bytes
+```
+
 ## Reflected precedence uses runtime classes
 
 `IntFlag` values are commonly accumulated into a mask that starts at the integer zero. At runtime,

--- a/crates/ty_python_semantic/resources/mdtest/with/sync.md
+++ b/crates/ty_python_semantic/resources/mdtest/with/sync.md
@@ -611,6 +611,78 @@ def _(context_expr: Manager1 | Manager2):
         reveal_type(f)  # revealed: str | int
 ```
 
+## Intersection context managers with conditional methods
+
+A context manager can define `__enter__` differently depending on a runtime condition. Excluding an
+unrelated class from its type preserves both possible return types.
+
+```py
+def enabled() -> bool:
+    return True
+
+class Manager:
+    if enabled():
+        def __enter__(self) -> str:
+            return "entered"
+
+    else:
+        def __enter__(self) -> int:
+            return 42
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None: ...
+
+class Excluded: ...
+
+def negative(context_expr: Manager):
+    if not isinstance(context_expr, Excluded):
+        with context_expr as target:
+            reveal_type(target)  # revealed: str | int
+```
+
+Narrowing the same context manager to a class whose `__enter__` returns `int` constrains the result
+to `int`. We intersect that return type with the union of the conditional method's return types.
+
+```py
+class IntManager:
+    def __enter__(self) -> int:
+        return 0
+
+def positive(context_expr: Manager):
+    if isinstance(context_expr, IntManager):
+        with context_expr as target:
+            reveal_type(target)  # revealed: int
+```
+
+## Intersection context managers with multiple union return types
+
+Intersecting independent union return types can require many combinations. When that expansion
+exceeds the complexity limit, we conservatively use the union of the component return types.
+
+```py
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+class E: ...
+
+class FirstManager:
+    def __enter__(self) -> A | B | C:
+        return A()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None: ...
+
+class SecondManager:
+    def __enter__(self) -> D | E:
+        return D()
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None: ...
+
+def combine(context_expr: FirstManager):
+    if isinstance(context_expr, SecondManager):
+        with context_expr as target:
+            reveal_type(target)  # revealed: A | B | C | D | E
+```
+
 ## Type aliases preserve context manager behavior
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/with/sync.md
+++ b/crates/ty_python_semantic/resources/mdtest/with/sync.md
@@ -675,8 +675,6 @@ class SecondManager:
     def __enter__(self) -> D | E:
         return D()
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None: ...
-
 def combine(context_expr: FirstManager):
     if isinstance(context_expr, SecondManager):
         with context_expr as target:

--- a/crates/ty_python_semantic/resources/mdtest/with/sync.md
+++ b/crates/ty_python_semantic/resources/mdtest/with/sync.md
@@ -655,8 +655,8 @@ def positive(context_expr: Manager):
 
 ## Intersection context managers with multiple union return types
 
-Intersecting independent union return types can require many combinations. When that expansion
-exceeds the complexity limit, we conservatively use the union of the component return types.
+The result must satisfy one alternative from each context manager's union return type. Distributing
+these unions preserves all six possible intersections.
 
 ```py
 class A: ...
@@ -678,7 +678,7 @@ class SecondManager:
 def combine(context_expr: FirstManager):
     if isinstance(context_expr, SecondManager):
         with context_expr as target:
-            reveal_type(target)  # revealed: A | B | C | D | E
+            reveal_type(target)  # revealed: (A & D) | (B & D) | (C & D) | (A & E) | (B & E) | (C & E)
 ```
 
 ## Type aliases preserve context manager behavior

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use bitflags::bitflags;
-use call::{CallDunderError, CallError, CallErrorKind};
+use call::{CallDunderError, CallDunderResult, CallError, CallErrorKind};
 use context::InferContext;
 pub use context::ProgramEnvironment;
 use ruff_db::Instant;
@@ -5774,7 +5774,7 @@ impl<'db> Type<'db> {
             CallArguments::none(),
             TypeContext::default(),
         ) {
-            Ok(bindings) => bindings.return_type(db, env),
+            Ok(bindings) => bindings.return_type(),
             Err(CallDunderError::PossiblyUnbound { bindings, .. }) => bindings.return_type(db, env),
 
             // TODO: emit a diagnostic
@@ -7021,7 +7021,7 @@ impl<'db> Type<'db> {
         name: &str,
         mut argument_types: CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
-    ) -> Result<Bindings<'db>, CallDunderError<'db>> {
+    ) -> Result<CallDunderResult<'db>, CallDunderError<'db>> {
         self.try_call_dunder_with_policy(
             db,
             env,
@@ -7047,7 +7047,7 @@ impl<'db> Type<'db> {
         argument_types: &mut CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
-    ) -> Result<Bindings<'db>, CallDunderError<'db>> {
+    ) -> Result<CallDunderResult<'db>, CallDunderError<'db>> {
         if let Type::Intersection(intersection) = self {
             return intersection.try_call_dunder_with_policy(
                 db,
@@ -7060,7 +7060,9 @@ impl<'db> Type<'db> {
         }
 
         if let Type::Union(union) = self {
-            return union.try_call_dunder_with_policy(db, env, name, argument_types, tcx, policy);
+            return union
+                .try_call_dunder_with_policy(db, env, name, argument_types, tcx, policy)
+                .map(|bindings| CallDunderResult::new(db, env, bindings));
         }
 
         // Implicit calls to dunder methods never access instance members, so we pass
@@ -7092,7 +7094,7 @@ impl<'db> Type<'db> {
                         unbound_on: None,
                     });
                 }
-                Ok(bindings)
+                Ok(CallDunderResult::new(db, env, bindings))
             }
             Place::Undefined => Err(CallDunderError::MethodNotAvailable),
         }
@@ -7214,7 +7216,7 @@ impl<'db> Type<'db> {
                 CallArguments::positional([name_type]),
                 TypeContext::default(),
             ) {
-                Ok(outcome) => Place::bound(outcome.return_type(db, env)).into(),
+                Ok(outcome) => Place::bound(outcome.return_type()).into(),
                 Err(CallDunderError::CallError(_, bindings, _)) => member_lookup_result(
                     db,
                     Place::bound(bindings.return_type(db, env)).into(),
@@ -7249,7 +7251,7 @@ impl<'db> Type<'db> {
             TypeContext::default(),
             getattribute_policy,
         ) {
-            Ok(bindings) => Place::bound(bindings.return_type(db, env)).into(),
+            Ok(bindings) => Place::bound(bindings.return_type()).into(),
             Err(CallDunderError::CallError(_, bindings, _)) => member_lookup_result(
                 db,
                 Place::bound(bindings.return_type(db, env)).into(),
@@ -7358,9 +7360,12 @@ impl<'db> Type<'db> {
         );
         match await_result {
             Ok(bindings) => {
-                let return_type = bindings.return_type(db, env);
+                let return_type = bindings.return_type();
                 Ok(return_type.generator_return_type(db, env).ok_or_else(|| {
-                    AwaitError::InvalidReturnType(return_type, Box::new(bindings))
+                    AwaitError::InvalidReturnType(
+                        return_type,
+                        Box::new(bindings.into_binding_metadata()),
+                    )
                 })?)
             }
             Err(call_error) => Err(AwaitError::Call(call_error)),
@@ -9460,7 +9465,7 @@ impl<'db> IntersectionType<'db> {
         argument_types: &mut CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
-    ) -> Result<Bindings<'db>, CallDunderError<'db>> {
+    ) -> Result<CallDunderResult<'db>, CallDunderError<'db>> {
         if let Some(alternatives) = self.finite_alternative_union(db, env) {
             return alternatives.try_call_dunder_with_policy(
                 db,
@@ -9499,7 +9504,9 @@ impl<'db> IntersectionType<'db> {
                 .with_provenance(error_provenance));
         }
 
-        Ok(Bindings::from_intersection(
+        Ok(CallDunderResult::from_intersection(
+            db,
+            env,
             Type::Intersection(self),
             successful_bindings,
         ))

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -100,7 +100,7 @@ impl<'db> Type<'db> {
                 TypeContext::default(),
             ) {
                 Ok(outcome) => {
-                    let return_type = outcome.return_type(db, env);
+                    let return_type = outcome.return_type();
                     if !return_type.is_assignable_to(db, env, KnownClass::Bool.to_instance(db, env))
                     {
                         // The type has a `__bool__` method, but it doesn't return a
@@ -157,7 +157,7 @@ impl<'db> Type<'db> {
                         TypeContext::default(),
                     ) {
                         Ok(outcome) => {
-                            let return_type = outcome.return_type(db, env);
+                            let return_type = outcome.return_type();
                             if return_type.is_assignable_to(
                                 db,
                                 env,

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -44,14 +44,12 @@ impl<'db> CallDunderResult<'db> {
         receiver: Type<'db>,
         results: Vec<Self>,
     ) -> Self {
-        let return_types = results.iter().map(Self::return_type);
-        let return_type = IntersectionType::bounded_from_elements(db, env, return_types.clone())
-            .unwrap_or_else(|| {
-                // Preserve all possible results if exact distribution exceeds the type budget.
-                UnionType::from_elements(db, env, return_types)
-            });
         Self {
-            return_type,
+            return_type: IntersectionType::from_elements(
+                db,
+                env,
+                results.iter().map(Self::return_type),
+            ),
             bindings: Bindings::from_intersection(
                 receiver,
                 results.into_iter().map(Self::into_binding_metadata),

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -1,5 +1,5 @@
 use super::context::InferContext;
-use super::{ClassType, Signature, Type, TypeContext, UnionType};
+use super::{ClassType, IntersectionType, Signature, Type, TypeContext, UnionType};
 use crate::Db;
 use crate::place::Provenance;
 use crate::types::call::bind::BindingError;
@@ -13,6 +13,84 @@ pub(super) use arguments::{Argument, CallArguments};
 pub(super) use bind::{
     Binding, Bindings, CallDiagnosticOverride, CallableBinding, MatchedArgument,
 };
+
+/// The result of a checked implicit dunder call.
+///
+/// Compose return types before combining binding metadata: `Bindings::from_intersection`
+/// flattens union alternatives within each component. For example, a conditional `__enter__`
+/// returning either `str` or `int` must keep `str | int` when its receiver is narrowed to an
+/// intersection, rather than intersecting those alternatives into `Never`.
+#[derive(Debug)]
+pub(crate) struct CallDunderResult<'db> {
+    return_type: Type<'db>,
+    bindings: Bindings<'db>,
+}
+
+impl<'db> CallDunderResult<'db> {
+    pub(super) fn new(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        bindings: Bindings<'db>,
+    ) -> Self {
+        Self {
+            return_type: bindings.return_type(db, env),
+            bindings,
+        }
+    }
+
+    pub(super) fn from_intersection(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        receiver: Type<'db>,
+        results: Vec<Self>,
+    ) -> Self {
+        let return_types = results.iter().map(Self::return_type);
+        let return_type = IntersectionType::bounded_from_elements(db, env, return_types.clone())
+            .unwrap_or_else(|| {
+                // Preserve all possible results if exact distribution exceeds the type budget.
+                UnionType::from_elements(db, env, return_types)
+            });
+        Self {
+            return_type,
+            bindings: Bindings::from_intersection(
+                receiver,
+                results.into_iter().map(Self::into_binding_metadata),
+            ),
+        }
+    }
+
+    fn from_union(db: &'db dyn Db, env: &ProgramEnvironment<'db>, results: [Self; 2]) -> Self {
+        let return_type = UnionType::from_elements(db, env, results.iter().map(Self::return_type));
+        let callable_type = UnionType::from_elements(
+            db,
+            env,
+            results.iter().map(|result| result.bindings.callable_type()),
+        );
+        Self {
+            return_type,
+            bindings: Bindings::from_union(
+                callable_type,
+                results.into_iter().map(Self::into_binding_metadata),
+            ),
+        }
+    }
+
+    pub(super) fn return_type(&self) -> Type<'db> {
+        self.return_type
+    }
+
+    /// The existing binding representation, for diagnostics and signature inspection only.
+    /// Use `Self::return_type` for the result of the call, since these bindings may have lost
+    /// union alternatives when combining intersection components.
+    pub(super) fn binding_metadata(&self) -> &Bindings<'db> {
+        &self.bindings
+    }
+
+    /// Consume the result when only diagnostics or signature information is needed.
+    pub(super) fn into_binding_metadata(self) -> Bindings<'db> {
+        self.bindings
+    }
+}
 
 /// Whether the right operand's reflected method has priority based on the possible runtime
 /// classes of both operands.
@@ -125,7 +203,7 @@ impl<'db> Type<'db> {
                     TypeContext::default(),
                     policy,
                 )
-                .map(|outcome| outcome.return_type(db, env))
+                .map(|outcome| outcome.return_type())
                 .ok()
         };
 
@@ -169,7 +247,7 @@ impl<'db> Type<'db> {
             let env = &ProgramEnvironment::from_program(program);
             Type::try_call_bin_op(db, env, left_ty, op, right_ty)
                 .ok()
-                .map(|bindings| bindings.return_type(db, env))
+                .map(|bindings| bindings.return_type())
         }
 
         try_call_bin_op_return_type_impl(db, env.program(db), left_ty, op, right_ty)
@@ -181,7 +259,7 @@ impl<'db> Type<'db> {
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
-    ) -> Result<Bindings<'db>, CallBinOpError> {
+    ) -> Result<CallDunderResult<'db>, CallBinOpError> {
         Self::try_call_bin_op_with_policy(
             db,
             env,
@@ -199,7 +277,7 @@ impl<'db> Type<'db> {
         op: ast::Operator,
         right_ty: Type<'db>,
         policy: MemberLookupPolicy,
-    ) -> Result<Bindings<'db>, CallBinOpError> {
+    ) -> Result<CallDunderResult<'db>, CallBinOpError> {
         // We either want to call lhs.__op__ or rhs.__rop__. The full decision tree from
         // the Python spec [1] is:
         //
@@ -259,18 +337,11 @@ impl<'db> Type<'db> {
                 );
 
                 return match (call_on_right_instance, call_on_left_instance) {
-                    (Ok(right_bindings), Ok(left_bindings)) => {
-                        let callable_type = UnionType::from_two_elements(
-                            db,
-                            env,
-                            right_bindings.callable_type(),
-                            left_bindings.callable_type(),
-                        );
-                        Ok(Bindings::from_union(
-                            callable_type,
-                            [right_bindings, left_bindings],
-                        ))
-                    }
+                    (Ok(right_bindings), Ok(left_bindings)) => Ok(CallDunderResult::from_union(
+                        db,
+                        env,
+                        [right_bindings, left_bindings],
+                    )),
                     (Ok(bindings), Err(_)) | (Err(_), Ok(bindings)) => Ok(bindings),
                     (Err(_), Err(error)) => Err(error.into()),
                 };

--- a/crates/ty_python_semantic/src/types/context_manager.rs
+++ b/crates/ty_python_semantic/src/types/context_manager.rs
@@ -3,7 +3,7 @@ use crate::ProgramEnvironment;
 use crate::{
     FxOrderSet, Program,
     types::{
-        Bindings, CallArguments, CallDunderError, KnownClass, MemberLookupPolicy, Type,
+        CallArguments, CallDunderError, CallDunderResult, KnownClass, MemberLookupPolicy, Type,
         TypeContext, call::CallErrorKind, context::InferContext,
         diagnostic::INVALID_CONTEXT_MANAGER,
     },
@@ -206,13 +206,16 @@ impl<'db> Type<'db> {
         );
 
         let awaited_enter_type = if mode.is_async() {
-            let return_type = |call: &Result<Bindings<'db>, CallDunderError<'db>>| match call {
-                Ok(bindings) => Some(bindings.return_type(db, env)),
-                Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
-                    Some(bindings.return_type(db, env))
-                }
-                Err(CallDunderError::MethodNotAvailable | CallDunderError::CallError(..)) => None,
-            };
+            let return_type =
+                |call: &Result<CallDunderResult<'db>, CallDunderError<'db>>| match call {
+                    Ok(bindings) => Some(bindings.return_type()),
+                    Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
+                        Some(bindings.return_type(db, env))
+                    }
+                    Err(CallDunderError::MethodNotAvailable | CallDunderError::CallError(..)) => {
+                        None
+                    }
+                };
 
             let enter_return_type = return_type(&enter);
             let exit_return_type = return_type(&exit);
@@ -242,7 +245,7 @@ impl<'db> Type<'db> {
         // TODO: Make use of Protocols when we support it (the manager be assignable to `contextlib.AbstractContextManager`).
         match (enter, exit) {
             (Ok(enter), Ok(_)) => {
-                let return_type = enter.return_type(db, env);
+                let return_type = enter.return_type();
                 Ok(if mode.is_async() {
                     awaited_enter_type.unwrap_or(Type::unknown())
                 } else {
@@ -250,7 +253,7 @@ impl<'db> Type<'db> {
                 })
             }
             (Ok(enter), Err(exit_error)) => {
-                let return_type = enter.return_type(db, env);
+                let return_type = enter.return_type();
                 Err(ContextManagerError::Exit {
                     enter_return_type: if mode.is_async() {
                         awaited_enter_type.unwrap_or(Type::unknown())

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4023,10 +4023,7 @@ pub(crate) fn report_invalid_or_unsupported_base(
         TypeContext::default(),
     ) {
         Ok(ret) => {
-            if ret
-                .return_type(db, env)
-                .is_assignable_to(db, env, tuple_of_types)
-            {
+            if ret.return_type().is_assignable_to(db, env, tuple_of_types) {
                 report_unsupported_base(context, base_node, base_type, class);
             } else {
                 let Some(mut diagnostic) =

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -2015,7 +2015,7 @@ fn known_literal_equality<'db>(
                 | MemberLookupPolicy::MRO_NO_INT_OR_STR_LOOKUP,
         )
         && let Some(result) = bindings
-            .return_type(db, env)
+            .return_type()
             .as_literal_value()
             .and_then(LiteralValueType::as_bool)
     {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -1433,6 +1433,7 @@ pub fn definitions_for_bin_op<'db>(
         return None;
     };
 
+    let bindings = bindings.binding_metadata();
     let callable_type = promote_for_self(db, env, bindings.callable_type());
 
     let definitions: Vec<_> = bindings
@@ -1471,7 +1472,7 @@ pub fn definitions_for_unary_op<'db>(
         CallArguments::none(),
         TypeContext::default(),
     ) {
-        Ok(bindings) => bindings,
+        Ok(bindings) => bindings.into_binding_metadata(),
         Err(CallDunderError::MethodNotAvailable) if unary_op.op == ast::UnaryOp::Not => {
             // The runtime falls back to `__len__` for `not` if `__bool__` is not defined.
             match operand_ty.try_call_dunder(
@@ -1481,7 +1482,7 @@ pub fn definitions_for_unary_op<'db>(
                 CallArguments::none(),
                 TypeContext::default(),
             ) {
-                Ok(bindings) => bindings,
+                Ok(bindings) => bindings.into_binding_metadata(),
                 Err(CallDunderError::MethodNotAvailable) => return None,
                 Err(
                     CallDunderError::PossiblyUnbound { bindings, .. }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -54,7 +54,9 @@ use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attri
 use crate::types::call::bind::{
     ArgumentTypeContext, CheckTypesMode, OverloadSet, requires_overload_evaluation,
 };
-use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
+use crate::types::call::{
+    Binding, Bindings, CallArguments, CallDunderResult, CallError, CallErrorKind,
+};
 use crate::types::callable::CallableTypeKind;
 use crate::types::class::{
     ClassLiteral, CodeGeneratorKind, FrozenDataclassDispatch, MethodDecorator,
@@ -3124,7 +3126,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     unbound_on: None,
                                 })
                             }
-                            Ok(bindings) => Ok(bindings),
+                            Ok(bindings) => Ok(CallDunderResult::new(db, env, bindings)),
                             Err(CallError(kind, bindings)) => {
                                 Err(CallDunderError::CallError(kind, bindings, provenance))
                             }
@@ -3146,7 +3148,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     frozen_dataclass_dispatch,
                     Some(FrozenDataclassDispatch::FrozenField)
                 ) || match &delattr_dunder_call_result {
-                    Ok(result) => result.return_type(db, env).is_never(),
+                    Ok(result) => result.return_type().is_never(),
                     Err(err) => err.return_type(db, env).is_some_and(|ty| ty.is_never()),
                 };
                 if returns_never {
@@ -3228,7 +3230,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // value to mutate; it is not a concrete descriptor with a terminal deleter.
                     let deleter_returns_never = !attr_ty.is_never()
                         && match &delete_dunder_call_result {
-                            Ok(bindings) => bindings.return_type(db, env).is_never(),
+                            Ok(bindings) => bindings.return_type().is_never(),
                             Err(error) => {
                                 error.return_type(db, env).is_some_and(|ty| ty.is_never())
                             }
@@ -9734,7 +9736,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     CallArguments::none(),
                     TypeContext::default(),
                 ) {
-                    Ok(bindings) => Some(bindings.return_type(db, env)),
+                    Ok(bindings) => Some(bindings.return_type()),
                     Err(CallDunderError::PossiblyUnbound { .. }) => {
                         // Iteration can fall back to `__getitem__` where `__iter__` is absent.
                         // The available `__iter__` bindings do not describe those alternatives.
@@ -10930,8 +10932,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 TypeContext::default(),
             ) {
                 Ok(outcome) => {
-                    self.check_deprecated_bindings(unary, &outcome);
-                    outcome.return_type(db, env)
+                    self.check_deprecated_bindings(unary, outcome.binding_metadata());
+                    outcome.return_type()
                 }
                 Err(e) => {
                     let bindings = match &e {
@@ -11059,7 +11061,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .collect();
                         for outcome in &outcomes {
                             let bindings = match outcome {
-                                Ok(bindings) => Some(bindings),
+                                Ok(bindings) => Some(bindings.binding_metadata()),
                                 // A method can be deprecated even if it is missing from some
                                 // union members or its signature rejects the implicit call.
                                 // Preserve those bindings so the deprecation is reported
@@ -11084,7 +11086,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             constraints,
                             |_constraint| {
                                 let outcome = outcomes.next()?.ok()?;
-                                Some(outcome.return_type(db, env))
+                                Some(outcome.return_type())
                             },
                         );
                         match result {
@@ -11108,7 +11110,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     )
                                     .map_or_else(
                                         |e| e.fallback_return_type(db, env),
-                                        |b| b.return_type(db, env),
+                                        |b| b.return_type(),
                                     )
                             }
                         }
@@ -11127,7 +11129,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             CallArguments::none(),
                             TypeContext::default(),
                         ) {
-                            Ok(outcome) => outcome.return_type(db, env),
+                            Ok(outcome) => outcome.return_type(),
                             Err(e) => {
                                 self.report_unsupported_unary_operator(
                                     unary,

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -8,7 +8,7 @@ use crate::types::attribute_write::{
     FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
     ProtocolMemberWriteRequirement, attribute_write_requirement, property_setter_returns_never,
 };
-use crate::types::call::{Bindings, CallArguments, CallDiagnosticOverride, CallError};
+use crate::types::call::{CallArguments, CallDiagnosticOverride, CallDunderResult, CallError};
 use crate::types::class::FrozenDataclassDispatch;
 use crate::types::dedicated::pydantic;
 use crate::types::diagnostic::{
@@ -125,7 +125,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         &mut self,
         object_ty: Type<'db>,
         emit_diagnostics: bool,
-    ) -> (Result<Bindings<'db>, CallDunderError<'db>>, Type<'db>) {
+    ) -> (
+        Result<CallDunderResult<'db>, CallDunderError<'db>>,
+        Type<'db>,
+    ) {
         let db = self.builder.db();
         let name_ty = Type::string_literal(db, self.attribute);
         let ast_arguments = [
@@ -155,7 +158,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             TypeContext::default(),
         );
         let value_ty = self.infer_with_last_context(emit_diagnostics);
-        (setattr_result, value_ty)
+        (
+            setattr_result.map(|bindings| {
+                CallDunderResult::new(db, self.builder.program_environment(), bindings)
+            }),
+            value_ty,
+        )
     }
 
     fn evaluate(
@@ -406,7 +414,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             frozen_dataclass_dispatch,
             Some(FrozenDataclassDispatch::FrozenField)
         ) || match &setattr_result {
-            Ok(bindings) => bindings.return_type(db, env).is_never(),
+            Ok(bindings) => bindings.return_type().is_never(),
             Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
         };
 
@@ -558,7 +566,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 let (setattr_result, value_ty) =
                     self.infer_and_try_call_setattr(object_ty, emit_diagnostics);
                 let setattr_returns_never = match &setattr_result {
-                    Ok(bindings) => bindings.return_type(db, env).is_never(),
+                    Ok(bindings) => bindings.return_type().is_never(),
                     Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
                 };
                 if setattr_returns_never {

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -158,12 +158,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             TypeContext::default(),
         );
         let value_ty = self.infer_with_last_context(emit_diagnostics);
-        (
-            setattr_result.map(|bindings| {
-                CallDunderResult::new(db, self.builder.program_environment(), bindings)
-            }),
-            value_ty,
-        )
+        let setattr_result = setattr_result.map(|bindings| {
+            CallDunderResult::new(db, self.builder.program_environment(), bindings)
+        });
+        (setattr_result, value_ty)
     }
 
     fn evaluate(

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -200,7 +200,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 TypeContext::default(),
             )
             .ok()
-            .map(|bindings| bindings.return_type(db, env))
+            .map(|bindings| bindings.return_type())
     }
 
     /// Handle `TypedDict |= value` before the normal `__ior__` path runs.
@@ -968,7 +968,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
             .ok()
-            .map(|binding| binding.return_type(db, env)),
+            .map(|binding| binding.return_type()),
 
             // We've handled all of the special cases that we support for literals, so we need to
             // fall back on looking for dunder methods on one of the operand types.

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -1083,7 +1083,7 @@ fn infer_membership_test_comparison<'db>(
         TypeContext::default(),
     ) {
         // If `__contains__` is available, it is used directly for the membership test.
-        Ok(bindings) => Some(bindings.return_type(db, env)),
+        Ok(bindings) => Some(bindings.return_type()),
         // If `__contains__` is not available or possibly unbound,
         // fall back to iteration-based membership test.
         Err(CallDunderError::MethodNotAvailable | CallDunderError::PossiblyUnbound { .. }) => right

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -1,9 +1,9 @@
 use crate::Db;
 use crate::ProgramEnvironment;
 use crate::types::{
-    AwaitError, Bindings, CallArguments, CallDunderError, KnownClass, LintDiagnosticGuard,
-    LintDiagnosticGuardBuilder, LiteralValueTypeKind, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionType,
+    AwaitError, Bindings, CallArguments, CallDunderError, CallDunderResult, KnownClass,
+    LintDiagnosticGuard, LintDiagnosticGuardBuilder, LiteralValueTypeKind, Type, TypeContext,
+    TypeVarBoundOrConstraints, UnionType,
     call::CallErrorKind,
     context::InferContext,
     diagnostic::NOT_ITERABLE,
@@ -297,7 +297,7 @@ impl<'db> Type<'db> {
                         TypeContext::default(),
                     )
                     .map(|dunder_anext_outcome| {
-                        dunder_anext_outcome.return_type(db, env).try_await(db, env)
+                        dunder_anext_outcome.return_type().try_await(db, env)
                     })
             };
 
@@ -309,7 +309,7 @@ impl<'db> Type<'db> {
                 TypeContext::default(),
             ) {
                 Ok(dunder_aiter_bindings) => {
-                    let iterator = dunder_aiter_bindings.return_type(db, env);
+                    let iterator = dunder_aiter_bindings.return_type();
                     match try_call_dunder_anext_on_iterator(iterator) {
                         Ok(Ok(result)) => Ok(Cow::Owned(TupleSpec::homogeneous(result))),
                         Ok(Err(AwaitError::InvalidReturnType(..))) => {
@@ -367,7 +367,7 @@ impl<'db> Type<'db> {
                 CallArguments::positional([KnownClass::Int.to_instance(db, env)]),
                 TypeContext::default(),
             )
-            .map(|dunder_getitem_outcome| dunder_getitem_outcome.return_type(db, env))
+            .map(|dunder_getitem_outcome| dunder_getitem_outcome.return_type())
         };
 
         let try_call_dunder_next_on_iterator = |iterator: Type<'db>| {
@@ -379,7 +379,7 @@ impl<'db> Type<'db> {
                     CallArguments::none(),
                     TypeContext::default(),
                 )
-                .map(|dunder_next_outcome| dunder_next_outcome.return_type(db, env))
+                .map(|dunder_next_outcome| dunder_next_outcome.return_type())
         };
 
         let dunder_iter_result = self
@@ -390,7 +390,7 @@ impl<'db> Type<'db> {
                 CallArguments::none(),
                 TypeContext::default(),
             )
-            .map(|dunder_iter_outcome| dunder_iter_outcome.return_type(db, env));
+            .map(|dunder_iter_outcome| dunder_iter_outcome.return_type());
 
         match dunder_iter_result {
             Ok(iterator) => {
@@ -535,9 +535,9 @@ impl<'db> IterationError<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<Type<'db>> {
-        let return_type = |result: Result<Bindings<'db>, CallDunderError<'db>>| {
+        let return_type = |result: Result<CallDunderResult<'db>, CallDunderError<'db>>| {
             result
-                .map(|outcome| Some(outcome.return_type(db, env)))
+                .map(|outcome| Some(outcome.return_type()))
                 .unwrap_or_else(|call_error| call_error.return_type(db, env))
         };
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -2515,7 +2515,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
         if match &setattr_result {
-            Ok(bindings) => bindings.return_type(db, env).is_never(),
+            Ok(bindings) => bindings.return_type().is_never(),
             Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
         } {
             return self.never();

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -927,7 +927,7 @@ impl<'db> Type<'db> {
             TypeContext::default(),
         ) {
             Ok(outcome) => {
-                return Ok(outcome.return_type(db, env));
+                return Ok(outcome.return_type());
             }
             Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
                 return Err(SubscriptError::new(


### PR DESCRIPTION
Implicit dunder calls on narrowed intersection receivers preserve the union of a conditionally defined method's return types. For example, a context manager whose `__enter__` returns either `str` or `int` retains `str | int` after excluding an unrelated class with `isinstance`, instead of collapsing to `Never`.

Keep checked return types separate from binding metadata and compose them before aggregating metadata for intersection calls or binary dispatch. Intersections distribute multiple union return types exactly; binding metadata remains available for diagnostics and signature inspection.

Related to #28045.

## Test plan

Added mdtests covering conditional context-manager methods under negative and positive narrowing, binary dispatch combining normal and conditional reflected results, and exact distribution across multiple union return types.
