### PR TITLE
[ty] Avoid repeated attribute errors after local assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -90,13 +90,129 @@ class _:
 a = A()
 # error: [unresolved-attribute]
 a.dynamically_added = 0
-# error: [unresolved-attribute]
 reveal_type(a.dynamically_added)  # revealed: Literal[0]
 
 # error: [unresolved-reference]
 does.nt.exist = 0
 # error: [unresolved-reference]
 reveal_type(does.nt.exist)  # revealed: Literal[0]
+```
+
+### Recovery after an undeclared attribute assignment
+
+Assigning an undeclared attribute reports an error. Simple reads following that assignment in the
+same straight-line block use its recovery type without repeating the missing-attribute error.
+
+```py
+class Item: ...
+
+def immediate_reads(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    item.value
+    return item.value
+```
+
+The same recovery applies to module attributes, including a read used as a call argument. Arguments
+are evaluated before the call runs.
+
+```py
+import logging
+
+logging.TRACE = 9  # error: [unresolved-attribute]
+reveal_type(logging.TRACE)  # revealed: Literal[9]
+```
+
+### Permitted writes do not establish read recovery
+
+Recovery does not hide a missing read after a permitted write. A custom setter can accept an
+assignment without storing the attribute.
+
+```py
+class Sink:
+    def __setattr__(self, name: str, value: object) -> None:
+        pass
+
+sink = Sink()
+sink.value = 1
+sink.value  # error: [unresolved-attribute]
+```
+
+### Writes and calls end attribute-read recovery
+
+Deletion and receiver reassignment end recovery. A later plain attribute assignment starts it again.
+
+```py
+class Item: ...
+
+def deleted(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    del item.value  # error: [unresolved-attribute]
+    item.value  # error: [unresolved-attribute]
+    item.value = 2  # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[2]
+
+def replaced(item: Item, other: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    item = other
+    item.value  # error: [unresolved-attribute]
+```
+
+Calls can mutate the receiver. A read after a call reports the missing attribute, including when the
+call appears in an earlier argument of the same expression.
+
+```py
+def consume(*args: object) -> None: ...
+def called(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    consume(item.value)
+    item.value  # error: [unresolved-attribute]
+
+def called_in_argument(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    consume(consume(), item.value)  # error: [unresolved-attribute]
+```
+
+### Attribute-read recovery stays within a block
+
+A branch or loop body can recover from its own assignments. That recovery does not extend past the
+block or establish presence on a later loop iteration.
+
+```py
+class Item: ...
+
+def conditional(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+        item.value
+    item.value  # error: [unresolved-attribute]
+
+def loop(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    for _ in range(2):
+        item.value  # error: [unresolved-attribute]
+        item.value = 2  # error: [unresolved-attribute]
+        item.value
+        del item.value  # error: [unresolved-attribute]
+```
+
+A class body ends recovery in its enclosing block. Reads in nested scopes also report their own
+missing-attribute errors.
+
+```py
+def eager_scope(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        del item.value  # error: [unresolved-attribute]
+
+    item.value  # error: [unresolved-attribute]
+
+def nested_scopes(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    [item.value for _ in range(1)]  # error: [unresolved-attribute]
+
+    def inner():
+        return item.value  # error: [unresolved-attribute]
 ```
 
 ### Narrowing chain

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -156,6 +156,7 @@ use ty_python_core::{ExpressionNodeKey, Statement};
 
 mod annotation_expression;
 mod attribute_assignment;
+mod attribute_read_recovery;
 mod binary_expressions;
 mod class;
 mod dict;
@@ -10708,6 +10709,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 }
                             }
                         }
+                        return fallback();
+                    }
+
+                    if !bound_on_instance
+                        && attribute.ctx.is_load()
+                        && assigned_type.is_some()
+                        && attribute_read_recovery::eligible_reads(db, self.scope())
+                            .contains(&ast::ExprRef::Attribute(attribute).into())
+                        // Modules reject undeclared assignments directly. For other receivers,
+                        // a custom setter can accept a write without making it readable.
+                        && (matches!(value_type, Type::ModuleLiteral(_))
+                            || value_type
+                                .member_lookup_with_policy(
+                                    db,
+                                    env,
+                                    "__setattr__",
+                                    MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
+                                        | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                                )
+                                .place
+                                .is_undefined())
+                    {
                         return fallback();
                     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_read_recovery.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_read_recovery.rs
@@ -1,0 +1,99 @@
+use ruff_db::parsed::parsed_module;
+use ruff_python_ast as ast;
+use ruff_python_ast::visitor::{Visitor, walk_expr, walk_stmt};
+use rustc_hash::FxHashSet;
+use ty_python_core::ExpressionNodeKey;
+use ty_python_core::place::PlaceExpr;
+use ty_python_core::scope::{NodeWithScopeKind, ScopeId};
+
+use crate::Db;
+
+/// Find simple reads following an assignment to the same attribute in a straight-line block.
+/// These reads can reuse an existing assignment's recovery type without repeating the diagnostic
+/// for a missing attribute. The caller must still check that the assignment is definitely bound.
+///
+/// This query only controls diagnostics; it does not establish member presence. Calls, other
+/// writes, complex expressions, and control-flow boundaries end recovery. Computing eligibility
+/// from syntax keeps it independent of the order in which inference queries run.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+pub(super) fn eligible_reads(db: &dyn Db, scope: ScopeId<'_>) -> FxHashSet<ExpressionNodeKey> {
+    let module = parsed_module(db, scope.python_file(db)).load(db);
+    let body = match scope.node(db) {
+        NodeWithScopeKind::Module => &module.syntax().body,
+        NodeWithScopeKind::Function(function) => &function.node(&module).body,
+        NodeWithScopeKind::Class(class) => &class.node(&module).body,
+        _ => return FxHashSet::default(),
+    };
+    let mut visitor = AttributeReadRecovery::default();
+    visitor.visit_body(body);
+    visitor.reads.shrink_to_fit();
+    visitor.reads
+}
+
+#[derive(Default)]
+struct AttributeReadRecovery {
+    assignment: Option<PlaceExpr>,
+    reads: FxHashSet<ExpressionNodeKey>,
+}
+
+impl<'ast> Visitor<'ast> for AttributeReadRecovery {
+    fn visit_body(&mut self, body: &'ast [ast::Stmt]) {
+        self.assignment = None;
+        for statement in body {
+            self.visit_stmt(statement);
+        }
+        self.assignment = None;
+    }
+
+    fn visit_stmt(&mut self, statement: &'ast ast::Stmt) {
+        match statement {
+            ast::Stmt::Assign(assignment) => {
+                self.visit_expr(&assignment.value);
+                self.assignment = match assignment.targets.as_slice() {
+                    [target @ ast::Expr::Attribute(_)] => PlaceExpr::try_from_expr(target),
+                    _ => None,
+                };
+            }
+            ast::Stmt::Expr(statement) => self.visit_expr(&statement.value),
+            ast::Stmt::Return(statement) => {
+                if let Some(value) = &statement.value {
+                    self.visit_expr(value);
+                }
+                self.assignment = None;
+            }
+            ast::Stmt::ClassDef(_) | ast::Stmt::FunctionDef(_) => self.assignment = None,
+            _ => {
+                self.assignment = None;
+                walk_stmt(self, statement);
+                self.assignment = None;
+            }
+        }
+    }
+
+    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+        match expression {
+            ast::Expr::Attribute(attribute) => {
+                self.visit_expr(&attribute.value);
+                if attribute.ctx.is_load()
+                    && let Some(assignment) = &self.assignment
+                    && PlaceExpr::try_from_expr(expression).as_ref() == Some(assignment)
+                {
+                    self.reads.insert(expression.into());
+                }
+            }
+            ast::Expr::Call(_) => {
+                // Arguments are evaluated before the call can invalidate the assignment.
+                walk_expr(self, expression);
+                self.assignment = None;
+            }
+            ast::Expr::Name(_)
+            | ast::Expr::NumberLiteral(_)
+            | ast::Expr::StringLiteral(_)
+            | ast::Expr::BytesLiteral(_)
+            | ast::Expr::BooleanLiteral(_)
+            | ast::Expr::NoneLiteral(_)
+            | ast::Expr::EllipsisLiteral(_) => {}
+            _ => self.assignment = None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

We now avoid repeating a missing-attribute error for a simple read immediately after assigning that attribute in the same block:

```python
import logging

logging.TRACE = 9  # Still reports unresolved-attribute.
logging.log(logging.TRACE, "message")  # No repeated error for TRACE.
```

We use the assignment's existing recovery type and filter only the read diagnostic. Recovery ends at calls, other writes, complex expressions, and control-flow or scope boundaries. Call arguments are evaluated before the call ends recovery. Receivers with a custom `__setattr__` keep their normal read diagnostics, since a permitted write need not make an attribute readable.
