### PR TITLE
[ty] Validate type variable scopes in implicit aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -808,6 +808,129 @@ def g(obj: Y[bool, range]):
     reveal_type(obj)  # revealed: tuple[bool, *tuple[tuple[int, str, range], ...], bytes]
 ```
 
+### Class-scoped type variables
+
+An implicit generic alias binds its own type variables. It cannot capture a type variable already
+bound to its enclosing class, including through a nested type argument or a union.
+
+```py
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+class Box(Generic[T]):
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Items = list[T]
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Nested = list[list[T]]
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Optional = T | None
+
+    Independent = list[S]
+    Concrete = list[int]
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Specialized = Independent[T]
+
+reveal_type(Box.Independent[str]())  # revealed: list[str]
+reveal_type(Box.Concrete())  # revealed: list[int]
+```
+
+Ordinary value assignments can use the class's type variables. A constructor call creates an
+instance, and an explicit value annotation distinguishes a class-valued attribute from an alias.
+Type variables in `Annotated` metadata do not become alias parameters.
+
+```py
+from typing import Annotated
+
+class Values(Generic[T]):
+    instance = list[T]()
+    constructor: type[list[T]] = list[T]
+    declared_constructor: type[list[T]]
+    declared_constructor = list[T]
+    constructors = [list[T]]
+    indexed_constructor = (list[T],)[0]
+    constructor_tuple = (list[T],)
+    tuple_constructor = constructor_tuple[0]
+    Metadata = Annotated[int, list[T]]
+
+    def make(self) -> list[T]:
+        return list[T]()
+```
+
+The same restriction applies to implicit aliases inside PEP 695 classes. A `type` statement can
+capture the enclosing class's parameter because its own type parameters are declared explicitly.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Modern[T]:
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Items = list[T]
+    type Captured = list[T]
+```
+
+Referring to another alias does not permit an implicit alias to capture the class's parameter.
+Recursive aliases are subject to the same rule.
+
+```py
+class Indirect[T]:
+    type Captured = list[T]
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Items = Captured
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Optional = Captured | None
+
+    type Recursive = T | list[Recursive]
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    RecursiveItems = Recursive
+
+    type ConcreteRecursive = int | list[ConcreteRecursive]
+    ConcreteItems = ConcreteRecursive
+```
+
+### Class-scoped variadic type variables
+
+Implicit aliases cannot capture a `ParamSpec` or `TypeVarTuple` bound to their enclosing class.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Callable, Generic, ParamSpec, TypeVarTuple
+
+P = ParamSpec("P")
+Ts = TypeVarTuple("Ts")
+
+class Callbacks(Generic[P]):
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `P`"
+    Callback = Callable[P, None]
+
+class Tuples(Generic[*Ts]):
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `Ts`"
+    Items = tuple[*Ts]
+```
+
+### Class-scoped implicit aliases in stubs
+
+Implicit aliases in stubs follow the same scoping rules as aliases in Python source files.
+
+```pyi
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Box(Generic[T]):
+    # error: [invalid-type-form] "Type alias cannot capture class-scoped type variable `T`"
+    Items = list[T]
+    constructor: type[list[T]] = list[T]
+```
+
 ### Error cases
 
 A generic alias that is already fully specialized cannot be specialized again:

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3558,6 +3558,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     self.infer_expression(value, tcx)
                 };
 
+                if tcx.annotation.is_none() && target.is_name_expr() {
+                    self.check_implicit_type_alias_scope(value, value_ty);
+                }
+
                 self.typevar_binding_context = previous_typevar_binding_context;
 
                 // `TYPE_CHECKING` is a special variable that should only be assigned `False`

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -22,6 +22,7 @@ use crate::types::signatures::{ConcatenateTail, Signature};
 use crate::types::special_form::{AliasSpec, LegacyStdlibAlias};
 use crate::types::string_annotation::parse_string_annotation;
 use crate::types::tuple::{TupleSpec, TupleSpecBuilder, TupleType};
+use crate::types::visitor::find_over_type;
 use ty_python_core::definition::DefinitionKind;
 use ty_python_core::scope::ScopeKind;
 
@@ -3251,6 +3252,86 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
     }
 
+    /// Check class-scoped implicit aliases after value inference has distinguished them from
+    /// ordinary assignments, such as `items = list[T]()`.
+    pub(super) fn check_implicit_type_alias_scope(&self, expression: &ast::Expr, ty: Type<'db>) {
+        let db = self.db();
+        if self.scope().scope(db).kind() != ScopeKind::Class
+            || !self.is_implicit_type_alias_expression(expression)
+        {
+            return;
+        }
+
+        if let Ok(alias_ty) = ty.in_type_expression(
+            db,
+            self.scope(),
+            self.typevar_binding_context,
+            self.inference_flags(),
+        ) {
+            self.check_type_alias_scope(
+                expression,
+                alias_ty.expand_eagerly(db, self.program_environment()),
+            );
+        }
+    }
+
+    /// Whether an expression can define an implicit alias. Subscripting a value such as a tuple
+    /// of constructors is an ordinary value expression, even when the result is a class object.
+    fn is_implicit_type_alias_expression(&self, expression: &ast::Expr) -> bool {
+        match expression {
+            ast::Expr::Name(_) | ast::Expr::Attribute(_) => is_dotted_name(expression),
+            ast::Expr::Subscript(subscript) => {
+                is_dotted_name(&subscript.value)
+                    && self
+                        .expression_type(&subscript.value)
+                        .in_type_expression(
+                            self.db(),
+                            self.scope(),
+                            self.typevar_binding_context,
+                            self.inference_flags(),
+                        )
+                        .is_ok()
+            }
+            ast::Expr::BinOp(ast::ExprBinOp {
+                left,
+                op: ast::Operator::BitOr,
+                right,
+                ..
+            }) => {
+                self.is_implicit_type_alias_expression(left)
+                    && self.is_implicit_type_alias_expression(right)
+            }
+            ast::Expr::NoneLiteral(_) => true,
+            _ => false,
+        }
+    }
+
+    fn check_type_alias_scope(&self, expression: &ast::Expr, ty: Type<'db>) {
+        let db = self.db();
+        // Bounds and protocol members have their own generic scopes. Inspect the alias's type
+        // arguments without descending into these lazily inferred attributes.
+        let Some(typevar) = find_over_type(db, self.program_environment(), ty, false, |ty| {
+            if let Type::TypeVar(typevar) = ty
+                && let Some(owner) = typevar.binding_context(db).definition()
+                && matches!(owner.kind(db), DefinitionKind::Class(_))
+            {
+                Some(typevar)
+            } else {
+                None
+            }
+        }) else {
+            return;
+        };
+
+        self.report_invalid_type_expression(
+            expression,
+            format_args!(
+                "Type alias cannot capture class-scoped type variable `{}`",
+                typevar.name(db)
+            ),
+        );
+    }
+
     /// Check whether a type variable can be used in the current type expression.
     ///
     /// Unbound variables fall back to `Unknown`. Bound variables retain their type so that an
@@ -3259,23 +3340,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         // Legacy aliases introduce independent type parameters. PEP 695 aliases can instead
         // capture their enclosing class's parameters.
-        if let Type::TypeVar(typevar) = ty
+        if let Type::TypeVar(_) = ty
             && self
                 .inference_flags()
                 .contains(InferenceFlags::IN_TYPE_ALIAS)
             && self.typevar_binding_context.is_some_and(|definition| {
                 matches!(definition.kind(db), DefinitionKind::AnnotatedAssignment(_))
             })
-            && let Some(owner) = typevar.binding_context(db).definition()
-            && matches!(owner.kind(db), DefinitionKind::Class(_))
         {
-            self.report_invalid_type_expression(
-                expression,
-                format_args!(
-                    "Type alias cannot capture class-scoped type variable `{}`",
-                    typevar.name(db)
-                ),
-            );
+            self.check_type_alias_scope(expression, ty);
             return ty;
         }
 


### PR DESCRIPTION
## Summary

We now report `invalid-type-form` for implicit type aliases that capture a type variable bound to their enclosing class, matching explicit `TypeAlias` declarations:

```python
from typing import Generic, TypeVar

T = TypeVar("T")

class Box(Generic[T]):
    Items = list[T]  # Error: cannot capture the class-scoped T.
```

The check covers nested type arguments, unions, aliases of aliases, and variadic type parameters. Aliases with independent parameters remain valid, as do constructor calls, explicitly annotated class-valued attributes, and PEP 695 `type` statements that capture enclosing parameters.

Follow-up to https://github.com/astral-sh/ruff/pull/28130#discussion_r3904758407.
