### PR TITLE
[ty] Preserve generic protocol materialization relations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1091,6 +1091,45 @@ static_assert(not is_subtype_of(Top[Cell[Any]], EquivalentCell[Any]))
 static_assert(not is_subtype_of(Top[Cell[Any]], Bottom[EquivalentCell[Any]]))
 ```
 
+Property getters and setters use the bound in their respective read and write positions:
+
+```py
+class PropertyCell[T: str](Protocol):
+    @property
+    def value(self) -> T: ...
+    @value.setter
+    def value(self, value: T) -> None: ...
+
+class EquivalentPropertyCell[T: str](Protocol):
+    @property
+    def value(self) -> T: ...
+    @value.setter
+    def value(self, value: T) -> None: ...
+
+static_assert(is_subtype_of(PropertyCell[Any], Top[EquivalentPropertyCell[Any]]))
+static_assert(is_subtype_of(Bottom[PropertyCell[Any]], EquivalentPropertyCell[Any]))
+static_assert(is_subtype_of(Bottom[PropertyCell[Any]], Top[EquivalentPropertyCell[Any]]))
+static_assert(not is_subtype_of(PropertyCell[Any], Bottom[EquivalentPropertyCell[Any]]))
+static_assert(not is_subtype_of(Top[PropertyCell[Any]], EquivalentPropertyCell[Any]))
+static_assert(not is_subtype_of(Top[PropertyCell[Any]], Bottom[EquivalentPropertyCell[Any]]))
+```
+
+A member can use both bounded and unbounded type parameters. Each argument is substituted without
+losing the bound on the other parameter:
+
+```py
+class Pair[T: str, U](Protocol):
+    def read(self) -> tuple[T, U]: ...
+
+class EquivalentPair[T: str, U](Protocol):
+    def read(self) -> tuple[T, U]: ...
+
+static_assert(is_subtype_of(Pair[Any, int], Top[EquivalentPair[Any, int]]))
+static_assert(is_subtype_of(Bottom[Pair[Any, int]], EquivalentPair[Any, int]))
+static_assert(not is_subtype_of(Pair[Any, int], Top[EquivalentPair[Any, str]]))
+static_assert(not is_subtype_of(Top[Pair[Any, int]], Bottom[EquivalentPair[Any, int]]))
+```
+
 ## Callable
 
 The general principle is that a callable type is a subtype of another if it's more flexible in what

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -989,8 +989,8 @@ static_assert(is_subtype_of(Covariant[RecursiveGradual], Covariant[object]))
 
 ## Generic protocol materializations
 
-A generic protocol lies between its bottom and top materializations, even when its type parameters
-have constraints:
+Every gradual type is a supertype of its bottom materialization and a subtype of its top
+materialization. Here, we check this for generic protocols:
 
 ```py
 from typing import Any, Protocol
@@ -1005,8 +1005,7 @@ static_assert(is_subtype_of(Bottom[Constrained[Any]], Constrained[Any]))
 static_assert(not is_subtype_of(Constrained[str], Top[Constrained[bytes]]))
 ```
 
-Materializing a bounded parameter can replace `Any` with its bound. The same relations hold when the
-protocol also has an explicit `Any` member:
+The same relations hold when the protocol also has an explicit `Any` member:
 
 ```py
 class Bounded[T: str](Protocol):

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -997,14 +997,16 @@ from typing import Any, Protocol
 from ty_extensions import Bottom, Top, static_assert
 from ty_extensions._internal import is_subtype_of
 
-class Constrained[T: (str, bytes)](Protocol):
+class Unbounded[T](Protocol):
     def read(self) -> T: ...
     def other(self) -> Any: ...
 
-static_assert(is_subtype_of(Constrained[Any], Top[Constrained[Any]]))
-static_assert(is_subtype_of(Bottom[Constrained[Any]], Constrained[Any]))
-static_assert(is_subtype_of(Bottom[Constrained[Any]], Top[Constrained[Any]]))
-static_assert(not is_subtype_of(Constrained[str], Top[Constrained[bytes]]))
+static_assert(is_subtype_of(Unbounded[Any], Top[Unbounded[Any]]))
+static_assert(is_subtype_of(Bottom[Unbounded[Any]], Unbounded[Any]))
+static_assert(is_subtype_of(Bottom[Unbounded[Any]], Top[Unbounded[Any]]))
+static_assert(not is_subtype_of(Unbounded[Any], Bottom[Unbounded[Any]]))
+static_assert(not is_subtype_of(Top[Unbounded[Any]], Unbounded[Any]))
+static_assert(not is_subtype_of(Top[Unbounded[Any]], Bottom[Unbounded[Any]]))
 ```
 
 The same relations hold when the type parameter has a bound:
@@ -1017,7 +1019,25 @@ class Bounded[T: str](Protocol):
 static_assert(is_subtype_of(Bounded[Any], Top[Bounded[Any]]))
 static_assert(is_subtype_of(Bottom[Bounded[Any]], Bounded[Any]))
 static_assert(is_subtype_of(Bottom[Bounded[Any]], Top[Bounded[Any]]))
+static_assert(not is_subtype_of(Bounded[Any], Bottom[Bounded[Any]]))
 static_assert(not is_subtype_of(Top[Bounded[Any]], Bounded[Any]))
+static_assert(not is_subtype_of(Top[Bounded[Any]], Bottom[Bounded[Any]]))
+```
+
+The same relations also hold when the type parameter has constraints:
+
+```py
+class Constrained[T: (str, bytes)](Protocol):
+    def read(self) -> T: ...
+    def other(self) -> Any: ...
+
+static_assert(is_subtype_of(Constrained[Any], Top[Constrained[Any]]))
+static_assert(is_subtype_of(Bottom[Constrained[Any]], Constrained[Any]))
+static_assert(is_subtype_of(Bottom[Constrained[Any]], Top[Constrained[Any]]))
+static_assert(not is_subtype_of(Constrained[Any], Bottom[Constrained[Any]]))
+static_assert(not is_subtype_of(Top[Constrained[Any]], Constrained[Any]))
+static_assert(not is_subtype_of(Top[Constrained[Any]], Bottom[Constrained[Any]]))
+static_assert(not is_subtype_of(Constrained[str], Top[Constrained[bytes]]))
 ```
 
 ## Callable

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1091,45 +1091,6 @@ static_assert(not is_subtype_of(Top[Cell[Any]], EquivalentCell[Any]))
 static_assert(not is_subtype_of(Top[Cell[Any]], Bottom[EquivalentCell[Any]]))
 ```
 
-Property getters and setters use the bound in their respective read and write positions:
-
-```py
-class PropertyCell[T: str](Protocol):
-    @property
-    def value(self) -> T: ...
-    @value.setter
-    def value(self, value: T) -> None: ...
-
-class EquivalentPropertyCell[T: str](Protocol):
-    @property
-    def value(self) -> T: ...
-    @value.setter
-    def value(self, value: T) -> None: ...
-
-static_assert(is_subtype_of(PropertyCell[Any], Top[EquivalentPropertyCell[Any]]))
-static_assert(is_subtype_of(Bottom[PropertyCell[Any]], EquivalentPropertyCell[Any]))
-static_assert(is_subtype_of(Bottom[PropertyCell[Any]], Top[EquivalentPropertyCell[Any]]))
-static_assert(not is_subtype_of(PropertyCell[Any], Bottom[EquivalentPropertyCell[Any]]))
-static_assert(not is_subtype_of(Top[PropertyCell[Any]], EquivalentPropertyCell[Any]))
-static_assert(not is_subtype_of(Top[PropertyCell[Any]], Bottom[EquivalentPropertyCell[Any]]))
-```
-
-A member can use both bounded and unbounded type parameters. Each argument is substituted without
-losing the bound on the other parameter:
-
-```py
-class Pair[T: str, U](Protocol):
-    def read(self) -> tuple[T, U]: ...
-
-class EquivalentPair[T: str, U](Protocol):
-    def read(self) -> tuple[T, U]: ...
-
-static_assert(is_subtype_of(Pair[Any, int], Top[EquivalentPair[Any, int]]))
-static_assert(is_subtype_of(Bottom[Pair[Any, int]], EquivalentPair[Any, int]))
-static_assert(not is_subtype_of(Pair[Any, int], Top[EquivalentPair[Any, str]]))
-static_assert(not is_subtype_of(Top[Pair[Any, int]], Bottom[EquivalentPair[Any, int]]))
-```
-
 ## Callable
 
 The general principle is that a callable type is a subtype of another if it's more flexible in what

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1024,6 +1024,21 @@ static_assert(not is_subtype_of(Top[Bounded[Any]], Bounded[Any]))
 static_assert(not is_subtype_of(Top[Bounded[Any]], Bottom[Bounded[Any]]))
 ```
 
+These relations also hold between distinct protocols with the same members:
+
+```py
+class EquivalentBounded[T: str](Protocol):
+    def read(self) -> T: ...
+    def other(self) -> Any: ...
+
+static_assert(is_subtype_of(Bounded[Any], Top[EquivalentBounded[Any]]))
+static_assert(is_subtype_of(Bottom[Bounded[Any]], EquivalentBounded[Any]))
+static_assert(is_subtype_of(Bottom[Bounded[Any]], Top[EquivalentBounded[Any]]))
+static_assert(not is_subtype_of(Bounded[Any], Bottom[EquivalentBounded[Any]]))
+static_assert(not is_subtype_of(Top[Bounded[Any]], EquivalentBounded[Any]))
+static_assert(not is_subtype_of(Top[Bounded[Any]], Bottom[EquivalentBounded[Any]]))
+```
+
 The same relations also hold when the type parameter has constraints:
 
 ```py
@@ -1038,6 +1053,42 @@ static_assert(not is_subtype_of(Constrained[Any], Bottom[Constrained[Any]]))
 static_assert(not is_subtype_of(Top[Constrained[Any]], Constrained[Any]))
 static_assert(not is_subtype_of(Top[Constrained[Any]], Bottom[Constrained[Any]]))
 static_assert(not is_subtype_of(Constrained[str], Top[Constrained[bytes]]))
+```
+
+A bound also limits the parameter type of a contravariant protocol. The same structural relations
+hold between distinct protocols with this method:
+
+```py
+class Writer[T: str](Protocol):
+    def write(self, value: T) -> None: ...
+
+class EquivalentWriter[T: str](Protocol):
+    def write(self, value: T) -> None: ...
+
+static_assert(is_subtype_of(Writer[Any], Top[EquivalentWriter[Any]]))
+static_assert(is_subtype_of(Bottom[Writer[Any]], EquivalentWriter[Any]))
+static_assert(is_subtype_of(Bottom[Writer[Any]], Top[EquivalentWriter[Any]]))
+static_assert(not is_subtype_of(Writer[Any], Bottom[EquivalentWriter[Any]]))
+static_assert(not is_subtype_of(Top[Writer[Any]], EquivalentWriter[Any]))
+static_assert(not is_subtype_of(Top[Writer[Any]], Bottom[EquivalentWriter[Any]]))
+```
+
+Constraints also limit both the read and write types of a mutable attribute. These protocols are
+invariant, and their structural relations still respect the materialization directions:
+
+```py
+class Cell[T: (str, bytes)](Protocol):
+    value: T
+
+class EquivalentCell[T: (str, bytes)](Protocol):
+    value: T
+
+static_assert(is_subtype_of(Cell[Any], Top[EquivalentCell[Any]]))
+static_assert(is_subtype_of(Bottom[Cell[Any]], EquivalentCell[Any]))
+static_assert(is_subtype_of(Bottom[Cell[Any]], Top[EquivalentCell[Any]]))
+static_assert(not is_subtype_of(Cell[Any], Bottom[EquivalentCell[Any]]))
+static_assert(not is_subtype_of(Top[Cell[Any]], EquivalentCell[Any]))
+static_assert(not is_subtype_of(Top[Cell[Any]], Bottom[EquivalentCell[Any]]))
 ```
 
 ## Callable

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -987,6 +987,37 @@ type RecursiveGradual = Covariant[RecursiveGradual] | Invariant[Any]
 static_assert(is_subtype_of(Covariant[RecursiveGradual], Covariant[object]))
 ```
 
+## Generic protocol materializations
+
+A generic protocol lies between its bottom and top materializations, even when its type parameters
+have constraints:
+
+```py
+from typing import Any, Protocol
+from ty_extensions import Bottom, Top, static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Constrained[T: (str, bytes)](Protocol):
+    def read(self) -> T: ...
+
+static_assert(is_subtype_of(Constrained[Any], Top[Constrained[Any]]))
+static_assert(is_subtype_of(Bottom[Constrained[Any]], Constrained[Any]))
+static_assert(not is_subtype_of(Constrained[str], Top[Constrained[bytes]]))
+```
+
+Materializing a bounded parameter can replace `Any` with its bound. The same relations hold when the
+protocol also has an explicit `Any` member:
+
+```py
+class Bounded[T: str](Protocol):
+    def read(self) -> T: ...
+    def other(self) -> Any: ...
+
+static_assert(is_subtype_of(Bounded[Any], Top[Bounded[Any]]))
+static_assert(is_subtype_of(Bottom[Bounded[Any]], Bounded[Any]))
+static_assert(not is_subtype_of(Top[Bounded[Any]], Bounded[Any]))
+```
+
 ## Callable
 
 The general principle is that a callable type is a subtype of another if it's more flexible in what

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -999,13 +999,15 @@ from ty_extensions._internal import is_subtype_of
 
 class Constrained[T: (str, bytes)](Protocol):
     def read(self) -> T: ...
+    def other(self) -> Any: ...
 
 static_assert(is_subtype_of(Constrained[Any], Top[Constrained[Any]]))
 static_assert(is_subtype_of(Bottom[Constrained[Any]], Constrained[Any]))
+static_assert(is_subtype_of(Bottom[Constrained[Any]], Top[Constrained[Any]]))
 static_assert(not is_subtype_of(Constrained[str], Top[Constrained[bytes]]))
 ```
 
-The same relations hold when the protocol also has an explicit `Any` member:
+The same relations hold when the type parameter has a bound:
 
 ```py
 class Bounded[T: str](Protocol):
@@ -1014,6 +1016,7 @@ class Bounded[T: str](Protocol):
 
 static_assert(is_subtype_of(Bounded[Any], Top[Bounded[Any]]))
 static_assert(is_subtype_of(Bottom[Bounded[Any]], Bounded[Any]))
+static_assert(is_subtype_of(Bottom[Bounded[Any]], Top[Bounded[Any]]))
 static_assert(not is_subtype_of(Top[Bounded[Any]], Bounded[Any]))
 ```
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1246,31 +1246,48 @@ impl<'db> Specialization<'db> {
         mapped_types.map_or(Cow::Borrowed(types), Cow::Owned)
     }
 
-    /// Intersects gradual type arguments with their type parameters' upper bounds.
+    /// Splits off gradual arguments whose type parameter has an upper bound.
     ///
-    /// For example, in a protocol `P[T: str]`, a member typed as `T` remains bounded by
-    /// `str` when the argument is `Any`. Using `Any & str` lets structural comparisons
-    /// materialize the member in either direction without losing that bound.
-    pub(super) fn with_typevar_bounds(self, db: &'db dyn Db) -> Self {
+    /// The first specialization substitutes the other arguments and leaves these type
+    /// variables in place. The optional second specialization substitutes the deferred
+    /// arguments, allowing specialization and materialization to be applied together.
+    /// For example, a member returning `T` from a protocol `P[T: str]` must retain `T`
+    /// so the top materialization of the argument `Any` can be limited to `str`.
+    pub(super) fn defer_bounded_arguments(self, db: &'db dyn Db) -> (Self, Option<Self>) {
         let env = ProgramEnvironment::from_program(self.generic_context(db).program(db));
-        let types = self.map_types(db, |_, typevar, ty| {
-            if ty.is_fully_static(db, &env) {
-                return ty;
+        let eager = self.map_types(db, |_, typevar, ty| {
+            let identity = Type::TypeVar(typevar);
+            if ty != identity
+                && typevar.typevar(db).bound_or_constraints(db, &env).is_some()
+                && !ty.is_fully_static(db, &env)
+            {
+                identity
+            } else {
+                ty
             }
-            let Some(upper_bound) = typevar.top_materialized_upper_bound(db) else {
-                return ty;
-            };
-            IntersectionType::from_two_elements(db, &env, ty, upper_bound)
         });
-        if matches!(types, Cow::Borrowed(_)) {
-            return self;
-        }
-        Self::new(
-            db,
-            self.generic_context(db),
-            types.into_owned().into_boxed_slice(),
-            self.materialization_kind(db),
-            self.tuple_inner(db),
+        let Cow::Owned(eager) = eager else {
+            return (self, None);
+        };
+        let deferred = self.map_types(db, |index, typevar, ty| {
+            if eager[index] != ty {
+                ty
+            } else {
+                Type::TypeVar(typevar)
+            }
+        });
+        let specialization = |types| {
+            Self::new(
+                db,
+                self.generic_context(db),
+                types,
+                self.materialization_kind(db),
+                self.tuple_inner(db),
+            )
+        };
+        (
+            specialization(eager.into_boxed_slice()),
+            Some(specialization(deferred.into_owned().into_boxed_slice())),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1246,6 +1246,34 @@ impl<'db> Specialization<'db> {
         mapped_types.map_or(Cow::Borrowed(types), Cow::Owned)
     }
 
+    /// Preserves the upper bounds of gradual arguments when exposing protocol members.
+    ///
+    /// For `P[T: str]`, substituting `Any` for `T` must not erase the fact that a member
+    /// typed as `T` is bounded by `str`. Keep `Any & str` so that structural comparisons
+    /// can materialize the member in either direction without losing that bound.
+    pub(super) fn with_typevar_bounds(self, db: &'db dyn Db) -> Self {
+        let env = ProgramEnvironment::from_program(self.generic_context(db).program(db));
+        let types = self.map_types(db, |_, typevar, ty| {
+            if ty.is_fully_static(db, &env) {
+                return ty;
+            }
+            let Some(upper_bound) = typevar.top_materialized_upper_bound(db) else {
+                return ty;
+            };
+            IntersectionType::from_two_elements(db, &env, ty, upper_bound)
+        });
+        if matches!(types, Cow::Borrowed(_)) {
+            return self;
+        }
+        Self::new(
+            db,
+            self.generic_context(db),
+            types.into_owned().into_boxed_slice(),
+            self.materialization_kind(db),
+            self.tuple_inner(db),
+        )
+    }
+
     /// Restricts this specialization to only include the typevars in a generic context. If the
     /// specialization does not include all of those typevars, returns `None`.
     pub(crate) fn restrict(

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1246,11 +1246,11 @@ impl<'db> Specialization<'db> {
         mapped_types.map_or(Cow::Borrowed(types), Cow::Owned)
     }
 
-    /// Preserves the upper bounds of gradual arguments when exposing protocol members.
+    /// Intersects gradual type arguments with their type parameters' upper bounds.
     ///
-    /// For `P[T: str]`, substituting `Any` for `T` must not erase the fact that a member
-    /// typed as `T` is bounded by `str`. Keep `Any & str` so that structural comparisons
-    /// can materialize the member in either direction without losing that bound.
+    /// For example, in a protocol `P[T: str]`, a member typed as `T` remains bounded by
+    /// `str` when the argument is `Any`. Using `Any & str` lets structural comparisons
+    /// materialize the member in either direction without losing that bound.
     pub(super) fn with_typevar_bounds(self, db: &'db dyn Db) -> Self {
         let env = ProgramEnvironment::from_program(self.generic_context(db).program(db));
         let types = self.map_types(db, |_, typevar, ty| {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1246,48 +1246,31 @@ impl<'db> Specialization<'db> {
         mapped_types.map_or(Cow::Borrowed(types), Cow::Owned)
     }
 
-    /// Splits off gradual arguments whose type parameter has an upper bound.
+    /// Intersects gradual type arguments with their type parameters' upper bounds.
     ///
-    /// The first specialization substitutes the other arguments and leaves these type
-    /// variables in place. The optional second specialization substitutes the deferred
-    /// arguments, allowing specialization and materialization to be applied together.
-    /// For example, a member returning `T` from a protocol `P[T: str]` must retain `T`
-    /// so the top materialization of the argument `Any` can be limited to `str`.
-    pub(super) fn defer_bounded_arguments(self, db: &'db dyn Db) -> (Self, Option<Self>) {
+    /// For example, in a protocol `P[T: str]`, a member typed as `T` remains bounded by
+    /// `str` when the argument is `Any`. Using `Any & str` lets structural comparisons
+    /// materialize the member in either direction without losing that bound.
+    pub(super) fn with_typevar_bounds(self, db: &'db dyn Db) -> Self {
         let env = ProgramEnvironment::from_program(self.generic_context(db).program(db));
-        let eager = self.map_types(db, |_, typevar, ty| {
-            let identity = Type::TypeVar(typevar);
-            if ty != identity
-                && typevar.typevar(db).bound_or_constraints(db, &env).is_some()
-                && !ty.is_fully_static(db, &env)
-            {
-                identity
-            } else {
-                ty
+        let types = self.map_types(db, |_, typevar, ty| {
+            if ty.is_fully_static(db, &env) {
+                return ty;
             }
+            let Some(upper_bound) = typevar.top_materialized_upper_bound(db) else {
+                return ty;
+            };
+            IntersectionType::from_two_elements(db, &env, ty, upper_bound)
         });
-        let Cow::Owned(eager) = eager else {
-            return (self, None);
-        };
-        let deferred = self.map_types(db, |index, typevar, ty| {
-            if eager[index] != ty {
-                ty
-            } else {
-                Type::TypeVar(typevar)
-            }
-        });
-        let specialization = |types| {
-            Self::new(
-                db,
-                self.generic_context(db),
-                types,
-                self.materialization_kind(db),
-                self.tuple_inner(db),
-            )
-        };
-        (
-            specialization(eager.into_boxed_slice()),
-            Some(specialization(deferred.into_owned().into_boxed_slice())),
+        if matches!(types, Cow::Borrowed(_)) {
+            return self;
+        }
+        Self::new(
+            db,
+            self.generic_context(db),
+            types.into_owned().into_boxed_slice(),
+            self.materialization_kind(db),
+            self.tuple_inner(db),
         )
     }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1254,7 +1254,7 @@ impl<'db> Specialization<'db> {
     pub(super) fn with_typevar_bounds(self, db: &'db dyn Db) -> Self {
         let env = ProgramEnvironment::from_program(self.generic_context(db).program(db));
         let types = self.map_types(db, |_, typevar, ty| {
-            if ty.is_fully_static(db, &env) {
+            if !any_over_type_expanding_aliases(db, &env, ty, |ty| ty.is_dynamic()) {
                 return ty;
             }
             let Some(upper_bound) = typevar.top_materialized_upper_bound(db) else {

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -529,11 +529,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 return self.always();
             }
 
-            // Materializing generic arguments can change the specialization: for example,
-            // `P[Any]` with a covariant parameter bounded by `str` becomes `Top[P[str]]`.
-            // Compare top materializations when the target is top-materialized, or bottom
-            // materializations when only the source is bottom-materialized. The nominal
-            // comparison accounts for each parameter's variance, bounds, and constraints.
+            // A protocol's type arguments can change during materialization. For example,
+            // taking the top materialization replaces `Any` with `str` for a covariant
+            // parameter bounded by `str`. To recognize the relation despite that change,
+            // materialize both origins: use top if the target is top, and bottom otherwise.
+            // Comparing them as ordinary classes lets the existing generic checks handle
+            // variance, bounds, and constraints.
             let kind = protocol
                 .materialization_kind(db)
                 .unwrap_or(MaterializationKind::Bottom);

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -525,6 +525,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 (source.class_origin(db), protocol.class_origin(db))
             && source_origin.class_literal(db) == target_origin.class_literal(db)
         {
+            // As a fast path, compare the origins:
             if source_origin == target_origin {
                 return self.always();
             }
@@ -535,8 +536,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // valid subtype relation because those origins have different type arguments.
             // Instead, compare the top materializations of their nominal instances: here,
             // that checks `C[str] <: C[str]`. When only the source is bottom-materialized,
-            // compare bottom materializations instead. These nominal comparisons use the
-            // existing rules for variance, bounds, and constraints.
+            // compare bottom materializations instead.
             let kind = protocol
                 .materialization_kind(db)
                 .unwrap_or(MaterializationKind::Bottom);

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -531,11 +531,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             // Consider `C[Any] <: Top[C[Any]]` for a protocol `C[T: str]` with covariant `T`.
             // The target's top materialization replaces `Any` with `T`'s bound, `str`, so the
-            // origins are `C[Any]` and `C[str]`. They differ, but taking the top materialization
-            // of both origins gives `C[str]`, allowing us to recognize the subtype relation.
-            // Use top materializations when the target is top, and bottom otherwise.
-            // Comparing the origins as ordinary classes lets the existing generic checks
-            // handle variance, bounds, and constraints.
+            // origins are `C[Any]` and `C[str]`. The equality check above does not catch this
+            // valid subtype relation because those origins have different type arguments.
+            // Instead, compare the top materializations of their nominal instances: here,
+            // that checks `C[str] <: C[str]`. When only the source is bottom-materialized,
+            // compare bottom materializations instead. These nominal comparisons use the
+            // existing rules for variance, bounds, and constraints.
             let kind = protocol
                 .materialization_kind(db)
                 .unwrap_or(MaterializationKind::Bottom);

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -542,14 +542,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 .materialize(db, kind, self.materialization_visitor);
             let target = Type::NominalInstance(NominalInstanceType::from_class(db, *target_origin))
                 .materialize(db, kind, self.materialization_visitor);
-            if result
-                .union(
-                    db,
-                    self.constraints,
-                    self.check_type_pair(db, source, target),
-                )
-                .is_trivially_always_satisfied()
-            {
+            result = self.check_type_pair(db, source, target);
+            if result.is_trivially_always_satisfied() {
                 return result;
             }
         }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -523,31 +523,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             )
             && let (Some(source_origin), Some(target_origin)) =
                 (source.class_origin(db), protocol.class_origin(db))
-            && source_origin.class_literal(db) == target_origin.class_literal(db)
+            && source_origin == target_origin
         {
-            // As a fast path, compare the origins:
-            if source_origin == target_origin {
-                return self.always();
-            }
-
-            // Consider `C[Any] <: Top[C[Any]]` for a protocol `C[T: str]` with covariant `T`.
-            // The target's top materialization replaces `Any` with `T`'s bound, `str`, so the
-            // origins are `C[Any]` and `C[str]`. The equality check above does not catch this
-            // valid subtype relation because those origins have different type arguments.
-            // Instead, compare the top materializations of their nominal instances: here,
-            // that checks `C[str] <: C[str]`. When only the source is bottom-materialized,
-            // compare bottom materializations instead.
-            let kind = protocol
-                .materialization_kind(db)
-                .unwrap_or(MaterializationKind::Bottom);
-            let source = Type::NominalInstance(NominalInstanceType::from_class(db, *source_origin))
-                .materialize(db, kind, self.materialization_visitor);
-            let target = Type::NominalInstance(NominalInstanceType::from_class(db, *target_origin))
-                .materialize(db, kind, self.materialization_visitor);
-            result = self.check_type_pair(db, source, target);
-            if result.is_trivially_always_satisfied() {
-                return result;
-            }
+            return self.always();
         }
 
         let source_protocol_as_nominal =

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -529,12 +529,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 return self.always();
             }
 
-            // A protocol's type arguments can change during materialization. For example,
-            // taking the top materialization replaces `Any` with `str` for a covariant
-            // parameter bounded by `str`. To recognize the relation despite that change,
-            // materialize both origins: use top if the target is top, and bottom otherwise.
-            // Comparing them as ordinary classes lets the existing generic checks handle
-            // variance, bounds, and constraints.
+            // Consider `C[Any] <: Top[C[Any]]` for a protocol `C[T: str]` with covariant `T`.
+            // The target's top materialization replaces `Any` with `T`'s bound, `str`, so the
+            // origins are `C[Any]` and `C[str]`. They differ, but taking the top materialization
+            // of both origins gives `C[str]`, allowing us to recognize the subtype relation.
+            // Use top materializations when the target is top, and bottom otherwise.
+            // Comparing the origins as ordinary classes lets the existing generic checks
+            // handle variance, bounds, and constraints.
             let kind = protocol
                 .materialization_kind(db)
                 .unwrap_or(MaterializationKind::Bottom);

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -523,9 +523,34 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             )
             && let (Some(source_origin), Some(target_origin)) =
                 (source.class_origin(db), protocol.class_origin(db))
-            && source_origin == target_origin
+            && source_origin.class_literal(db) == target_origin.class_literal(db)
         {
-            return self.always();
+            if source_origin == target_origin {
+                return self.always();
+            }
+
+            // Materializing generic arguments can change the specialization: for example,
+            // `P[Any]` with a covariant parameter bounded by `str` becomes `Top[P[str]]`.
+            // Compare top materializations when the target is top-materialized, or bottom
+            // materializations when only the source is bottom-materialized. The nominal
+            // comparison accounts for each parameter's variance, bounds, and constraints.
+            let kind = protocol
+                .materialization_kind(db)
+                .unwrap_or(MaterializationKind::Bottom);
+            let source = Type::NominalInstance(NominalInstanceType::from_class(db, *source_origin))
+                .materialize(db, kind, self.materialization_visitor);
+            let target = Type::NominalInstance(NominalInstanceType::from_class(db, *target_origin))
+                .materialize(db, kind, self.materialization_visitor);
+            if result
+                .union(
+                    db,
+                    self.constraints,
+                    self.check_type_pair(db, source, target),
+                )
+                .is_trivially_always_satisfied()
+            {
+                return result;
+            }
         }
 
         let source_protocol_as_nominal =

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -160,6 +160,8 @@ impl<'db> ProtocolClass<'db> {
                 ))
             })
         {
+            let specialization =
+                specialization.map(|specialization| specialization.with_typevar_bounds(db));
             let use_def_map = use_def_map(db, parent_scope);
             let place_table = place_table(db, parent_scope);
             let mut direct_members = FxHashMap::default();

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -614,7 +614,7 @@ impl<'db> ProtocolInterfaceView<'db> {
                     .access(db, env, ProtocolMemberAccessMode::Instance)
                     .read
                     .and_then(|read| read.resolve(db, env))
-                    .map(|read| Place::bound(read.ty(db)))
+                    .map(|read| Place::bound(read.ty()))
                     .unwrap_or(Place::Undefined)
                     .with_provenance(Provenance::from_definition(member.definition())),
                 qualifiers: member.qualifiers(),
@@ -638,7 +638,7 @@ impl<'db> ProtocolInterfaceView<'db> {
             PlaceAndQualifiers {
                 place: read
                     .and_then(|read| read.resolve(db, env))
-                    .map(|read| Place::bound(read.ty(db)))
+                    .map(|read| Place::bound(read.ty()))
                     .unwrap_or(Place::Undefined)
                     .with_provenance(Provenance::from_definition(member.definition())),
                 qualifiers: member.qualifiers(),
@@ -699,8 +699,8 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
             let method = member
                 .materialization
                 .map_or(method, |kind| method.materialize(db, env, kind));
-            let Type::Callable(callable) = method.ty(db) else {
-                visitor.visit_type(db, method.ty(db));
+            let Type::Callable(callable) = method.ty() else {
+                visitor.visit_type(db, method.ty());
                 return;
             };
             for signature in callable.signatures(db) {
@@ -898,7 +898,7 @@ impl<'db> ProtocolInterface<'db> {
             .and_then(|write| write.resolve(db, env))
             .is_some_and(|write| {
                 matches!(
-                    write.ty(db),
+                    write.ty(),
                     Type::SubclassOf(subclass_of)
                         if subclass_of.into_type_var().is_some_and(|typevar| {
                             generic_context.contains(db, typevar.identity(db))
@@ -1162,7 +1162,7 @@ impl<'db> ProtocolMemberWrite<'db> {
         cycle: &salsa::Cycle,
     ) -> Self {
         let normalize = |member: ProtocolMemberType<'db>| {
-            member.with_ty(member.ty(db).recursive_type_normalized(db, env, cycle))
+            member.with_ty(member.ty().recursive_type_normalized(db, env, cycle))
         };
         match self {
             Self::Type(member) => Self::Type(normalize(member)),
@@ -1229,9 +1229,15 @@ impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
     }
 }
 
+/// A protocol member's exposed type and the context required to resolve it lazily.
+///
+/// Property accessors remain as callables until a relation needs their read or write type. Once
+/// resolved, `Value` retains the accessor's binding context so that only its own `Self` type is
+/// rebound during protocol checks.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
-enum ProtocolMemberTypeKind<'db> {
+enum ProtocolMemberType<'db> {
     Value {
+        ty: Type<'db>,
         // Accessor annotations can contain `Self` bound by the accessor definition. Retain that
         // context after reducing a property to its read/write types so relation checks only bind
         // the `Self` that belongs to this member.
@@ -1240,103 +1246,78 @@ enum ProtocolMemberTypeKind<'db> {
     // Property accessors remain as raw callable types until a relation or ordinary member access
     // needs the exposed value type. Resolving every property while constructing a protocol
     // interface causes unrelated protocol checks to materialize large return-type unions.
-    PropertyGetter,
-    PropertySetter,
-}
-
-/// A protocol member's exposed type and the context required to resolve it lazily.
-///
-/// Property accessors remain as callables until a relation needs their read or write type. Once
-/// resolved, `Value` retains the accessor's binding context so that only its own `Self` type is
-/// rebound during protocol checks.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
-struct ProtocolMemberType<'db> {
-    ty: Type<'db>,
-    kind: ProtocolMemberTypeKind<'db>,
-    // Substituting a gradual bounded argument here would erase its type variable's bound.
-    // Keep it pending until the read/write position determines how it materializes.
-    specialization: Option<Specialization<'db>>,
+    PropertyGetter(Type<'db>),
+    PropertySetter(Type<'db>),
 }
 
 impl<'db> ProtocolMemberType<'db> {
     const fn new(ty: Type<'db>) -> Self {
-        Self {
+        Self::Value {
             ty,
-            kind: ProtocolMemberTypeKind::Value {
-                self_binding_context: None,
-            },
-            specialization: None,
+            self_binding_context: None,
         }
     }
 
     fn with_definition(ty: Type<'db>, definition: Option<Definition<'db>>) -> Self {
-        Self {
-            kind: ProtocolMemberTypeKind::Value {
-                self_binding_context: definition.map(BindingContext::Definition),
-            },
-            ..Self::new(ty)
+        Self::Value {
+            ty,
+            self_binding_context: definition.map(BindingContext::Definition),
         }
     }
 
     const fn property_getter(ty: Type<'db>) -> Self {
-        Self {
-            kind: ProtocolMemberTypeKind::PropertyGetter,
-            ..Self::new(ty)
-        }
+        Self::PropertyGetter(ty)
     }
 
     const fn property_setter(ty: Type<'db>) -> Self {
-        Self {
-            kind: ProtocolMemberTypeKind::PropertySetter,
-            ..Self::new(ty)
-        }
+        Self::PropertySetter(ty)
     }
 
-    fn ty(self, db: &'db dyn Db) -> Type<'db> {
-        self.ty
-            .apply_optional_specialization(db, self.specialization)
+    const fn ty(self) -> Type<'db> {
+        match self {
+            Self::Value { ty, .. } | Self::PropertyGetter(ty) | Self::PropertySetter(ty) => ty,
+        }
     }
 
     const fn with_ty(self, ty: Type<'db>) -> Self {
-        Self {
-            ty,
-            specialization: None,
-            ..self
+        match self {
+            Self::Value {
+                self_binding_context,
+                ..
+            } => Self::Value {
+                ty,
+                self_binding_context,
+            },
+            Self::PropertyGetter(_) => Self::PropertyGetter(ty),
+            Self::PropertySetter(_) => Self::PropertySetter(ty),
         }
     }
 
-    /// Resolves an accessor before substituting its class's type arguments. This keeps the
-    /// original type variable available when a later materialization needs its bound.
+    /// Resolves a stored property accessor to the value type exposed by that access.
     fn resolve(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Option<Self> {
-        let resolved = match self.kind {
-            ProtocolMemberTypeKind::Value { .. } => return Some(self),
-            ProtocolMemberTypeKind::PropertyGetter => property_get_member_type(db, env, self.ty)?,
-            ProtocolMemberTypeKind::PropertySetter => property_set_member_type(db, env, self.ty)?,
-        };
-        Some(Self {
-            specialization: self.specialization,
-            ..resolved
-        })
+        match self {
+            Self::Value { .. } => Some(self),
+            Self::PropertyGetter(getter) => property_get_member_type(db, env, getter),
+            Self::PropertySetter(setter) => property_set_member_type(db, env, setter),
+        }
     }
 
-    /// Materialize the exposed value, so a setter's callable parameter does not introduce
-    /// a second contravariant flip. Substitute type arguments in the same operation to
-    /// preserve bounds on the original type variables.
+    /// Materialize the value exposed by a member, not the accessor implementing it.
+    ///
+    /// In particular, resolving a property setter before materialization prevents its callable
+    /// parameter from introducing a second contravariant flip.
     fn materialize(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         kind: MaterializationKind,
     ) -> Self {
-        let Some(mut resolved) = self.resolve(db, env) else {
+        let Some(resolved) = self.resolve(db, env) else {
             return self;
         };
-        resolved.specialization = resolved
-            .specialization
-            .map(|specialization| specialization.with_materialization_kind(db, Some(kind)));
         let ty = match kind {
-            MaterializationKind::Top => resolved.ty(db).top_materialization(db, env),
-            MaterializationKind::Bottom => resolved.ty(db).bottom_materialization(db, env),
+            MaterializationKind::Top => resolved.ty().top_materialization(db, env),
+            MaterializationKind::Bottom => resolved.ty().bottom_materialization(db, env),
         };
         resolved.with_ty(ty)
     }
@@ -1348,17 +1329,17 @@ impl<'db> ProtocolMemberType<'db> {
         env: &ProgramEnvironment<'db>,
         self_type: Type<'db>,
     ) -> Option<Type<'db>> {
-        let resolved = self.resolve(db, env)?;
-        let ProtocolMemberTypeKind::Value {
+        let Self::Value {
+            ty,
             self_binding_context,
-        } = resolved.kind
+        } = self.resolve(db, env)?
         else {
             return None;
         };
-        let ty = resolved.ty(db);
         if !ty.contains_self(db, env) {
             return Some(ty);
         }
+
         Some(ty.apply_type_mapping(
             db,
             env,
@@ -1374,9 +1355,7 @@ impl<'db> ProtocolMemberType<'db> {
         previous: Self,
         cycle: &salsa::Cycle,
     ) -> Self {
-        let ty = self
-            .ty(db)
-            .cycle_normalized(db, env, previous.ty(db), cycle);
+        let ty = self.ty().cycle_normalized(db, env, previous.ty(), cycle);
         self.with_ty(ty)
     }
 
@@ -1388,10 +1367,10 @@ impl<'db> ProtocolMemberType<'db> {
         nested: bool,
     ) -> Option<Self> {
         let ty = if nested {
-            self.ty(db)
+            self.ty()
                 .recursive_type_normalized_impl(db, env, div, true)?
         } else {
-            self.ty(db)
+            self.ty()
                 .recursive_type_normalized_impl(db, env, div, true)
                 .unwrap_or(div)
         };
@@ -1406,7 +1385,7 @@ impl<'db> ProtocolMemberType<'db> {
         visitor: &ApplyTypeMappingVisitor<'_, 'db>,
     ) -> Self {
         let ty = self
-            .ty(db)
+            .ty()
             .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
         self.with_ty(ty)
     }
@@ -1447,29 +1426,6 @@ impl<'db> ProtocolMemberAccess<'db> {
         }
     }
 
-    fn with_materialized_specialization(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
-        let specialize = |member: ProtocolMemberType<'db>, kind| ProtocolMemberType {
-            specialization: member
-                .specialization
-                .map(|specialization| specialization.with_materialization_kind(db, Some(kind))),
-            ..member
-        };
-        Self {
-            read: self.read.map(|read| specialize(read, kind)),
-            write: self.write.map(|write| match write {
-                ProtocolMemberWrite::Type(member) => {
-                    ProtocolMemberWrite::Type(specialize(member, kind.flip()))
-                }
-                ProtocolMemberWrite::Descriptor { descriptor, domain } => {
-                    ProtocolMemberWrite::Descriptor {
-                        descriptor,
-                        domain: domain.map(|member| specialize(member, kind.flip())),
-                    }
-                }
-            }),
-        }
-    }
-
     /// Resolve readable and writable accessor representations without losing descriptor identity.
     fn resolved(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Self {
         Self {
@@ -1487,13 +1443,13 @@ impl<'db> ProtocolMemberAccess<'db> {
     ) -> impl Iterator<Item = (Type<'db>, TypeVarVariance)> {
         self.read
             .and_then(|member| member.resolve(db, env))
-            .map(|member| (member.ty(db), TypeVarVariance::Covariant))
+            .map(|member| (member.ty(), TypeVarVariance::Covariant))
             .into_iter()
             .chain(
                 self.write
                     .and_then(ProtocolMemberWrite::domain)
                     .and_then(|member| member.resolve(db, env))
-                    .map(|member| (member.ty(db), TypeVarVariance::Contravariant)),
+                    .map(|member| (member.ty(), TypeVarVariance::Contravariant)),
             )
     }
 }
@@ -1539,7 +1495,7 @@ fn cycle_normalized_optional_type<'db>(
     match (current, previous) {
         (Some(current), Some(previous)) => Some(current.cycle_normalized(db, env, previous, cycle)),
         (Some(current), None) => {
-            Some(current.with_ty(current.ty(db).recursive_type_normalized(db, env, cycle)))
+            Some(current.with_ty(current.ty().recursive_type_normalized(db, env, cycle)))
         }
         (None, _) => None,
     }
@@ -1606,36 +1562,6 @@ impl<'db> ProtocolMemberData<'db> {
         }
     }
 
-    fn with_specialization(mut self, specialization: Option<Specialization<'db>>) -> Self {
-        let specialize = |member: ProtocolMemberType<'db>| ProtocolMemberType {
-            specialization,
-            ..member
-        };
-        self.kind = match self.kind {
-            ProtocolMemberKind::Method(member, kind) => {
-                ProtocolMemberKind::Method(specialize(member), kind)
-            }
-            ProtocolMemberKind::Attribute(member) => {
-                ProtocolMemberKind::Attribute(specialize(member))
-            }
-            ProtocolMemberKind::Property { read, write } => ProtocolMemberKind::Property {
-                read: read.map(specialize),
-                write: write.map(|write| match write {
-                    ProtocolMemberWrite::Type(member) => {
-                        ProtocolMemberWrite::Type(specialize(member))
-                    }
-                    ProtocolMemberWrite::Descriptor { descriptor, domain } => {
-                        ProtocolMemberWrite::Descriptor {
-                            descriptor: specialize(descriptor),
-                            domain: domain.map(specialize),
-                        }
-                    }
-                }),
-            },
-        };
-        self
-    }
-
     /// Derives the instance/class read/write capabilities exposed by this member.
     ///
     /// These are views of the canonical method, property, or attribute representation below;
@@ -1647,18 +1573,10 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> ProtocolMemberCapabilities<'db> {
         match self.kind {
             ProtocolMemberKind::Method(member, kind) => {
-                let instance_method = match (member.ty, kind) {
-                    (Type::Callable(callable), ProtocolMethodKind::Instance) => {
-                        ProtocolMemberType {
-                            ty: Type::Callable(protocol_bind_self(
-                                db,
-                                env.program(db),
-                                callable,
-                                None,
-                            )),
-                            ..member
-                        }
-                    }
+                let instance_method = match (member.ty(), kind) {
+                    (Type::Callable(callable), ProtocolMethodKind::Instance) => member.with_ty(
+                        Type::Callable(protocol_bind_self(db, env.program(db), callable, None)),
+                    ),
                     _ => member,
                 };
                 ProtocolMemberCapabilities {
@@ -1748,7 +1666,7 @@ impl<'db> ProtocolMemberData<'db> {
     ) {
         for member_type in self.kind.member_types() {
             member_type
-                .ty(db)
+                .ty()
                 .find_legacy_typevars(db, env, binding_context, typevars);
         }
     }
@@ -1763,24 +1681,21 @@ impl<'db> ProtocolMemberData<'db> {
     {
         std::fmt::from_fn(move |f| match self.kind {
             ProtocolMemberKind::Method(member, _) => {
-                write!(f, "MethodMember(`{}`)", member.ty(db).display(db, env))
+                write!(f, "MethodMember(`{}`)", member.ty().display(db, env))
             }
             ProtocolMemberKind::Property { read, write } => {
                 let mut d = f.debug_struct("PropertyMember");
                 if let Some(read) = read.and_then(|read| read.resolve(db, env)) {
-                    d.field("read", &format_args!("`{}`", read.ty(db).display(db, env)));
+                    d.field("read", &format_args!("`{}`", read.ty().display(db, env)));
                 }
                 if let Some(write) = write.and_then(|write| write.display_type(db, env)) {
-                    d.field(
-                        "write",
-                        &format_args!("`{}`", write.ty(db).display(db, env)),
-                    );
+                    d.field("write", &format_args!("`{}`", write.ty().display(db, env)));
                 }
                 d.finish()
             }
             ProtocolMemberKind::Attribute(attribute) => {
                 f.write_str("AttributeMember(")?;
-                write!(f, "`{}`", attribute.ty(db).display(db, env))?;
+                write!(f, "`{}`", attribute.ty().display(db, env))?;
                 if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) {
                     f.write_str("; ClassVar")?;
                 }
@@ -1832,7 +1747,7 @@ impl<'db> ProtocolMemberKind<'db> {
         match (self, previous) {
             (Self::Method(current, kind), Self::Method(previous, _)) => {
                 let (Type::Callable(current_callable), Type::Callable(previous_callable)) =
-                    (current.ty(db), previous.ty(db))
+                    (current.ty(), previous.ty())
                 else {
                     return Self::Method(current.cycle_normalized(db, env, previous, cycle), kind);
                 };
@@ -1972,14 +1887,14 @@ fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
             .into_iter()
             .flatten()
             {
-                visitor.visit_type(db, member_type.ty(db));
+                visitor.visit_type(db, member_type.ty());
             }
         }
         return;
     }
 
     for member_type in member.data.kind.member_types() {
-        visitor.visit_type(db, member_type.ty(db));
+        visitor.visit_type(db, member_type.ty());
     }
 }
 
@@ -2059,7 +1974,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     pub(super) fn has_explicit_receiver_annotation(&self, db: &'db dyn Db) -> bool {
         match self.data.kind {
             ProtocolMemberKind::Method(member, ProtocolMethodKind::Instance)
-                if let Type::Callable(callable) = member.ty(db) =>
+                if let Type::Callable(callable) = member.ty() =>
             {
                 callable
                     .signatures(db)
@@ -2089,7 +2004,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
             let is_finite = self.data.kind.member_types().all(|member| {
                 member
                     .resolve(db, env)
-                    .is_some_and(|member| !is_recursive_type(member.ty(db)))
+                    .is_some_and(|member| !is_recursive_type(member.ty()))
             });
             return if is_finite {
                 StructuralMemberPriority::Simple
@@ -2097,7 +2012,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
                 StructuralMemberPriority::Recursive
             };
         };
-        let Type::Callable(callable) = member.ty(db) else {
+        let Type::Callable(callable) = member.ty() else {
             return StructuralMemberPriority::Recursive;
         };
         let signatures = callable.signatures(db);
@@ -2831,7 +2746,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         if !member.is_method()
             && required_ty
                 .resolve(db, env)
-                .is_some_and(|required| required.ty(db).resolve_type_alias(db) == Type::object())
+                .is_some_and(|required| required.ty().resolve_type_alias(db) == Type::object())
             && receiver_ty
                 .member_lookup_with_policy(
                     db,
@@ -2873,7 +2788,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let Some(required_ty) = required_ty.resolve(db, env) else {
                 return self.never();
             };
-            let Type::Callable(required_callable) = required_ty.ty(db) else {
+            let Type::Callable(required_callable) = required_ty.ty() else {
                 return self.never();
             };
             attribute_type
@@ -2903,7 +2818,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let Some(required_ty) = required_ty.resolve(db, env) else {
                 return self.never();
             };
-            let Type::Callable(required_callable) = required_ty.ty(db) else {
+            let Type::Callable(required_callable) = required_ty.ty() else {
                 return self.never();
             };
             attribute_type
@@ -2930,7 +2845,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let Some(required_ty) = required_ty.resolve(db, env) else {
                 return self.never();
             };
-            let Type::Callable(required_callable) = required_ty.ty(db) else {
+            let Type::Callable(required_callable) = required_ty.ty() else {
                 return self.never();
             };
             self.check_type_pair(
@@ -3213,20 +3128,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        // Subtyping compares the source's top materialization with the target's bottom.
-        // Apply that direction while substituting bounded arguments, before their type
-        // variables disappear. Other gradual member types remain for the relation to handle.
-        let materialize_specialization = |access: ProtocolMemberAccess<'db>, kind| {
-            if self.relation.is_subtyping() {
-                access.with_materialized_specialization(db, kind)
-            } else {
-                access
-            }
-        };
-        let source = materialize_specialization(
-            source_member.access(db, env, access),
-            MaterializationKind::Top,
-        );
+        let source = source_member.access(db, env, access);
 
         if access == ProtocolMemberAccessMode::Class
             && source_member.is_method()
@@ -3236,10 +3138,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // access only establishes that the source member is also present on the class.
             return ConstraintSet::from_bool(self.constraints, source.read.is_some());
         }
-        let target = materialize_specialization(
-            target_member.access(db, env, access),
-            MaterializationKind::Bottom,
-        );
+        let target = target_member.access(db, env, access);
 
         let read_result = match (source.read, target.read) {
             (_, None) => self.always(),
@@ -3249,7 +3148,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                  member: &ProtocolMember<'_, 'db>| {
                     let member_type = member_type.resolve(db, env)?;
                     if member.is_method()
-                        && let Type::Callable(callable) = member_type.ty(db)
+                        && let Type::Callable(callable) = member_type.ty()
                     {
                         Some(Type::Callable(protocol_apply_self_with_receiver(
                             db,
@@ -3428,13 +3327,13 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 read_ty
                     .resolve(db, env)
                     .when_some_and(db, self.constraints, |read_ty| {
-                        let result = self.check_type_pair(db, ty, read_ty.ty(db));
+                        let result = self.check_type_pair(db, ty, read_ty.ty());
                         if let Some(context) = self.report_context()
                             && result.is_always_satisfied(db, env)
                         {
                             context.push(ErrorContext::DisjointTypes {
                                 left: ty,
-                                right: read_ty.ty(db),
+                                right: read_ty.ty(),
                             });
                         }
                         result
@@ -3444,7 +3343,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             let Some(Type::Callable(method)) = access
                 .read
                 .and_then(|read| read.resolve(db, env))
-                .map(|member| member.ty(db))
+                .map(ProtocolMemberType::ty)
             else {
                 return self.never();
             };
@@ -3598,7 +3497,7 @@ impl<'db> ProtocolMemberCandidate<'db> {
                 .flatten()
                 {
                     if let Some(member) = member.resolve(db, visitor.program_environment()) {
-                        visitor.visit_type(db, member.ty(db));
+                        visitor.visit_type(db, member.ty());
                     }
                 }
             }
@@ -3709,10 +3608,8 @@ fn cached_protocol_interface<'db>(
             return;
         }
 
-        let (specialization, deferred) = specialization.map_or((None, None), |specialization| {
-            let (eager, deferred) = specialization.defer_bounded_arguments(db);
-            (Some(eager), deferred)
-        });
+        let specialization =
+            specialization.map(|specialization| specialization.with_typevar_bounds(db));
         let candidate = candidate.apply_specialization(db, specialization);
         let ProtocolMemberCandidate {
             ty,
@@ -3754,7 +3651,7 @@ fn cached_protocol_interface<'db>(
             _ => ProtocolMemberData::attribute(ty, qualifiers, definition),
         };
 
-        members.insert(name.clone(), member.with_specialization(deferred));
+        members.insert(name.clone(), member);
     });
 
     ProtocolInterface::new(db, env.program(db), members)

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -160,8 +160,6 @@ impl<'db> ProtocolClass<'db> {
                 ))
             })
         {
-            let specialization =
-                specialization.map(|specialization| specialization.with_typevar_bounds(db));
             let use_def_map = use_def_map(db, parent_scope);
             let place_table = place_table(db, parent_scope);
             let mut direct_members = FxHashMap::default();
@@ -3610,6 +3608,8 @@ fn cached_protocol_interface<'db>(
             return;
         }
 
+        let specialization =
+            specialization.map(|specialization| specialization.with_typevar_bounds(db));
         let candidate = candidate.apply_specialization(db, specialization);
         let ProtocolMemberCandidate {
             ty,

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -614,7 +614,7 @@ impl<'db> ProtocolInterfaceView<'db> {
                     .access(db, env, ProtocolMemberAccessMode::Instance)
                     .read
                     .and_then(|read| read.resolve(db, env))
-                    .map(|read| Place::bound(read.ty()))
+                    .map(|read| Place::bound(read.ty(db)))
                     .unwrap_or(Place::Undefined)
                     .with_provenance(Provenance::from_definition(member.definition())),
                 qualifiers: member.qualifiers(),
@@ -638,7 +638,7 @@ impl<'db> ProtocolInterfaceView<'db> {
             PlaceAndQualifiers {
                 place: read
                     .and_then(|read| read.resolve(db, env))
-                    .map(|read| Place::bound(read.ty()))
+                    .map(|read| Place::bound(read.ty(db)))
                     .unwrap_or(Place::Undefined)
                     .with_provenance(Provenance::from_definition(member.definition())),
                 qualifiers: member.qualifiers(),
@@ -699,8 +699,8 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
             let method = member
                 .materialization
                 .map_or(method, |kind| method.materialize(db, env, kind));
-            let Type::Callable(callable) = method.ty() else {
-                visitor.visit_type(db, method.ty());
+            let Type::Callable(callable) = method.ty(db) else {
+                visitor.visit_type(db, method.ty(db));
                 return;
             };
             for signature in callable.signatures(db) {
@@ -898,7 +898,7 @@ impl<'db> ProtocolInterface<'db> {
             .and_then(|write| write.resolve(db, env))
             .is_some_and(|write| {
                 matches!(
-                    write.ty(),
+                    write.ty(db),
                     Type::SubclassOf(subclass_of)
                         if subclass_of.into_type_var().is_some_and(|typevar| {
                             generic_context.contains(db, typevar.identity(db))
@@ -1162,7 +1162,7 @@ impl<'db> ProtocolMemberWrite<'db> {
         cycle: &salsa::Cycle,
     ) -> Self {
         let normalize = |member: ProtocolMemberType<'db>| {
-            member.with_ty(member.ty().recursive_type_normalized(db, env, cycle))
+            member.with_ty(member.ty(db).recursive_type_normalized(db, env, cycle))
         };
         match self {
             Self::Type(member) => Self::Type(normalize(member)),
@@ -1229,15 +1229,9 @@ impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
     }
 }
 
-/// A protocol member's exposed type and the context required to resolve it lazily.
-///
-/// Property accessors remain as callables until a relation needs their read or write type. Once
-/// resolved, `Value` retains the accessor's binding context so that only its own `Self` type is
-/// rebound during protocol checks.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
-enum ProtocolMemberType<'db> {
+enum ProtocolMemberTypeKind<'db> {
     Value {
-        ty: Type<'db>,
         // Accessor annotations can contain `Self` bound by the accessor definition. Retain that
         // context after reducing a property to its read/write types so relation checks only bind
         // the `Self` that belongs to this member.
@@ -1246,78 +1240,103 @@ enum ProtocolMemberType<'db> {
     // Property accessors remain as raw callable types until a relation or ordinary member access
     // needs the exposed value type. Resolving every property while constructing a protocol
     // interface causes unrelated protocol checks to materialize large return-type unions.
-    PropertyGetter(Type<'db>),
-    PropertySetter(Type<'db>),
+    PropertyGetter,
+    PropertySetter,
+}
+
+/// A protocol member's exposed type and the context required to resolve it lazily.
+///
+/// Property accessors remain as callables until a relation needs their read or write type. Once
+/// resolved, `Value` retains the accessor's binding context so that only its own `Self` type is
+/// rebound during protocol checks.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+struct ProtocolMemberType<'db> {
+    ty: Type<'db>,
+    kind: ProtocolMemberTypeKind<'db>,
+    // Substituting a gradual bounded argument here would erase its type variable's bound.
+    // Keep it pending until the read/write position determines how it materializes.
+    specialization: Option<Specialization<'db>>,
 }
 
 impl<'db> ProtocolMemberType<'db> {
     const fn new(ty: Type<'db>) -> Self {
-        Self::Value {
+        Self {
             ty,
-            self_binding_context: None,
+            kind: ProtocolMemberTypeKind::Value {
+                self_binding_context: None,
+            },
+            specialization: None,
         }
     }
 
     fn with_definition(ty: Type<'db>, definition: Option<Definition<'db>>) -> Self {
-        Self::Value {
-            ty,
-            self_binding_context: definition.map(BindingContext::Definition),
+        Self {
+            kind: ProtocolMemberTypeKind::Value {
+                self_binding_context: definition.map(BindingContext::Definition),
+            },
+            ..Self::new(ty)
         }
     }
 
     const fn property_getter(ty: Type<'db>) -> Self {
-        Self::PropertyGetter(ty)
+        Self {
+            kind: ProtocolMemberTypeKind::PropertyGetter,
+            ..Self::new(ty)
+        }
     }
 
     const fn property_setter(ty: Type<'db>) -> Self {
-        Self::PropertySetter(ty)
+        Self {
+            kind: ProtocolMemberTypeKind::PropertySetter,
+            ..Self::new(ty)
+        }
     }
 
-    const fn ty(self) -> Type<'db> {
-        match self {
-            Self::Value { ty, .. } | Self::PropertyGetter(ty) | Self::PropertySetter(ty) => ty,
-        }
+    fn ty(self, db: &'db dyn Db) -> Type<'db> {
+        self.ty
+            .apply_optional_specialization(db, self.specialization)
     }
 
     const fn with_ty(self, ty: Type<'db>) -> Self {
-        match self {
-            Self::Value {
-                self_binding_context,
-                ..
-            } => Self::Value {
-                ty,
-                self_binding_context,
-            },
-            Self::PropertyGetter(_) => Self::PropertyGetter(ty),
-            Self::PropertySetter(_) => Self::PropertySetter(ty),
+        Self {
+            ty,
+            specialization: None,
+            ..self
         }
     }
 
-    /// Resolves a stored property accessor to the value type exposed by that access.
+    /// Resolves an accessor before substituting its class's type arguments. This keeps the
+    /// original type variable available when a later materialization needs its bound.
     fn resolve(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Option<Self> {
-        match self {
-            Self::Value { .. } => Some(self),
-            Self::PropertyGetter(getter) => property_get_member_type(db, env, getter),
-            Self::PropertySetter(setter) => property_set_member_type(db, env, setter),
-        }
+        let resolved = match self.kind {
+            ProtocolMemberTypeKind::Value { .. } => return Some(self),
+            ProtocolMemberTypeKind::PropertyGetter => property_get_member_type(db, env, self.ty)?,
+            ProtocolMemberTypeKind::PropertySetter => property_set_member_type(db, env, self.ty)?,
+        };
+        Some(Self {
+            specialization: self.specialization,
+            ..resolved
+        })
     }
 
-    /// Materialize the value exposed by a member, not the accessor implementing it.
-    ///
-    /// In particular, resolving a property setter before materialization prevents its callable
-    /// parameter from introducing a second contravariant flip.
+    /// Materialize the exposed value, so a setter's callable parameter does not introduce
+    /// a second contravariant flip. Substitute type arguments in the same operation to
+    /// preserve bounds on the original type variables.
     fn materialize(
         self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         kind: MaterializationKind,
     ) -> Self {
-        let Some(resolved) = self.resolve(db, env) else {
+        let Some(mut resolved) = self.resolve(db, env) else {
             return self;
         };
+        resolved.specialization = resolved
+            .specialization
+            .map(|specialization| specialization.with_materialization_kind(db, Some(kind)));
         let ty = match kind {
-            MaterializationKind::Top => resolved.ty().top_materialization(db, env),
-            MaterializationKind::Bottom => resolved.ty().bottom_materialization(db, env),
+            MaterializationKind::Top => resolved.ty(db).top_materialization(db, env),
+            MaterializationKind::Bottom => resolved.ty(db).bottom_materialization(db, env),
         };
         resolved.with_ty(ty)
     }
@@ -1329,17 +1348,17 @@ impl<'db> ProtocolMemberType<'db> {
         env: &ProgramEnvironment<'db>,
         self_type: Type<'db>,
     ) -> Option<Type<'db>> {
-        let Self::Value {
-            ty,
+        let resolved = self.resolve(db, env)?;
+        let ProtocolMemberTypeKind::Value {
             self_binding_context,
-        } = self.resolve(db, env)?
+        } = resolved.kind
         else {
             return None;
         };
+        let ty = resolved.ty(db);
         if !ty.contains_self(db, env) {
             return Some(ty);
         }
-
         Some(ty.apply_type_mapping(
             db,
             env,
@@ -1355,7 +1374,9 @@ impl<'db> ProtocolMemberType<'db> {
         previous: Self,
         cycle: &salsa::Cycle,
     ) -> Self {
-        let ty = self.ty().cycle_normalized(db, env, previous.ty(), cycle);
+        let ty = self
+            .ty(db)
+            .cycle_normalized(db, env, previous.ty(db), cycle);
         self.with_ty(ty)
     }
 
@@ -1367,10 +1388,10 @@ impl<'db> ProtocolMemberType<'db> {
         nested: bool,
     ) -> Option<Self> {
         let ty = if nested {
-            self.ty()
+            self.ty(db)
                 .recursive_type_normalized_impl(db, env, div, true)?
         } else {
-            self.ty()
+            self.ty(db)
                 .recursive_type_normalized_impl(db, env, div, true)
                 .unwrap_or(div)
         };
@@ -1385,7 +1406,7 @@ impl<'db> ProtocolMemberType<'db> {
         visitor: &ApplyTypeMappingVisitor<'_, 'db>,
     ) -> Self {
         let ty = self
-            .ty()
+            .ty(db)
             .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
         self.with_ty(ty)
     }
@@ -1426,6 +1447,29 @@ impl<'db> ProtocolMemberAccess<'db> {
         }
     }
 
+    fn with_materialized_specialization(self, db: &'db dyn Db, kind: MaterializationKind) -> Self {
+        let specialize = |member: ProtocolMemberType<'db>, kind| ProtocolMemberType {
+            specialization: member
+                .specialization
+                .map(|specialization| specialization.with_materialization_kind(db, Some(kind))),
+            ..member
+        };
+        Self {
+            read: self.read.map(|read| specialize(read, kind)),
+            write: self.write.map(|write| match write {
+                ProtocolMemberWrite::Type(member) => {
+                    ProtocolMemberWrite::Type(specialize(member, kind.flip()))
+                }
+                ProtocolMemberWrite::Descriptor { descriptor, domain } => {
+                    ProtocolMemberWrite::Descriptor {
+                        descriptor,
+                        domain: domain.map(|member| specialize(member, kind.flip())),
+                    }
+                }
+            }),
+        }
+    }
+
     /// Resolve readable and writable accessor representations without losing descriptor identity.
     fn resolved(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Self {
         Self {
@@ -1443,13 +1487,13 @@ impl<'db> ProtocolMemberAccess<'db> {
     ) -> impl Iterator<Item = (Type<'db>, TypeVarVariance)> {
         self.read
             .and_then(|member| member.resolve(db, env))
-            .map(|member| (member.ty(), TypeVarVariance::Covariant))
+            .map(|member| (member.ty(db), TypeVarVariance::Covariant))
             .into_iter()
             .chain(
                 self.write
                     .and_then(ProtocolMemberWrite::domain)
                     .and_then(|member| member.resolve(db, env))
-                    .map(|member| (member.ty(), TypeVarVariance::Contravariant)),
+                    .map(|member| (member.ty(db), TypeVarVariance::Contravariant)),
             )
     }
 }
@@ -1495,7 +1539,7 @@ fn cycle_normalized_optional_type<'db>(
     match (current, previous) {
         (Some(current), Some(previous)) => Some(current.cycle_normalized(db, env, previous, cycle)),
         (Some(current), None) => {
-            Some(current.with_ty(current.ty().recursive_type_normalized(db, env, cycle)))
+            Some(current.with_ty(current.ty(db).recursive_type_normalized(db, env, cycle)))
         }
         (None, _) => None,
     }
@@ -1562,6 +1606,36 @@ impl<'db> ProtocolMemberData<'db> {
         }
     }
 
+    fn with_specialization(mut self, specialization: Option<Specialization<'db>>) -> Self {
+        let specialize = |member: ProtocolMemberType<'db>| ProtocolMemberType {
+            specialization,
+            ..member
+        };
+        self.kind = match self.kind {
+            ProtocolMemberKind::Method(member, kind) => {
+                ProtocolMemberKind::Method(specialize(member), kind)
+            }
+            ProtocolMemberKind::Attribute(member) => {
+                ProtocolMemberKind::Attribute(specialize(member))
+            }
+            ProtocolMemberKind::Property { read, write } => ProtocolMemberKind::Property {
+                read: read.map(specialize),
+                write: write.map(|write| match write {
+                    ProtocolMemberWrite::Type(member) => {
+                        ProtocolMemberWrite::Type(specialize(member))
+                    }
+                    ProtocolMemberWrite::Descriptor { descriptor, domain } => {
+                        ProtocolMemberWrite::Descriptor {
+                            descriptor: specialize(descriptor),
+                            domain: domain.map(specialize),
+                        }
+                    }
+                }),
+            },
+        };
+        self
+    }
+
     /// Derives the instance/class read/write capabilities exposed by this member.
     ///
     /// These are views of the canonical method, property, or attribute representation below;
@@ -1573,10 +1647,18 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> ProtocolMemberCapabilities<'db> {
         match self.kind {
             ProtocolMemberKind::Method(member, kind) => {
-                let instance_method = match (member.ty(), kind) {
-                    (Type::Callable(callable), ProtocolMethodKind::Instance) => member.with_ty(
-                        Type::Callable(protocol_bind_self(db, env.program(db), callable, None)),
-                    ),
+                let instance_method = match (member.ty, kind) {
+                    (Type::Callable(callable), ProtocolMethodKind::Instance) => {
+                        ProtocolMemberType {
+                            ty: Type::Callable(protocol_bind_self(
+                                db,
+                                env.program(db),
+                                callable,
+                                None,
+                            )),
+                            ..member
+                        }
+                    }
                     _ => member,
                 };
                 ProtocolMemberCapabilities {
@@ -1666,7 +1748,7 @@ impl<'db> ProtocolMemberData<'db> {
     ) {
         for member_type in self.kind.member_types() {
             member_type
-                .ty()
+                .ty(db)
                 .find_legacy_typevars(db, env, binding_context, typevars);
         }
     }
@@ -1681,21 +1763,24 @@ impl<'db> ProtocolMemberData<'db> {
     {
         std::fmt::from_fn(move |f| match self.kind {
             ProtocolMemberKind::Method(member, _) => {
-                write!(f, "MethodMember(`{}`)", member.ty().display(db, env))
+                write!(f, "MethodMember(`{}`)", member.ty(db).display(db, env))
             }
             ProtocolMemberKind::Property { read, write } => {
                 let mut d = f.debug_struct("PropertyMember");
                 if let Some(read) = read.and_then(|read| read.resolve(db, env)) {
-                    d.field("read", &format_args!("`{}`", read.ty().display(db, env)));
+                    d.field("read", &format_args!("`{}`", read.ty(db).display(db, env)));
                 }
                 if let Some(write) = write.and_then(|write| write.display_type(db, env)) {
-                    d.field("write", &format_args!("`{}`", write.ty().display(db, env)));
+                    d.field(
+                        "write",
+                        &format_args!("`{}`", write.ty(db).display(db, env)),
+                    );
                 }
                 d.finish()
             }
             ProtocolMemberKind::Attribute(attribute) => {
                 f.write_str("AttributeMember(")?;
-                write!(f, "`{}`", attribute.ty().display(db, env))?;
+                write!(f, "`{}`", attribute.ty(db).display(db, env))?;
                 if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) {
                     f.write_str("; ClassVar")?;
                 }
@@ -1747,7 +1832,7 @@ impl<'db> ProtocolMemberKind<'db> {
         match (self, previous) {
             (Self::Method(current, kind), Self::Method(previous, _)) => {
                 let (Type::Callable(current_callable), Type::Callable(previous_callable)) =
-                    (current.ty(), previous.ty())
+                    (current.ty(db), previous.ty(db))
                 else {
                     return Self::Method(current.cycle_normalized(db, env, previous, cycle), kind);
                 };
@@ -1887,14 +1972,14 @@ fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
             .into_iter()
             .flatten()
             {
-                visitor.visit_type(db, member_type.ty());
+                visitor.visit_type(db, member_type.ty(db));
             }
         }
         return;
     }
 
     for member_type in member.data.kind.member_types() {
-        visitor.visit_type(db, member_type.ty());
+        visitor.visit_type(db, member_type.ty(db));
     }
 }
 
@@ -1974,7 +2059,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
     pub(super) fn has_explicit_receiver_annotation(&self, db: &'db dyn Db) -> bool {
         match self.data.kind {
             ProtocolMemberKind::Method(member, ProtocolMethodKind::Instance)
-                if let Type::Callable(callable) = member.ty() =>
+                if let Type::Callable(callable) = member.ty(db) =>
             {
                 callable
                     .signatures(db)
@@ -2004,7 +2089,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
             let is_finite = self.data.kind.member_types().all(|member| {
                 member
                     .resolve(db, env)
-                    .is_some_and(|member| !is_recursive_type(member.ty()))
+                    .is_some_and(|member| !is_recursive_type(member.ty(db)))
             });
             return if is_finite {
                 StructuralMemberPriority::Simple
@@ -2012,7 +2097,7 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
                 StructuralMemberPriority::Recursive
             };
         };
-        let Type::Callable(callable) = member.ty() else {
+        let Type::Callable(callable) = member.ty(db) else {
             return StructuralMemberPriority::Recursive;
         };
         let signatures = callable.signatures(db);
@@ -2746,7 +2831,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         if !member.is_method()
             && required_ty
                 .resolve(db, env)
-                .is_some_and(|required| required.ty().resolve_type_alias(db) == Type::object())
+                .is_some_and(|required| required.ty(db).resolve_type_alias(db) == Type::object())
             && receiver_ty
                 .member_lookup_with_policy(
                     db,
@@ -2788,7 +2873,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let Some(required_ty) = required_ty.resolve(db, env) else {
                 return self.never();
             };
-            let Type::Callable(required_callable) = required_ty.ty() else {
+            let Type::Callable(required_callable) = required_ty.ty(db) else {
                 return self.never();
             };
             attribute_type
@@ -2818,7 +2903,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let Some(required_ty) = required_ty.resolve(db, env) else {
                 return self.never();
             };
-            let Type::Callable(required_callable) = required_ty.ty() else {
+            let Type::Callable(required_callable) = required_ty.ty(db) else {
                 return self.never();
             };
             attribute_type
@@ -2845,7 +2930,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let Some(required_ty) = required_ty.resolve(db, env) else {
                 return self.never();
             };
-            let Type::Callable(required_callable) = required_ty.ty() else {
+            let Type::Callable(required_callable) = required_ty.ty(db) else {
                 return self.never();
             };
             self.check_type_pair(
@@ -3128,7 +3213,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        let source = source_member.access(db, env, access);
+        // Subtyping compares the source's top materialization with the target's bottom.
+        // Apply that direction while substituting bounded arguments, before their type
+        // variables disappear. Other gradual member types remain for the relation to handle.
+        let materialize_specialization = |access: ProtocolMemberAccess<'db>, kind| {
+            if self.relation.is_subtyping() {
+                access.with_materialized_specialization(db, kind)
+            } else {
+                access
+            }
+        };
+        let source = materialize_specialization(
+            source_member.access(db, env, access),
+            MaterializationKind::Top,
+        );
 
         if access == ProtocolMemberAccessMode::Class
             && source_member.is_method()
@@ -3138,7 +3236,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // access only establishes that the source member is also present on the class.
             return ConstraintSet::from_bool(self.constraints, source.read.is_some());
         }
-        let target = target_member.access(db, env, access);
+        let target = materialize_specialization(
+            target_member.access(db, env, access),
+            MaterializationKind::Bottom,
+        );
 
         let read_result = match (source.read, target.read) {
             (_, None) => self.always(),
@@ -3148,7 +3249,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                  member: &ProtocolMember<'_, 'db>| {
                     let member_type = member_type.resolve(db, env)?;
                     if member.is_method()
-                        && let Type::Callable(callable) = member_type.ty()
+                        && let Type::Callable(callable) = member_type.ty(db)
                     {
                         Some(Type::Callable(protocol_apply_self_with_receiver(
                             db,
@@ -3327,13 +3428,13 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 read_ty
                     .resolve(db, env)
                     .when_some_and(db, self.constraints, |read_ty| {
-                        let result = self.check_type_pair(db, ty, read_ty.ty());
+                        let result = self.check_type_pair(db, ty, read_ty.ty(db));
                         if let Some(context) = self.report_context()
                             && result.is_always_satisfied(db, env)
                         {
                             context.push(ErrorContext::DisjointTypes {
                                 left: ty,
-                                right: read_ty.ty(),
+                                right: read_ty.ty(db),
                             });
                         }
                         result
@@ -3343,7 +3444,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             let Some(Type::Callable(method)) = access
                 .read
                 .and_then(|read| read.resolve(db, env))
-                .map(ProtocolMemberType::ty)
+                .map(|member| member.ty(db))
             else {
                 return self.never();
             };
@@ -3497,7 +3598,7 @@ impl<'db> ProtocolMemberCandidate<'db> {
                 .flatten()
                 {
                     if let Some(member) = member.resolve(db, visitor.program_environment()) {
-                        visitor.visit_type(db, member.ty());
+                        visitor.visit_type(db, member.ty(db));
                     }
                 }
             }
@@ -3608,8 +3709,10 @@ fn cached_protocol_interface<'db>(
             return;
         }
 
-        let specialization =
-            specialization.map(|specialization| specialization.with_typevar_bounds(db));
+        let (specialization, deferred) = specialization.map_or((None, None), |specialization| {
+            let (eager, deferred) = specialization.defer_bounded_arguments(db);
+            (Some(eager), deferred)
+        });
         let candidate = candidate.apply_specialization(db, specialization);
         let ProtocolMemberCandidate {
             ty,
@@ -3651,7 +3754,7 @@ fn cached_protocol_interface<'db>(
             _ => ProtocolMemberData::attribute(ty, qualifiers, definition),
         };
 
-        members.insert(name.clone(), member);
+        members.insert(name.clone(), member.with_specialization(deferred));
     });
 
     ProtocolInterface::new(db, env.program(db), members)


### PR DESCRIPTION
## Summary

Like every other gradual type, a generic protocol must satisfy `Bottom[P[Unknown]] <: P[Unknown] <: Top[P[Unknown]]`.

closes https://github.com/astral-sh/ty/issues/4448

## Test strategy

New regression tests.