### PR TITLE
[flake8-bugbear] Skip B006 preview fix for multiline string defaults

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_10.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bugbear/B006_10.py
@@ -1,0 +1,15 @@
+def f1(value=["""first
+second"""]):
+    return value
+
+
+def f2(value={"key": """first
+second
+third"""}):
+    return value
+
+
+def f3(value=["""first
+second"""]):
+    """Docstring, insertion happens after this."""
+    return value

--- a/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
@@ -48,6 +48,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_7.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_8.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_9.py"))]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_10.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_1.pyi"))]
     #[test_case(Rule::NoExplicitStacklevel, Path::new("B028.py"))]
@@ -94,6 +95,7 @@ mod tests {
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_7.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_8.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_9.py"))]
+    #[test_case(Rule::MutableArgumentDefault, Path::new("B006_10.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_B008.py"))]
     #[test_case(Rule::MutableArgumentDefault, Path::new("B006_1.pyi"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/mutable_argument_default.rs
@@ -185,14 +185,18 @@ fn move_initialization(
     content.push_str(stylist.line_ending().as_str());
     content.push_str(stylist.indentation());
     if is_b006_unsafe_fix_preserve_assignment_expr_enabled(checker.settings()) {
+        let default_source = locator.slice(
+            parenthesized_range(default.into(), parameter.into(), checker.tokens())
+                .unwrap_or(default.range()),
+        );
+        if default_source.contains('\n') || default_source.contains('\r') {
+            return None;
+        }
         let _ = write!(
             &mut content,
             "{} = {}",
             parameter.parameter.name(),
-            locator.slice(
-                parenthesized_range(default.into(), parameter.into(), checker.tokens())
-                    .unwrap_or(default.range())
-            )
+            default_source
         );
     } else {
         let _ = write!(

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__mutable-argument-default_B006_10.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__mutable-argument-default_B006_10.py.snap
@@ -1,0 +1,68 @@
+---
+source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+---
+B006 [*] Do not use mutable data structures for argument defaults
+ --> B006_10.py:1:14
+  |
+1 |   def f1(value=["""first
+  |  ______________^
+2 | | second"""]):
+  | |__________^
+3 |       return value
+  |
+help: Replace with `None`; initialize within function
+  |
+  - def f1(value=["""first
+  - second"""]):
+1 + def f1(value=None):
+2 +     if value is None:
+3 +         value = ["""first\nsecond"""]
+4 |     return value
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+ --> B006_10.py:6:14
+  |
+6 |   def f2(value={"key": """first
+  |  ______________^
+7 | | second
+8 | | third"""}):
+  | |_________^
+9 |       return value
+  |
+help: Replace with `None`; initialize within function
+  |
+5 |
+  - def f2(value={"key": """first
+  - second
+  - third"""}):
+6 + def f2(value=None):
+7 +     if value is None:
+8 +         value = {"key": """first\nsecond\nthird"""}
+9 |     return value
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+B006 [*] Do not use mutable data structures for argument defaults
+  --> B006_10.py:12:14
+   |
+12 |   def f3(value=["""first
+   |  ______________^
+13 | | second"""]):
+   | |__________^
+14 |       """Docstring, insertion happens after this."""
+15 |       return value
+   |
+help: Replace with `None`; initialize within function
+   |
+11 |
+   - def f3(value=["""first
+   - second"""]):
+12 + def f3(value=None):
+13 |     """Docstring, insertion happens after this."""
+14 +     if value is None:
+15 +         value = ["""first\nsecond"""]
+16 |     return value
+   |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__mutable-argument-default_B006_10.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/snapshots/ruff_linter__rules__flake8_bugbear__tests__preview__mutable-argument-default_B006_10.py.snap
@@ -1,0 +1,37 @@
+---
+source: crates/ruff_linter/src/rules/flake8_bugbear/mod.rs
+---
+B006 Do not use mutable data structures for argument defaults
+ --> B006_10.py:1:14
+  |
+1 |   def f1(value=["""first
+  |  ______________^
+2 | | second"""]):
+  | |__________^
+3 |       return value
+  |
+help: Replace with `None`; initialize within function
+
+B006 Do not use mutable data structures for argument defaults
+ --> B006_10.py:6:14
+  |
+6 |   def f2(value={"key": """first
+  |  ______________^
+7 | | second
+8 | | third"""}):
+  | |_________^
+9 |       return value
+  |
+help: Replace with `None`; initialize within function
+
+B006 Do not use mutable data structures for argument defaults
+  --> B006_10.py:12:14
+   |
+12 |   def f3(value=["""first
+   |  ______________^
+13 | | second"""]):
+   | |__________^
+14 |       """Docstring, insertion happens after this."""
+15 |       return value
+   |
+help: Replace with `None`; initialize within function


### PR DESCRIPTION
closes #27022

the B006 preview fix copies default values verbatim with `locator.slice()` and indents them with `textwrap::indent`. problem: multiline string literals get their content corrupted because indent adds whitespace to internal lines:

```python
# before:
def f(value=["""first
second"""]):
    return value

# after fix (wrong — "second" gets indented):
def f(value=None):
    if value is None:
        value = ["""first
        second"""]  # content changed
    return value
```

fix: skip the autofix when the source text contains `\n` or `\r`. diagnostic still fires, just no broken fix offered.

added `B006_10.py` fixture with multiline string defaults. preview snapshot confirms no fix for multiline cases, non-preview behavior unchanged. all 77 flake8-bugbear tests pass.