### PR TITLE
Move `pytest-fixture-autouse` to `restriction`

### DIFF
--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -159,7 +159,7 @@ pub enum Category {
     /// Rules that are highly opinionated or prone to false positives
     Pedantic,
 
-    /// Rules that restrict the use of basic language features
+    /// Rules that restrict the use of certain features
     Restriction,
 
     /// Internal testing rules that shouldn't be exposed to users.
@@ -1412,7 +1412,7 @@ mod tests {
         security: Rules that flag potential security vulnerabilities but may be prone to false positives
         formatting: Rules that flag formatting issues that do not affect semantics
         pedantic: Rules that are highly opinionated or prone to false positives
-        restriction: Rules that restrict the use of basic language features
+        restriction: Rules that restrict the use of certain features
         ");
     }
 }

--- a/crates/ruff_linter/src/rules/ruff/rules/pytest_fixture_autouse.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/pytest_fixture_autouse.rs
@@ -61,7 +61,7 @@ use crate::rules::flake8_pytest_style::helpers::is_pytest_fixture;
 /// - [`pytest` documentation: Sharing fixtures across classes, modules, packages or session](https://docs.pytest.org/en/stable/how-to/fixtures.html#scope-sharing-fixtures-across-classes-modules-packages-or-session)
 /// - [`pytest` documentation: Fixtures can request other fixtures](https://docs.pytest.org/en/stable/how-to/fixtures.html#fixtures-can-request-other-fixtures)
 #[derive(ViolationMetadata)]
-#[violation_metadata(preview_since = "0.16.5", category = Category::Pedantic)]
+#[violation_metadata(preview_since = "0.16.5", category = Category::Restriction)]
 pub(crate) struct PytestFixtureAutouse;
 
 impl Violation for PytestFixtureAutouse {

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -170,7 +170,7 @@ order of decreasing severity, are:
 - **Pedantic**: These rules are generally stylistic, like those in the `style` or similar
   categories, but enforce styles that are too opinionated or are too prone to false positives to fit
   into another category.
-- **Restriction**: These rules restrict the usage of basic language features in arbitrary ways.
+- **Restriction**: These rules restrict the usage of certain features in arbitrary ways.
 
 The first five categories compose the default rule set:
 

--- a/docs/rule-proposals.md
+++ b/docs/rule-proposals.md
@@ -109,7 +109,7 @@ flowchart TD
 
 The first question filters out special categories of rules: those that relate to the visual
 presentation of code (`formatting`), those that relate to `security` vulnerabilities, and those that
-impose `restriction`s on language features. "Restriction" here specifically means an arbitrary or
+impose `restriction`s on certain features. "Restriction" here specifically means an arbitrary or
 severe restriction, not the broad way in which any lint rule could be considered to restrict usage.
 Examples of restriction lints are rules like `assert` (`S101`) and `print` (`T201`), which ban basic
 language features across the board.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

The `restriction` category description refers to “language features”. I made the wording more general so it can also apply to 3rd party APIs.

I switched one rule, `pytest-fixture-autouse` into there, as it bans a feature that is both considered idiomatic and has no replacement, which was pointed out by a pytest maintainer and several users:

- https://github.com/astral-sh/ruff/issues/27959#issuecomment-5485836053
- https://github.com/astral-sh/ruff/issues/12491

The rule has been disabled because it was so contentious, only to later be placed into the `pedantic` categories with many rules that actually improve most code bases. This puts it in the appropriate category.

## Test Plan

I ran all the tests, and grepped the docs grepped for “restriction” and “language feature” to make sure I didn’t miss any spot where the categories are described.