### PR TITLE
fix(UP046,UP047): skip autofix for starred TypeVar constraints

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
@@ -132,3 +132,8 @@ T: TypeAlias = ( # comment0
 # Test case for TypeVar with default - should be converted when preview mode is enabled
 T_default = TypeVar("T_default", default=int)
 DefaultList: TypeAlias = list[T_default]
+
+# Test case for TypeVar with starred constraints - should NOT be fixed
+constraints = (int, str)
+T_starred = TypeVar("T_starred", *constraints)
+StarredList = TypeAliasType("StarredList", list[T_starred], type_params=(T_starred,))

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP046_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP046_0.py
@@ -138,6 +138,16 @@ class DefaultOnlyTypeVar(Generic[W]):  # -> [W = int]
     var: W
 
 
+# Starred constraints can't be converted to PEP 695 syntax.
+# https://github.com/astral-sh/ruff/issues/26954
+constraints = (int, str)
+T_starred = TypeVar("T_starred", *constraints)
+
+
+class StarredConstraints(Generic[T_starred]):
+    var: T_starred
+
+
 # nested classes and functions are skipped
 class Outer:
     class Inner(Generic[T]):

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
@@ -58,6 +58,16 @@ def multi_param(t: list[T], c: Callable[[T], None]) -> T:
     return t[1]
 
 
+# Starred constraints can't be converted to PEP 695 syntax.
+# https://github.com/astral-sh/ruff/issues/26954
+constraints = (int, str)
+T_starred = TypeVar("T_starred", *constraints)
+
+
+def starred_constraints(v: T_starred) -> T_starred:
+    return v
+
+
 # these cases are not handled
 
 def outer():

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/mod.rs
@@ -338,9 +338,12 @@ pub(crate) fn expr_name_to_type_var<'a>(
                 let restriction = if let Some(bound) = arguments.find_keyword("bound") {
                     Some(TypeVarRestriction::Bound(&bound.value))
                 } else if arguments.args.len() > 1 {
-                    Some(TypeVarRestriction::Constraint(
-                        arguments.args.iter().skip(1).collect(),
-                    ))
+                    let constraints: Vec<&Expr> =
+                        arguments.args.iter().skip(1).collect();
+                    if constraints.iter().any(|expr| expr.is_starred_expr()) {
+                        return None;
+                    }
+                    Some(TypeVarRestriction::Constraint(constraints))
                 } else {
                     None
                 };

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -172,14 +172,8 @@ pub(crate) fn non_pep695_type_alias_type(checker: &Checker, stmt: &StmtAssign) {
     let Some(vars) = type_params
         .iter()
         .map(|expr| {
-            expr.as_name_expr().map(|name| {
-                expr_name_to_type_var(checker.semantic(), name).unwrap_or(TypeVar {
-                    name: &name.id,
-                    restriction: None,
-                    kind: TypeParamKind::TypeVar,
-                    default: None,
-                })
-            })
+            expr.as_name_expr()
+                .and_then(|name| expr_name_to_type_var(checker.semantic(), name))
         })
         .collect::<Option<Vec<_>>>()
     else {

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
@@ -56,10 +56,14 @@ UP040 [*] Type alias `DefaultList` uses `TypeAlias` annotation instead of the `t
 133 | T_default = TypeVar("T_default", default=int)
 134 | DefaultList: TypeAlias = list[T_default]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+135 |
+136 | # Test case for TypeVar with starred constraints - should NOT be fixed
+    |
 help: Use the `type` keyword
     |
 133 | T_default = TypeVar("T_default", default=int)
     - DefaultList: TypeAlias = list[T_default]
 134 + type DefaultList[T_default = int] = list[T_default]
+135 |
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
@@ -253,3 +253,12 @@ UP046 Generic class `TooManyGenerics` uses `Generic` subclass instead of type pa
 100 |     var: S
     |
 help: Use type parameters
+
+UP046 Generic class `StarredConstraints` uses `Generic` subclass instead of type parameters
+   --> UP046_0.py:147:26
+    |
+147 | class StarredConstraints(Generic[T_starred]):
+    |                          ^^^^^^^^^^^^^^^^^^
+148 |     var: T_starred
+    |
+help: Use type parameters


### PR DESCRIPTION
## Summary

Fixes #26954.

When `TypeVar` is called with starred positional arguments (e.g. `TypeVar("T", *constraints)`), the constraints cannot be statically resolved. UP046 and UP047 would previously attempt to convert these to PEP 695 syntax, producing invalid output like `class Foo[T: (*constraints)]`.

This PR makes `expr_name_to_type_var` return `None` when any constraint argument is a starred expression, so the TypeVar is not recognized for conversion. The diagnostic may still be emitted but no autofix is offered.

## Test plan

- Added test cases to both `UP046_0.py` and `UP047_0.py` fixtures with `TypeVar("T_starred", *constraints)`
- UP046 snapshot updated: diagnostic emitted for `StarredConstraints` class but no fix content (correct — TypeVar not recognized)
- UP047 snapshot unchanged: `starred_constraints()` function produces no diagnostic at all (correct — TypeVar not recognized, so the function isn't detected as generic)
- All 161 pyupgrade tests pass