### PR TITLE
[ty] Handle union arguments in generic overload resolution (astral-sh/ty#3825)

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -185,6 +185,75 @@ def _(ab: A | B, ac: A | C, bc: B | C):
     reveal_type(f(*(ac,)))  # revealed: A | C
 ```
 
+### Generic overloads with an awaited call
+
+Each expanded union member solves generic constraints independently.
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+`generic.pyi`:
+
+```pyi
+from typing import Any, Generic, TypeVar, overload
+
+Single = TypeVar("Single")
+Multiple = TypeVar("Multiple", bound=tuple[Any, Any, *tuple[Any, ...]])
+Ts = TypeVar("Ts", bound=tuple[Any, ...])
+
+class Select(Generic[Ts]): ...
+
+@overload
+async def query(value: Select[tuple[Single]]) -> list[Single]: ...
+@overload
+async def query(value: Select[Multiple]) -> list[Multiple]: ...
+```
+
+```py
+from generic import Multiple, Select, Single, query
+
+async def generic(value: Select[tuple[Single]] | Select[Multiple]) -> list[Single] | list[Multiple]:
+    result: list[Single] | list[Multiple] = await query(value)
+    reveal_type(result)  # revealed: list[Single@generic] | list[Multiple@generic]
+    return await query(value)
+```
+
+### Expansion requires every union member to match
+
+Expansion succeeds only if every member matches an overload, without combining invalid argument pairs.
+
+`guards.pyi`:
+
+```pyi
+from typing import overload
+
+@overload
+def f(x: int) -> int: ...
+@overload
+def f(x: str) -> str: ...
+@overload
+def only_int(x: int) -> int: ...
+@overload
+def only_int(x: bytes) -> bytes: ...
+@overload
+def pair(x: int, y: bytes) -> int: ...
+@overload
+def pair(x: str, y: float) -> str: ...
+```
+
+```py
+from guards import f, only_int, pair
+
+def valid(x: int | str):
+    reveal_type(f(x))  # revealed: int | str
+
+def invalid(x: int | str, y: bytes | float):
+    only_int(x)  # error: [no-matching-overload]
+    pair(x, y)  # error: [no-matching-overload]
+```
+
 ### Expanding first argument
 
 If the set of argument lists created by expanding the first argument evaluates successfully, the

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -52,6 +52,7 @@ use crate::types::function::{
 };
 use crate::types::generics::{
     GenericContext, Specialization, SpecializationBuilder, SpecializationError, TypeVarInference,
+    TypeVarInferenceFallback, TypeVarInferenceSolutions,
 };
 use crate::types::infer::original_class_type;
 use crate::types::known_instance::{FieldInstance, InternedConstraintSetSolution};
@@ -3878,6 +3879,7 @@ impl<'db> CallableBinding<'db> {
         }
 
         let snapshotter = CallableBindingSnapshotter::new(overloads_for_expansion);
+        let expansion_nonce_generator = TypeVarNonceGenerator::default();
 
         // State of the bindings _after_ evaluating (type checking) the matching overloads using
         // the non-expanded argument types.
@@ -3904,6 +3906,16 @@ impl<'db> CallableBinding<'db> {
             let mut return_types = Vec::new();
 
             for expanded_arguments in &expanded_argument_lists {
+                let narrow_targets = call_expression_tcx.narrow_call_targets(db, env);
+                let branch_contexts = narrow_targets
+                    .as_deref()
+                    .into_iter()
+                    .flatten()
+                    .copied()
+                    .map(TypeContext::from)
+                    .chain(std::iter::once(call_expression_tcx))
+                    .unique();
+
                 // The spec mentions that each expanded argument list should be re-evaluated from
                 // step 2 but we need to re-evaluate from step 1 because our step 1 does more than
                 // what the spec mentions. Step 1 of the spec means only "eliminate impossible
@@ -3912,76 +3924,85 @@ impl<'db> CallableBinding<'db> {
                 // allows us to correctly handle cases involving a variadic argument that could
                 // expand into different number of arguments with each expansion. Refer to
                 // https://github.com/astral-sh/ty/issues/735 for more details.
+                let expansion_nonce = expansion_nonce_generator.next().value();
                 for overload in &mut self.overloads {
                     // Clear the state of all overloads before re-evaluating from step 1
                     overload.reset(db);
+                    overload.freshen_bound_typevars(db, env, expansion_nonce);
                     overload.match_parameters(db, env, expanded_arguments);
                 }
 
-                tracing::trace!(
-                    target: "ty_python_semantic::types::call::bind",
-                    matching_overload_index = ?self.matching_overload_index(),
-                    "after step 1",
-                );
+                let branch_state = self.clone();
+                let branch_return_type = branch_contexts.into_iter().find_map(|branch_context| {
+                    *self = branch_state.clone();
 
-                for (_, overload) in self.matching_overloads_mut() {
-                    overload.check_types(
-                        db,
-                        env,
-                        constraints,
-                        expanded_arguments,
-                        call_expression_tcx,
+                    let branch_constraints = ConstraintSetBuilder::new();
+
+                    tracing::trace!(
+                        target: "ty_python_semantic::types::call::bind",
+                        matching_overload_index = ?self.matching_overload_index(),
+                        "after step 1",
                     );
-                }
 
-                tracing::trace!(
-                    target: "ty_python_semantic::types::call::bind",
-                    matching_overload_index = ?self.matching_overload_index(),
-                    "after step 2",
-                );
-
-                let return_type = match self.matching_overload_index() {
-                    MatchingOverloadIndex::None => None,
-                    MatchingOverloadIndex::Single(index) => {
-                        Some(self.overloads[index].return_type())
-                    }
-                    MatchingOverloadIndex::Multiple(matching_overload_indexes) => {
-                        self.filter_overloads_containing_variadic(&matching_overload_indexes);
-
-                        tracing::trace!(
-                            target: "ty_python_semantic::types::call::bind",
-                            matching_overload_index = ?self.matching_overload_index(),
-                            "after step 4",
+                    for (_, overload) in self.matching_overloads_mut() {
+                        overload.check_types(
+                            db,
+                            env,
+                            &branch_constraints,
+                            expanded_arguments,
+                            branch_context,
                         );
+                    }
+                    self.reject_unsatisfiable_overloads(db);
+                    tracing::trace!(
+                        target: "ty_python_semantic::types::call::bind",
+                        matching_overload_index = ?self.matching_overload_index(),
+                        "after step 2",
+                    );
 
-                        match self.matching_overload_index() {
-                            MatchingOverloadIndex::None => {
-                                tracing::debug!(
-                                    "All overloads have been filtered out in step 4 during argument type expansion"
-                                );
-                                None
-                            }
-                            MatchingOverloadIndex::Single(_) => Some(self.return_type()),
-                            MatchingOverloadIndex::Multiple(indexes) => {
-                                self.filter_overloads_using_any_or_unknown(
-                                    db,
-                                    env,
-                                    constraints,
-                                    expanded_arguments,
-                                    &indexes,
-                                );
+                    match self.matching_overload_index() {
+                        MatchingOverloadIndex::None => None,
+                        MatchingOverloadIndex::Single(index) => {
+                            Some(self.overloads[index].return_type())
+                        }
+                        MatchingOverloadIndex::Multiple(matching_overload_indexes) => {
+                            self.filter_overloads_containing_variadic(&matching_overload_indexes);
 
-                                tracing::trace!(
-                                    target: "ty_python_semantic::types::call::bind",
-                                    matching_overload_index = ?self.matching_overload_index(),
-                                    "after step 5",
-                                );
+                            tracing::trace!(
+                                target: "ty_python_semantic::types::call::bind",
+                                matching_overload_index = ?self.matching_overload_index(),
+                                "after step 4",
+                            );
 
-                                Some(self.return_type())
+                            match self.matching_overload_index() {
+                                MatchingOverloadIndex::None => {
+                                    tracing::debug!(
+                                        "All overloads have been filtered out in step 4 during argument type expansion"
+                                    );
+                                    None
+                                }
+                                MatchingOverloadIndex::Single(_) => Some(self.return_type()),
+                                MatchingOverloadIndex::Multiple(indexes) => {
+                                    self.filter_overloads_using_any_or_unknown(
+                                        db,
+                                        env,
+                                        &branch_constraints,
+                                        expanded_arguments,
+                                        &indexes,
+                                    );
+
+                                    tracing::trace!(
+                                        target: "ty_python_semantic::types::call::bind",
+                                        matching_overload_index = ?self.matching_overload_index(),
+                                        "after step 5",
+                                    );
+
+                                    Some(self.return_type())
+                                }
                             }
                         }
                     }
-                };
+                });
 
                 // This split between initializing and updating the merged evaluation state is
                 // required because otherwise it's difficult to differentiate between the
@@ -3996,7 +4017,7 @@ impl<'db> CallableBinding<'db> {
                     merged_evaluation_state = Some(snapshotter.take(self));
                 }
 
-                if let Some(return_type) = return_type {
+                if let Some(return_type) = branch_return_type {
                     return_types.push(return_type);
                 } else {
                     // No need to check the remaining argument lists if the current argument list
@@ -4377,6 +4398,28 @@ impl<'db> CallableBinding<'db> {
                 } else {
                     MatchingOverloadIndex::Single(first)
                 }
+            }
+        }
+    }
+
+    /// Rejects unsatisfiable candidates only when resolving overloads.
+    fn reject_unsatisfiable_overloads(&mut self, db: &'db dyn Db) {
+        if self.overloads.len() < 2 {
+            return;
+        }
+
+        for overload in &mut self.overloads {
+            if overload.errors.is_empty()
+                && overload.inference.is_some_and(|inference| {
+                    matches!(
+                        inference.solutions(db),
+                        TypeVarInferenceSolutions::Unavailable(
+                            TypeVarInferenceFallback::Unsatisfiable
+                        )
+                    )
+                })
+            {
+                overload.mark_as_unmatched_overload();
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -752,6 +752,29 @@ impl<'db> TypeContext<'db> {
         // explosion of inference attempts, and is rarely needed in practice.
         Some(targets)
     }
+
+    /// Returns the targets used to infer a call against a union type context.
+    pub(super) fn narrow_call_targets(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<Cow<'db, [Type<'db>]>> {
+        if let Some(awaitable) =
+            self.annotation?
+                .known_specialization(db, env, KnownClass::Awaitable)
+            && let [inner] = awaitable.types(db)
+        {
+            let targets = TypeContext::from(*inner).narrow_targets(db, env)?;
+            return Some(Cow::Owned(
+                targets
+                    .iter()
+                    .map(|inner| KnownClass::Awaitable.to_specialized_instance(db, env, &[*inner]))
+                    .collect(),
+            ));
+        }
+
+        self.narrow_targets(db, env)
+    }
 }
 
 impl<'db> From<Type<'db>> for TypeContext<'db> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5696,7 +5696,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // If the type context is a union, attempt to narrow to a specific element.
         let narrow_targets = call_expression_tcx
-            .narrow_targets(db, env)
+            .narrow_call_targets(db, env)
             // We only need to attempt narrowing on generic calls, otherwise the type
             // context has no effect.
             .filter(|_| has_generic_context)


### PR DESCRIPTION


<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

Fix false positive for generic overloads when argument is union and call is awaited (this issue: astral-sh/ty#3825)

Before, `ty` could report "no matching overload" even when a correct overload was there. Now, every branch is checked separately with fresh generic constraints.

Added test for that case.

## Test Plan

Tested with the code from astral-sh/ty#3825, both in `ty check`and as LSP in Zed.

And ran this:

`cargo test --workspace --all-features`