### PR TITLE
[ty] Defer decorator-call diagnostics to avoid recursive-default cycles

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -298,6 +298,26 @@ assert g
 def g(x: object = lambda: g) -> None: ...
 ```
 
+### Diagnostics for self-referential decorated functions
+
+We reject a decorator that expects an integer instead of a function. Displaying the function's
+signature in that diagnostic can infer its self-referential default value. We report the error after
+function inference finishes, so diagnostic formatting does not create a cycle through the
+reachability check for the earlier assertion. This is a regression test for
+<https://github.com/astral-sh/ty/issues/4440>.
+
+```py
+def decorator(value: int) -> int:
+    return value
+
+f = lambda: f
+assert f
+
+# error: [invalid-argument-type] "Expected `int`, found `def f(x=...) -> Unknown`"
+@decorator
+def f(x=lambda: f): ...
+```
+
 ### Self-referential property construction
 
 Constructing a property explicitly has the same behavior as decorator syntax:

--- a/crates/ty_python_semantic/resources/mdtest/decorators.md
+++ b/crates/ty_python_semantic/resources/mdtest/decorators.md
@@ -274,6 +274,26 @@ def f(x): ...
 reveal_type(f)  # revealed: str
 ```
 
+Each error in a decorator stack describes the value received at that step. An inner decorator can
+replace the function before a failing call, and an outer decorator can replace the result again.
+
+```py
+def returns_bytes(value: object) -> bytes:
+    return b""
+
+def requires_bytes(value: bytes) -> bool:
+    return bool(value)
+
+# error: [invalid-argument-type] "Expected `bytes`, found `str`"
+@requires_bytes
+# error: [invalid-argument-type] "Expected `int`, found `bytes`"
+@wrong_signature
+@returns_bytes
+def stacked(): ...
+
+reveal_type(stacked)  # revealed: bool
+```
+
 #### Wrong number of arguments
 
 Decorators need to be callable with a single argument. If they are not, we emit a diagnostic:
@@ -294,6 +314,25 @@ def takes_no_argument() -> str:
 # error: [too-many-positional-arguments] "Too many positional arguments to function `takes_no_argument`: expected 0, got 1"
 @takes_no_argument
 def g(x): ...
+```
+
+#### No matching overload
+
+An overloaded decorator is rejected when none of its signatures accepts the function being
+decorated.
+
+```py
+from typing import overload
+
+@overload
+def scalar(value: int) -> None: ...
+@overload
+def scalar(value: str) -> None: ...
+def scalar(value: int | str) -> None: ...
+
+# error: [no-matching-overload]
+@scalar
+def f() -> None: ...
 ```
 
 ### Class, with wrong signature, used as a decorator

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
@@ -38,22 +38,38 @@ def test() -> int:
             return a + 5
 ```
 
-## Error in preceding decorator
+## Errors in decorator applications
 
-Don't suppress diagnostics for decorator expressions appearing before the `no_type_check` decorator.
+We currently suppress all decorator-application errors on a function decorated with `no_type_check`,
+regardless of whether those errors occur in applying decorators appearing before or after
+`@no_type_check`. TODO: it would be more intuitive and consistent with our behavior for
+decorator-expression errors (see below) if we only suppressed these for decorators located after
+`@no_type_check` in source order.
 
 ```py
 from typing import no_type_check
 
-@unknown_decorator  # error: [unresolved-reference]
+def takes_int(value: int) -> int:
+    return value
+
+# TODO this should be an error:
+@takes_int
 @no_type_check
-def test() -> int:
-    return a + 5
+def before() -> None: ...
+
+# no error, swallowed by `no_type_check`:
+@no_type_check
+@takes_int
+def after() -> None: ...
+
+# error: [invalid-argument-type]
+@takes_int
+def checked() -> None: ...
 ```
 
-## Error in following decorator
+## Error in following decorator expression
 
-Unlike Pyright and mypy, we suppress diagnostics in decorator expressions appearing after the
+Unlike Pyright and mypy, we also suppress diagnostics in decorator expressions appearing after the
 `no_type_check` decorator. We do this because it more closely matches Python's runtime semantics of
 decorators. For more details, see the discussion on the
 [PR adding `@no_type_check` support](https://github.com/astral-sh/ruff/pull/15122#discussion_r1896869411).
@@ -67,27 +83,18 @@ def test() -> int:
     return a + 5
 ```
 
-## Errors in decorator applications
+## Error in preceding decorator expression
 
-`no_type_check` suppresses errors from applying decorators to the function, regardless of its
-position in the decorator list. This does not suppress the same error on other functions.
+We don't suppress diagnostics for decorator expressions appearing before the `no_type_check`
+decorator.
 
 ```py
 from typing import no_type_check
 
-def takes_int(value: int) -> int:
-    return value
-
-@takes_int
+@unknown_decorator  # error: [unresolved-reference]
 @no_type_check
-def before() -> None: ...
-@no_type_check
-@takes_int
-def after() -> None: ...
-
-# error: [invalid-argument-type]
-@takes_int
-def checked() -> None: ...
+def test() -> int:
+    return a + 5
 ```
 
 ## Error in default value

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
@@ -40,8 +40,7 @@ def test() -> int:
 
 ## Error in preceding decorator
 
-Don't suppress diagnostics for decorator expressions appearing before the `no_type_check`
-decorator.
+Don't suppress diagnostics for decorator expressions appearing before the `no_type_check` decorator.
 
 ```py
 from typing import no_type_check
@@ -82,7 +81,6 @@ def takes_int(value: int) -> int:
 @takes_int
 @no_type_check
 def before() -> None: ...
-
 @no_type_check
 @takes_int
 def after() -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
@@ -53,7 +53,7 @@ def test() -> int:
 
 ## Error in following decorator
 
-Unlike Pyright and mypy, suppress diagnostics in decorator expressions appearing after the
+Unlike Pyright and mypy, we suppress diagnostics in decorator expressions appearing after the
 `no_type_check` decorator. We do this because it more closely matches Python's runtime semantics of
 decorators. For more details, see the discussion on the
 [PR adding `@no_type_check` support](https://github.com/astral-sh/ruff/pull/15122#discussion_r1896869411).

--- a/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
@@ -40,7 +40,8 @@ def test() -> int:
 
 ## Error in preceding decorator
 
-Don't suppress diagnostics for decorators appearing before the `no_type_check` decorator.
+Don't suppress diagnostics for decorator expressions appearing before the `no_type_check`
+decorator.
 
 ```py
 from typing import no_type_check
@@ -53,9 +54,9 @@ def test() -> int:
 
 ## Error in following decorator
 
-Unlike Pyright and mypy, suppress diagnostics appearing after the `no_type_check` decorator. We do
-this because it more closely matches Python's runtime semantics of decorators. For more details, see
-the discussion on the
+Unlike Pyright and mypy, suppress diagnostics in decorator expressions appearing after the
+`no_type_check` decorator. We do this because it more closely matches Python's runtime semantics of
+decorators. For more details, see the discussion on the
 [PR adding `@no_type_check` support](https://github.com/astral-sh/ruff/pull/15122#discussion_r1896869411).
 
 ```py
@@ -65,6 +66,30 @@ from typing import no_type_check
 @unknown_decorator
 def test() -> int:
     return a + 5
+```
+
+## Errors in decorator applications
+
+`no_type_check` suppresses errors from applying decorators to the function, regardless of its
+position in the decorator list. This does not suppress the same error on other functions.
+
+```py
+from typing import no_type_check
+
+def takes_int(value: int) -> int:
+    return value
+
+@takes_int
+@no_type_check
+def before() -> None: ...
+
+@no_type_check
+@takes_int
+def after() -> None: ...
+
+# error: [invalid-argument-type]
+@takes_int
+def checked() -> None: ...
 ```
 
 ## Error in default value

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1341,6 +1341,9 @@ struct OtherDefinitionInferenceExtra<'db> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
+    /// Input types for failed decorator applications that are checked after inference.
+    deferred_decorator_calls: FrozenMap<ExpressionNodeKey, Type<'db>>,
+
     /// Whether synthesized dictionary-key assignments derived from the right-hand side should be
     /// discarded.
     discards_dict_key_assignments: bool,
@@ -1510,6 +1513,18 @@ impl<'db> DefinitionInference<'db> {
             definition,
         );
 
+        if let Some(DefinitionInferenceExtra::Other(extra)) = self.extra.as_deref_mut() {
+            for (expression, ty) in &mut extra.deferred_decorator_calls {
+                *ty = if let Some(previous_ty) =
+                    previous_inference.deferred_decorator_input_type(*expression)
+                {
+                    ty.cycle_normalized(db, &env, previous_ty, cycle)
+                } else {
+                    ty.recursive_type_normalized(db, &env, cycle)
+                };
+            }
+        }
+
         if cycle.iteration() > crate::TAINTED_CYCLES
             && let Some(previous_constraints) = previous_inference
                 .extra
@@ -1664,6 +1679,19 @@ impl<'db> DefinitionInference<'db> {
                 Some(extra.undecorated_type)
             }
             Some(DefinitionInferenceExtra::Other(extra)) => extra.undecorated_type,
+            Some(_) | None => None,
+        }
+    }
+
+    fn deferred_decorator_input_type(
+        &self,
+        expression: impl Into<ExpressionNodeKey>,
+    ) -> Option<Type<'db>> {
+        match self.extra.as_deref() {
+            Some(DefinitionInferenceExtra::Other(extra)) => extra
+                .deferred_decorator_calls
+                .get(&expression.into())
+                .copied(),
             Some(_) | None => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5579,7 +5579,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn defer_decorator_call(&mut self, decorator: &ast::Decorator, input_ty: Type<'db>) {
-        // The enclosing scope's post-inference context does not have this definition-local flag.
+        // We replay failed decorator applications after inference only to report call errors,
+        // such as incompatible argument types or missing arguments. `@no_type_check` suppresses
+        // these errors. Skip recording the calls here because the enclosing scope's post-inference
+        // diagnostic context does not inherit this definition-local flag.
         if !self
             .inference_flags()
             .contains(InferenceFlags::IN_NO_TYPE_CHECK)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -373,6 +373,12 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
+    /// Input types for failed decorator applications, keyed by decorator expression.
+    ///
+    /// Recheck these calls after inference so formatting diagnostics cannot pull deferred
+    /// function defaults into definition inference cycles.
+    deferred_decorator_calls: Vec<(ExpressionNodeKey, Type<'db>)>,
+
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
 
@@ -508,6 +514,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             typevar_binding_context: None,
             deferred: VecSet::default(),
             undecorated_type: None,
+            deferred_decorator_calls: Vec::new(),
             cycle_recovery: None,
             discards_dict_key_assignments: false,
             dataclass_field_specifiers: SmallVec::new(),
@@ -1178,6 +1185,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let ty = ty_and_quals.inner_type();
                 match definition.kind(self.db()) {
                     DefinitionKind::Function(function) => {
+                        post_inference::check_decorator_calls(
+                            &self.context,
+                            definition,
+                            &function.node(self.module()).decorator_list,
+                        );
                         post_inference::function::check_function_definition(
                             &self.context,
                             definition,
@@ -1199,6 +1211,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                     }
                     DefinitionKind::Class(class_node) => {
+                        post_inference::check_decorator_calls(
+                            &self.context,
+                            definition,
+                            &class_node.node(self.module()).decorator_list,
+                        );
                         let original_ty = match self.region {
                             InferenceRegion::Definition(current) if current == definition => {
                                 self.undecorated_type
@@ -5517,7 +5534,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             Ok(bindings) => (bindings.return_type(db, env), Some(bindings)),
             Err(CallError(_, bindings)) => {
-                bindings.report_diagnostics(&self.context, decorator_node.into());
+                self.defer_decorator_call(decorator_node, decorated_ty);
                 (bindings.return_type(db, env), None)
             }
         };
@@ -5559,6 +5576,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         inferred_ty
+    }
+
+    fn defer_decorator_call(&mut self, decorator: &ast::Decorator, input_ty: Type<'db>) {
+        // The enclosing scope's post-inference context does not have this definition-local flag.
+        if !self
+            .inference_flags()
+            .contains(InferenceFlags::IN_NO_TYPE_CHECK)
+        {
+            self.deferred_decorator_calls
+                .push(((&decorator.expression).into(), input_ty));
+        }
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -11474,6 +11502,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            deferred_decorator_calls: _,
             discards_dict_key_assignments: _,
 
             // builder only state
@@ -11537,6 +11566,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            deferred_decorator_calls: _,
             discards_dict_key_assignments: _,
 
             // builder only state
@@ -11649,6 +11679,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             collection_use_constraints: _,
             dataclass_field_specifiers: _,
             undecorated_type: _,
+            deferred_decorator_calls: _,
             discards_dict_key_assignments: _,
             typevar_binding_context: _,
             deferred_state: _,
@@ -11696,6 +11727,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred,
             cycle_recovery,
             undecorated_type,
+            deferred_decorator_calls,
             discards_dict_key_assignments,
             called_functions,
 
@@ -11720,6 +11752,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             + usize::from(!type_expression_flags.is_empty())
             + usize::from(cycle_recovery.is_some())
             + usize::from(!deferred.is_empty())
+            + usize::from(!deferred_decorator_calls.is_empty())
             + usize::from(!diagnostics.is_empty())
             + usize::from(discards_dict_key_assignments)
             + usize::from(!qualifiers.is_empty());
@@ -11778,6 +11811,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     deferred: deferred.into_boxed_slice(),
                     diagnostics,
                     undecorated_type,
+                    deferred_decorator_calls: deferred_decorator_calls.into_iter().collect(),
                     discards_dict_key_assignments,
                     qualifiers: FrozenMap::from(qualifiers),
                 };
@@ -11838,6 +11872,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            deferred_decorator_calls: _,
             discards_dict_key_assignments: _,
 
             // Builder only state
@@ -11917,6 +11952,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred: _,
             called_functions: _,
             undecorated_type: _,
+            deferred_decorator_calls: _,
             discards_dict_key_assignments: _,
             qualifiers: _,
             type_expression_flags: _,
@@ -11982,6 +12018,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Ignored; only relevant to definition regions
             undecorated_type: _,
+            deferred_decorator_calls: _,
             discards_dict_key_assignments: _,
 
             // builder only state

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1185,7 +1185,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let ty = ty_and_quals.inner_type();
                 match definition.kind(self.db()) {
                     DefinitionKind::Function(function) => {
-                        post_inference::check_decorator_calls(
+                        post_inference::decorator::check_decorator_calls(
                             &self.context,
                             definition,
                             &function.node(self.module()).decorator_list,
@@ -1211,7 +1211,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                     }
                     DefinitionKind::Class(class_node) => {
-                        post_inference::check_decorator_calls(
+                        post_inference::decorator::check_decorator_calls(
                             &self.context,
                             definition,
                             &class_node.node(self.module()).decorator_list,

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -317,7 +317,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let decorated_ty = match decorator_result {
                 Ok(return_ty) => return_ty,
                 Err(CallError(_, bindings)) => {
-                    bindings.report_diagnostics(&self.context, decorator_node.into());
+                    self.defer_decorator_call(decorator_node, inferred_ty);
                     bindings.return_type(db, env)
                 }
             };

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/decorator.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/decorator.rs
@@ -1,0 +1,30 @@
+use ruff_python_ast as ast;
+use ty_python_core::definition::Definition;
+
+use crate::types::call::{CallArguments, CallError};
+use crate::types::context::InferContext;
+use crate::types::infer::infer_definition_types;
+
+pub(crate) fn check_decorator_calls<'db>(
+    context: &InferContext<'db, '_>,
+    definition: Definition<'db>,
+    decorators: &[ast::Decorator],
+) {
+    if decorators.is_empty() {
+        return;
+    }
+
+    let db = context.db();
+    let env = context.program_environment();
+    let inference = infer_definition_types(db, definition);
+    for decorator in decorators.iter().rev() {
+        let Some(input_ty) = inference.deferred_decorator_input_type(&decorator.expression) else {
+            continue;
+        };
+        let decorator_ty = inference.expression_type(&decorator.expression);
+        let arguments = CallArguments::positional([input_ty]);
+        if let Err(CallError(_, bindings)) = decorator_ty.try_call(db, env, &arguments) {
+            bindings.report_diagnostics(context, decorator.into());
+        }
+    }
+}

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/mod.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/mod.rs
@@ -1,6 +1,13 @@
 //! A home for deferred checks that must be done after the `TypeInferenceBuilder` has done an initial
 //! inference pass over the whole scope.
 
+use ruff_python_ast as ast;
+use ty_python_core::definition::Definition;
+
+use crate::types::call::{CallArguments, CallError};
+use crate::types::context::InferContext;
+use crate::types::infer::infer_definition_types;
+
 pub(super) mod dynamic_class;
 pub(super) mod final_variable;
 pub(super) mod function;
@@ -10,3 +17,27 @@ pub(super) mod static_class;
 pub(super) mod type_param_validation;
 pub(super) mod typed_dict;
 pub(super) mod typeguard;
+
+pub(super) fn check_decorator_calls<'db>(
+    context: &InferContext<'db, '_>,
+    definition: Definition<'db>,
+    decorators: &[ast::Decorator],
+) {
+    if decorators.is_empty() {
+        return;
+    }
+
+    let db = context.db();
+    let env = context.program_environment();
+    let inference = infer_definition_types(db, definition);
+    for decorator in decorators.iter().rev() {
+        let Some(input_ty) = inference.deferred_decorator_input_type(&decorator.expression) else {
+            continue;
+        };
+        let decorator_ty = inference.expression_type(&decorator.expression);
+        let arguments = CallArguments::positional([input_ty]);
+        if let Err(CallError(_, bindings)) = decorator_ty.try_call(db, env, &arguments) {
+            bindings.report_diagnostics(context, decorator.into());
+        }
+    }
+}

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/mod.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/mod.rs
@@ -1,13 +1,7 @@
 //! A home for deferred checks that must be done after the `TypeInferenceBuilder` has done an initial
 //! inference pass over the whole scope.
 
-use ruff_python_ast as ast;
-use ty_python_core::definition::Definition;
-
-use crate::types::call::{CallArguments, CallError};
-use crate::types::context::InferContext;
-use crate::types::infer::infer_definition_types;
-
+pub(super) mod decorator;
 pub(super) mod dynamic_class;
 pub(super) mod final_variable;
 pub(super) mod function;
@@ -17,27 +11,3 @@ pub(super) mod static_class;
 pub(super) mod type_param_validation;
 pub(super) mod typed_dict;
 pub(super) mod typeguard;
-
-pub(super) fn check_decorator_calls<'db>(
-    context: &InferContext<'db, '_>,
-    definition: Definition<'db>,
-    decorators: &[ast::Decorator],
-) {
-    if decorators.is_empty() {
-        return;
-    }
-
-    let db = context.db();
-    let env = context.program_environment();
-    let inference = infer_definition_types(db, definition);
-    for decorator in decorators.iter().rev() {
-        let Some(input_ty) = inference.deferred_decorator_input_type(&decorator.expression) else {
-            continue;
-        };
-        let decorator_ty = inference.expression_type(&decorator.expression);
-        let arguments = CallArguments::positional([input_ty]);
-        if let Err(CallError(_, bindings)) = decorator_ty.try_call(db, env, &arguments) {
-            bindings.report_diagnostics(context, decorator.into());
-        }
-    }
-}


### PR DESCRIPTION
Reporting a decorator-call error could panic when displaying a function signature required inferring a self-referential parameter default. Formatting the diagnostic during definition inference introduced a cycle through reachability checks that never converged.

Defer failed decorator-call diagnostics until the scope's post-inference checks. Retain the input type for each failed application so stacked decorators are rechecked against the correct intermediate value, for both function and class decorators. This preserves displayed default values and `@no_type_check` suppression.

Fixes astral-sh/ty#4440.

## Test plan

Add mdtests covering the recursive-default panic, failures at separate stages of a decorator stack, an overloaded decorator with no matching signature, and suppressed decorator-application errors with `@no_type_check` in either position alongside an unsuppressed control.
