### PR TITLE
[ruff] Detect all indented form feeds on a line (RUF054)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF054.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF054.py
@@ -30,3 +30,12 @@ def _():
 
 def f():
 	pass 
+
+
+# Multiple form feeds in leading whitespace (errors)
+
+if True:
+  print("!")
+
+if True:
+   print("!")

--- a/crates/ruff_linter/src/rules/ruff/rules/indented_form_feed.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/indented_form_feed.rs
@@ -52,21 +52,27 @@ const TAB: u8 = b'\t';
 
 /// RUF054
 pub(crate) fn indented_form_feed(line: &Line, context: &LintContext) {
-    let Some(index_relative_to_line) = memchr(FORM_FEED, line.as_bytes()) else {
+    let bytes = line.as_bytes();
+
+    // A run of form feeds at the very start of the line is ignored for indentation
+    // purposes, per the language reference.
+    let leading_form_feeds = bytes.iter().take_while(|byte| **byte == FORM_FEED).count();
+
+    // Any other form feed occurring in the rest of the leading whitespace has an
+    // undefined effect and must be flagged; a non-whitespace byte means the
+    // indentation has ended.
+    let Some(index_in_remainder) = memchr(FORM_FEED, &bytes[leading_form_feeds..]) else {
         return;
     };
 
-    if index_relative_to_line == 0 {
-        return;
-    }
-
-    if line[..index_relative_to_line]
-        .as_bytes()
+    if bytes[leading_form_feeds..][..index_in_remainder]
         .iter()
         .any(|byte| *byte != SPACE && *byte != TAB)
     {
         return;
     }
+
+    let index_relative_to_line = leading_form_feeds + index_in_remainder;
 
     let Ok(relative_index) = u32::try_from(index_relative_to_line) else {
         return;

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__indented-form-feed_RUF054.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__indented-form-feed_RUF054.py.snap
@@ -39,3 +39,22 @@ RUF054 Indented form feed
 17 |     ␌print('T')
    |     ^
 help: Remove form feed
+
+RUF054 Indented form feed
+  --> RUF054.py:38:3
+   |
+37 | if True:
+38 | ␌ ␌ print("!")
+   |   ^
+39 |
+40 | if True:
+   |
+help: Remove form feed
+
+RUF054 Indented form feed
+  --> RUF054.py:41:2
+   |
+40 | if True:
+41 |  ␌ ␌ print("!")
+   |  ^
+help: Remove form feed


### PR DESCRIPTION
fixes #16139

`RUF054` only checked the first form feed on a physical line. if there were more form feeds later in leading whitespace, they got ignored.

per the [language reference](https://docs.python.org/3/reference/lexical_analysis.html#indentation), form feed is only harmless at column 0 — anywhere else in leading whitespace its effect is undefined and should be flagged.

```python
if True:
\f \f print("!")
```

before: ruff reported nothing here becuase the first form feed is at column 0 and the check returned early. now it correctly flags the second one.

added fixture cases for multiple form feeds. snapshot updated, 162 ruff_linter tests pass.