### PR TITLE
[ty] Stabilize cyclic terminal-call reachability

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -1496,6 +1496,22 @@ async def main(flag: bool):
     reveal_type(x)  # revealed: Literal["test"]
 ```
 
+### Calls before loop-back imports
+
+Inference converges when a call's target is imported later in the same loop, even if the imported
+function never returns. The import does not guarantee that `sys` is defined at the call. The
+function definition before the call also requires looking for previous definitions of its name
+across loop iterations.
+
+```py
+for i in range(1):
+    def f():
+        pass
+
+    sys.exit()  # error: [possibly-unresolved-reference]
+    import sys
+```
+
 ## Nested functions
 
 Free references inside of a function body refer to variables defined in the containing scope.

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1735,6 +1735,17 @@ fn analyze_single_pattern_predicate_kind<'db>(
 #[salsa::tracked(
     returns(copy),
     cycle_initial = |_, _, _, _, _| Truthiness::AlwaysTrue,
+    cycle_fn = |_, cycle: &salsa::Cycle, previous: &Truthiness, result: Truthiness, _, _, _| {
+        // A call can determine whether its own target is reachable, as with `sys.exit()` before
+        // `import sys` in a loop. Expression inference can lose its previous result when it stops
+        // being a cycle head, so widen the predicate itself to ensure convergence. Delay widening
+        // to allow the optimistic initial value to resolve to a terminal call.
+        if cycle.iteration() > crate::TAINTED_CYCLES {
+            previous.or(result)
+        } else {
+            result
+        }
+    },
     heap_size = get_size2::GetSize::get_heap_size
 )]
 fn analyze_non_terminal_call<'db>(


### PR DESCRIPTION
A call whose target is imported later in the same loop can make reachability inference oscillate until Salsa panics. Widen terminal-call predicate results after the initial cycle iterations, conservatively treating unstable calls as returning so inference converges.

Closes https://github.com/astral-sh/ty/issues/4434.

## Test plan

Adds an mdtest with a function definition and a `sys.exit()` call before `import sys` in the same loop. It verifies that inference completes and reports the possibly undefined `sys` reference.
