### PR TITLE
fix(UP040): parenthesize multi-line values in type alias fix

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
@@ -132,3 +132,15 @@ T: TypeAlias = ( # comment0
 # Test case for TypeVar with default - should be converted when preview mode is enabled
 T_default = TypeVar("T_default", default=int)
 DefaultList: TypeAlias = list[T_default]
+
+# Multi-line union inside TypeAliasType must be parenthesized in the fix.
+# https://github.com/astral-sh/ruff/issues/28102
+MultiLineUnion = TypeAliasType(
+    "MultiLineUnion",
+    int
+    | str
+    | float
+    | bool
+    | None
+    | bytes,
+)

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -276,14 +276,38 @@ fn create_diagnostic(
     let tokens = checker.tokens();
     let comment_ranges = checker.comment_ranges();
 
-    let range_with_parentheses =
-        parenthesized_range(value.into(), stmt.into(), tokens).unwrap_or(value.range());
+    let parens = parenthesized_range(value.into(), stmt.into(), tokens);
+    let range_with_parentheses = parens.unwrap_or(value.range());
 
-    let content = format!(
-        "type {name}{type_params} = {value}",
-        type_params = DisplayTypeVars { type_vars, source },
-        value = &source[range_with_parentheses]
+    let value_text = &source[range_with_parentheses];
+    let has_implicit_continuation = matches!(
+        value,
+        Expr::Tuple(_)
+            | Expr::List(_)
+            | Expr::Set(_)
+            | Expr::Dict(_)
+            | Expr::Call(_)
+            | Expr::Subscript(_)
+            | Expr::ListComp(_)
+            | Expr::SetComp(_)
+            | Expr::DictComp(_)
+            | Expr::Generator(_)
     );
+    let needs_parentheses = parens.is_none()
+        && !has_implicit_continuation
+        && (value_text.contains('\n') || value_text.contains('\r'));
+
+    let content = if needs_parentheses {
+        format!(
+            "type {name}{type_params} = ({value_text})",
+            type_params = DisplayTypeVars { type_vars, source },
+        )
+    } else {
+        format!(
+            "type {name}{type_params} = {value_text}",
+            type_params = DisplayTypeVars { type_vars, source },
+        )
+    };
     let edit = Edit::range_replacement(content, stmt.range());
 
     let applicability =

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
@@ -436,3 +436,34 @@ help: Use the `type` keyword
 123 |     # comment1
     |
 note: This is an unsafe fix and may change runtime behavior
+
+UP040 [*] Type alias `MultiLineUnion` uses `TypeAliasType` assignment instead of the `type` keyword
+   --> UP040.py:138:1
+    |
+136 |   # Multi-line union inside TypeAliasType must be parenthesized in the fix.
+137 |   # https://github.com/astral-sh/ruff/issues/28102
+138 | / MultiLineUnion = TypeAliasType(
+139 | |     "MultiLineUnion",
+140 | |     int
+141 | |     | str
+142 | |     | float
+143 | |     | bool
+144 | |     | None
+145 | |     | bytes,
+146 | | )
+    | |_^
+help: Use the `type` keyword
+    |
+137 | # https://github.com/astral-sh/ruff/issues/28102
+    - MultiLineUnion = TypeAliasType(
+    -     "MultiLineUnion",
+    -     int
+138 + type MultiLineUnion = (int
+139 |     | str
+140 |     | float
+141 |     | bool
+142 |     | None
+    -     | bytes,
+    - )
+143 +     | bytes)
+    |

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
@@ -56,10 +56,14 @@ UP040 [*] Type alias `DefaultList` uses `TypeAlias` annotation instead of the `t
 133 | T_default = TypeVar("T_default", default=int)
 134 | DefaultList: TypeAlias = list[T_default]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+135 |
+136 | # Multi-line union inside TypeAliasType must be parenthesized in the fix.
+    |
 help: Use the `type` keyword
     |
 133 | T_default = TypeVar("T_default", default=int)
     - DefaultList: TypeAlias = list[T_default]
 134 + type DefaultList[T_default = int] = list[T_default]
+135 |
     |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Fixes #28102.

## Problem

The `UP040` autofix for `TypeAliasType()` calls can produce invalid syntax when the
value argument is a multi-line expression without surrounding delimiters. For example:

```python
Bug = TypeAliasType(
    "Bug",
    int
    | str
    | float,
)
```

produces:

```python
type Bug = int
    | str
    | float
```

This is a syntax error because the `type` statement requires parentheses around
multi-line continuation expressions that don't have their own implicit continuation
(brackets, braces, or parentheses).

## Fix

Before emitting the replacement, check whether the value text spans multiple lines
and whether the expression already provides implicit line continuation (subscript,
tuple, list, dict, call, or comprehension). If it doesn't, wrap the value in
parentheses:

```python
type Bug = (int
    | str
    | float)
```

Expressions that already use brackets or parentheses (`tuple[int, str]`, `list[T]`,
function calls, etc.) are left unwrapped since they already have implicit continuation.

## Test

Added a `TypeAliasType()` case with a multi-line union value to `UP040.py` and
verified the snapshot shows parenthesized output.