### PR TITLE
[ty] Bound recursive protocol traversal in generic intersections

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -650,6 +650,27 @@ def alias(value: Co[Dynamic] & Top[Child[Any]]) -> str:
     return value.get()
 ```
 
+### Nested specializations of nonrecursive protocols
+
+A protocol can appear inside its own type argument without a recursive declaration. These finite
+nested specializations still allow intersection simplification:
+
+```pyi
+from typing import Protocol, reveal_type
+
+class Value[T](Protocol):
+    @property
+    def value(self) -> T: ...
+
+class Co[T]:
+    def get(self) -> T: ...
+
+class Child[T](Co[T]): ...
+
+def _(value: Co[Value[Value[int]]] & Child[object]):
+    reveal_type(value)  # revealed: Child[Value[Value[int]]]
+```
+
 ### Specializations with recursive types
 
 Fully static recursive types still allow simplification. Evaluating protocol attributes and
@@ -681,6 +702,18 @@ def _(
     reveal_type(record)  # revealed: Child[RecursiveRecord]
 ```
 
+A generic protocol method that returns the same specialization also permits simplification. Its
+recursive return type does not introduce new type arguments:
+
+```pyi
+class RecursiveMethods[T](Protocol):
+    def value(self) -> T: ...
+    def next(self) -> RecursiveMethods[T]: ...
+
+def _(value: Co[RecursiveMethods[int]] & Child[object]):
+    reveal_type(value)  # revealed: Child[RecursiveMethods[int]]
+```
+
 Recursive generic specializations can grow on each step, so we conservatively leave these
 intersections unsimplified. Checking only for repeated specializations does not prevent infinite
 expansion:
@@ -697,4 +730,64 @@ def _(
 ):
     reveal_type(alias)  # revealed: Co[GrowingAlias[int]] & Child[object]
     reveal_type(record)  # revealed: Co[GrowingRecord[int]] & Child[object]
+```
+
+### Inherited properties with recursive protocol bounds
+
+Reading an inherited generic property preserves its type parameter, even when the parameter's bound
+contains a method with an expanding recursive return type:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol, reveal_type
+
+class Recursive[T](Protocol):
+    def grow(self) -> Recursive[tuple[int, T]]: ...
+
+class Base[T]:
+    @property
+    def value(self) -> T:
+        raise NotImplementedError
+
+class Child[T: Recursive[int]](Base[T]):
+    def read(self) -> T:
+        reveal_type(self.value)  # revealed: T@Child
+        return self.value
+```
+
+### Recursive protocols with gradual members
+
+An `Any` member does not remove an expanding recursive method from a protocol. Intersections with
+these protocols remain unsimplified regardless of member order:
+
+```pyi
+from typing import Any, Protocol, reveal_type
+
+class AnyFirst[T](Protocol):
+    a_marker: Any
+
+    def grow(self) -> AnyFirst[tuple[int, T]]: ...
+
+class AnyLast[T](Protocol):
+    def grow(self) -> AnyLast[tuple[int, T]]: ...
+
+    z_marker: Any
+
+class Co[T]:
+    def get(self) -> T: ...
+
+class Child[T](Co[T]): ...
+
+def _(
+    first: Co[AnyFirst[int]] & Child[object],
+    last: Co[AnyLast[int]] & Child[object],
+):
+    reveal_type(first)  # revealed: Co[AnyFirst[int]] & Child[object]
+    reveal_type(last)  # revealed: Co[AnyLast[int]] & Child[object]
 ```

--- a/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
@@ -1,7 +1,6 @@
-use crate::types::cyclic::TypeIdentity;
 use crate::types::generics::specialization_variance;
 use crate::types::tuple::TupleSpec;
-use crate::types::visitor::any_over_type;
+use crate::types::visitor::contains_growing_type;
 use crate::types::{
     ClassBase, ClassType, IntersectionType, KnownClass, MaterializationKind, Type, TypeVarVariance,
     UnionType,
@@ -89,28 +88,8 @@ fn nominal_top_intersection<'db>(
 
     // Inspect lazy attributes only after establishing that the classes are related. Expanding a
     // recursive generic alias or member can re-enter intersection simplification with ever-growing
-    // type arguments. Non-generic recursion cannot grow its specialization and can still be checked.
-    if any_over_type(db, env, base, true, |ty| {
-        let is_generic = match ty {
-            Type::TypeAlias(alias) => alias.generic_context(db).is_some(),
-            Type::ProtocolInstance(protocol) => protocol
-                .class_origin(db)
-                .and_then(|class| class.class_literal(db).generic_context(db))
-                .is_some(),
-            Type::TypedDict(typed_dict) => typed_dict
-                .defining_class()
-                .and_then(|class| class.class_literal(db).generic_context(db))
-                .is_some(),
-            _ => false,
-        };
-        is_generic
-            && matches!(
-                ty.to_type_identity(db),
-                TypeIdentity::GrowingTypeAlias(_)
-                    | TypeIdentity::GrowingProtocol(_)
-                    | TypeIdentity::GrowingTypedDict(_)
-            )
-    }) {
+    // type arguments. Exact recursive specializations can still be checked.
+    if contains_growing_type(db, env, base) {
         return Some(GenericIntersection::Recursive);
     }
     if base_specialization.materialization_kind(db).is_some()

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -644,6 +644,109 @@ fn dynamic_content_impl<'db>(
     visitor.content.get()
 }
 
+/// Whether inspecting `ty` can encounter recursive types with changing specializations.
+///
+/// Exact recursive types are safe to inspect once. For protocol methods, conservatively treat
+/// a new specialization of an active protocol definition as potentially growing: their signatures
+/// are not included in the specialization-flow analysis used by [`TypeIdentity`].
+pub(super) fn contains_growing_type<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+) -> bool {
+    struct GrowingTypeVisitor<'a, 'db> {
+        env: &'a ProgramEnvironment<'db>,
+        recursion_guard: TypeCollector<'db>,
+        active_class_protocols: ActiveRecursionDetector<StaticClassLiteral<'db>>,
+        found: Cell<bool>,
+    }
+
+    impl<'db> TypeVisitor<'db> for GrowingTypeVisitor<'_, 'db> {
+        fn program_environment(&self) -> &ProgramEnvironment<'db> {
+            self.env
+        }
+
+        fn should_visit_lazy_type_attributes(&self) -> bool {
+            true
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if self.found.get() {
+                return;
+            }
+
+            let is_generic = match ty {
+                Type::TypeAlias(alias) => alias.generic_context(db).is_some(),
+                Type::ProtocolInstance(protocol) => protocol
+                    .class_origin(db)
+                    .and_then(|class| class.class_literal(db).generic_context(db))
+                    .is_some(),
+                Type::TypedDict(typed_dict) => typed_dict
+                    .defining_class()
+                    .and_then(|class| class.class_literal(db).generic_context(db))
+                    .is_some(),
+                _ => false,
+            };
+            if is_generic
+                && matches!(
+                    ty.to_type_identity(db),
+                    TypeIdentity::GrowingTypeAlias(_)
+                        | TypeIdentity::GrowingProtocol(_)
+                        | TypeIdentity::GrowingTypedDict(_)
+                )
+            {
+                self.found.set(true);
+                return;
+            }
+
+            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+        }
+
+        fn visit_protocol_instance_type(
+            &self,
+            db: &'db dyn Db,
+            protocol: ProtocolInstanceType<'db>,
+        ) {
+            let protocol_ty = Type::ProtocolInstance(protocol);
+            let Some((origin, specialization)) = protocol
+                .class_origin(db)
+                .and_then(|class| class.static_class_literal(db))
+            else {
+                walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
+                return;
+            };
+
+            if let Some(specialization) = specialization {
+                // Inspect arguments before activating the definition so finite nesting such as
+                // `P[P[int]]` does not look like an expanding recursive declaration.
+                walk_specialization_types(db, specialization, self);
+                if self.found.get() {
+                    return;
+                }
+            }
+
+            self.active_class_protocols.visit(
+                &origin,
+                || self.found.set(true),
+                || {
+                    // Bind implicit receivers so they do not introduce recursive edges of their
+                    // own. Explicitly recursive method signatures still need to be inspected.
+                    walk_protocol_instance_interface(db, protocol.interface(db), protocol_ty, self);
+                },
+            );
+        }
+    }
+
+    let visitor = GrowingTypeVisitor {
+        env,
+        recursion_guard: TypeCollector::default(),
+        active_class_protocols: ActiveRecursionDetector::default(),
+        found: Cell::new(false),
+    };
+    visitor.visit_type(db, ty);
+    visitor.found.get()
+}
+
 #[derive(Clone, Copy)]
 enum TypeSearchMode {
     SkipLazyAttributes,


### PR DESCRIPTION
Fix a stack overflow when reading an inherited generic property whose type parameter is bounded by a protocol with an expanding recursive method return type.

Use a guarded traversal when inspecting types for generic-intersection simplification. The traversal detects protocol definitions revisited with changing type arguments, binds implicit method receivers, and preserves simplification for exact recursion and finite nesting.

Fixes https://github.com/astral-sh/ty/issues/4430.

## Test plan

Add mdtests for inherited properties with recursive protocol bounds, exact recursive method returns, finite nested protocol specializations, and expanding methods alongside `Any` members in either traversal order.
