### PR TITLE
fix(formatter): alternate quotes in format-spec interpolations

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/fstring.py
@@ -750,5 +750,10 @@ print(f"{  # Tuple with multiple elements that doesn't fit on a single line gets
 print(f"{ {}, 1, }")
 
 
+# Regression tests for https://github.com/astral-sh/ruff/issues/28218
+# Quotes inside format-spec interpolations should be alternated, not preserved.
+a = f'x {d["k"]} y'
+b = f'x {v:,.{d["n"]}f} y'
+
 # The inner quotes should not be changed to double quotes before Python 3.12
 f"{f'''{'nested'} inner'''} outer"

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -228,6 +228,17 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
 
                     token(":").fmt(f)?;
 
+                    // Reset the interpolated string state so that interpolations
+                    // inside the format spec are treated as direct children of
+                    // the enclosing f-string, not as nested. Without this,
+                    // `f'x {v:,.{d["n"]}f} y'` would preserve the inner double
+                    // quotes instead of alternating them to single.
+                    let f =
+                        &mut WithInterpolatedStringState::new(
+                            InterpolatedStringState::Outside,
+                            &mut **f,
+                        );
+
                     for element in &format_spec.elements {
                         FormatInterpolatedStringElement::new(element, context).fmt(f)?;
                     }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -756,6 +756,11 @@ print(f"{  # Tuple with multiple elements that doesn't fit on a single line gets
 print(f"{ {}, 1, }")
 
 
+# Regression tests for https://github.com/astral-sh/ruff/issues/28218
+# Quotes inside format-spec interpolations should be alternated, not preserved.
+a = f'x {d["k"]} y'
+b = f'x {v:,.{d["n"]}f} y'
+
 # The inner quotes should not be changed to double quotes before Python 3.12
 f"{f'''{'nested'} inner'''} outer"
 ```
@@ -1525,7 +1530,7 @@ f'{f"""other " """}'
 f'{1: hy "user"}'
 f'{1:hy "user"}'
 f'{1: abcd "{1}" }'
-f'{1: abcd "{'aa'}" }'
+f'{1: abcd "{"aa"}" }'
 f'{1=: "abcd {'aa'}}'
 f"{x:a{z:hy \"user\"}} '''"
 
@@ -1575,6 +1580,11 @@ print(
 # Regression tests for https://github.com/astral-sh/ruff/issues/15536
 print(f"{ {}, 1 }")
 
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/28218
+# Quotes inside format-spec interpolations should be alternated, not preserved.
+a = f"x {d['k']} y"
+b = f"x {v:,.{d['n']}f} y"
 
 # The inner quotes should not be changed to double quotes before Python 3.12
 f"{f'''{'nested'} inner'''} outer"
@@ -2345,7 +2355,7 @@ f'{f"""other " """}'
 f'{1: hy "user"}'
 f'{1:hy "user"}'
 f'{1: abcd "{1}" }'
-f'{1: abcd "{'aa'}" }'
+f'{1: abcd "{"aa"}" }'
 f'{1=: "abcd {'aa'}}'
 f"{x:a{z:hy \"user\"}} '''"
 
@@ -2395,6 +2405,11 @@ print(
 # Regression tests for https://github.com/astral-sh/ruff/issues/15536
 print(f"{ {}, 1 }")
 
+
+# Regression tests for https://github.com/astral-sh/ruff/issues/28218
+# Quotes inside format-spec interpolations should be alternated, not preserved.
+a = f"x {d['k']} y"
+b = f"x {v:,.{d['n']}f} y"
 
 # The inner quotes should not be changed to double quotes before Python 3.12
 f"{f'''{'nested'} inner'''} outer"


### PR DESCRIPTION
fixes #28218

interpolations inside an f-string format spec (like `{d["n"]}` in `f'x {v:,.{d["n"]}f} y'`) were getting treated as nested f-strings. that meant quote preservation instead of alternation, wich on python < 3.12 produces a syntax error — inner double quotes match the outer instead of getting flipped.

the issue is in how `InterpolatedStringState` tracks nesting. format spec interpolations advance to `NestedInterpolatedElement`, but they're not nested f-strings — they're direct children of the enclosing string. so `preferred_quote_style` wrongly preserves their quotes.

fix: reset `InterpolatedStringState` to `Outside` before formatting format spec elements (using `WithInterpolatedStringState` RAII guard). now interpolations in the format spec enter `InsideInterpolatedElement` and get proper quote alternation.

added fixture tests for both regular and format-spec interpolations, snapshot shows correct alternation now. all 427 formatter tests pass.