### PR TITLE
[ty] Relax symlink_inside_project index assertion

### DIFF
--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -2019,6 +2019,9 @@ mod unix {
         // * PyCharm doesn't update diagnostics if a symlinked module is changed (same as ty).
         //
         // That's why I think it's fine to not support this case for now.
+        //
+        // Applying a change event for the symlink path also adds `bar/baz.py` to the project
+        // index. inotify reports that path on some hosts, so allow it as the only extra entry.
 
         let patched_baz_text = source_text(case.db(), patched_bar_baz_file);
         let did_update_patched_baz = patched_baz_text.as_str() == "def baz(): print('Version 2')";
@@ -2033,7 +2036,18 @@ mod unix {
             bar_baz_text = bar_baz_text.as_str()
         );
 
-        case.assert_indexed_project_files([patched_bar_baz_file]);
+        let indexed = case.db().project().files(case.db());
+        assert!(
+            indexed.contains(patched_bar_baz_file),
+            "Expected '{patched_bar_baz}' to remain indexed."
+        );
+        for file in &indexed {
+            let path = file.path(case.db());
+            assert!(
+                file == patched_bar_baz_file || file == baz_file,
+                "Indexed project files contains '{path}' which was not expected."
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

`unix::symlink_inside_project` already documents that the file watcher may emit the change for the original path (`patched/bar/baz.py`) or the symlink path (`bar/baz.py`). Applying a change event for `bar/baz.py` adds that path to the project index. inotify reports the symlink path on some hosts, including riscv64, so the strict "original path only" check fails there.

Keep the original path indexed and allow the symlink path as the only extra entry.

## Test Plan

<!-- How was it tested? -->

`cargo clippy -p ty --test file_watching --locked -- -D warnings` and `prek` on `crates/ty/tests/file_watching.rs`.