### PR TITLE
[ty] Track attribute presence through flow checkpoints

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -979,6 +979,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             return FxHashMap::default();
         }
 
+        if popped_scope_laziness.is_eager() && !popped_scope_kind.is_annotation() {
+            self.current_use_def_map_mut().checkpoint_member_presence();
+        }
+
         // In the common case where we don't have any nested `global` or `nonlocal` declarations at
         // all, short-circuit so that we don't walk the place table for no reason.
         if nested_global_or_nonlocal_declarations.is_empty()
@@ -1850,6 +1854,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         loop_stmt: LoopStmtRef<'ast>,
         bound_places: Vec<PlaceExpr>,
     ) -> (LoopHeaderId, FxHashSet<ScopedPlaceId>, ScopedDefinitionId) {
+        self.current_use_def_map_mut().checkpoint_member_presence();
         let loop_header_id = self.current_use_def_map_mut().reserve_loop_header();
         let bound_places: Vec<_> = bound_places
             .into_iter()
@@ -3539,7 +3544,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             ast::Expr::Call(_) | ast::Expr::BinOp(_) => {
                 walk_expr(self, expr);
+                self.current_use_def_map_mut().checkpoint_member_presence();
                 self.record_exception_checkpoint();
+
+                // The callee is resolved later. Register the member so that a presence guard,
+                // including an alias of `hasattr`, can constrain it before its first use.
+                if let ast::Expr::Call(call) = expr
+                    && let [base, ast::Expr::StringLiteral(name)] = &*call.arguments.args
+                    && call.arguments.keywords.is_empty()
+                    && let Some(member) = PlaceExpr::attribute(base.into(), name.value.to_str())
+                {
+                    self.add_place(member);
+                }
             }
             ast::Expr::UnaryOp(unary) => {
                 self.visit_expr_with_context(

--- a/crates/ty_python_core/src/builder/except_handlers.rs
+++ b/crates/ty_python_core/src/builder/except_handlers.rs
@@ -130,9 +130,11 @@ impl ExceptionContextStackManager {
                 break;
             }
 
-            if !exception_context_stack
-                .record_exception_checkpoint(use_def_map, &mut has_intervening_finally)
-            {
+            if !exception_context_stack.record_exception_checkpoint(
+                use_def_map,
+                scope_stack_index + 1 < builder.scope_stack.len(),
+                &mut has_intervening_finally,
+            ) {
                 break;
             }
 
@@ -284,9 +286,13 @@ impl ExceptionContextStack {
     fn record_exception_checkpoint(
         &mut self,
         use_def_map: &UseDefMapBuilder<'_>,
+        crosses_scope_boundary: bool,
         has_intervening_finally: &mut bool,
     ) -> bool {
-        let checkpoint_key = use_def_map.exception_checkpoint_key();
+        let checkpoint_key = (
+            use_def_map.exception_checkpoint_key(),
+            crosses_scope_boundary,
+        );
 
         for context in self.0.iter_mut().rev() {
             if *has_intervening_finally && matches!(context.kind, ExceptionContextKind::With) {
@@ -298,7 +304,11 @@ impl ExceptionContextStack {
                 ExceptionHandlers::Propagating(snapshots)
                 | ExceptionHandlers::CatchAll(snapshots) => {
                     if context.last_checkpoint_key != Some(checkpoint_key) {
-                        snapshots.push(use_def_map.snapshot());
+                        let mut snapshot = use_def_map.snapshot();
+                        if crosses_scope_boundary {
+                            snapshot.checkpoint_member_presence();
+                        }
+                        snapshots.push(snapshot);
                         context.last_checkpoint_key = Some(checkpoint_key);
                     }
                     if context.exception_handlers.is_catch_all() {
@@ -349,7 +359,7 @@ enum ExceptionContextKind {
 pub(super) struct ExceptionContext {
     exception_handlers: ExceptionHandlers,
     kind: ExceptionContextKind,
-    last_checkpoint_key: Option<ExceptionCheckpointKey>,
+    last_checkpoint_key: Option<(ExceptionCheckpointKey, bool)>,
     /// Whether an exception escaped this suite and must also propagate after its cleanup.
     has_escaping_exception: bool,
     /// Whether apparently terminal control flow in a nested context-manager body, such as a

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -234,6 +234,8 @@ pub fn global_scope<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> ScopeId<'db
 pub enum EnclosingSnapshotResult<'map, 'db> {
     FoundConstraint(ScopedNarrowingConstraint),
     FoundBindings(BindingWithConstraintsIterator<'map, 'db>),
+    /// Binding state that constrains an enclosing value without supplying a value itself.
+    FoundUnboundBindings(BindingWithConstraintsIterator<'map, 'db>),
     NotFound,
     NoLongerInEagerContext,
 }

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -214,6 +214,16 @@ pub(super) struct MemberExprBuilder {
 }
 
 impl MemberExprBuilder {
+    pub(super) fn attribute(expr: ast::ExprRef<'_>, name: &str) -> Option<Self> {
+        let mut builder = Self::visit_expr(expr)?;
+        let start = builder.path.as_str().text_len();
+        builder.path = CharStr::concat(&[builder.path.as_str(), name]);
+        builder
+            .segments
+            .push(SegmentInfo::new(SegmentKind::Attribute, start));
+        Some(builder)
+    }
+
     pub(super) fn visit_expr(expr: ast::ExprRef) -> Option<MemberExprBuilder> {
         match expr {
             ast::ExprRef::Name(name) => {

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -45,6 +45,13 @@ pub enum PlaceExpr {
 }
 
 impl PlaceExpr {
+    /// Construct the member place read by a presence check such as `hasattr(value, "name")`.
+    /// This lets the check constrain `value.name` even without an attribute expression in the AST.
+    /// Returns `None` when the base is not trackable, such as the result of a function call.
+    pub fn attribute(base: ast::ExprRef<'_>, name: &str) -> Option<Self> {
+        Self::try_from_member_expr(MemberExprBuilder::attribute(base, name)?)
+    }
+
     /// Create a new `PlaceExpr` from a name.
     ///
     /// This always returns a `PlaceExpr::Symbol` with empty flags and `name`.
@@ -685,6 +692,14 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
     /// or narrow based on TypeGuard/TypeIs return types.
     fn expr_call(&self, expr_call: &ast::ExprCall) -> PossiblyNarrowedPlaces {
         let mut places = PossiblyNarrowedPlaces::default();
+
+        if let [base, ast::Expr::StringLiteral(name)] = &*expr_call.arguments.args
+            && expr_call.arguments.keywords.is_empty()
+            && let Some(member) = PlaceExpr::attribute(base.into(), name.value.to_str())
+            && let Some(place) = self.places.place_id((&member).into())
+        {
+            places.insert(place);
+        }
 
         // Under the current narrowing semantics, we only ever use the first two positional
         // arguments: argument 0 for most narrowing calls, and argument 1 for unbound

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -503,6 +503,7 @@ impl RetainedBindingsBuilder {
         for binding in &self.live_bindings {
             reachability_constraints.mark_used(binding.reachability_constraint());
             narrowing_constraints.mark_used(binding.narrowing_constraint());
+            narrowing_constraints.mark_used(binding.presence_constraint());
         }
         RetainedBindings {
             ends: self.ends.into(),
@@ -597,6 +598,7 @@ struct DefinitionsAtDefinition<B, D> {
 enum InternedEnclosingSnapshotId {
     Constraint(ScopedNarrowingConstraint),
     Bindings(InternedBindingsId),
+    UnboundBindings(InternedBindingsId),
 }
 
 /// Lookup tables needed to evaluate reachability and narrowing constraints.
@@ -954,12 +956,11 @@ impl<'db> UseDefMap<'db> {
                 })
             }
             ConstraintKey::NestedScope(nested_scope) => {
-                let EnclosingSnapshotResult::FoundBindings(bindings) =
+                let (EnclosingSnapshotResult::FoundBindings(bindings)
+                | EnclosingSnapshotResult::FoundUnboundBindings(bindings)) =
                     index.enclosing_snapshot(enclosing_scope, expr, nested_scope)
                 else {
-                    unreachable!(
-                        "The result of `SemanticIndex::eager_snapshot` must be `FoundBindings`"
-                    )
+                    unreachable!("Expected binding state for a nested-scope constraint")
                 };
                 ApplicableConstraints::ConstrainedBindings(bindings)
             }
@@ -1073,6 +1074,14 @@ impl<'db> UseDefMap<'db> {
             }
             Some(InternedEnclosingSnapshotId::Bindings(bindings_id)) => {
                 EnclosingSnapshotResult::FoundBindings(
+                    self.bindings_iterator(
+                        &self.interned_bindings[*bindings_id],
+                        boundness_analysis,
+                    ),
+                )
+            }
+            Some(InternedEnclosingSnapshotId::UnboundBindings(bindings_id)) => {
+                EnclosingSnapshotResult::FoundUnboundBindings(
                     self.bindings_iterator(
                         &self.interned_bindings[*bindings_id],
                         boundness_analysis,
@@ -1295,6 +1304,11 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
                     constraint: live_binding.narrowing_constraint(),
                     constraint_tables: self.constraint_tables,
                 },
+                presence_constraint: NarrowingEvaluator {
+                    constraint: live_binding.presence_constraint(),
+                    constraint_tables: self.constraint_tables,
+                },
+                inherits_presence: live_binding.inherits_presence(),
                 reachability_constraint: live_binding.reachability_constraint(),
             })
     }
@@ -1307,6 +1321,8 @@ pub struct BindingWithConstraints<'map, 'db> {
     /// Stable binding order within the containing scope.
     pub binding_order: ScopedDefinitionId,
     pub narrowing_constraint: NarrowingEvaluator<'map, 'db>,
+    pub presence_constraint: NarrowingEvaluator<'map, 'db>,
+    pub inherits_presence: bool,
     pub reachability_constraint: ScopedReachabilityConstraintId,
 }
 
@@ -1399,9 +1415,19 @@ pub(super) struct FlowSnapshot {
     checkpoint_flow: ScopedReachabilityConstraintId,
     checkpoint_state: ExceptionCheckpointSnapshot,
     pending_reachability: PendingReachabilityId,
+    presence_checkpoint: bool,
 }
 
 impl FlowSnapshot {
+    pub(super) fn checkpoint_member_presence(&mut self) {
+        self.presence_checkpoint = true;
+        for state in &mut self.member_states {
+            if state.state.needs_presence_checkpoint() {
+                Rc::make_mut(&mut state.state).invalidate_presence();
+            }
+        }
+    }
+
     pub(super) fn is_always_unreachable(&self) -> bool {
         self.reachability == ScopedReachabilityConstraintId::ALWAYS_FALSE
     }
@@ -1826,6 +1852,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// Restorable identity of the bindings visible to exception handlers.
     checkpoint_state: ExceptionCheckpointState,
 
+    // New member places also need to know whether an enclosing scope's proof is stale.
+    presence_checkpoint: bool,
+
     /// Live bindings for each so-far-recorded definition and, for binding-only definitions, the
     /// live declarations.
     definitions_by_definition:
@@ -1873,6 +1902,7 @@ impl<'db> UseDefMapBuilder<'db> {
             range_reachability: Vec::new(),
             checkpoint_flow: ScopedReachabilityConstraintId::ALWAYS_TRUE,
             checkpoint_state: ExceptionCheckpointState::default(),
+            presence_checkpoint: false,
             definitions_by_definition: FxHashMap::default(),
             symbol_states: IndexVec::new(),
             member_states: IndexVec::new(),
@@ -1929,8 +1959,12 @@ impl<'db> UseDefMapBuilder<'db> {
                 debug_assert_eq!(symbol, new_place);
             }
             ScopedPlaceId::Member(member) => {
+                let mut state = PlaceState::undefined(self.reachability);
+                if self.presence_checkpoint {
+                    state.invalidate_presence();
+                }
                 let new_place = self.member_states.push(PendingPlaceState::new(
-                    PlaceState::undefined(self.reachability),
+                    state,
                     self.pending_reachability.current,
                 ));
                 debug_assert_eq!(member, new_place);
@@ -1985,6 +2019,11 @@ impl<'db> UseDefMapBuilder<'db> {
             previous_definitions,
             can_be_shadowed,
         );
+        if matches!(previous_definitions, PreviousDefinitions::AreShadowed) {
+            place_state.establish_presence();
+        } else if self.presence_checkpoint && place.is_member() {
+            place_state.invalidate_presence();
+        }
         self.definitions_by_definition
             .insert(binding, definitions_at_definition);
 
@@ -2005,6 +2044,9 @@ impl<'db> UseDefMapBuilder<'db> {
             PreviousDefinitions::AreKept,
             can_be_shadowed,
         );
+        if matches!(previous_definitions, PreviousDefinitions::AreShadowed) {
+            bindings.establish_presence();
+        }
     }
 
     pub(crate) fn bindings_at_use(
@@ -2445,6 +2487,8 @@ impl<'db> UseDefMapBuilder<'db> {
                 PreviousDefinitions::AreKept,
                 FutureDefinitions::ShadowThisOne,
             );
+            place_state.establish_presence();
+            reachable_definitions.bindings.establish_presence();
         }
     }
 
@@ -2468,6 +2512,36 @@ impl<'db> UseDefMapBuilder<'db> {
             PreviousDefinitions::AreShadowed,
             FutureDefinitions::ShadowThisOne,
         );
+        place_state.invalidate_presence();
+    }
+
+    /// Forget member-presence evidence before executing code whose effects are unknown.
+    /// The value constraints are unchanged. Flow snapshots retain both constraint sets, so
+    /// restoring a branch or merging exception entries also restores or joins presence.
+    pub(super) fn checkpoint_member_presence(&mut self) {
+        if self.reachability == ScopedReachabilityConstraintId::ALWAYS_FALSE {
+            return;
+        }
+        let mut changed = !self.presence_checkpoint;
+        self.presence_checkpoint = true;
+        let pending = self.pending_reachability.current;
+        for state in &mut self.member_states {
+            if !state.state.needs_presence_checkpoint() {
+                continue;
+            }
+            changed = true;
+            self.pending_reachability
+                .materialize(
+                    state,
+                    pending,
+                    &mut self.narrowing_constraints,
+                    &mut self.reachability_constraints,
+                )
+                .invalidate_presence();
+        }
+        if changed {
+            self.checkpoint_state.record_binding_change();
+        }
     }
 
     pub(super) fn record_use(&mut self, place: ScopedPlaceId, use_id: ScopedUseId) {
@@ -2621,10 +2695,17 @@ impl<'db> UseDefMapBuilder<'db> {
         let is_forwarding_symbol = enclosing_place_expr
             .as_symbol()
             .is_some_and(|symbol| symbol.is_global() || symbol.is_nonlocal());
-        let stores_visible_bindings = enclosing_place_expr.is_bound()
-            && bindings
-                .iter()
-                .any(|binding| !binding.binding().is_unbound());
+        let has_bindings = bindings
+            .iter()
+            .any(|binding| !binding.binding().is_unbound());
+        let stores_visible_bindings = enclosing_place_expr.is_bound() && has_bindings;
+        // Even an unbound member can carry a presence checkpoint or a guard that must be
+        // applied before consulting an enclosing assignment.
+        if enclosing_place.is_member() && !stores_visible_bindings {
+            return self
+                .enclosing_snapshots
+                .push(EnclosingSnapshot::UnboundBindings(bindings.clone()));
+        }
         // Names bound in class scopes are never visible to nested scopes (but
         // attributes/subscripts are visible), so we never need to save eager scope bindings in a
         // class scope. There is one exception to this rule: annotation scopes can see names
@@ -2663,7 +2744,10 @@ impl<'db> UseDefMapBuilder<'db> {
             .bindings()
             .clone();
         match self.enclosing_snapshots.get_mut(snapshot_id) {
-            Some(EnclosingSnapshot::Bindings(bindings)) => {
+            Some(
+                EnclosingSnapshot::Bindings(bindings)
+                | EnclosingSnapshot::UnboundBindings(bindings),
+            ) => {
                 bindings.merge(
                     new_bindings,
                     &mut self.narrowing_constraints,
@@ -2702,6 +2786,7 @@ impl<'db> UseDefMapBuilder<'db> {
             checkpoint_flow: self.checkpoint_flow,
             checkpoint_state: self.checkpoint_state.snapshot(),
             pending_reachability: self.pending_reachability.current,
+            presence_checkpoint: self.presence_checkpoint,
         }
     }
 
@@ -2742,6 +2827,7 @@ impl<'db> UseDefMapBuilder<'db> {
         self.reachability = snapshot.reachability;
         self.checkpoint_flow = snapshot.checkpoint_flow;
         self.pending_reachability.current = snapshot.pending_reachability;
+        self.presence_checkpoint = snapshot.presence_checkpoint;
 
         // If the snapshot we are restoring is missing some places we've recorded since, we need
         // to fill them in so the place IDs continue to line up. Since they don't exist in the
@@ -2751,7 +2837,11 @@ impl<'db> UseDefMapBuilder<'db> {
             self.pending_reachability.current,
         );
         self.symbol_states.resize(num_symbols, undefined.clone());
-        self.member_states.resize(num_members, undefined);
+        let mut undefined_member = undefined;
+        if self.presence_checkpoint {
+            Rc::make_mut(&mut undefined_member.state).invalidate_presence();
+        }
+        self.member_states.resize(num_members, undefined_member);
     }
 
     /// Merge the given snapshot into the current state, reflecting that we might have taken either
@@ -2774,6 +2864,7 @@ impl<'db> UseDefMapBuilder<'db> {
         }
 
         self.checkpoint_state.merge(snapshot.checkpoint_state);
+        self.presence_checkpoint |= snapshot.presence_checkpoint;
 
         // We never remove places from `place_states` (it's an IndexVec, and the place
         // IDs must line up), so the current number of known places must always be equal to or
@@ -2790,9 +2881,18 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
+        let mut member_states = snapshot.member_states;
+        if snapshot.presence_checkpoint {
+            let mut undefined = PlaceState::undefined(snapshot.reachability);
+            undefined.invalidate_presence();
+            member_states.resize(
+                self.member_states.len(),
+                PendingPlaceState::new(undefined, branch),
+            );
+        }
         self.pending_reachability.merge_place_states(
             &mut self.member_states,
-            snapshot.member_states,
+            member_states,
             branch,
             snapshot.reachability,
             &mut self.narrowing_constraints,
@@ -3103,6 +3203,10 @@ impl<'db> UseDefMapBuilder<'db> {
                 EnclosingSnapshot::Bindings(bindings) => {
                     let interned_bindings_id = place_state_interner.intern_bindings(&bindings);
                     InternedEnclosingSnapshotId::Bindings(interned_bindings_id)
+                }
+                EnclosingSnapshot::UnboundBindings(bindings) => {
+                    let interned_bindings_id = place_state_interner.intern_bindings(&bindings);
+                    InternedEnclosingSnapshotId::UnboundBindings(interned_bindings_id)
                 }
                 EnclosingSnapshot::Constraint(constraint) => {
                     InternedEnclosingSnapshotId::Constraint(constraint)

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -212,11 +212,13 @@ impl Declarations {
 /// If there are bindings in a (non-class) scope, they are stored in `Bindings`.
 /// Even if it's a class scope (class variables are not visible to nested scopes) or there are no
 /// bindings, the current narrowing constraint is necessary for narrowing, so it's stored in
-/// `Constraint`.
+/// `Constraint`. An unbound member can also carry deletions, which `UnboundBindings` retains
+/// without making this scope the source of the member's value.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub(super) enum EnclosingSnapshot {
     Constraint(ScopedNarrowingConstraint),
     Bindings(Bindings),
+    UnboundBindings(Bindings),
 }
 
 /// Live bindings for a single place at some point in control flow. Each live binding comes
@@ -240,6 +242,8 @@ impl Bindings {
         self.unbound_narrowing_constraint.is_none()
             && binding.binding() == ScopedDefinitionId::UNBOUND
             && binding.narrowing_constraint == ScopedNarrowingConstraint::ALWAYS_TRUE
+            && binding.presence_constraint == ScopedNarrowingConstraint::ALWAYS_TRUE
+            && binding.inherits_presence()
             && binding.reachability_constraint == ScopedReachabilityConstraintId::ALWAYS_TRUE
             && binding.can_be_shadowed() == FutureDefinitions::ShadowThisOne
     }
@@ -258,6 +262,7 @@ impl Bindings {
         for binding in &self.live_bindings {
             reachability_constraints.mark_used(binding.reachability_constraint);
             narrowing_constraints.mark_used(binding.narrowing_constraint);
+            narrowing_constraints.mark_used(binding.presence_constraint);
         }
     }
 }
@@ -268,23 +273,28 @@ pub struct LiveBinding {
     binding: PackedDefinitionId,
     narrowing_constraint: ScopedNarrowingConstraint,
     reachability_constraint: ScopedReachabilityConstraintId,
+    // Paths on which presence still needs to be established. `ALWAYS_FALSE` means that
+    // every path has evidence; `ALWAYS_TRUE` means that none does. Keeping this separate
+    // lets execution checkpoints forget presence without discarding the inferred value.
+    presence_constraint: ScopedNarrowingConstraint,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
 struct PackedDefinitionId(u32);
 
 impl PackedDefinitionId {
-    // Scope-local definition IDs cannot practically use the high bit, so retain the shadowing
-    // policy there instead of adding a byte plus padding to every `LiveBinding`.
+    // Scope-local definition IDs cannot practically use the high bits, so retain the two
+    // binding policies there instead of adding bytes plus padding to every `LiveBinding`.
     const DONT_SHADOW: u32 = 1 << 31;
-    const DEFINITION_MASK: u32 = !Self::DONT_SHADOW;
+    const LOCAL_PRESENCE: u32 = 1 << 30;
+    const DEFINITION_MASK: u32 = !(Self::DONT_SHADOW | Self::LOCAL_PRESENCE);
 
     fn new(binding: ScopedDefinitionId, can_be_shadowed: FutureDefinitions) -> Self {
         let binding = binding.as_u32();
         assert_eq!(
-            binding & Self::DONT_SHADOW,
+            binding & !Self::DEFINITION_MASK,
             0,
-            "scopes cannot contain more than 2^31 definitions"
+            "scopes cannot contain more than 2^30 definitions"
         );
         Self(
             binding
@@ -319,6 +329,7 @@ impl LiveBinding {
             binding: PackedDefinitionId::new(binding, can_be_shadowed),
             narrowing_constraint,
             reachability_constraint,
+            presence_constraint: narrowing_constraint,
         }
     }
 
@@ -334,12 +345,23 @@ impl LiveBinding {
         self.reachability_constraint
     }
 
+    /// Constraints that establish presence independently of the binding's inferred type.
+    pub const fn presence_constraint(&self) -> ScopedNarrowingConstraint {
+        self.presence_constraint
+    }
+
+    /// Whether an enclosing scope can supply presence evidence for this binding.
+    /// Assignments and checkpoints establish local state that shadows enclosing evidence.
+    pub const fn inherits_presence(&self) -> bool {
+        self.binding.0 & PackedDefinitionId::LOCAL_PRESENCE == 0
+    }
+
     const fn can_be_shadowed(&self) -> FutureDefinitions {
         self.binding.can_be_shadowed()
     }
 }
 
-static_assertions::assert_eq_size!(LiveBinding, [u32; 3]);
+static_assertions::assert_eq_size!(LiveBinding, [u32; 4]);
 
 pub(super) type LiveBindingsIterator<'a> = std::slice::Iter<'a, LiveBinding>;
 
@@ -395,7 +417,30 @@ impl Bindings {
         for binding in &mut self.live_bindings {
             binding.narrowing_constraint =
                 narrowing_constraints.add_and_constraint(binding.narrowing_constraint, constraint);
+            binding.presence_constraint =
+                narrowing_constraints.add_and_constraint(binding.presence_constraint, constraint);
         }
+    }
+
+    pub(super) fn establish_presence(&mut self) {
+        if let Some(binding) = self.live_bindings.last_mut() {
+            binding.presence_constraint = ScopedNarrowingConstraint::ALWAYS_FALSE;
+            binding.binding.0 |= PackedDefinitionId::LOCAL_PRESENCE;
+        }
+    }
+
+    pub(super) fn invalidate_presence(&mut self) {
+        for binding in &mut self.live_bindings {
+            binding.presence_constraint = ScopedNarrowingConstraint::ALWAYS_TRUE;
+            binding.binding.0 |= PackedDefinitionId::LOCAL_PRESENCE;
+        }
+    }
+
+    fn needs_presence_checkpoint(&self) -> bool {
+        self.live_bindings.iter().any(|binding| {
+            binding.inherits_presence()
+                || binding.presence_constraint != ScopedNarrowingConstraint::ALWAYS_TRUE
+        })
     }
 
     /// Add given reachability constraint to all live bindings.
@@ -453,12 +498,18 @@ impl Bindings {
                         .add_or_constraint(a.reachability_constraint, b.reachability_constraint);
 
                     debug_assert_eq!(a.can_be_shadowed(), b.can_be_shadowed());
-                    self.live_bindings.push(LiveBinding::new(
+                    let mut binding = LiveBinding::new(
                         a.binding(),
                         narrowing_constraint,
                         reachability_constraint,
                         a.can_be_shadowed(),
-                    ));
+                    );
+                    binding.presence_constraint = narrowing_constraints
+                        .add_or_constraint(a.presence_constraint, b.presence_constraint);
+                    if !a.inherits_presence() || !b.inherits_presence() {
+                        binding.binding.0 |= PackedDefinitionId::LOCAL_PRESENCE;
+                    }
+                    self.live_bindings.push(binding);
                 }
 
                 EitherOrBoth::Left(binding) | EitherOrBoth::Right(binding) => {
@@ -476,6 +527,18 @@ pub(crate) struct PlaceState {
 }
 
 impl PlaceState {
+    pub(super) fn needs_presence_checkpoint(&self) -> bool {
+        self.bindings.needs_presence_checkpoint()
+    }
+
+    pub(super) fn establish_presence(&mut self) {
+        self.bindings.establish_presence();
+    }
+
+    pub(super) fn invalidate_presence(&mut self) {
+        self.bindings.invalidate_presence();
+    }
+
     /// Return a new [`PlaceState`] representing an unbound, undeclared place.
     pub(super) fn undefined(reachability: ScopedReachabilityConstraintId) -> Self {
         Self {
@@ -529,6 +592,8 @@ impl PlaceState {
             {
                 binding.narrowing_constraint = narrowing_constraints
                     .add_and_constraint(binding.narrowing_constraint, constraint);
+                binding.presence_constraint = narrowing_constraints
+                    .add_and_constraint(binding.presence_constraint, constraint);
             }
         }
     }
@@ -544,6 +609,8 @@ impl PlaceState {
             if bindings.contains(&binding.binding()) {
                 binding.narrowing_constraint = narrowing_constraints
                     .add_and_constraint(binding.narrowing_constraint, constraint);
+                binding.presence_constraint = narrowing_constraints
+                    .add_and_constraint(binding.presence_constraint, constraint);
             }
         }
     }

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2675,6 +2675,33 @@ def _(flag1: bool, flag2: bool):
     C().x = 100
 ```
 
+### Never-valued attributes
+
+A `Never`-valued attribute on one union member does not establish that the attribute exists on the
+other members. The receiver can still be an instance of the class without the attribute, so we
+report the missing attribute before the read can produce a value.
+
+```py
+from typing_extensions import Never
+
+class HasValue:
+    value: Never
+
+class Missing: ...
+
+def read(obj: HasValue | Missing):
+    obj.value  # error: [unresolved-attribute]
+```
+
+An assignment on one branch does not establish presence on the other branch.
+
+```py
+def partially_assigned(obj: HasValue | Missing, condition: bool):
+    if condition:
+        obj.value = 1  # error: [invalid-assignment]
+    obj.value  # error: [unresolved-attribute]
+```
+
 ### Possibly-unbound within a class
 
 We raise the same diagnostic if the attribute is possibly-unbound in at least one element of the

--- a/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/assignment.md
@@ -90,13 +90,425 @@ class _:
 a = A()
 # error: [unresolved-attribute]
 a.dynamically_added = 0
-# error: [unresolved-attribute]
+# The assignment is invalid, but establishes the attribute's presence for subsequent reads.
 reveal_type(a.dynamically_added)  # revealed: Literal[0]
 
 # error: [unresolved-reference]
 does.nt.exist = 0
 # error: [unresolved-reference]
 reveal_type(does.nt.exist)  # revealed: Literal[0]
+```
+
+### Presence after conditional assignments
+
+Assigning an undeclared attribute is still an error, but a subsequent read does not repeat the error
+when every branch assigns the attribute.
+
+```py
+class Item: ...
+
+def assigned_on_both_branches(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+    else:
+        item.value = 2  # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[1, 2]
+```
+
+An assignment on only one branch does not establish presence after the conditional.
+
+```py
+def assigned_on_one_branch(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+    item.value  # error: [unresolved-attribute]
+```
+
+A branch that exits without reaching the read does not affect whether the attribute is present.
+
+```py
+def assigned_or_raised(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+    else:
+        raise ValueError
+    reveal_type(item.value)  # revealed: Literal[1]
+```
+
+### Presence across calls and branch joins
+
+A call can mutate an object. Its arguments observe the preceding assignment, but later reads need
+new presence evidence. Forgetting presence preserves the inferred value type.
+
+```py
+class Item: ...
+
+def mutate(item: object) -> None: ...
+def after_call(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    mutate(item.value)
+    # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[1]
+    assert hasattr(item, "value")
+    item.value
+```
+
+Each branch can establish presence independently, through either an assignment or a guard.
+
+```py
+def separate_proofs(item: Item, condition: bool):
+    if condition:
+        item.value = 1  # error: [unresolved-attribute]
+    else:
+        assert hasattr(item, "value")
+    item.value
+
+def renewed_proof(item: Item, condition: bool):
+    item.value = 1  # error: [unresolved-attribute]
+    if condition:
+        mutate(item)
+        assert hasattr(item, "value")
+    item.value
+
+def missing_proof(item: Item, condition: bool):
+    item.value = 1  # error: [unresolved-attribute]
+    if condition:
+        mutate(item)
+    item.value  # error: [unresolved-attribute]
+```
+
+A call can mutate an object before raising, so its exception handler also needs fresh evidence. An
+assignment in the handler can establish presence for the join with the successful path.
+
+```py
+def caught_mutation(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    try:
+        mutate(item)
+    except Exception:
+        item.value  # error: [unresolved-attribute]
+
+def renewed_in_handler(item: Item):
+    try:
+        mutate(item)
+        item.value = 1  # error: [unresolved-attribute]
+    except Exception:
+        item.value = 2  # error: [unresolved-attribute]
+    item.value
+```
+
+### Presence when an eager scope raises
+
+An eager class body can delete an attribute and then raise before the enclosing scope resumes. The
+handler cannot rely on the assignment from before the class body.
+
+```py
+class Item: ...
+
+def eager_exception(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    try:
+        class Inner:
+            del item.value
+            raise ValueError
+
+    except Exception:
+        item.value  # error: [unresolved-attribute]
+```
+
+An attribute first read after a call in a class body cannot inherit stale presence. A new local
+assignment establishes presence even if an enclosing scope previously discarded its proof.
+
+```py
+def mutate(item: Item) -> None: ...
+def first_read_after_call(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        mutate(item)
+        item.value  # error: [unresolved-attribute]
+
+def assigned_in_class(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    mutate(item)
+
+    class Inner:
+        item.value = 2  # error: [unresolved-attribute]
+        item.value
+```
+
+### Presence after deletion in an eager scope
+
+An assignment in an enclosing scope establishes presence in an eager class body. Deleting the
+attribute in that class body invalidates this evidence, so a later read reports the missing
+attribute.
+
+```py
+class Item: ...
+
+item = Item()
+item.value = 1  # error: [unresolved-attribute]
+
+class Inner:
+    item.value
+    del item.value
+    item.value  # error: [unresolved-attribute]
+```
+
+A conditional deletion also invalidates presence after the branches join. Assigning the attribute
+again establishes presence for subsequent reads.
+
+```py
+def conditional_deletion(item: Item, condition: bool):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if condition:
+            del item.value
+        item.value  # error: [unresolved-attribute]
+        item.value = 2  # error: [unresolved-attribute]
+        reveal_type(item.value)  # revealed: Literal[2]
+```
+
+An unreachable deletion does not invalidate presence from the enclosing scope.
+
+```py
+def unreachable_deletion(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if False:
+            del item.value
+        reveal_type(item.value)  # revealed: Literal[1]
+```
+
+### Presence after deletion across eager scopes
+
+A comprehension inside a class body observes deletions made before it runs. An earlier assignment in
+the enclosing function does not establish presence after that deletion.
+
+```py
+class Item: ...
+
+def deleted_before_comprehension(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        del item.value
+        [item.value for _ in range(1)]  # error: [unresolved-attribute]
+```
+
+An unreachable deletion preserves the assigned type. The call that constructs the iterable clears
+presence evidence before the comprehension runs.
+
+```py
+def unreachable_deletion_before_comprehension(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if False:
+            del item.value
+        # error: [unresolved-attribute]
+        [reveal_type(item.value) for _ in range(1)]  # revealed: Literal[1]
+```
+
+### Presence after deletion across loop iterations
+
+A read before a deletion can still observe that deletion on a later iteration. An assignment before
+the class body does not establish that the attribute is present on every iteration.
+
+```py
+class Item: ...
+
+def deleted_on_previous_iteration(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        for _ in range(2):
+            item.value  # error: [unresolved-attribute]
+            del item.value  # error: [unresolved-attribute]
+```
+
+The deletion also affects a read in a comprehension nested inside the loop.
+
+```py
+def deleted_on_previous_iteration_in_comprehension(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        for _ in range(2):
+            [item.value for _ in range(1)]  # error: [unresolved-attribute]
+            del item.value  # error: [unresolved-attribute]
+```
+
+Assigning the attribute before each read establishes presence again, even when the previous
+iteration deleted it.
+
+```py
+def assigned_on_each_iteration(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        for _ in range(2):
+            item.value = 2  # error: [unresolved-attribute]
+            item.value
+            del item.value
+```
+
+### Presence after receiver reassignment
+
+Reassigning the receiver discards evidence that an attribute was assigned on the previous object.
+
+```py
+class Item: ...
+
+def f(item: Item, other: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[1]
+    item = other
+    item.value  # error: [unresolved-attribute]
+```
+
+### Presence after an eager scope exits
+
+A class body executes before the enclosing scope continues. Deleting an attribute in the class body
+invalidates an earlier assignment in the enclosing scope. Assigning it again restores presence.
+
+```py
+class Item: ...
+
+def deleted_in_class(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        item.value
+        del item.value
+
+    item.value  # error: [unresolved-attribute]
+    [item.value for _ in range(1)]  # error: [unresolved-attribute]
+    item.value = 2  # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[2]
+```
+
+The invalidation also reaches enclosing scopes through nested class bodies.
+
+```py
+def deleted_in_nested_class(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Outer:
+        class Inner:
+            del item.value
+
+        item.value  # error: [unresolved-attribute]
+
+    item.value  # error: [unresolved-attribute]
+```
+
+A conditional deletion can leave the attribute missing. Eager scope boundaries conservatively clear
+presence even when the mutation is unreachable; the assigned type is preserved.
+
+```py
+def conditionally_deleted_in_class(item: Item, condition: bool):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if condition:
+            del item.value
+
+    item.value  # error: [unresolved-attribute]
+
+def unreachable_deletion_in_class(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        if False:
+            del item.value
+
+    # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[1]
+```
+
+### Presence after receiver reassignment in an eager scope
+
+Replacing a member invalidates assignments to attributes of the previous object.
+
+```py
+class Item: ...
+
+class Box:
+    item: Item
+
+def replaced_in_class(box: Box):
+    box.item.value = 1  # error: [unresolved-attribute]
+
+    class Inner:
+        box.item = Item()
+
+    box.item.value  # error: [unresolved-attribute]
+```
+
+### Eager mutations across enclosing loop iterations
+
+A class body can delete an attribute before the next iteration reads it.
+
+```py
+class Item: ...
+
+def deleted_in_loop(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+    for _ in range(2):
+        item.value  # error: [unresolved-attribute]
+
+        class Inner:
+            del item.value  # error: [unresolved-attribute]
+```
+
+### Conservative eager scope boundaries
+
+A class-local receiver refers to a different object. We preserve the enclosing assignment's type,
+but conservatively discard presence when the class body finishes.
+
+```py
+class Item: ...
+
+item = Item()
+item.value = 1  # error: [unresolved-attribute]
+
+class Inner:
+    item = Item()
+    item.value = 2  # error: [unresolved-attribute]
+    del item.value
+
+# error: [unresolved-attribute]
+reveal_type(item.value)  # revealed: Literal[1]
+```
+
+A loop around the class body also clears presence.
+
+```py
+for _ in range(2):
+    class InLoop:
+        item = Item()
+        item.value = 2  # error: [unresolved-attribute]
+        del item.value
+
+    # error: [unresolved-attribute]
+    reveal_type(item.value)  # revealed: Literal[1]
+```
+
+A function body does not execute when the function is defined, including class bodies nested inside
+it.
+
+```py
+def outer(item: Item):
+    item.value = 1  # error: [unresolved-attribute]
+
+    def deferred():
+        class Inner:
+            del item.value  # error: [unresolved-attribute]
+
+    reveal_type(item.value)  # revealed: Literal[1]
 ```
 
 ### Narrowing chain

--- a/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/hasattr.md
@@ -1,5 +1,7 @@
 # Narrowing using `hasattr()`
 
+## Basic checks
+
 The builtin function `hasattr()` can be used to narrow nominal and structural types. This is
 accomplished using an intersection with a synthesized protocol:
 
@@ -97,4 +99,77 @@ def f(x: object):
 
         # error: [unresolved-attribute] "Object of type `<Protocol with members '__qualname__'>` has no attribute `foo`"
         reveal_type(x.foo)  # revealed: Unknown
+```
+
+## Presence at branch joins
+
+An attribute is available after a guard when it either passed the check or was assigned in the
+missing branch. Assigning an undeclared attribute still reports an error, but the subsequent read
+does not repeat it.
+
+```py
+class Item: ...
+
+def initialized(item: Item):
+    if not hasattr(item, "value"):
+        item.value = 1  # error: [invalid-assignment]
+    reveal_type(item.value)  # revealed: object
+```
+
+A successful guard on only one branch does not establish presence after the conditional. Aliases of
+`hasattr` provide the same presence information as the builtin.
+
+```py
+from builtins import hasattr as has_attribute
+
+def partially_checked(item: Item, condition: bool):
+    if condition:
+        assert has_attribute(item, "value")
+        reveal_type(item.value)  # revealed: object
+    item.value  # error: [unresolved-attribute]
+```
+
+## Receiver reassignment
+
+Reassigning the receiver forgets the successful guard's presence information. The new object does
+not inherit the member established for the previous object.
+
+```py
+class Item: ...
+
+def f(item: Item, other: Item):
+    if hasattr(item, "value"):
+        reveal_type(item.value)  # revealed: object
+        item = other
+        item.value  # error: [unresolved-attribute]
+```
+
+## Negative checks and later narrowing
+
+A failed check retains its negative protocol constraint. Later checks can use that constraint to
+rule out a receiver with the attribute, regardless of the order of the checks.
+
+```py
+class WithValue:
+    value = 1
+
+def f(obj: object):
+    if not hasattr(obj, "value") and isinstance(obj, WithValue):
+        reveal_type(obj)  # revealed: Never
+
+    if isinstance(obj, WithValue) and not hasattr(obj, "value"):
+        reveal_type(obj)  # revealed: Never
+```
+
+The constraint also excludes intersections of a remaining union member with a type that has the
+attribute.
+
+```py
+class Other: ...
+
+def g(obj: WithValue | Other):
+    if not hasattr(obj, "value"):
+        reveal_type(obj)  # revealed: Other & ~<Protocol with members 'value'>
+        if isinstance(obj, WithValue):
+            reveal_type(obj)  # revealed: Never
 ```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -14,6 +14,7 @@ use crate::reachability::{
     NarrowingProjector, ReachabilityEvaluationCache, evaluate_reachability,
     evaluate_reachability_with_cache,
 };
+use crate::types::narrow::NarrowedPlace;
 use crate::types::{
     DynamicType, KnownClass, MemberLookupPolicy, Type, TypeAndQualifiers, TypeQualifiers,
     UnionBuilder, UnionType, binding_type, inferred_declaration, is_discarded_dict_key_assignment,
@@ -1839,19 +1840,22 @@ fn place_from_bindings_impl<'db>(
             let narrowed = match narrowing_constraint.constraint() {
                 ScopedNarrowingConstraint::ALWAYS_TRUE => binding_ty,
                 ScopedNarrowingConstraint::ALWAYS_FALSE => Type::Never,
-                constraint => narrowing_projector
-                    .get_or_insert_with(|| {
-                        NarrowingProjector::new(
-                            db,
-                            env,
-                            narrowing_constraint.narrowing_constraints(),
-                            predicates,
-                            narrowing_constraint.predicate_narrowing_targets(),
-                            binding.place(db),
-                            binding_ty,
-                        )
-                    })
-                    .narrow(constraint, binding_ty),
+                constraint => {
+                    narrowing_projector
+                        .get_or_insert_with(|| {
+                            NarrowingProjector::new(
+                                db,
+                                env,
+                                narrowing_constraint.narrowing_constraints(),
+                                predicates,
+                                narrowing_constraint.predicate_narrowing_targets(),
+                                binding.place(db),
+                                NarrowedPlace::new(binding_ty),
+                            )
+                        })
+                        .narrow(constraint, NarrowedPlace::new(binding_ty))
+                        .ty
+                }
             };
             Some((narrowed, static_reachability))
         },

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -439,6 +439,13 @@ impl<'db, 'ast> PlaceLoadResolution<'db, 'ast> {
                             eagerly_undefined = true;
                         }
                     }
+                    EnclosingSnapshotResult::FoundUnboundBindings(_) => {
+                        self.constraints
+                            .push(enclosing_file_scope, ConstraintKey::NestedScope(file_scope));
+                        if scope.scope(db).is_eager() {
+                            eagerly_undefined = true;
+                        }
+                    }
                     EnclosingSnapshotResult::FoundBindings(bindings) => {
                         if forwards_to_global {
                             self.crosses_scope_declaration = true;
@@ -548,6 +555,13 @@ impl<'db, 'ast> PlaceLoadResolution<'db, 'ast> {
                     self.constraints.push(
                         FileScopeId::global(),
                         ConstraintKey::NarrowingConstraint(constraint),
+                    );
+                    return None;
+                }
+                EnclosingSnapshotResult::FoundUnboundBindings(_) => {
+                    self.constraints.push(
+                        FileScopeId::global(),
+                        ConstraintKey::NestedScope(current_scope),
                     );
                     return None;
                 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -194,6 +194,7 @@
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
 use crate::ProgramEnvironment;
+use crate::types::narrow::{NarrowedPlace, NarrowedPlaceBuilder};
 use std::cell::RefCell;
 
 use crate::{
@@ -877,17 +878,17 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     }
 }
 
-pub(crate) fn narrow_type_by_constraint<'db>(
+pub(crate) fn narrow_place_by_constraint<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     evaluator: &NarrowingEvaluator<'_, 'db>,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
     place: ScopedPlaceId,
-) -> Type<'db> {
+) -> NarrowedPlace<'db> {
     let id = evaluator.constraint();
     match id {
         ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
-        ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
+        ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::unreachable(),
         _ => {}
     }
 
@@ -906,13 +907,17 @@ pub(crate) fn narrow_type_by_constraint<'db>(
 fn apply_accumulated_narrowing<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
     accumulated: Option<NarrowingConstraint<'db>>,
-) -> Type<'db> {
+) -> NarrowedPlace<'db> {
     match accumulated {
-        Some(constraint) => NarrowingConstraint::intersection(base_ty)
-            .merge_constraint_and(constraint)
-            .evaluate_constraint_type(db, env),
+        Some(constraint) => {
+            let mut narrowed = NarrowingConstraint::intersection(base_ty.ty)
+                .merge_constraint_and(constraint)
+                .evaluate_place(db, env);
+            narrowed.known_present |= base_ty.known_present;
+            narrowed
+        }
         None => base_ty,
     }
 }
@@ -948,7 +953,7 @@ enum ProjectedNarrowingEntry<'db> {
     /// A nonterminal suffix. Constant suffixes use the graph's existing terminal IDs instead.
     Checkpoint {
         constraint: ScopedNarrowingConstraint,
-        ty: Type<'db>,
+        ty: NarrowedPlace<'db>,
     },
 }
 
@@ -984,7 +989,7 @@ impl<'db> ProjectedNarrowingGraph<'db> {
     }
 }
 
-/// A cached type together with the terminal shape of its canonical projected graph.
+/// A cached value type and presence together with the terminal shape of its projected graph.
 ///
 /// Joins need to recognize an unconstrained suffix before applying `TypeGuard` replacement.
 /// Similarly, an unreachable graph must be eliminated before a later predicate can replace `Never`.
@@ -992,13 +997,13 @@ impl<'db> ProjectedNarrowingGraph<'db> {
 enum ProjectedNarrowingCheckpoint<'db> {
     Unreachable,
     Unconstrained,
-    Narrowed(Type<'db>),
+    Narrowed(NarrowedPlace<'db>),
 }
 
 impl<'db> ProjectedNarrowingCheckpoint<'db> {
-    fn ty(self, base_ty: Type<'db>) -> Type<'db> {
+    fn place(self, base_ty: NarrowedPlace<'db>) -> NarrowedPlace<'db> {
         match self {
-            Self::Unreachable => Type::Never,
+            Self::Unreachable => NarrowedPlace::unreachable(),
             Self::Unconstrained => base_ty,
             Self::Narrowed(ty) => ty,
         }
@@ -1008,16 +1013,17 @@ impl<'db> ProjectedNarrowingCheckpoint<'db> {
 /// Evaluates a stable suffix with the canonical projected-graph evaluator.
 ///
 /// The root is projected directly to avoid querying its own checkpoint. Descendant checkpoints
-/// contribute their cached types and terminal shape. Nonterminal suffixes are expanded locally only
+/// contribute their cached types, presence, and terminal shape. Nonterminal suffixes are expanded only
 /// when simplifying a join requires their predicates.
 #[salsa::tracked(
     returns(copy),
-    cycle_initial = |_, id, _, _, _, _| ProjectedNarrowingCheckpoint::Narrowed(Type::divergent(id)),
+    cycle_initial = |_, id, _, _, _, _| ProjectedNarrowingCheckpoint::Narrowed(NarrowedPlace::new(Type::divergent(id))),
     cycle_fn = |db: &'db dyn Db, cycle, previous: &ProjectedNarrowingCheckpoint<'db>, result: ProjectedNarrowingCheckpoint<'db>, scope: ScopeId<'db>, _, _, base_ty| {
         match result {
-            ProjectedNarrowingCheckpoint::Narrowed(ty) => ProjectedNarrowingCheckpoint::Narrowed(
-                ty.cycle_normalized(db, &ProgramEnvironment::from_scope(scope), previous.ty(base_ty), cycle)
-            ),
+            ProjectedNarrowingCheckpoint::Narrowed(narrowed) => ProjectedNarrowingCheckpoint::Narrowed(NarrowedPlace {
+                ty: narrowed.ty.cycle_normalized(db, &ProgramEnvironment::from_scope(scope), previous.place(base_ty).ty, cycle),
+                known_present: narrowed.known_present,
+            }),
             _ => result,
         }
     },
@@ -1028,7 +1034,7 @@ fn evaluate_projected_narrowing_checkpoint<'db>(
     scope: ScopeId<'db>,
     place: ScopedPlaceId,
     constraint: ScopedNarrowingConstraint,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
 ) -> ProjectedNarrowingCheckpoint<'db> {
     let env = ProgramEnvironment::from_scope(scope);
     let use_def = use_def_map(db, scope);
@@ -1058,11 +1064,12 @@ pub(crate) struct NarrowingProjector<'a, 'db> {
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
     predicate_narrowing_targets: &'a PredicateNarrowingTargets,
     place: ScopedPlaceId,
-    base_ty: Type<'db>,
-    /// Checkpoint entries retain narrowed types, so projections are specific to the binding type.
-    project_cache: FxHashMap<(ScopedNarrowingConstraint, Type<'db>), ProjectedNarrowingNodeId>,
+    base_ty: NarrowedPlace<'db>,
+    /// Checkpoints retain types and presence, so both must be part of the projection key.
+    project_cache:
+        FxHashMap<(ScopedNarrowingConstraint, NarrowedPlace<'db>), ProjectedNarrowingNodeId>,
     graph: ProjectedNarrowingGraph<'db>,
-    narrowed_cache: FxHashMap<(ProjectedNarrowingNodeId, Type<'db>), Type<'db>>,
+    narrowed_cache: FxHashMap<(ProjectedNarrowingNodeId, NarrowedPlace<'db>), NarrowedPlace<'db>>,
 }
 
 impl<'a, 'db> NarrowingProjector<'a, 'db> {
@@ -1074,7 +1081,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
         predicate_narrowing_targets: &'a PredicateNarrowingTargets,
         place: ScopedPlaceId,
-        base_ty: Type<'db>,
+        base_ty: NarrowedPlace<'db>,
     ) -> Self {
         Self {
             db,
@@ -1094,12 +1101,12 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     pub(crate) fn narrow(
         &mut self,
         constraint: ScopedNarrowingConstraint,
-        base_ty: Type<'db>,
-    ) -> Type<'db> {
+        base_ty: NarrowedPlace<'db>,
+    ) -> NarrowedPlace<'db> {
         self.base_ty = base_ty;
         match constraint {
             ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
-            ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
+            ScopedNarrowingConstraint::ALWAYS_FALSE => return NarrowedPlace::unreachable(),
             _ => {}
         }
 
@@ -1119,13 +1126,13 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     fn narrow_projected(
         &mut self,
         root: ProjectedNarrowingNodeId,
-        base_ty: Type<'db>,
-    ) -> Type<'db> {
+        base_ty: NarrowedPlace<'db>,
+    ) -> NarrowedPlace<'db> {
         if root == ProjectedNarrowingNodeId::ALWAYS_TRUE {
             return base_ty;
         }
         if root == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return Type::Never;
+            return NarrowedPlace::unreachable();
         }
         self.graph.record_reference(root);
 
@@ -1486,14 +1493,15 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     }
 }
 
-/// Evaluates narrowed types over a projected narrowing graph.
+/// Evaluates value types and member presence together over a projected narrowing graph.
 struct ProjectedNarrowingContext<'a, 'db> {
     db: &'db dyn Db,
     env: &'a ProgramEnvironment<'db>,
-    base_ty: Type<'db>,
+    base_ty: NarrowedPlace<'db>,
     graph: &'a ProjectedNarrowingGraph<'db>,
-    /// Caches each shared suffix for the binding type being narrowed.
-    join_cache: &'a mut FxHashMap<(ProjectedNarrowingNodeId, Type<'db>), Type<'db>>,
+    /// Caches each shared suffix for the binding type and presence being narrowed.
+    join_cache:
+        &'a mut FxHashMap<(ProjectedNarrowingNodeId, NarrowedPlace<'db>), NarrowedPlace<'db>>,
 }
 
 impl<'db> ProjectedNarrowingContext<'_, 'db> {
@@ -1501,8 +1509,8 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         !id.is_terminal() && self.graph.joins[id.0]
     }
 
-    /// Evaluates one projected join from its boundary and caches its narrowed suffix type.
-    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> Type<'db> {
+    /// Evaluates one projected join from its boundary and caches its narrowed type and presence.
+    fn narrow_join(&mut self, id: ProjectedNarrowingNodeId) -> NarrowedPlace<'db> {
         let key = (id, self.base_ty);
         if let Some(cached) = self.join_cache.get(&key) {
             return *cached;
@@ -1518,7 +1526,7 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         &mut self,
         id: ProjectedNarrowingNodeId,
         accumulated: Option<NarrowingConstraint<'db>>,
-    ) -> Type<'db> {
+    ) -> NarrowedPlace<'db> {
         let db = self.db;
         if self.is_join(id) {
             // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
@@ -1535,10 +1543,10 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         &mut self,
         id: ProjectedNarrowingNodeId,
         accumulated: Option<NarrowingConstraint<'db>>,
-    ) -> Type<'db> {
+    ) -> NarrowedPlace<'db> {
         let db = self.db;
         if id == ProjectedNarrowingNodeId::ALWAYS_FALSE {
-            return Type::Never;
+            return NarrowedPlace::unreachable();
         }
 
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
@@ -1572,9 +1580,11 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
                 let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
                 let false_ty = self.narrow(node.if_false, false_accumulated);
 
-                let true_or_uncertain =
-                    UnionType::from_two_elements(db, self.env, true_ty, uncertain_ty);
-                UnionType::from_two_elements(db, self.env, true_or_uncertain, false_ty)
+                let mut union = NarrowedPlaceBuilder::new(db, self.env);
+                union.add(true_ty);
+                union.add(uncertain_ty);
+                union.add(false_ty);
+                union.build()
             }
         }
     }
@@ -2357,7 +2367,7 @@ class TargetB:
                     &predicates,
                     evaluator.predicate_narrowing_targets(),
                     ScopedPlaceId::Symbol(x),
-                    Type::unknown(),
+                    NarrowedPlace::new(Type::unknown()),
                 );
 
                 assert_eq!(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -103,8 +103,8 @@ use crate::types::infer::{
     nearest_enclosing_function, original_class_type,
 };
 use crate::types::match_pattern::{ClassPatternPositionalResult, class_pattern_positional_result};
-use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::narrow::pattern_success_types;
+use crate::types::narrow::{NarrowedPlace, NarrowedPlaceBuilder, NarrowingEvaluatorExtension};
 use crate::types::newtype::NewType;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::signatures::{CallableSignature, ReturnCallableTypeVarScope};
@@ -9893,16 +9893,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         })
     }
 
-    // Perform narrowing with applicable constraints between the current scope and the enclosing scope.
+    /// Narrow a place's value type and presence using constraints from its load resolution.
     fn narrow_place_with_applicable_constraints(
         &self,
         expr: PlaceExprRef,
-        mut ty: Type<'db>,
+        mut narrowed: NarrowedPlace<'db>,
         constraint_keys: &[(FileScopeId, ConstraintKey)],
-    ) -> Type<'db> {
+    ) -> NarrowedPlace<'db> {
         let db = self.db();
         let env = self.program_environment();
+        // Constraints are ordered from inner to outer scopes. A local assignment or checkpoint
+        // shadows enclosing presence evidence, while preserving guards after the checkpoint.
+        let mut presence_is_local = false;
         for (enclosing_scope_file_id, constraint_key) in constraint_keys {
+            let inner_known_present = narrowed.known_present;
+            let mut shadows_enclosing_presence = false;
             let use_def = self.index.use_def_map(*enclosing_scope_file_id);
             let place_table = self.index.place_table(*enclosing_scope_file_id);
             let place = place_table.place_id(expr).unwrap();
@@ -9914,7 +9919,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.index,
             ) {
                 ApplicableConstraints::UnboundBinding(constraint) => {
-                    ty = constraint.narrow(db, env, ty, place);
+                    narrowed = constraint.narrow_place(db, env, narrowed, place);
                 }
                 // Performs narrowing based on constrained bindings.
                 // This handling must be performed even if narrowing is attempted and failed using `infer_place_load`.
@@ -9934,7 +9939,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ApplicableConstraints::ConstrainedBindings(bindings) => {
                     let reachability_constraints = bindings.reachability_constraints();
                     let predicates = bindings.predicates();
-                    let mut union = UnionBuilder::new(db, env);
+                    let mut union = NarrowedPlaceBuilder::new(db, env);
                     let mut loop_header_fallbacks = FxHashMap::default();
                     for binding in bindings {
                         let static_reachability = evaluate_reachability_with_cache(
@@ -9947,7 +9952,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         if static_reachability.is_always_false() {
                             continue;
                         }
-                        match binding.binding {
+                        shadows_enclosing_presence |= !binding.inherits_presence;
+                        let mut contribution = match binding.binding {
                             DefinitionState::Defined(definition)
                                 if !is_discarded_dict_key_assignment(db, definition) =>
                             {
@@ -9955,7 +9961,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 if definition.kind(db).is_loop_header() {
                                     let fallback_ty = self.loop_header_fallback_type(
                                         definition,
-                                        ty,
+                                        narrowed.ty,
                                         &mut loop_header_fallbacks,
                                     );
                                     binding_ty = UnionType::from_elements(
@@ -9964,30 +9970,48 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         [binding_ty, fallback_ty],
                                     );
                                 }
-                                union.add_in_place(
-                                    binding
-                                        .narrowing_constraint
-                                        .narrow(db, env, binding_ty, place),
-                                );
+                                let bound = NarrowedPlace {
+                                    ty: binding_ty,
+                                    known_present: false,
+                                };
+                                binding
+                                    .narrowing_constraint
+                                    .narrow_place(db, env, bound, place)
                             }
                             DefinitionState::Defined(_)
                             | DefinitionState::Undefined
-                            | DefinitionState::Deleted => {
-                                union.add_in_place(
-                                    binding.narrowing_constraint.narrow(db, env, ty, place),
-                                );
-                            }
-                        }
+                            | DefinitionState::Deleted => binding
+                                .narrowing_constraint
+                                .narrow_place(db, env, narrowed, place),
+                        };
+                        contribution.known_present = binding
+                            .presence_constraint
+                            .narrow_place(
+                                db,
+                                env,
+                                NarrowedPlace {
+                                    ty: Type::unknown(),
+                                    known_present: binding.inherits_presence
+                                        && narrowed.known_present,
+                                },
+                                place,
+                            )
+                            .known_present;
+                        union.add(contribution);
                     }
                     // If there are no visible bindings, the union becomes `Never`.
                     // Since an unbound binding is recorded even for an undefined place,
                     // this can only happen if the code is unreachable
                     // and therefore it is correct to set the result to `Never`.
-                    ty = union.build();
+                    narrowed = union.build();
                 }
             }
+            if presence_is_local {
+                narrowed.known_present = inner_known_present;
+            }
+            presence_is_local |= shadows_enclosing_presence;
         }
-        ty
+        narrowed
     }
 
     /// Compute the type for reads such as `box.value` or `items[0]` in loop iterations after
@@ -10303,7 +10327,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             place
         } else {
             place.map_type(|ty| {
-                self.narrow_place_with_applicable_constraints(place_expr, ty, narrowing_constraints)
+                self.narrow_place_with_applicable_constraints(
+                    place_expr,
+                    NarrowedPlace::new(ty),
+                    narrowing_constraints,
+                )
+                .ty
             })
         }
     }
@@ -10488,9 +10517,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(place_expr) = PlaceExpr::try_from_expr(target) {
             self.narrow_place_with_applicable_constraints(
                 PlaceExprRef::from(&place_expr),
-                target_ty,
+                NarrowedPlace::new(target_ty),
                 constraint_keys,
             )
+            .ty
         } else {
             target_ty
         }
@@ -10594,10 +10624,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .unwrap_or_else(|error| {
                 error.report_diagnostic(&self.context, value_type, attribute, assigned_type);
                 error.fallback_member(db)
-            })
-            .map_type(|ty| {
-                self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)
             });
+
+        let fallback_place = if let Some(member) = PlaceExpr::try_from_expr(attribute) {
+            let narrowed =
+                NarrowedPlace::new(fallback_place.place.raw_type().unwrap_or_else(Type::object));
+            self.narrow_place_with_applicable_constraints(
+                (&member).into(),
+                narrowed,
+                &constraint_keys,
+            )
+            .apply_to(fallback_place)
+        } else {
+            fallback_place
+        };
 
         // An augmented assignment also loads its target, but its write validation reports this
         // error. Avoid reporting the same invalid access twice.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
 
-use crate::place::loop_header_reachability;
+use crate::place::{Definedness, Place, PlaceAndQualifiers, loop_header_reachability};
 use crate::reachability::{
-    binding_reachability, narrow_type_by_constraint, type_narrowed_by_previous_patterns,
+    binding_reachability, narrow_place_by_constraint, type_narrowed_by_previous_patterns,
 };
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
@@ -717,18 +717,101 @@ impl ClassInfoConstraintFunction {
     }
 }
 
+/// A place's value type and positive evidence that it is present.
+///
+/// `known_present = false` leaves definedness to ordinary member lookup; it does not establish
+/// absence. Unreachable paths have type `Never` and contribute neither a value type nor presence
+/// at a control-flow join.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(crate) struct NarrowedPlace<'db> {
+    pub(crate) ty: Type<'db>,
+    pub(crate) known_present: bool,
+}
+
+impl<'db> NarrowedPlace<'db> {
+    pub(crate) fn new(ty: Type<'db>) -> Self {
+        Self {
+            ty,
+            known_present: false,
+        }
+    }
+
+    /// An unreachable path contributes neither values nor missingness at a control-flow join.
+    pub(crate) fn unreachable() -> Self {
+        Self {
+            ty: Type::Never,
+            known_present: true,
+        }
+    }
+
+    /// Apply flow facts after ordinary lookup and write validation, preserving lookup qualifiers.
+    ///
+    /// An assignment can establish presence for error recovery even when the write is invalid:
+    ///
+    /// ```python
+    /// class C: ...
+    /// c = C()
+    /// c.value = 1  # Reports an undeclared attribute.
+    /// c.value      # Does not repeat the missing-attribute error.
+    /// ```
+    ///
+    /// A `Never`-valued member can still be missing; only positive presence evidence changes
+    /// definedness.
+    pub(crate) fn apply_to(self, mut member: PlaceAndQualifiers<'db>) -> PlaceAndQualifiers<'db> {
+        member = member.map_type(|_| self.ty);
+        member.place = match (self.known_present, member.place) {
+            (true, Place::Defined(defined)) => {
+                Place::Defined(defined.with_definedness(Definedness::AlwaysDefined))
+            }
+            (true, Place::Undefined) => Place::bound(self.ty),
+            (false, place) => place,
+        };
+        member
+    }
+}
+
+/// Join value types and retain only presence facts shared by all reachable alternatives.
+pub(crate) struct NarrowedPlaceBuilder<'db> {
+    types: UnionBuilder<'db>,
+    known_present: bool,
+}
+
+impl<'db> NarrowedPlaceBuilder<'db> {
+    pub(crate) fn new(db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Self {
+        Self {
+            types: UnionBuilder::new(db, env),
+            known_present: true,
+        }
+    }
+
+    pub(crate) fn add(&mut self, place: NarrowedPlace<'db>) {
+        self.known_present &= place.known_present;
+        self.types.add_in_place(place.ty);
+    }
+
+    pub(crate) fn build(self) -> NarrowedPlace<'db> {
+        NarrowedPlace {
+            ty: self.types.build(),
+            known_present: self.known_present,
+        }
+    }
+}
+
 #[derive(Hash, PartialEq, Debug, Eq, Clone, Copy, get_size2::GetSize, salsa::SalsaValue)]
 enum NarrowingOperation<'db> {
     /// Narrow the subject by intersecting it directly with this type.
     Intersection(Type<'db>),
     /// Narrow to this generic type while preserving type arguments already known about the subject.
     GenericFiltering(Type<'db>),
+    /// Establish presence of the member place itself, independently of its value type.
+    MemberPresent,
 }
 
 impl<'db> NarrowingOperation<'db> {
     const fn ty(self) -> Type<'db> {
         match self {
             Self::Intersection(ty) | Self::GenericFiltering(ty) => ty,
+            Self::MemberPresent => Type::object(),
         }
     }
 }
@@ -772,22 +855,29 @@ impl<'db> Conjunctions<'db> {
         self
     }
 
-    fn evaluate_constraint_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        if self.conjuncts.len() == 1 {
-            return self.conjuncts[0].ty();
+    /// Apply conjunctions in order, tracking presence independently of constraints on the value.
+    fn evaluate_place(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> NarrowedPlace<'db> {
+        if let [NarrowingOperation::Intersection(ty) | NarrowingOperation::GenericFiltering(ty)] =
+            &*self.conjuncts
+        {
+            return NarrowedPlace::new(*ty);
         }
-
         // Collapse shared union arms before distributing the next constraint over them.
-        self.conjuncts
-            .into_iter()
-            .fold(Type::object(), |accumulated, conjunct| match conjunct {
+        let mut place = NarrowedPlace::new(Type::object());
+        for operation in self.conjuncts {
+            match operation {
                 NarrowingOperation::Intersection(ty) => {
-                    IntersectionType::from_two_elements(db, env, accumulated, ty)
+                    place.ty = IntersectionType::from_two_elements(db, env, place.ty, ty);
                 }
                 NarrowingOperation::GenericFiltering(ty) => {
-                    filter_generic_narrowing_constraint(db, env, accumulated, ty)
+                    place.ty = filter_generic_narrowing_constraint(db, env, place.ty, ty);
                 }
-            })
+                NarrowingOperation::MemberPresent => {
+                    place.known_present = true;
+                }
+            }
+        }
+        place
     }
 }
 
@@ -1092,6 +1182,15 @@ pub(crate) struct NarrowingConstraint<'db> {
 }
 
 impl<'db> NarrowingConstraint<'db> {
+    fn member_present() -> Self {
+        Self {
+            intersection_disjuncts: smallvec![Conjunctions {
+                conjuncts: smallvec![NarrowingOperation::MemberPresent]
+            }],
+            replacement_disjuncts: smallvec![],
+        }
+    }
+
     /// Create an "intersection" constraint: the previous type will be
     /// intersected with this constraint
     pub(crate) fn intersection(constraint: Type<'db>) -> Self {
@@ -1180,23 +1279,26 @@ impl<'db> NarrowingConstraint<'db> {
             .extend(other.replacement_disjuncts);
     }
 
-    /// Evaluate the type this effectively constrains to
-    ///
-    /// Forgets whether each constraint originated from a `replacement` disjunct or not
-    pub(crate) fn evaluate_constraint_type(
+    /// Evaluate the type and member-presence constraints together.
+    pub(crate) fn evaluate_place(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-    ) -> Type<'db> {
-        let mut union = UnionBuilder::new(db, env);
-        for conjunctions in self
+    ) -> NarrowedPlace<'db> {
+        let mut union = NarrowedPlaceBuilder::new(db, env);
+        for conjunction in self
             .replacement_disjuncts
             .into_iter()
             .chain(self.intersection_disjuncts)
         {
-            union.add_in_place(conjunctions.evaluate_constraint_type(db, env));
+            union.add(conjunction.evaluate_place(db, env));
         }
         union.build()
+    }
+
+    /// Evaluate the type, disregarding whether the constraint also establishes member presence.
+    fn evaluate_constraint_type(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
+        self.evaluate_place(db, env).ty
     }
 }
 
@@ -4350,14 +4452,22 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         [(attr, Type::object())],
                     );
 
-                    return Some(NarrowingConstraints::from_iter([(
+                    let mut constraints = NarrowingConstraints::from_iter([(
                         place,
                         NarrowingConstraint::intersection(constraint.negate_if(
                             db,
                             &self.env,
                             !is_positive,
                         )),
-                    )]));
+                    )]);
+                    if is_positive
+                        && let Some(member) =
+                            PlaceExpr::attribute((&expr_call.arguments.args[0]).into(), attr)
+                        && let Some(member_place) = self.places().place_id(&member)
+                    {
+                        constraints.insert(member_place, NarrowingConstraint::member_present());
+                    }
+                    return Some(constraints);
                 }
 
                 let function = function.into_classinfo_constraint_function()?;
@@ -5345,16 +5455,15 @@ fn all_matching_tuple_elements_have_literal_types<'db>(
 }
 
 pub(crate) trait NarrowingEvaluatorExtension<'db> {
-    fn narrow(
+    /// Apply this evaluator's constraints to a place's value type and positive presence evidence.
+    fn narrow_place(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        base_type: Type<'db>,
+        base: NarrowedPlace<'db>,
         place: ScopedPlaceId,
-    ) -> Type<'db>;
-}
+    ) -> NarrowedPlace<'db>;
 
-impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
     fn narrow(
         &self,
         db: &'db dyn Db,
@@ -5362,6 +5471,19 @@ impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
         base_type: Type<'db>,
         place: ScopedPlaceId,
     ) -> Type<'db> {
-        narrow_type_by_constraint(db, env, self, base_type, place)
+        self.narrow_place(db, env, NarrowedPlace::new(base_type), place)
+            .ty
+    }
+}
+
+impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
+    fn narrow_place(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        base: NarrowedPlace<'db>,
+        place: ScopedPlaceId,
+    ) -> NarrowedPlace<'db> {
+        narrow_place_by_constraint(db, env, self, base, place)
     }
 }


### PR DESCRIPTION
## Summary

Previously, we could report a missing-attribute error again immediately after assigning the attribute. We now track positive presence evidence alongside the narrowed value type, so subsequent reads can reuse the assignment:

```python
import logging

logging.TRACE = 9  # Still reports unresolved-attribute.
logging.log(logging.TRACE, "message")  # No repeated error for TRACE.
```

Assignments and successful `hasattr` checks can each establish presence. We retain that evidence at a branch join only when every reachable path establishes presence, including when one branch checks for the attribute and another assigns it. A `Never`-valued member alone does not establish presence.

Each binding carries a presence constraint separately from its value constraint. Both participate in the existing flow snapshots and narrowing evaluation, so branches and exception handlers can restore and join presence without discarding the inferred value type. Deletions and receiver reassignment invalidate local evidence, and enclosing bindings cannot restore evidence shadowed by a local assignment or checkpoint.

We conservatively clear presence across calls, binary operations, loop entries, and eager scope exits. Exception snapshots crossing an eager scope boundary also clear enclosing presence. This loses precision across harmless operations, including class bodies that only mutate a separate local receiver; fresh assignments and guards establish presence again.

The additional constraint increases `LiveBinding` from 12 to 16 bytes, and checkpoints scan the current member states. The runtime and memory impact still need measurement.
