### PR TITLE
[refurb] Mark FURB101/FURB103 fix unsafe for bytes path arguments

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB101_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB101_0.py
@@ -145,3 +145,11 @@ with open("file1.txt", encoding="utf-8") as f:
 # `open` accepts a file descriptor, but `Path` does not
 with open(3) as f:
     x = f.read()
+
+# FURB101 but fix is unsafe because `Path` does not accept a `bytes` path
+with open(b"file.txt") as f:
+    x = f.read()
+
+# FURB101 but fix is unsafe because `Path` does not accept a `bytes` path
+with open(b"file.txt", "rb") as f:
+    x = f.read()

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB103_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB103_0.py
@@ -167,3 +167,7 @@ with open("tmp_path/pyproject.toml", "w") as f:
 # `open` accepts a file descriptor, but `Path` does not
 with open(3, "w") as f:
     f.write("test")
+
+# FURB103 but fix is unsafe because `Path` does not accept a `bytes` path
+with open(b"file.txt", "wb") as f:
+    f.write(b"data")

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -166,6 +166,16 @@ impl OpenArgument<'_> {
     pub(super) fn display<'src>(&self, source: &'src str) -> &'src str {
         &source[self.range()]
     }
+
+    /// Returns `true` if the argument is a `bytes` literal, e.g. `open(b"file.txt")`.
+    /// `pathlib.Path` does not accept `bytes` paths, so replacing this pattern with a
+    /// `Path` method call would raise a `TypeError` at runtime.
+    pub(super) fn is_bytes_literal(&self) -> bool {
+        match self {
+            OpenArgument::Builtin { filename } => filename.is_bytes_literal_expr(),
+            OpenArgument::Pathlib { path } => path.is_bytes_literal_expr(),
+        }
+    }
 }
 
 impl Ranged for OpenArgument<'_> {

--- a/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
@@ -36,7 +36,9 @@ use crate::{FixAvailability, Violation};
 /// contents = Path("file.txt").read_text()
 /// ```
 /// ## Fix Safety
-/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the original expression.
+/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the
+/// original expression, or if the path argument is a `bytes` literal (`pathlib.Path` does not
+/// accept `bytes` paths, so the fix would change the runtime behavior of the code).
 ///
 /// ## References
 /// - [Python documentation: `Path.read_bytes`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.read_bytes)
@@ -260,7 +262,9 @@ fn generate_fix(
         _ => return None,
     };
 
-    let applicability = if checker.comment_ranges().intersects(with_stmt.range()) {
+    let applicability = if checker.comment_ranges().intersects(with_stmt.range())
+        || open.argument.is_bytes_literal()
+    {
         Applicability::Unsafe
     } else {
         Applicability::Safe

--- a/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/write_whole_file.rs
@@ -36,7 +36,9 @@ use crate::{FixAvailability, Locator, Violation};
 /// ```
 ///
 /// ## Fix Safety
-/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the original expression.
+/// This rule's fix is marked as unsafe if the replacement would remove comments attached to the
+/// original expression, or if the path argument is a `bytes` literal (`pathlib.Path` does not
+/// accept `bytes` paths, so the fix would change the runtime behavior of the code).
 ///
 /// ## References
 /// - [Python documentation: `Path.write_bytes`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.write_bytes)
@@ -232,7 +234,9 @@ fn generate_fix(
 
     let replacement = format!("{target}.{suggestion}");
 
-    let applicability = if checker.comment_ranges().intersects(with_stmt.range()) {
+    let applicability = if checker.comment_ranges().intersects(with_stmt.range())
+        || open.argument.is_bytes_literal()
+    {
         Applicability::Unsafe
     } else {
         Applicability::Safe

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__read-whole-file_FURB101_0.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__read-whole-file_FURB101_0.py.snap
@@ -256,3 +256,44 @@ FURB101 `open` and `read` should be replaced by `Path("file1.txt").read_text(enc
 142 |     contents: str = process_contents(f.read())
     |
 help: Replace with `Path("file1.txt").read_text(encoding="utf-8")`
+
+FURB101 [*] `open` and `read` should be replaced by `Path(b"file.txt").read_text()`
+   --> FURB101_0.py:150:6
+    |
+149 | # FURB101 but fix is unsafe because `Path` does not accept a `bytes` path
+150 | with open(b"file.txt") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^
+151 |     x = f.read()
+    |
+help: Replace with `Path(b"file.txt").read_text()`
+    |
+1   + import pathlib
+2   | def foo():
+--------------------------------------------------------------------------------
+150 | # FURB101 but fix is unsafe because `Path` does not accept a `bytes` path
+    - with open(b"file.txt") as f:
+    -     x = f.read()
+151 + x = pathlib.Path(b"file.txt").read_text()
+152 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB101 [*] `open` and `read` should be replaced by `Path(b"file.txt").read_bytes()`
+   --> FURB101_0.py:154:6
+    |
+153 | # FURB101 but fix is unsafe because `Path` does not accept a `bytes` path
+154 | with open(b"file.txt", "rb") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+155 |     x = f.read()
+    |
+help: Replace with `Path(b"file.txt").read_bytes()`
+    |
+1   + import pathlib
+2   | def foo():
+--------------------------------------------------------------------------------
+154 | # FURB101 but fix is unsafe because `Path` does not accept a `bytes` path
+    - with open(b"file.txt", "rb") as f:
+    -     x = f.read()
+155 + x = pathlib.Path(b"file.txt").read_bytes()
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__write-whole-file_FURB103_0.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__write-whole-file_FURB103_0.py.snap
@@ -270,3 +270,24 @@ help: Replace with `Path("tmp_path/pyproject.toml")....`
 159 + pathlib.Path("tmp_path/pyproject.toml").write_text(dedent(
 160 |         """
     |
+
+FURB103 [*] `open` and `write` should be replaced by `Path(b"file.txt").write_bytes(b"data")`
+   --> FURB103_0.py:172:6
+    |
+171 | # FURB103 but fix is unsafe because `Path` does not accept a `bytes` path
+172 | with open(b"file.txt", "wb") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+173 |     f.write(b"data")
+    |
+help: Replace with `Path(b"file.txt").write_bytes(b"data")`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+172 | # FURB103 but fix is unsafe because `Path` does not accept a `bytes` path
+    - with open(b"file.txt", "wb") as f:
+    -     f.write(b"data")
+173 + pathlib.Path(b"file.txt").write_bytes(b"data")
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__write_whole_file_python_39.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__write_whole_file_python_39.snap
@@ -208,3 +208,24 @@ help: Replace with `Path("tmp_path/pyproject.toml")....`
 159 + pathlib.Path("tmp_path/pyproject.toml").write_text(dedent(
 160 |         """
     |
+
+FURB103 [*] `open` and `write` should be replaced by `Path(b"file.txt").write_bytes(b"data")`
+   --> FURB103_0.py:172:6
+    |
+171 | # FURB103 but fix is unsafe because `Path` does not accept a `bytes` path
+172 | with open(b"file.txt", "wb") as f:
+    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+173 |     f.write(b"data")
+    |
+help: Replace with `Path(b"file.txt").write_bytes(b"data")`
+    |
+150 | import json
+151 + import pathlib
+152 |
+--------------------------------------------------------------------------------
+172 | # FURB103 but fix is unsafe because `Path` does not accept a `bytes` path
+    - with open(b"file.txt", "wb") as f:
+    -     f.write(b"data")
+173 + pathlib.Path(b"file.txt").write_bytes(b"data")
+    |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Mark FURB101 and FURB103 autofixes as unsafe when the file path argument is a bytes literal.

`open(b"file.txt")` works at runtime, but `pathlib.Path` does not accept bytes paths, so the autofix rewriting to `Path(b"file.txt").read_text()` / `.write_bytes()` raises `TypeError`.

Closes #26922.

## Test plan

- Added bytes-literal path test cases to FURB101 and FURB103 fixtures
- Verified snapshots show `unsafe` applicability for bytes paths
- All 45 refurb tests pass