### PR TITLE
Add duplicate work guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 This repository contains both Ruff (a Python linter and formatter) and ty (a Python type checker). The crates follow a naming convention: `ruff_*` for Ruff-specific code and `ty_*` for ty-specific code. ty reuses several Ruff crates, including the Python parser (`ruff_python_parser`) and AST definitions (`ruff_python_ast`).
 
+## Before contributing
+
+Before starting work on an issue and again before opening a pull request, follow the
+[guidance on avoiding duplicate work](CONTRIBUTING.md#avoiding-duplicate-work). If an open pull
+request already addresses the issue, do not submit a competing one without maintainer agreement.
+
 ## Code Review Rules
 
 When reviewing a branch or pull request, be deliberately nitpicky. Report not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,13 @@ exploration of new features, we will often close these pull requests immediately
 new feature to ruff creates a long-term maintenance burden and requires strong consensus from the ruff
 team before it is appropriate to begin work on an implementation.
 
+### Avoiding duplicate work
+
+Before starting on an issue, take a look at the discussion and any linked pull requests, including
+those in the sidebar. An issue may still be open while a fix is under review. Even if a previous
+attempt was closed, it may contain useful context or review comments that you could incorporate
+before submitting a new PR.
+
 ## Use of AI
 
 We **require all use of AI in contributions to follow our


### PR DESCRIPTION
Summary
--

I've noticed that some issues seem to attract a lot of (likely automated) duplicate PRs. #28102 is a
recent example that elicited four PRs in the five days it has been open. I'm not sure if the changes
here will actually help, but I've tried to add both contributor- and agent-facing documentation to
suggest checking for linked PRs before opening another one.

Test Plan
--

Future issues
