### PR TITLE
Try CodSpeed's Ryzen runner for walltime benchmarks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,4 +15,4 @@ self-hosted-runner:
     - depot-ubuntu-24.04-arm-8
     - github-windows-2025-x86_64-8
     - github-windows-2025-x86_64-16
-    - codspeed-macro
+    - codspeed-macro-x86-ryzen-9950x-ubuntu-24-04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1308,7 +1308,8 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           prefix-key: v0-rust-walltime-${{ runner.arch }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Populate this PR's isolated cache for warm-cache runner comparisons.
+          save-if: ${{ github.ref == 'refs/heads/main' || github.event.pull_request.number == 28225 }}
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.6"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1286,7 +1286,7 @@ jobs:
     name: "benchmarks walltime (build)"
     # We only run this job if `github.repository == 'astral-sh/ruff'`,
     # so hardcoding depot here is fine
-    runs-on: depot-ubuntu-22.04-arm-4
+    runs-on: depot-ubuntu-24.04-4
     needs: determine_changes
     if: |
       github.repository == 'astral-sh/ruff' &&
@@ -1307,10 +1307,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
+          prefix-key: v0-rust-walltime-${{ runner.arch }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.6"
+          cache-suffix: walltime-${{ runner.arch }}
 
       - name: "Install Rust toolchain"
         run: rustup show
@@ -1328,30 +1330,13 @@ jobs:
           retention-days: 1
 
   benchmarks-walltime-run:
-    name: "benchmarks walltime (${{ matrix.benchmark.name }})"
-    runs-on: codspeed-macro
+    name: "benchmarks walltime (x86_64)"
+    runs-on: codspeed-macro-x86-ryzen-9950x-ubuntu-24-04
     needs: benchmarks-walltime-build
     timeout-minutes: 20
     permissions:
       contents: read # required for actions/checkout
       id-token: write # required for OIDC authentication with CodSpeed
-    strategy:
-      matrix:
-        benchmark:
-          - name: script
-            target: ty_script
-          - name: sympy
-            target: ty_walltime
-            filter: sympy
-          - name: "pandas|tanjun"
-            target: ty_walltime
-            filter: "pandas|tanjun"
-          - name: "colour_science|static_frame"
-            target: ty_walltime
-            filter: "colour_science|static_frame"
-          - name: "pydantic|freqtrade|multithreaded|altair"
-            target: ty_walltime
-            filter: "pydantic|freqtrade|multithreaded|altair"
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1361,6 +1346,7 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.6"
+          cache-suffix: walltime-${{ runner.arch }}
 
       - name: "Download benchmark binary"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1381,7 +1367,7 @@ jobs:
           CODSPEED_PERF_ENABLED: false
         with:
           mode: walltime
-          run: uv run --only-dev cargo codspeed run --bench "${{ matrix.benchmark.target }}" -m walltime "${{ matrix.benchmark.filter }}"
+          run: uv run --only-dev cargo codspeed run -m walltime
 
   required-checks-passed:
     name: "all required checks passed"


### PR DESCRIPTION
Run the walltime benchmarks together on CodSpeed's x86 Ryzen 9950X runner instead of splitting them across five ARM jobs. Only one of the new runners is available, so the combined job avoids repeating setup for each matrix entry while retaining both `ty_walltime` and `ty_script`.

Build the binaries on x86 Ubuntu 24.04 and use separate architecture-specific caches. Allow this PR to populate the isolated Rust cache for repeated warm-cache measurements. The instrumented benchmarks are unchanged.

Compare five warm-cache Ryzen pipelines at one fixed revision with the 20 most recent eligible initial `main` pipelines at or before the pinned base. The ARM history spans August 31–September 1, 2026 (UTC). Each ARM sample contains one build and the complete five-job benchmark matrix; the matrix entries are not counted as independent samples.

The aggregate benchmark runner-time speedup is **5.35×**, while the visible benchmark stage is **1.40× faster** and build-to-finish is **1.28× faster**.

| Runtime | ARM mean (95% CI; 20 runs) | Ryzen mean (95% CI; 5 runs) | Speedup (95% CI) |
| --- | ---: | ---: | ---: |
| Build job | 3m09s (3m02s–3m15s) | 3m14s (2m24s–4m03s) | 0.97× (0.84×–1.16×) |
| Total benchmark job time | 19m33s (19m23s–19m43s) | 3m39s (3m29s–3m49s) | 5.35× (5.18×–5.48×) |
| Visible benchmark elapsed time | 5m07s (5m00s–5m15s) | 3m39s (3m29s–3m49s) | 1.40× (1.35×–1.45×) |
| Total job time, including build | 22m42s (22m28s–22m55s) | 6m53s (5m58s–7m48s) | 3.30× (3.05×–3.59×) |
| Build start to benchmarks finished | 9m26s (9m17s–9m36s) | 7m24s (6m29s–8m19s) | 1.28× (1.18×–1.38×) |

Speedup is ARM mean runtime divided by Ryzen mean runtime; values below 1× mean longer runtime. For summed job time, the factor describes runner-time efficiency rather than elapsed CI time. Build time alone shows no clear improvement. Total time sums job durations, including setup and teardown. Visible benchmark time spans the first benchmark job start through the last benchmark job completion. Build-to-finish also includes the handoff from build to execution; unrelated CI jobs are excluded.

Every selected build restored a full-key Rust dependency cache, and every benchmark consumed its corresponding build artifact. Workspace crates were still rebuilt. ARM samples were selected chronologically, skipping incomplete or failed walltime pipelines and cache misses, without excluding slow valid samples or pipelines with unrelated CI failures. The five Ryzen samples are serial build-and-benchmark runs at checkout `d113ec0b8f3e41934bce0f79ad7941a746f08d02`; the [cold pilot](https://github.com/astral-sh/ruff/actions/runs/33530798689) and [cache-seeding run](https://github.com/astral-sh/ruff/actions/runs/33532296185) are excluded.

This is a historical CI comparison, not an isolated measurement of the hardware change. The walltime benchmark definitions and project fixtures were unchanged across the selected ARM revisions, but application code and dependencies changed. Eighteen ARM runs installed `cargo-codspeed` with `taiki-e/install-action`; the two newest used the `uv` toolchain, as the Ryzen runs do. That setup difference is included in job runtimes.

Mean intervals use two-sided 95% Student-t intervals. Speedup intervals are derived from 100,000 independent whole-pipeline bootstrap resamples from both the 20 ARM and five Ryzen observations (seed `20260901`). They are indicative under an independent, representative-run assumption; they do not account for temporal correlation or remove code/configuration differences.

<details>
<summary>Five Ryzen samples</summary>

| Sample | Build | Benchmark (total and visible) | Total including build | Build start to finish |
| --- | ---: | ---: | ---: | ---: |
| 1 | [2m26s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99947974486) | [3m37s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99948796485) | 6m03s | 6m35s |
| 2 | [3m43s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99953701009) | [3m38s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99954933664) | 7m21s | 7m52s |
| 3 | [2m35s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99957705216) | [3m35s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99958573222) | 6m10s | 6m40s |
| 4 | [3m48s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99961631677) | [3m53s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99962866016) | 7m41s | 8m12s |
| 5 | [3m37s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99965322607) | [3m33s](https://github.com/astral-sh/ruff/actions/runs/33535245228/job/99966509431) | 7m10s | 7m41s |

</details>

<details>
<summary>Twenty ARM main samples</summary>

All runs use their initial attempt; timestamps below are UTC. Each run link contains the complete five-job matrix.

| Run started | Build | Benchmark total | Benchmark visible | Total including build | Build start to finish |
| --- | ---: | ---: | ---: | ---: | ---: |
| [2026-09-01 15:22:01](https://github.com/astral-sh/ruff/actions/runs/33525291565/attempts/1) | [3m58s](https://github.com/astral-sh/ruff/actions/runs/33525291565/job/99914559297) | 19m57s | 5m18s | 23m55s | 10m29s |
| [2026-09-01 14:52:38](https://github.com/astral-sh/ruff/actions/runs/33522213402/attempts/1) | [3m09s](https://github.com/astral-sh/ruff/actions/runs/33522213402/job/99905694902) | 19m42s | 6m00s | 22m51s | 9m38s |
| [2026-09-01 14:30:56](https://github.com/astral-sh/ruff/actions/runs/33519963755/attempts/1) | [3m25s](https://github.com/astral-sh/ruff/actions/runs/33519963755/job/99899039512) | 19m29s | 5m01s | 22m54s | 9m42s |
| [2026-09-01 14:09:37](https://github.com/astral-sh/ruff/actions/runs/33517773980/attempts/1) | [3m07s](https://github.com/astral-sh/ruff/actions/runs/33517773980/job/99889206850) | 19m39s | 5m05s | 22m46s | 9m34s |
| [2026-09-01 12:30:50](https://github.com/astral-sh/ruff/actions/runs/33508095785/attempts/1) | [3m05s](https://github.com/astral-sh/ruff/actions/runs/33508095785/job/99856976101) | 19m40s | 5m10s | 22m45s | 9m31s |
| [2026-09-01 09:47:13](https://github.com/astral-sh/ruff/actions/runs/33494029970/attempts/1) | [2m48s](https://github.com/astral-sh/ruff/actions/runs/33494029970/job/99812032956) | 19m35s | 5m01s | 22m23s | 9m16s |
| [2026-09-01 06:56:13](https://github.com/astral-sh/ruff/actions/runs/33479774822/attempts/1) | [2m53s](https://github.com/astral-sh/ruff/actions/runs/33479774822/job/99766662376) | 19m16s | 4m55s | 22m09s | 9m04s |
| [2026-08-31 23:31:33](https://github.com/astral-sh/ruff/actions/runs/33451041079/attempts/1) | [3m08s](https://github.com/astral-sh/ruff/actions/runs/33451041079/job/99680831709) | 19m21s | 4m58s | 22m29s | 9m21s |
| [2026-08-31 22:54:17](https://github.com/astral-sh/ruff/actions/runs/33448344253/attempts/1) | [3m05s](https://github.com/astral-sh/ruff/actions/runs/33448344253/job/99672444161) | 19m09s | 4m58s | 22m14s | 9m18s |
| [2026-08-31 22:42:45](https://github.com/astral-sh/ruff/actions/runs/33447467539/attempts/1) | [3m11s](https://github.com/astral-sh/ruff/actions/runs/33447467539/job/99669742603) | 19m15s | 4m53s | 22m26s | 9m19s |
| [2026-08-31 22:18:34](https://github.com/astral-sh/ruff/actions/runs/33445604275/attempts/1) | [3m02s](https://github.com/astral-sh/ruff/actions/runs/33445604275/job/99663977950) | 19m06s | 5m25s | 22m08s | 9m49s |
| [2026-08-31 21:39:17](https://github.com/astral-sh/ruff/actions/runs/33442447065/attempts/1) | [3m00s](https://github.com/astral-sh/ruff/actions/runs/33442447065/job/99653701824) | 20m46s | 5m13s | 23m46s | 9m24s |
| [2026-08-31 21:35:20](https://github.com/astral-sh/ruff/actions/runs/33442113746/attempts/1) | [3m00s](https://github.com/astral-sh/ruff/actions/runs/33442113746/job/99652654929) | 19m41s | 4m58s | 22m41s | 9m11s |
| [2026-08-31 20:34:10](https://github.com/astral-sh/ruff/actions/runs/33436739924/attempts/1) | [3m02s](https://github.com/astral-sh/ruff/actions/runs/33436739924/job/99635014966) | 19m19s | 5m39s | 22m21s | 8m44s |
| [2026-08-31 18:19:47](https://github.com/astral-sh/ruff/actions/runs/33424399124/attempts/1) | [3m11s](https://github.com/astral-sh/ruff/actions/runs/33424399124/job/99594615886) | 19m25s | 5m00s | 22m36s | 9m28s |
| [2026-08-31 17:27:16](https://github.com/astral-sh/ruff/actions/runs/33419645721/attempts/1) | [3m09s](https://github.com/astral-sh/ruff/actions/runs/33419645721/job/99578729575) | 19m52s | 5m04s | 23m01s | 9m24s |
| [2026-08-31 15:46:24](https://github.com/astral-sh/ruff/actions/runs/33410353032/attempts/1) | [3m20s](https://github.com/astral-sh/ruff/actions/runs/33410353032/job/99548198893) | 19m39s | 5m01s | 22m59s | 9m36s |
| [2026-08-31 15:34:09](https://github.com/astral-sh/ruff/actions/runs/33409187499/attempts/1) | [3m09s](https://github.com/astral-sh/ruff/actions/runs/33409187499/job/99544340768) | 19m21s | 5m00s | 22m30s | 9m23s |
| [2026-08-31 14:32:08](https://github.com/astral-sh/ruff/actions/runs/33403197187/attempts/1) | [3m06s](https://github.com/astral-sh/ruff/actions/runs/33403197187/job/99525021304) | 19m25s | 4m55s | 22m31s | 9m20s |
| [2026-08-31 13:17:51](https://github.com/astral-sh/ruff/actions/runs/33396186232/attempts/1) | [3m04s](https://github.com/astral-sh/ruff/actions/runs/33396186232/job/99501255328) | 19m24s | 4m55s | 22m28s | 9m14s |

</details>
