### PR TITLE
[ty] Report deprecated property accessors on intersections

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -615,7 +615,7 @@ class AlsoDeprecated:
 
 def deprecated_intersection(value: Deprecated) -> None:
     if isinstance(value, AlsoDeprecated):
-        # error: [deprecated] "Use of 2 deprecated functions"
+        # error: [deprecated] "Possible use of deprecated methods: `Deprecated.__invert__`, `AlsoDeprecated.__invert__`"
         ~value
 ```
 
@@ -667,7 +667,7 @@ class Second:
 T = TypeVar("T", First, Second)
 
 def f(value: T) -> None:
-    # error: [deprecated] "Use of 2 deprecated functions"
+    # error: [deprecated] "Possible use of deprecated methods: `First.__invert__`, `Second.__invert__`"
     ~value
 ```
 
@@ -699,7 +699,7 @@ W = TypeVar("W", First | Third, Second)
 
 def nested_union(value: W) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "Use of 2 deprecated functions"
+    # error: [deprecated] "Possible use of deprecated methods: `First.__invert__`, `Second.__invert__`"
     ~value
 ```
 
@@ -716,7 +716,7 @@ X = TypeVar("X", Invalid, Second)
 
 def invalid_operator(value: X) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "Use of 2 deprecated functions"
+    # error: [deprecated] "Possible use of deprecated methods: `Invalid.__invert__`, `Second.__invert__`"
     ~value
 ```
 
@@ -1019,12 +1019,12 @@ def check_both(value: Old):
     if isinstance(value, AlsoOld):
         # snapshot: deprecated
         value.value
-        value.value = 1  # error: [deprecated] "Use of 2 deprecated functions"
-        del value.value  # error: [deprecated] "Use of 2 deprecated functions"
+        value.value = 1  # error: [deprecated] "Possible use of deprecated methods: `Old.value`, `AlsoOld.value`"
+        del value.value  # error: [deprecated] "Possible use of deprecated methods: `Old.value`, `AlsoOld.value`"
 ```
 
 ```snapshot
-warning[deprecated]: Use of 2 deprecated functions
+warning[deprecated]: Possible use of deprecated methods: `Old.value`, `AlsoOld.value`
   --> src/mdtest_snippet.py:45:15
    |
 45 |         value.value
@@ -1056,7 +1056,7 @@ class ActiveGetter:
 def check_active_getter(value: Old):
     if isinstance(value, ActiveGetter):
         value.value
-        value.value = 1  # error: [deprecated] "Use of 2 deprecated functions"
+        value.value = 1  # error: [deprecated] "Possible use of deprecated methods: `Old.value`, `ActiveGetter.value`"
 ```
 
 ## Invalid property getter calls
@@ -1294,6 +1294,29 @@ def check(value: list[Any] | set[Any]):
     convert(value)
 ```
 
+### Several deprecated overloads of one function
+
+When multiple deprecated overloads match, the summary names the function once. The individual
+overload messages remain available in the full diagnostic.
+
+```py
+from typing import overload
+from typing_extensions import deprecated
+
+@overload
+@deprecated("integer overload")
+def convert(value: int) -> str: ...
+@overload
+@deprecated("string overload")
+def convert(value: str) -> str: ...
+def convert(value: int | str) -> str:
+    return str(value)
+
+def check(value: int | str):
+    # error: [deprecated] "Possible use of deprecated function: `convert`"
+    convert(value)
+```
+
 ### Overloads for different receivers
 
 The `self` annotations restrict which overloads each instance can call. A call on `C[str]` reports
@@ -1527,12 +1550,13 @@ class InPlace(Number):
         return self
 
 def check_mixed(number: First | InPlace, value: int | str):
-    number += value  # error: [deprecated] "Use of 2 deprecated functions"
+    # error: [deprecated] "Possible use of deprecated methods: `Number.__add__`, `InPlace.__iadd__`"
+    number += value
 ```
 
 ## Calls to different deprecated methods
 
-When a call can invoke different deprecated methods, one warning points to both method definitions.
+When a call can invoke different deprecated methods, the summary names each method's defining class.
 Each message appears with its own definition, preserving its punctuation and line breaks. Inherited
 copies of the same method are listed only once.
 
@@ -1555,7 +1579,7 @@ def check(value: First | Second | Inherited):
 ```
 
 ```snapshot
-warning[deprecated]: Use of 2 deprecated functions
+warning[deprecated]: Possible use of deprecated methods: `First.__call__`, `Second.__call__`
   --> src/mdtest_snippet.py:15:5
    |
 15 |     value()
@@ -1571,4 +1595,31 @@ Direct calls will be removed in version 3.
   |
 9 |     def __call__(self) -> None: ...
   |         ^^^^^^^^
+```
+
+## Calls to deprecated generic methods
+
+Generic methods retain the defining class in the summary, including when the class is generic too.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing_extensions import deprecated
+
+class First[T]:
+    @deprecated("first method")
+    def __call__[U](self, value: U) -> U:
+        return value
+
+class Second:
+    @deprecated("second method")
+    def __call__[U](self, value: U) -> U:
+        return value
+
+def check(value: First[int] | Second):
+    # error: [deprecated] "Possible use of deprecated methods: `First.__call__`, `Second.__call__`"
+    value(1)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -974,6 +974,9 @@ class Old:
     @value.setter
     @deprecated("old setter")
     def value(self, value: int) -> None: ...
+    @value.deleter
+    @deprecated("old deleter")
+    def value(self) -> None: ...
 
 class Active:
     value: int
@@ -994,6 +997,66 @@ def check_marker(value: Old):
     if isinstance(value, Marker):
         value.value  # error: [deprecated] "old getter"
         value.value = 1  # error: [deprecated] "old setter"
+```
+
+When both members provide deprecated accessors, the warning includes both messages.
+
+```py
+class AlsoOld:
+    @property
+    @deprecated("another getter")
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    @deprecated("another setter")
+    def value(self, value: int) -> None: ...
+    @value.deleter
+    @deprecated("another deleter")
+    def value(self) -> None: ...
+
+def check_both(value: Old):
+    if isinstance(value, AlsoOld):
+        # snapshot: deprecated
+        value.value
+        value.value = 1  # error: [deprecated] "old setter; another setter"
+        del value.value  # error: [deprecated] "old deleter; another deleter"
+```
+
+```snapshot
+warning[deprecated]: Use of deprecated functions
+  --> src/mdtest_snippet.py:45:15
+   |
+45 |         value.value
+   |               ^^^^^ old getter; another getter
+   |
+  ::: src/mdtest_snippet.py:6:9
+   |
+ 6 |     def value(self) -> int:
+   |         ----- old getter
+   |
+  ::: src/mdtest_snippet.py:32:9
+   |
+32 |     def value(self) -> int:
+   |         ----- another getter
+```
+
+A non-deprecated getter suppresses the getter warning without hiding deprecated setters.
+
+```py
+class ActiveGetter:
+    @property
+    def value(self) -> int:
+        return 0
+
+    @value.setter
+    @deprecated("another setter")
+    def value(self, value: int) -> None: ...
+
+def check_active_getter(value: Old):
+    if isinstance(value, ActiveGetter):
+        value.value
+        value.value = 1  # error: [deprecated] "old setter; another setter"
 ```
 
 ## Invalid property getter calls

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -615,7 +615,7 @@ class AlsoDeprecated:
 
 def deprecated_intersection(value: Deprecated) -> None:
     if isinstance(value, AlsoDeprecated):
-        # error: [deprecated] "Possible use of deprecated methods: `Deprecated.__invert__`, `AlsoDeprecated.__invert__`"
+        # error: [deprecated] "`Deprecated.__invert__`, `AlsoDeprecated.__invert__`"
         ~value
 ```
 
@@ -667,7 +667,7 @@ class Second:
 T = TypeVar("T", First, Second)
 
 def f(value: T) -> None:
-    # error: [deprecated] "Possible use of deprecated methods: `First.__invert__`, `Second.__invert__`"
+    # error: [deprecated] "`First.__invert__`, `Second.__invert__`"
     ~value
 ```
 
@@ -699,7 +699,7 @@ W = TypeVar("W", First | Third, Second)
 
 def nested_union(value: W) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "Possible use of deprecated methods: `First.__invert__`, `Second.__invert__`"
+    # error: [deprecated] "`First.__invert__`, `Second.__invert__`"
     ~value
 ```
 
@@ -716,7 +716,7 @@ X = TypeVar("X", Invalid, Second)
 
 def invalid_operator(value: X) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "Possible use of deprecated methods: `Invalid.__invert__`, `Second.__invert__`"
+    # error: [deprecated] "`Invalid.__invert__`, `Second.__invert__`"
     ~value
 ```
 
@@ -999,49 +999,33 @@ def check_marker(value: Old):
         value.value = 1  # error: [deprecated] "old setter"
 ```
 
-When both members provide deprecated accessors, the warning includes both messages.
+When both members define their own deprecated property, reading, assigning, and deleting the
+attribute report the getter, setter, and deleter deprecations, respectively. Each warning names both
+declarations.
 
 ```py
 class AlsoOld:
     @property
-    @deprecated("another getter")
+    @deprecated("old getter")
     def value(self) -> int:
         return 0
 
     @value.setter
-    @deprecated("another setter")
+    @deprecated("old setter")
     def value(self, value: int) -> None: ...
     @value.deleter
-    @deprecated("another deleter")
+    @deprecated("old deleter")
     def value(self) -> None: ...
 
 def check_both(value: Old):
     if isinstance(value, AlsoOld):
-        # snapshot: deprecated
-        value.value
-        value.value = 1  # error: [deprecated] "Possible use of deprecated methods: `Old.value`, `AlsoOld.value`"
-        del value.value  # error: [deprecated] "Possible use of deprecated methods: `Old.value`, `AlsoOld.value`"
+        value.value  # error: [deprecated] "`Old.value`, `AlsoOld.value`: old getter"
+        value.value = 1  # error: [deprecated] "`Old.value`, `AlsoOld.value`: old setter"
+        del value.value  # error: [deprecated] "`Old.value`, `AlsoOld.value`: old deleter"
 ```
 
-```snapshot
-warning[deprecated]: Possible use of deprecated methods: `Old.value`, `AlsoOld.value`
-  --> src/mdtest_snippet.py:45:15
-   |
-45 |         value.value
-   |               ^^^^^
-info: old getter
- --> src/mdtest_snippet.py:6:9
-  |
-6 |     def value(self) -> int:
-  |         ^^^^^
-info: another getter
-  --> src/mdtest_snippet.py:32:9
-   |
-32 |     def value(self) -> int:
-   |         ^^^^^
-```
-
-A non-deprecated getter suppresses the getter warning without hiding deprecated setters.
+A non-deprecated getter suppresses the warning on reads. Assignments still warn when both setters
+are deprecated.
 
 ```py
 class ActiveGetter:
@@ -1050,13 +1034,13 @@ class ActiveGetter:
         return 0
 
     @value.setter
-    @deprecated("another setter")
+    @deprecated("old setter")
     def value(self, value: int) -> None: ...
 
 def check_active_getter(value: Old):
     if isinstance(value, ActiveGetter):
         value.value
-        value.value = 1  # error: [deprecated] "Possible use of deprecated methods: `Old.value`, `ActiveGetter.value`"
+        value.value = 1  # error: [deprecated] "`Old.value`, `ActiveGetter.value`: old setter"
 ```
 
 ## Invalid property getter calls
@@ -1294,10 +1278,10 @@ def check(value: list[Any] | set[Any]):
     convert(value)
 ```
 
-### Several deprecated overloads of one function
+### Calls that select several deprecated overloads
 
-When multiple deprecated overloads match, the summary names the function once. The individual
-overload messages remain available in the full diagnostic.
+An `int | str` argument selects a different overload for each member of the union. When both
+overloads are deprecated, the warning names the function once.
 
 ```py
 from typing import overload
@@ -1319,7 +1303,7 @@ def check(value: int | str):
 
 ### Shared deprecation messages across overloads
 
-When matching overloads share a deprecation message, the warning includes that message once in both
+When selected overloads share a deprecation message, the warning includes that message once in both
 full and concise output. The full diagnostic points to each deprecated overload.
 
 ```py
@@ -1590,47 +1574,48 @@ class InPlace(Number):
         return self
 
 def check_mixed(number: First | InPlace, value: int | str):
-    # error: [deprecated] "Possible use of deprecated methods: `Number.__add__`, `InPlace.__iadd__`"
+    # error: [deprecated] "`Number.__add__`, `InPlace.__iadd__`"
     number += value
 ```
 
 ## Calls to different deprecated methods
 
-When a call can invoke different deprecated methods, the summary names each method's defining class.
-Each message appears with its own definition, preserving its punctuation and line breaks. Inherited
-copies of the same method are listed only once.
+Deprecation messages can contain several sentences, semicolons, and line breaks.
 
 ```py
 from typing_extensions import deprecated
 
 class First:
-    @deprecated("Direct calls are deprecated. Use `invoke()` instead; support ends in version 2.")
+    @deprecated("Use `invoke` instead. Direct calls are deprecated; support ends in version 2.")
     def __call__(self) -> None: ...
 
 class Second:
-    @deprecated("Use the replacement API.\nDirect calls will be removed in version 3.")
+    @deprecated("Use `invoke` instead.\nSupport ends in version 3.")
     def __call__(self) -> None: ...
+```
 
-class Inherited(First): ...
+When either method can be called, the warning names both defining classes. The full diagnostic shows
+each message beside its method's definition, preserving its punctuation and line breaks.
 
-def check(value: First | Second | Inherited):
+```py
+def check(value: First | Second):
     # snapshot: deprecated
     value()
 ```
 
 ```snapshot
 warning[deprecated]: Possible use of deprecated methods: `First.__call__`, `Second.__call__`
-  --> src/mdtest_snippet.py:15:5
+  --> src/mdtest_snippet.py:12:5
    |
-15 |     value()
+12 |     value()
    |     ^^^^^
-info: Direct calls are deprecated. Use `invoke()` instead; support ends in version 2.
+info: Use `invoke` instead. Direct calls are deprecated; support ends in version 2.
  --> src/mdtest_snippet.py:5:9
   |
 5 |     def __call__(self) -> None: ...
   |         ^^^^^^^^
-info: Use the replacement API.
-Direct calls will be removed in version 3.
+info: Use `invoke` instead.
+Support ends in version 3.
  --> src/mdtest_snippet.py:9:9
   |
 9 |     def __call__(self) -> None: ...
@@ -1639,7 +1624,8 @@ Direct calls will be removed in version 3.
 
 ## Calls to deprecated generic methods
 
-Generic methods retain the defining class in the summary, including when the class is generic too.
+The warning includes the defining class's name even when both the class and method have type
+parameters.
 
 ```toml
 [environment]
@@ -1656,7 +1642,7 @@ class First[T]:
 
 class Second:
     @deprecated("second method")
-    def __call__[U](self, value: U) -> U:
+    def __call__(self, value: int) -> int:
         return value
 
 def check(value: First[int] | Second):

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -1317,6 +1317,46 @@ def check(value: int | str):
     convert(value)
 ```
 
+### Shared deprecation messages across overloads
+
+When matching overloads share a deprecation message, the warning includes that message once in both
+full and concise output. The full diagnostic points to each deprecated overload.
+
+```py
+from typing import overload
+from typing_extensions import deprecated
+
+@overload
+@deprecated("Use `parse` instead. Support ends in version 2.")
+def convert(value: int) -> str: ...
+@overload
+@deprecated("Use `parse` instead. Support ends in version 2.")
+def convert(value: str) -> str: ...
+def convert(value: int | str) -> str:
+    return str(value)
+
+def check(value: int | str):
+    # snapshot: deprecated
+    convert(value)
+```
+
+```snapshot
+warning[deprecated]: Possible use of deprecated function: `convert`
+  --> src/mdtest_snippet.py:15:5
+   |
+15 |     convert(value)
+   |     ^^^^^^^ Use `parse` instead. Support ends in version 2.
+   |
+  ::: src/mdtest_snippet.py:6:5
+   |
+ 6 | def convert(value: int) -> str: ...
+   |     -------
+ 7 | @overload
+ 8 | @deprecated("Use `parse` instead. Support ends in version 2.")
+ 9 | def convert(value: str) -> str: ...
+   |     -------
+```
+
 ### Overloads for different receivers
 
 The `self` annotations restrict which overloads each instance can call. A call on `C[str]` reports

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -615,7 +615,7 @@ class AlsoDeprecated:
 
 def deprecated_intersection(value: Deprecated) -> None:
     if isinstance(value, AlsoDeprecated):
-        # error: [deprecated] "old inversion; another old inversion"
+        # error: [deprecated] "Use of 2 deprecated functions"
         ~value
 ```
 
@@ -667,7 +667,7 @@ class Second:
 T = TypeVar("T", First, Second)
 
 def f(value: T) -> None:
-    # error: [deprecated] "first; second"
+    # error: [deprecated] "Use of 2 deprecated functions"
     ~value
 ```
 
@@ -699,7 +699,7 @@ W = TypeVar("W", First | Third, Second)
 
 def nested_union(value: W) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "first; second"
+    # error: [deprecated] "Use of 2 deprecated functions"
     ~value
 ```
 
@@ -716,7 +716,7 @@ X = TypeVar("X", Invalid, Second)
 
 def invalid_operator(value: X) -> None:
     # error: [unsupported-operator]
-    # error: [deprecated] "invalid inversion; second"
+    # error: [deprecated] "Use of 2 deprecated functions"
     ~value
 ```
 
@@ -1019,26 +1019,26 @@ def check_both(value: Old):
     if isinstance(value, AlsoOld):
         # snapshot: deprecated
         value.value
-        value.value = 1  # error: [deprecated] "old setter; another setter"
-        del value.value  # error: [deprecated] "old deleter; another deleter"
+        value.value = 1  # error: [deprecated] "Use of 2 deprecated functions"
+        del value.value  # error: [deprecated] "Use of 2 deprecated functions"
 ```
 
 ```snapshot
-warning[deprecated]: Use of deprecated functions
+warning[deprecated]: Use of 2 deprecated functions
   --> src/mdtest_snippet.py:45:15
    |
 45 |         value.value
-   |               ^^^^^ old getter; another getter
-   |
-  ::: src/mdtest_snippet.py:6:9
-   |
- 6 |     def value(self) -> int:
-   |         ----- old getter
-   |
-  ::: src/mdtest_snippet.py:32:9
+   |               ^^^^^
+info: old getter
+ --> src/mdtest_snippet.py:6:9
+  |
+6 |     def value(self) -> int:
+  |         ^^^^^
+info: another getter
+  --> src/mdtest_snippet.py:32:9
    |
 32 |     def value(self) -> int:
-   |         ----- another getter
+   |         ^^^^^
 ```
 
 A non-deprecated getter suppresses the getter warning without hiding deprecated setters.
@@ -1056,7 +1056,7 @@ class ActiveGetter:
 def check_active_getter(value: Old):
     if isinstance(value, ActiveGetter):
         value.value
-        value.value = 1  # error: [deprecated] "old setter; another setter"
+        value.value = 1  # error: [deprecated] "Use of 2 deprecated functions"
 ```
 
 ## Invalid property getter calls
@@ -1527,23 +1527,24 @@ class InPlace(Number):
         return self
 
 def check_mixed(number: First | InPlace, value: int | str):
-    number += value  # error: [deprecated] "addition; in-place addition"
+    number += value  # error: [deprecated] "Use of 2 deprecated functions"
 ```
 
 ## Calls to different deprecated methods
 
-When a call can invoke different deprecated methods, one warning includes both messages and points
-to both method definitions. Inherited copies of the same method are listed only once.
+When a call can invoke different deprecated methods, one warning points to both method definitions.
+Each message appears with its own definition, preserving its punctuation and line breaks. Inherited
+copies of the same method are listed only once.
 
 ```py
 from typing_extensions import deprecated
 
 class First:
-    @deprecated("first message")
+    @deprecated("Direct calls are deprecated. Use `invoke()` instead; support ends in version 2.")
     def __call__(self) -> None: ...
 
 class Second:
-    @deprecated("second message")
+    @deprecated("Use the replacement API.\nDirect calls will be removed in version 3.")
     def __call__(self) -> None: ...
 
 class Inherited(First): ...
@@ -1554,19 +1555,20 @@ def check(value: First | Second | Inherited):
 ```
 
 ```snapshot
-warning[deprecated]: Use of deprecated functions
+warning[deprecated]: Use of 2 deprecated functions
   --> src/mdtest_snippet.py:15:5
    |
 15 |     value()
-   |     ^^^^^ first message; second message
-   |
-  ::: src/mdtest_snippet.py:5:9
-   |
- 5 |     def __call__(self) -> None: ...
-   |         -------- first message
- 6 |
- 7 | class Second:
- 8 |     @deprecated("second message")
- 9 |     def __call__(self) -> None: ...
-   |         -------- second message
+   |     ^^^^^
+info: Direct calls are deprecated. Use `invoke()` instead; support ends in version 2.
+ --> src/mdtest_snippet.py:5:9
+  |
+5 |     def __call__(self) -> None: ...
+  |         ^^^^^^^^
+info: Use the replacement API.
+Direct calls will be removed in version 3.
+ --> src/mdtest_snippet.py:9:9
+  |
+9 |     def __call__(self) -> None: ...
+  |         ^^^^^^^^
 ```

--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -1368,8 +1368,12 @@ def check(integer: C[int], string: C[str]):
 
 ## Deprecated constructors
 
-Calling a class implicitly invokes its constructor methods. A deprecated `__init__` or `__new__`
-produces a warning even when the class itself is not deprecated.
+Calling a class can invoke `__new__`, `__init__`, or a custom metaclass's `__call__`. We warn about
+deprecated methods that the call invokes, even when the class itself is not deprecated.
+
+### `__init__`
+
+Calling a class reports the deprecation of its initializer.
 
 ```py
 from typing_extensions import Self, deprecated
@@ -1378,23 +1382,18 @@ class OldInit:
     @deprecated("old init")
     def __init__(self) -> None: ...
 
-class OldNew:
-    @deprecated("old new")
-    def __new__(cls) -> Self:
-        return super().__new__(cls)
-
 OldInit()  # error: [deprecated] "old init"
-OldNew()  # error: [deprecated] "old new"
 ```
 
-Explicit references and calls still report the constructor's deprecation only once.
+An explicit call on an instance also produces only one warning.
 
 ```py
-OldInit.__init__  # error: [deprecated] "old init"
-OldNew.__new__(OldNew)  # error: [deprecated] "old new"
+def explicit_init(value: OldInit):
+    value.__init__()  # error: [deprecated] "old init"
 ```
 
-An active `__new__` does not hide a deprecated `__init__`, including an inherited initializer.
+If a non-deprecated `__new__` returns an instance of the class, Python still calls the inherited
+deprecated initializer.
 
 ```py
 class NewWithOldInit(OldInit):
@@ -1402,33 +1401,6 @@ class NewWithOldInit(OldInit):
         return super().__new__(cls)
 
 NewWithOldInit()  # error: [deprecated] "old init"
-```
-
-If both constructor methods are deprecated, one warning includes both messages.
-
-```py
-class Both(OldNew, OldInit): ...
-
-# snapshot: deprecated
-Both()
-```
-
-```snapshot
-warning[deprecated]: Use of deprecated functions
-  --> src/mdtest_snippet.py:24:1
-   |
-24 | Both()
-   | ^^^^ old new; old init
-   |
-  ::: src/mdtest_snippet.py:5:9
-   |
- 5 |     def __init__(self) -> None: ...
-   |         -------- old init
- 6 |
- 7 | class OldNew:
- 8 |     @deprecated("old new")
- 9 |     def __new__(cls) -> Self:
-   |         ------- old new
 ```
 
 When `__new__` returns an unrelated type, `__init__` does not run and produces no warning.
@@ -1441,9 +1413,73 @@ class ReturnsInt(OldInit):
 ReturnsInt()
 ```
 
-A deprecated metaclass `__call__` also warns when invoked implicitly by constructing a class.
+### `__new__`
+
+Calling a class also reports the deprecation of the method that creates the instance.
 
 ```py
+from typing_extensions import Self, deprecated
+
+class OldNew:
+    @deprecated("old new")
+    def __new__(cls) -> Self:
+        return super().__new__(cls)
+
+OldNew()  # error: [deprecated] "old new"
+```
+
+Calling `__new__` explicitly produces only one warning.
+
+```py
+OldNew.__new__(OldNew)  # error: [deprecated] "old new"
+```
+
+### Both constructor methods
+
+When both methods are deprecated, the class call produces one warning that points to both
+declarations and includes both messages.
+
+```py
+from typing_extensions import Self, deprecated
+
+class Both:
+    @deprecated("old new")
+    def __new__(cls) -> Self:
+        return super().__new__(cls)
+
+    @deprecated("old init")
+    def __init__(self) -> None: ...
+
+# snapshot: deprecated
+Both()
+```
+
+```snapshot
+warning[deprecated]: Possible use of deprecated methods: `Both.__new__`, `Both.__init__`
+  --> src/mdtest_snippet.py:12:1
+   |
+12 | Both()
+   | ^^^^
+info: old new
+ --> src/mdtest_snippet.py:5:9
+  |
+5 |     def __new__(cls) -> Self:
+  |         ^^^^^^^
+info: old init
+ --> src/mdtest_snippet.py:9:9
+  |
+9 |     def __init__(self) -> None: ...
+  |         ^^^^^^^^
+```
+
+### Metaclass `__call__`
+
+Calling a class with a custom metaclass invokes the metaclass's `__call__` method. If that method is
+deprecated, the class call produces a warning.
+
+```py
+from typing_extensions import deprecated
+
 class Meta(type):
     @deprecated("metaclass call")
     def __call__(cls) -> int:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -84,7 +84,7 @@ pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_
 pub(crate) use crate::types::equality::{ComparisonSoundnessPolicy, equality_truthiness};
 use crate::types::function::{
     DataclassTransformerFlags, DataclassTransformerParams, FunctionDecorators, FunctionSpans,
-    FunctionType, KnownFunction,
+    FunctionType, KnownFunction, OverloadLiteral,
 };
 pub(crate) use crate::types::generics::GenericContext;
 use crate::types::generics::{ApplySpecialization, Specialization, bind_typevar};
@@ -911,10 +911,61 @@ struct DeprecatedMember<'db> {
     #[returns(copy)]
     member: PlaceAndQualifiers<'db>,
     #[returns(copy)]
-    properties: Type<'db>,
+    properties: PropertyDeprecations<'db>,
 }
 
 impl get_size2::GetSize for DeprecatedMember<'_> {}
+
+/// Deprecated property accessors retained independently of descriptor types. Distinct property
+/// objects are disjoint types, but either can implement an attribute on an intersection.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+struct PropertyDeprecations<'db> {
+    /// Getter, setter, and deleter implementations, in that order.
+    #[returns(ref)]
+    accessors: [Box<[OverloadLiteral<'db>]>; 3],
+}
+
+impl get_size2::GetSize for PropertyDeprecations<'_> {}
+
+impl<'db> PropertyDeprecations<'db> {
+    fn functions(self, db: &'db dyn Db, access: ast::ExprContext) -> &'db [OverloadLiteral<'db>] {
+        let index = match access {
+            ast::ExprContext::Load => 0,
+            ast::ExprContext::Store => 1,
+            ast::ExprContext::Del => 2,
+            ast::ExprContext::Invalid => return &[],
+        };
+        &self.accessors(db)[index]
+    }
+
+    fn getters_only(self, db: &'db dyn Db) -> Self {
+        Self::new(
+            db,
+            [self.accessors(db)[0].clone(), Box::new([]), Box::new([])],
+        )
+    }
+
+    fn union(self, db: &'db dyn Db, other: Self) -> Self {
+        self.combine(db, other, false)
+    }
+
+    fn intersection(self, db: &'db dyn Db, other: Self) -> Self {
+        self.combine(db, other, true)
+    }
+
+    fn combine(self, db: &'db dyn Db, other: Self, intersection: bool) -> Self {
+        let accessors: [Box<[_]>; 3] = std::array::from_fn(|index| {
+            let left = &self.accessors(db)[index];
+            let right = &other.accessors(db)[index];
+            if intersection && (left.is_empty() || right.is_empty()) {
+                Box::<[_]>::default()
+            } else {
+                left.iter().chain(right).copied().unique().collect()
+            }
+        });
+        Self::new(db, accessors)
+    }
+}
 
 impl<'db> ResolvedMember<'db> {
     fn member(self, db: &'db dyn Db) -> PlaceAndQualifiers<'db> {
@@ -924,7 +975,7 @@ impl<'db> ResolvedMember<'db> {
         }
     }
 
-    fn deprecated_properties(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    fn deprecated_properties(self, db: &'db dyn Db) -> Option<PropertyDeprecations<'db>> {
         match self {
             Self::WithDeprecations(member) => Some(member.properties(db)),
             Self::Plain(_) => None,
@@ -934,7 +985,7 @@ impl<'db> ResolvedMember<'db> {
     fn new(
         db: &'db dyn Db,
         member: PlaceAndQualifiers<'db>,
-        properties: Option<Type<'db>>,
+        properties: Option<PropertyDeprecations<'db>>,
     ) -> Self {
         match properties {
             Some(properties) => {
@@ -954,16 +1005,15 @@ impl<'db> ResolvedMember<'db> {
     }
 }
 
-/// Combine deprecated descriptors from alternative lookup paths. A non-deprecated path (`None`)
+/// Combine accessor deprecations from alternative lookup paths. A non-deprecated path (`None`)
 /// does not suppress deprecations from another possible path.
 fn union_deprecated_properties<'db>(
     db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    left: Option<Type<'db>>,
-    right: Option<Type<'db>>,
-) -> Option<Type<'db>> {
+    left: Option<PropertyDeprecations<'db>>,
+    right: Option<PropertyDeprecations<'db>>,
+) -> Option<PropertyDeprecations<'db>> {
     match (left, right) {
-        (Some(left), Some(right)) => Some(UnionType::from_two_elements(db, env, left, right)),
+        (Some(left), Some(right)) => Some(left.union(db, right)),
         _ => left.or(right),
     }
 }
@@ -972,7 +1022,7 @@ fn member_lookup_result<'db>(
     db: &'db dyn Db,
     member: PlaceAndQualifiers<'db>,
     error: Option<MemberLookupErrorKind<'db>>,
-    properties: Option<Type<'db>>,
+    properties: Option<PropertyDeprecations<'db>>,
 ) -> MemberLookupResult<'db> {
     let member = ResolvedMember::new(db, member, properties);
     match error {
@@ -1027,12 +1077,8 @@ fn distribute_member_lookup_over_bound_or_constraints<'db>(
                     });
                 error = error.or_else(|| result.err().map(|error| error.kind(db)));
                 let member = result.unwrap_or_else(|error| error.fallback_member(db));
-                properties = union_deprecated_properties(
-                    db,
-                    env,
-                    properties,
-                    member.deprecated_properties(db),
-                );
+                properties =
+                    union_deprecated_properties(db, properties, member.deprecated_properties(db));
                 member.member(db)
             });
             member_lookup_result(db, member, error, properties)
@@ -1069,7 +1115,6 @@ fn member_lookup_or_fall_back_to<'db>(
                     .or_else(|| fallback.err().map(|error| error.kind(db))),
                 union_deprecated_properties(
                     db,
-                    env,
                     resolved.deprecated_properties(db),
                     fallback_member.deprecated_properties(db),
                 ),
@@ -4334,6 +4379,58 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Collect accessor implementations without intersecting their function or descriptor types.
+    fn property_deprecations(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<PropertyDeprecations<'db>> {
+        if !self.has_deprecated_property(db) {
+            return None;
+        }
+        match self {
+            Type::PropertyInstance(property) => Some(PropertyDeprecations::new(
+                db,
+                [
+                    property.getter(db),
+                    property.setter(db),
+                    property.deleter(db),
+                ]
+                .map(|accessor| {
+                    accessor.map_or_else(Box::<[_]>::default, |accessor| {
+                        accessor
+                            .bindings(db, env)
+                            .deprecated_functions(db)
+                            .map(|(_, function)| function)
+                            // Accessor references do not resolve an overload call.
+                            .filter(|function| !function.is_overload(db))
+                            .unique()
+                            .collect()
+                    })
+                }),
+            )),
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .filter_map(|ty| ty.property_deprecations(db, env))
+                .reduce(|left, right| left.union(db, right)),
+            Type::Intersection(intersection) => {
+                let mut properties = None;
+                for ty in intersection.positive(db) {
+                    let deprecated = ty.property_deprecations(db, env)?;
+                    properties = Some(properties.map_or(
+                        deprecated,
+                        |properties: PropertyDeprecations<'db>| {
+                            properties.intersection(db, deprecated)
+                        },
+                    ));
+                }
+                properties
+            }
+            _ => None,
+        }
+    }
+
     /// Returns the descriptor result type for directly dynamic values and gradual class-object
     /// values.
     fn dynamic_descriptor_type(self) -> Option<Type<'db>> {
@@ -4921,7 +5018,7 @@ impl<'db> Type<'db> {
         ) = Self::try_call_dunder_get_on_attribute(db, env, meta_attr_plain, Some(receiver), owner);
 
         let meta_attr_error = meta_attr_error.map(MemberLookupErrorKind::DescriptorGet);
-        let meta_properties = meta_attr_ty.filter(|ty| ty.has_deprecated_property(db));
+        let meta_properties = meta_attr_ty.and_then(|ty| ty.property_deprecations(db, env));
         let fallback_error = fallback.err().map(|error| error.kind(db));
         let fallback_member = fallback.unwrap_or_else(|error| error.fallback_member(db));
         let fallback_properties = fallback_member.deprecated_properties(db);
@@ -4998,7 +5095,7 @@ impl<'db> Type<'db> {
                 })
                 .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
                 meta_attr_error.or(fallback_error),
-                union_deprecated_properties(db, env, meta_properties, fallback_properties),
+                union_deprecated_properties(db, meta_properties, fallback_properties),
             ),
 
             // `meta_attr` is *not* a data descriptor. This means that the `fallback` type has
@@ -5053,7 +5150,7 @@ impl<'db> Type<'db> {
                 })
                 .with_qualifiers(meta_attr_qualifiers.union(fallback_qualifiers)),
                 meta_attr_error.or(fallback_error),
-                union_deprecated_properties(db, env, meta_properties, fallback_properties),
+                union_deprecated_properties(db, meta_properties, fallback_properties),
             ),
 
             // If the attribute is not found on the meta-type, we simply return the fallback.
@@ -5349,7 +5446,6 @@ impl<'db> Type<'db> {
                         let member = result.unwrap_or_else(|error| error.fallback_member(db));
                         properties = union_deprecated_properties(
                             db,
-                            env,
                             properties,
                             member.deprecated_properties(db),
                         );
@@ -5367,7 +5463,7 @@ impl<'db> Type<'db> {
                     } else {
                         let receiver = Some(receiver.unwrap_or(this));
                         let mut error = None;
-                        let mut properties = IntersectionBuilder::new(db, env);
+                        let mut properties: Option<PropertyDeprecations<'db>> = None;
                         let mut all_deprecated = true;
                         let member =
                             intersection.map_with_boundness_and_qualifiers(db, env, |elem| {
@@ -5378,7 +5474,10 @@ impl<'db> Type<'db> {
                                 let member =
                                     result.unwrap_or_else(|error| error.fallback_member(db));
                                 if let Some(deprecated) = member.deprecated_properties(db) {
-                                    properties.add_positive_in_place(deprecated);
+                                    properties =
+                                        Some(properties.map_or(deprecated, |properties| {
+                                            properties.intersection(db, deprecated)
+                                        }));
                                 } else if !member.member(db).place.is_undefined() {
                                     all_deprecated = false;
                                 }
@@ -5388,8 +5487,7 @@ impl<'db> Type<'db> {
                             db,
                             member,
                             error,
-                            (all_deprecated && !member.place.is_undefined())
-                                .then(|| properties.build()),
+                            properties.filter(|_| all_deprecated && !member.place.is_undefined()),
                         )
                     }
                 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -941,12 +941,7 @@ impl<'db> PropertyDeprecations<'db> {
     }
 
     fn getters_only(self, db: &'db dyn Db) -> Self {
-        Self::new(
-            db,
-            self.getters(db).clone(),
-            Box::<[_]>::default(),
-            Box::<[_]>::default(),
-        )
+        Self::new(db, self.getters(db), [].as_slice(), [].as_slice())
     }
 
     /// Retain either alternative's deprecations: a union can invoke either accessor.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -920,28 +920,32 @@ impl get_size2::GetSize for DeprecatedMember<'_> {}
 /// objects are disjoint types, but either can implement an attribute on an intersection.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct PropertyDeprecations<'db> {
-    /// Getter, setter, and deleter implementations, in that order.
     #[returns(ref)]
-    accessors: [Box<[OverloadLiteral<'db>]>; 3],
+    getters: Box<[OverloadLiteral<'db>]>,
+    #[returns(ref)]
+    setters: Box<[OverloadLiteral<'db>]>,
+    #[returns(ref)]
+    deleters: Box<[OverloadLiteral<'db>]>,
 }
 
 impl get_size2::GetSize for PropertyDeprecations<'_> {}
 
 impl<'db> PropertyDeprecations<'db> {
     fn functions(self, db: &'db dyn Db, access: ast::ExprContext) -> &'db [OverloadLiteral<'db>] {
-        let index = match access {
-            ast::ExprContext::Load => 0,
-            ast::ExprContext::Store => 1,
-            ast::ExprContext::Del => 2,
-            ast::ExprContext::Invalid => return &[],
-        };
-        &self.accessors(db)[index]
+        match access {
+            ast::ExprContext::Load => self.getters(db),
+            ast::ExprContext::Store => self.setters(db),
+            ast::ExprContext::Del => self.deleters(db),
+            ast::ExprContext::Invalid => &[],
+        }
     }
 
     fn getters_only(self, db: &'db dyn Db) -> Self {
         Self::new(
             db,
-            [self.accessors(db)[0].clone(), Box::new([]), Box::new([])],
+            self.getters(db).clone(),
+            Box::<[_]>::default(),
+            Box::<[_]>::default(),
         )
     }
 
@@ -957,16 +961,19 @@ impl<'db> PropertyDeprecations<'db> {
     }
 
     fn combine(self, db: &'db dyn Db, other: Self, intersection: bool) -> Self {
-        let accessors: [Box<[_]>; 3] = std::array::from_fn(|index| {
-            let left = &self.accessors(db)[index];
-            let right = &other.accessors(db)[index];
+        let combine = |left: &[OverloadLiteral<'db>], right: &[OverloadLiteral<'db>]| {
             if intersection && (left.is_empty() || right.is_empty()) {
                 Box::<[_]>::default()
             } else {
                 left.iter().chain(right).copied().unique().collect()
             }
-        });
-        Self::new(db, accessors)
+        };
+        Self::new(
+            db,
+            combine(self.getters(db), other.getters(db)),
+            combine(self.setters(db), other.setters(db)),
+            combine(self.deleters(db), other.deleters(db)),
+        )
     }
 }
 
@@ -4398,7 +4405,7 @@ impl<'db> Type<'db> {
 
         match self {
             Type::PropertyInstance(property) => {
-                let accessors = [
+                let [getters, setters, deleters] = [
                     property.getter(db),
                     property.setter(db),
                     property.deleter(db),
@@ -4410,10 +4417,11 @@ impl<'db> Type<'db> {
                     }
                     functions.into_iter().unique().collect::<Box<[_]>>()
                 });
-                accessors
-                    .iter()
-                    .any(|functions| !functions.is_empty())
-                    .then(|| PropertyDeprecations::new(db, accessors))
+                if getters.is_empty() && setters.is_empty() && deleters.is_empty() {
+                    None
+                } else {
+                    Some(PropertyDeprecations::new(db, getters, setters, deleters))
+                }
             }
             Type::Union(union) => union
                 .elements(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -945,10 +945,13 @@ impl<'db> PropertyDeprecations<'db> {
         )
     }
 
+    /// Retain either alternative's deprecations: a union can invoke either accessor.
     fn union(self, db: &'db dyn Db, other: Self) -> Self {
         self.combine(db, other, false)
     }
 
+    /// Retain deprecations only for access kinds deprecated in both alternatives. A
+    /// non-deprecated getter can suppress read warnings without suppressing write warnings.
     fn intersection(self, db: &'db dyn Db, other: Self) -> Self {
         self.combine(db, other, true)
     }
@@ -995,7 +998,7 @@ impl<'db> ResolvedMember<'db> {
         }
     }
 
-    /// Transform the member's value type without changing its deprecated property descriptors.
+    /// Transform the member's value type without changing its property accessor deprecations.
     fn map_type(self, db: &'db dyn Db, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Self {
         Self::new(
             db,
@@ -4339,9 +4342,24 @@ impl<'db> Type<'db> {
     }
 
     /// Collect deprecated accessor implementations without inferring their signatures or
-    /// intersecting their function or descriptor types. Overload deprecations require a resolved
-    /// call and do not apply to accessor references.
+    /// intersecting their function or descriptor types. Retain the declarations so callers can
+    /// report deprecations after descriptor lookup replaces the property with its value type:
+    ///
+    /// ```python
+    /// from typing_extensions import deprecated
+    ///
+    /// class C:
+    ///     @property
+    ///     @deprecated("old getter")
+    ///     def value(self) -> int: ...
+    ///
+    /// C().value  # Warn about the getter, even though the attribute has type `int`.
+    /// ```
+    ///
+    /// Overload deprecations require a resolved call and do not apply to accessor references.
     fn property_deprecations(self, db: &'db dyn Db) -> Option<PropertyDeprecations<'db>> {
+        /// Append deprecated implementations, preserving earlier entries if a non-deprecated
+        /// intersection alternative suppresses this accessor's deprecations.
         fn collect<'db>(
             db: &'db dyn Db,
             accessor: Type<'db>,
@@ -4403,17 +4421,11 @@ impl<'db> Type<'db> {
                 .filter_map(|ty| ty.property_deprecations(db))
                 .reduce(|left, right| left.union(db, right)),
             Type::Intersection(intersection) => {
-                let mut properties = None;
-                for ty in intersection.positive(db) {
-                    let deprecated = ty.property_deprecations(db)?;
-                    properties = Some(properties.map_or(
-                        deprecated,
-                        |properties: PropertyDeprecations<'db>| {
-                            properties.intersection(db, deprecated)
-                        },
-                    ));
-                }
-                properties
+                let mut elements = intersection.positive(db).iter();
+                let first = elements.next()?.property_deprecations(db)?;
+                elements.try_fold(first, |properties, ty| {
+                    Some(properties.intersection(db, ty.property_deprecations(db)?))
+                })
             }
             _ => None,
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4338,86 +4338,74 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Whether this descriptor contains a property with a deprecated accessor implementation.
-    /// Overload deprecations require a resolved call and do not apply to accessor references.
-    ///
-    /// This determines whether to retain deprecation metadata, not whether to report a diagnostic.
-    /// Reporting also accounts for the access kind and non-deprecated intersection alternatives.
-    fn has_deprecated_property(self, db: &'db dyn Db) -> bool {
-        fn deprecated(db: &dyn Db, ty: Type<'_>) -> bool {
-            match ty {
-                Type::FunctionLiteral(function) => function.implementation_deprecated(db).is_some(),
-                Type::BoundMethod(method) => {
-                    method.function(db).implementation_deprecated(db).is_some()
+    /// Collect deprecated accessor implementations without inferring their signatures or
+    /// intersecting their function or descriptor types. Overload deprecations require a resolved
+    /// call and do not apply to accessor references.
+    fn property_deprecations(self, db: &'db dyn Db) -> Option<PropertyDeprecations<'db>> {
+        fn collect<'db>(
+            db: &'db dyn Db,
+            accessor: Type<'db>,
+            functions: &mut Vec<OverloadLiteral<'db>>,
+        ) {
+            match accessor {
+                Type::FunctionLiteral(function) => {
+                    let (_, implementation) = function.overloads_and_implementation(db);
+                    functions.extend(
+                        implementation.filter(|function| function.deprecated(db).is_some()),
+                    );
                 }
-                Type::Union(union) => union.elements(db).iter().any(|ty| deprecated(db, *ty)),
-                Type::Intersection(intersection) => intersection
-                    .positive(db)
-                    .iter()
-                    .any(|ty| deprecated(db, *ty)),
-                _ => false,
+                Type::BoundMethod(method) => {
+                    collect(db, Type::FunctionLiteral(method.function(db)), functions);
+                }
+                Type::Union(union) => {
+                    for element in union.elements(db) {
+                        collect(db, *element, functions);
+                    }
+                }
+                Type::Intersection(intersection) => {
+                    let start = functions.len();
+                    for element in intersection.positive(db) {
+                        let element_start = functions.len();
+                        collect(db, *element, functions);
+                        if functions.len() == element_start {
+                            // A non-deprecated intersection member can supply the accessor.
+                            functions.truncate(start);
+                            break;
+                        }
+                    }
+                }
+                _ => {}
             }
         }
-        match self {
-            Type::PropertyInstance(property) => [
-                property.getter(db),
-                property.setter(db),
-                property.deleter(db),
-            ]
-            .into_iter()
-            .flatten()
-            .any(|ty| deprecated(db, ty)),
-            Type::Union(union) => union
-                .elements(db)
-                .iter()
-                .any(|ty| ty.has_deprecated_property(db)),
-            Type::Intersection(intersection) => intersection
-                .positive(db)
-                .iter()
-                .any(|ty| ty.has_deprecated_property(db)),
-            _ => false,
-        }
-    }
 
-    /// Collect accessor implementations without intersecting their function or descriptor types.
-    fn property_deprecations(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-    ) -> Option<PropertyDeprecations<'db>> {
-        if !self.has_deprecated_property(db) {
-            return None;
-        }
         match self {
-            Type::PropertyInstance(property) => Some(PropertyDeprecations::new(
-                db,
-                [
+            Type::PropertyInstance(property) => {
+                let accessors = [
                     property.getter(db),
                     property.setter(db),
                     property.deleter(db),
                 ]
                 .map(|accessor| {
-                    accessor.map_or_else(Box::<[_]>::default, |accessor| {
-                        accessor
-                            .bindings(db, env)
-                            .deprecated_functions(db)
-                            .map(|(_, function)| function)
-                            // Accessor references do not resolve an overload call.
-                            .filter(|function| !function.is_overload(db))
-                            .unique()
-                            .collect()
-                    })
-                }),
-            )),
+                    let mut functions = Vec::new();
+                    if let Some(accessor) = accessor {
+                        collect(db, accessor, &mut functions);
+                    }
+                    functions.into_iter().unique().collect::<Box<[_]>>()
+                });
+                accessors
+                    .iter()
+                    .any(|functions| !functions.is_empty())
+                    .then(|| PropertyDeprecations::new(db, accessors))
+            }
             Type::Union(union) => union
                 .elements(db)
                 .iter()
-                .filter_map(|ty| ty.property_deprecations(db, env))
+                .filter_map(|ty| ty.property_deprecations(db))
                 .reduce(|left, right| left.union(db, right)),
             Type::Intersection(intersection) => {
                 let mut properties = None;
                 for ty in intersection.positive(db) {
-                    let deprecated = ty.property_deprecations(db, env)?;
+                    let deprecated = ty.property_deprecations(db)?;
                     properties = Some(properties.map_or(
                         deprecated,
                         |properties: PropertyDeprecations<'db>| {
@@ -5018,7 +5006,7 @@ impl<'db> Type<'db> {
         ) = Self::try_call_dunder_get_on_attribute(db, env, meta_attr_plain, Some(receiver), owner);
 
         let meta_attr_error = meta_attr_error.map(MemberLookupErrorKind::DescriptorGet);
-        let meta_properties = meta_attr_ty.and_then(|ty| ty.property_deprecations(db, env));
+        let meta_properties = meta_attr_ty.and_then(|ty| ty.property_deprecations(db));
         let fallback_error = fallback.err().map(|error| error.kind(db));
         let fallback_member = fallback.unwrap_or_else(|error| error.fallback_member(db));
         let fallback_properties = fallback_member.deprecated_properties(db);

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -949,25 +949,6 @@ impl<'db> BoundSuperType<'db> {
         env: &ProgramEnvironment<'db>,
         attribute: PlaceAndQualifiers<'db>,
     ) -> Option<MemberLookupResult<'db>> {
-        /// Retain only getters in the deprecation metadata: `super` delegates reads to the
-        /// owner's descriptors, but not writes or deletions.
-        fn getters_only<'db>(
-            db: &'db dyn Db,
-            env: &ProgramEnvironment<'db>,
-            ty: Type<'db>,
-        ) -> Type<'db> {
-            match ty {
-                Type::PropertyInstance(property) => Type::PropertyInstance(
-                    property.with_accessors(db, property.getter(db), None, None),
-                ),
-                Type::Union(union) => union.map(db, env, |ty| getters_only(db, env, *ty)),
-                Type::Intersection(intersection) => {
-                    intersection.map_positive(db, env, |ty| getters_only(db, env, *ty))
-                }
-                _ => ty,
-            }
-        }
-
         let (instance, owner) = self.owner(db).descriptor_binding(db, env)?;
         let (member, _, descriptor_error) =
             Type::try_call_dunder_get_on_attribute(db, env, attribute, instance, owner);
@@ -977,8 +958,9 @@ impl<'db> BoundSuperType<'db> {
             descriptor_error.map(MemberLookupErrorKind::DescriptorGet),
             instance
                 .and_then(|_| attribute.place.ignore_possibly_undefined())
-                .filter(|ty| ty.has_deprecated_property(db))
-                .map(|ty| getters_only(db, env, ty)),
+                .and_then(|ty| ty.property_deprecations(db, env))
+                // `super` delegates reads to the owner's descriptors, but not writes or deletions.
+                .map(|properties| properties.getters_only(db)),
         ))
     }
 

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -958,7 +958,7 @@ impl<'db> BoundSuperType<'db> {
             descriptor_error.map(MemberLookupErrorKind::DescriptorGet),
             instance
                 .and_then(|_| attribute.place.ignore_possibly_undefined())
-                .and_then(|ty| ty.property_deprecations(db, env))
+                .and_then(|ty| ty.property_deprecations(db))
                 // `super` delegates reads to the owner's descriptors, but not writes or deletions.
                 .map(|properties| properties.getters_only(db)),
         ))

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -8486,13 +8486,42 @@ impl CallableBindingSnapshotter {
 }
 
 /// Describes a callable for the purposes of diagnostics.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub(crate) struct CallableDescription<'a> {
     name: Cow<'a, str>,
     kind: Option<&'static str>,
 }
 
+#[salsa::tracked]
 impl<'db> CallableDescription<'db> {
+    /// Describe a function definition without inferring its signature, qualifying methods by
+    /// their defining class. Cache the syntax lookup to avoid direct AST dependencies in callers.
+    #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+    pub(crate) fn from_overload(
+        db: &'db dyn Db,
+        function: OverloadLiteral<'db>,
+    ) -> CallableDescription<'static> {
+        let body_scope = function.body_scope(db);
+        let index = semantic_index(db, body_scope.program_file(db));
+        let class = index.class_definition_of_method(body_scope.file_scope_id(db));
+        let name = class.and_then(|class| class.name(db)).map_or_else(
+            || Cow::Owned(function.name(db).as_str().to_owned()),
+            |class_name| {
+                let mut name = format!("{class_name}.{}", function.name(db));
+                name.shrink_to_fit();
+                Cow::Owned(name)
+            },
+        );
+        CallableDescription {
+            name,
+            kind: Some(if class.is_some() {
+                "method"
+            } else {
+                "function"
+            }),
+        }
+    }
+
     fn defining_class(db: &'db dyn Db, callable_type: Type<'db>) -> Option<ClassLiteral<'db>> {
         let function = match callable_type {
             Type::FunctionLiteral(function) => function,
@@ -8519,6 +8548,10 @@ impl<'db> CallableDescription<'db> {
         &self.name
     }
 
+    pub(crate) fn kind(&self) -> Option<&'static str> {
+        self.kind
+    }
+
     fn new_with_settings(
         db: &'db dyn Db,
         callable_type: Type<'db>,
@@ -8529,22 +8562,20 @@ impl<'db> CallableDescription<'db> {
             function: FunctionType<'db>,
             settings: Option<&DisplaySettings<'db>>,
         ) -> Cow<'db, str> {
-            if let Some(class) =
-                CallableDescription::defining_class(db, Type::FunctionLiteral(function))
+            if let Some(settings) = settings
+                && let Some(class) =
+                    CallableDescription::defining_class(db, Type::FunctionLiteral(function))
             {
-                settings
-                    .map(|settings| {
-                        Cow::Owned(format!(
-                            "{}.{}",
-                            class.display_with(db, settings.clone()),
-                            function.name(db)
-                        ))
-                    })
-                    .unwrap_or_else(|| {
-                        Cow::Owned(format!("{}.{}", class.name(db), function.name(db)))
-                    })
+                Cow::Owned(format!(
+                    "{}.{}",
+                    class.display_with(db, settings.clone()),
+                    function.name(db)
+                ))
             } else {
-                Cow::Borrowed(function.name(db))
+                Cow::Borrowed(
+                    CallableDescription::from_overload(db, function.literal(db).last_definition)
+                        .name(),
+                )
             }
         }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -8486,7 +8486,7 @@ impl CallableBindingSnapshotter {
 }
 
 /// Describes a callable for the purposes of diagnostics.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 pub(crate) struct CallableDescription<'a> {
     name: Cow<'a, str>,
     kind: Option<&'static str>,
@@ -8504,16 +8504,13 @@ impl<'db> CallableDescription<'db> {
         let body_scope = function.body_scope(db);
         let index = semantic_index(db, body_scope.program_file(db));
         let class = index.class_definition_of_method(body_scope.file_scope_id(db));
-        let name = class.and_then(|class| class.name(db)).map_or_else(
-            || Cow::Owned(function.name(db).as_str().to_owned()),
-            |class_name| {
-                let mut name = format!("{class_name}.{}", function.name(db));
-                name.shrink_to_fit();
-                Cow::Owned(name)
-            },
+        let mut name = class.and_then(|class| class.name(db)).map_or_else(
+            || function.name(db).as_str().to_owned(),
+            |class_name| format!("{class_name}.{}", function.name(db)),
         );
+        name.shrink_to_fit();
         CallableDescription {
-            name,
+            name: Cow::Owned(name),
             kind: Some(if class.is_some() {
                 "method"
             } else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10189,25 +10189,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             diagnostic
         } else {
-            let descriptions: SmallVec<[_; 1]> = functions
-                .iter()
-                .map(|function| CallableDescription::from_overload(db, *function))
-                .collect();
-            let names: SmallVec<[_; 1]> = descriptions
-                .iter()
-                .map(|description| description.name())
-                .unique()
-                .collect();
-            let kind = if descriptions
-                .iter()
-                .all(|description| description.kind() == Some("method"))
-            {
-                "method"
-            } else {
-                "function"
-            };
+            let mut names = FxOrderSet::default();
+            let mut all_methods = true;
+            for function in &functions {
+                let description = CallableDescription::from_overload(db, *function);
+                names.insert(description.name());
+                all_methods &= description.kind() == Some("method");
+            }
+            let kind = if all_methods { "method" } else { "function" };
             let plural = if names.len() == 1 { "" } else { "s" };
-            let names = names.iter().map(|name| format!("`{name}`")).join(", ");
+            let names = names
+                .iter()
+                .format_with(", ", |name, f| f(&format_args!("`{name}`")));
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Possible use of deprecated {kind}{plural}: {names}"
             ));

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use compact_str::CompactString;
 use itertools::Itertools;
-use ruff_db::diagnostic::{Annotation, Span};
+use ruff_db::diagnostic::{Annotation, Span, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
@@ -10154,8 +10154,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Report the distinct deprecated targets of one operation in a single diagnostic.
-    /// Deduplicate by source function or overload, retaining separate source annotations for
-    /// distinct declarations. Include their messages in the primary annotation for concise output.
+    /// Deduplicate by source function or overload. Put multiple deprecation messages in separate
+    /// subdiagnostics with their declarations so each message's prose and line breaks remain
+    /// readable. Concise output includes only the number of deprecated targets in that case.
     fn report_deprecated_functions(
         &self,
         ranged: impl Ranged,
@@ -10175,37 +10176,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 "function"
             };
-            builder.into_diagnostic(format_args!(
+            let mut diagnostic = builder.into_diagnostic(format_args!(
                 "The {kind} `{}` is deprecated",
                 first.name(db)
-            ))
+            ));
+            if let Some(message) = first
+                .deprecated(db)
+                .and_then(|deprecated| deprecated.message)
+            {
+                diagnostic.set_primary_annotation_message(message.value(db));
+            }
+            diagnostic
         } else {
-            let mut diagnostic = builder.into_diagnostic("Use of deprecated functions");
+            let mut diagnostic = builder.into_diagnostic(format_args!(
+                "Use of {} deprecated functions",
+                functions.len()
+            ));
             for function in &functions {
-                let mut annotation = Annotation::secondary(function.spans(db).name);
-                if let Some(message) = function
+                let message = function
                     .deprecated(db)
                     .and_then(|deprecated| deprecated.message)
-                {
-                    annotation = annotation.message(message.value(db));
-                }
-                diagnostic.annotate(annotation);
+                    .map(|message| message.value(db))
+                    .filter(|message| !message.is_empty())
+                    .unwrap_or("Deprecated function defined here");
+                let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, message);
+                sub.annotate(Annotation::primary(function.spans(db).name));
+                diagnostic.sub(sub);
             }
             diagnostic
         };
-        let messages = functions
-            .iter()
-            .filter_map(|function| {
-                function
-                    .deprecated(db)
-                    .and_then(|deprecated| deprecated.message)
-            })
-            .map(|message| message.value(db))
-            .unique()
-            .join("; ");
-        if !messages.is_empty() {
-            diagnostic.set_primary_annotation_message(messages);
-        }
         diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -127,12 +127,12 @@ use crate::types::{
     CallableTypes, ClassType, DynamicType, GeneratorTypeMode, InferenceFlags,
     InternedConstraintSet, InternedType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, KnownUnion, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy,
-    ParamSpecAttrKind, Parameter, Parameters, ProgramEnvironment, SentinelInstance, Signature,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypingModule,
-    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
-    extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
-    is_discarded_dict_key_assignment, todo_type,
+    ParamSpecAttrKind, Parameter, Parameters, ProgramEnvironment, PropertyDeprecations,
+    SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type, TypeAliasType,
+    TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind,
+    TypeVarVariance, TypingModule, UnionAccumulator, UnionBuilder, UnionType, any_over_type,
+    binding_type, extract_fixed_length_iterable_element_types, infer_complete_scope_types,
+    infer_scope_types, is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, DisplaySettings, FxIndexSet, FxOrderSet, SemanticModel};
 use ty_python_core::definition::{
@@ -10220,7 +10220,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
     }
 
-    /// Check the accessor invoked by an attribute operation, using the property descriptors
+    /// Check the accessor invoked by an attribute operation, using the deprecations
     /// retained by member lookup or assignment validation. `access` describes the operation,
     /// which may differ from the AST context: an augmented assignment also reads its target.
     ///
@@ -10243,46 +10243,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn check_deprecated_property(
         &self,
         attribute: &ast::ExprAttribute,
-        member: Type<'db>,
+        properties: PropertyDeprecations<'db>,
         access: ExprContext,
     ) {
-        /// Represent absent accessors and non-property members as `Unknown` to retain
-        /// non-deprecated intersection alternatives.
-        fn accessors<'db>(
-            db: &'db dyn Db,
-            env: &ProgramEnvironment<'db>,
-            ty: Type<'db>,
-            access: ExprContext,
-        ) -> Type<'db> {
-            match ty {
-                Type::PropertyInstance(property) => match access {
-                    ExprContext::Load => property.getter(db),
-                    ExprContext::Store => property.setter(db),
-                    ExprContext::Del => property.deleter(db),
-                    ExprContext::Invalid => None,
-                }
-                .unwrap_or_else(Type::unknown),
-                Type::Union(union) => union.map(db, env, |ty| accessors(db, env, *ty, access)),
-                Type::Intersection(intersection) => {
-                    intersection.map_positive(db, env, |ty| accessors(db, env, *ty, access))
-                }
-                _ => Type::unknown(),
-            }
-        }
-
-        if !self.context.is_lint_enabled(&diagnostic::DEPRECATED) {
-            return;
-        }
-        let db = self.db();
-        let env = self.program_environment();
-        let bindings = accessors(db, env, member, access).bindings(db, env);
         self.report_deprecated_functions(
             &attribute.attr,
-            bindings
-                .deprecated_functions(db)
-                .map(|(_, function)| function)
-                // These are accessor references, not resolved overload calls.
-                .filter(|function| !function.is_overload(db)),
+            properties.functions(self.db(), access).iter().copied(),
         );
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -52,7 +52,8 @@ use crate::reachability::{
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
 use crate::types::call::bind::{
-    ArgumentTypeContext, CheckTypesMode, OverloadSet, requires_overload_evaluation,
+    ArgumentTypeContext, CallableDescription, CheckTypesMode, OverloadSet,
+    requires_overload_evaluation,
 };
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::CallableTypeKind;
@@ -10156,7 +10157,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Report the distinct deprecated targets of one operation in a single diagnostic.
     /// Deduplicate by source function or overload. Put multiple deprecation messages in separate
     /// subdiagnostics with their declarations so each message's prose and line breaks remain
-    /// readable. Concise output includes only the number of deprecated targets in that case.
+    /// readable. The summary names the possible deprecated targets in both output formats.
     fn report_deprecated_functions(
         &self,
         ranged: impl Ranged,
@@ -10188,9 +10189,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             diagnostic
         } else {
+            let descriptions: SmallVec<[_; 1]> = functions
+                .iter()
+                .map(|function| CallableDescription::from_overload(db, *function))
+                .collect();
+            let names: SmallVec<[_; 1]> = descriptions
+                .iter()
+                .map(|description| description.name())
+                .unique()
+                .collect();
+            let kind = if descriptions
+                .iter()
+                .all(|description| description.kind() == Some("method"))
+            {
+                "method"
+            } else {
+                "function"
+            };
+            let plural = if names.len() == 1 { "" } else { "s" };
+            let names = names.iter().map(|name| format!("`{name}`")).join(", ");
             let mut diagnostic = builder.into_diagnostic(format_args!(
-                "Use of {} deprecated functions",
-                functions.len()
+                "Possible use of deprecated {kind}{plural}: {names}"
             ));
             for function in &functions {
                 let message = function

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10155,7 +10155,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Report the distinct deprecated targets of one operation in a single diagnostic.
-    /// Deduplicate by source function or overload. Put multiple deprecation messages in separate
+    /// Deduplicate by source function or overload. Keep a shared deprecation message in the
+    /// primary annotation so it appears in concise output. Put differing messages in separate
     /// subdiagnostics with their declarations so each message's prose and line breaks remain
     /// readable. The summary names the possible deprecated targets in both output formats.
     fn report_deprecated_functions(
@@ -10171,23 +10172,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Some(builder) = self.context.report_lint(&diagnostic::DEPRECATED, ranged) else {
             return;
         };
+        let shared_message = functions
+            .iter()
+            .filter_map(|function| function.deprecated(db)?.message)
+            .map(|message| message.value(db))
+            .filter(|message| !message.is_empty())
+            .all_equal_value()
+            .ok();
         let mut diagnostic = if functions.len() == 1 {
             let kind = if first.is_overload(db) {
                 "overload of"
             } else {
                 "function"
             };
-            let mut diagnostic = builder.into_diagnostic(format_args!(
+            builder.into_diagnostic(format_args!(
                 "The {kind} `{}` is deprecated",
                 first.name(db)
-            ));
-            if let Some(message) = first
-                .deprecated(db)
-                .and_then(|deprecated| deprecated.message)
-            {
-                diagnostic.set_primary_annotation_message(message.value(db));
-            }
-            diagnostic
+            ))
         } else {
             let mut names = FxOrderSet::default();
             let mut all_methods = true;
@@ -10205,6 +10206,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 "Possible use of deprecated {kind}{plural}: {names}"
             ));
             for function in &functions {
+                if shared_message.is_some() {
+                    diagnostic.annotate(Annotation::secondary(function.spans(db).name));
+                    continue;
+                }
                 let message = function
                     .deprecated(db)
                     .and_then(|deprecated| deprecated.message)
@@ -10217,6 +10222,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             diagnostic
         };
+        if let Some(message) = shared_message {
+            diagnostic.set_primary_annotation_message(message);
+        }
         diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -150,7 +150,7 @@ impl<'db> AttributeDeprecation<'db> {
                         ..
                     },
                 ..
-            } if let Some(properties) = descriptor_ty.property_deprecations(db, env) => {
+            } if let Some(properties) = descriptor_ty.property_deprecations(db) => {
                 Self::Deprecated(properties)
             }
             AttributeWriteRequirement::Instance {

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -17,8 +17,8 @@ use crate::types::diagnostic::{
     report_possibly_missing_attribute,
 };
 use crate::types::{
-    CallDunderError, DisplaySettings, IntersectionType, MemberLookupPolicy, Type, TypeContext,
-    TypeQualifiers, UnionType,
+    CallDunderError, DisplaySettings, MemberLookupPolicy, PropertyDeprecations, Type, TypeContext,
+    TypeQualifiers,
 };
 use crate::{Db, ProgramEnvironment};
 
@@ -99,8 +99,8 @@ enum AttributeDeprecation<'db> {
     Missing,
     /// A non-deprecated member can provide the implementation in an intersection.
     NotDeprecated,
-    /// Property descriptors whose accessor deprecations are checked at the assignment site.
-    Deprecated(Type<'db>),
+    /// Accessor deprecations checked at the assignment site.
+    Deprecated(PropertyDeprecations<'db>),
 }
 
 impl<'db> AttributeDeprecation<'db> {
@@ -116,22 +116,15 @@ impl<'db> AttributeDeprecation<'db> {
             AttributeWriteRequirement::All { element_tys, .. } => {
                 element_tys.iter().fold(Self::Missing, |deprecation, ty| {
                     let requirement = attribute_write_requirement(db, env, *ty, attribute);
-                    deprecation.union(
-                        db,
-                        env,
-                        Self::from_requirement(db, env, &requirement, attribute),
-                    )
+                    deprecation.union(db, Self::from_requirement(db, env, &requirement, attribute))
                 })
             }
             AttributeWriteRequirement::Any { intersection, .. } => {
                 let mut deprecation = Self::Missing;
                 for ty in intersection.positive(db) {
                     let requirement = attribute_write_requirement(db, env, *ty, attribute);
-                    deprecation = deprecation.intersection(
-                        db,
-                        env,
-                        Self::from_requirement(db, env, &requirement, attribute),
-                    );
+                    deprecation = deprecation
+                        .intersection(db, Self::from_requirement(db, env, &requirement, attribute));
                     if matches!(deprecation, Self::NotDeprecated) {
                         break;
                     }
@@ -157,7 +150,9 @@ impl<'db> AttributeDeprecation<'db> {
                         ..
                     },
                 ..
-            } if descriptor_ty.has_deprecated_property(db) => Self::Deprecated(*descriptor_ty),
+            } if let Some(properties) = descriptor_ty.property_deprecations(db, env) => {
+                Self::Deprecated(properties)
+            }
             AttributeWriteRequirement::Instance {
                 member: InstanceAttributeWriteMember::SetAttr,
                 ..
@@ -172,10 +167,10 @@ impl<'db> AttributeDeprecation<'db> {
     }
 
     /// A union can invoke either target, so either target can contribute a deprecation.
-    fn union(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, other: Self) -> Self {
+    fn union(self, db: &'db dyn Db, other: Self) -> Self {
         match (self, other) {
             (Self::Deprecated(left), Self::Deprecated(right)) => {
-                Self::Deprecated(UnionType::from_two_elements(db, env, left, right))
+                Self::Deprecated(left.union(db, right))
             }
             (deprecated @ Self::Deprecated(_), _) | (_, deprecated @ Self::Deprecated(_)) => {
                 deprecated
@@ -187,11 +182,11 @@ impl<'db> AttributeDeprecation<'db> {
 
     /// An intersection can use a non-deprecated member instead, but an absent member cannot
     /// provide an alternative implementation.
-    fn intersection(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, other: Self) -> Self {
+    fn intersection(self, db: &'db dyn Db, other: Self) -> Self {
         match (self, other) {
             (Self::NotDeprecated, _) | (_, Self::NotDeprecated) => Self::NotDeprecated,
             (Self::Deprecated(left), Self::Deprecated(right)) => {
-                Self::Deprecated(IntersectionType::from_two_elements(db, env, left, right))
+                Self::Deprecated(left.intersection(db, right))
             }
             (Self::Missing, other) | (other, Self::Missing) => other,
         }
@@ -311,7 +306,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         deprecation.as_ref().map(|_| &mut current),
                     );
                     if let Some(deprecation) = deprecation.as_deref_mut() {
-                        *deprecation = deprecation.union(db, env, current);
+                        *deprecation = deprecation.union(db, current);
                     }
                     valid
                 });
@@ -319,7 +314,6 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     *deprecation = requirements.fold(*deprecation, |deprecation, requirement| {
                         deprecation.union(
                             db,
-                            env,
                             AttributeDeprecation::from_requirement(
                                 db,
                                 env,
@@ -358,7 +352,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         deprecation.as_ref().map(|_| &mut current),
                     );
                     if let Some(deprecation) = deprecation.as_deref_mut() {
-                        *deprecation = deprecation.intersection(db, env, current);
+                        *deprecation = deprecation.intersection(db, current);
                     }
                     valid
                 });
@@ -368,7 +362,6 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     {
                         *deprecation = deprecation.intersection(
                             db,
-                            env,
                             AttributeDeprecation::from_requirement(
                                 db,
                                 env,

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -53,14 +53,11 @@ fn property_deprecations_do_not_infer_accessor_signatures() -> anyhow::Result<()
                 .is_empty()
         );
 
-        [getter, setter]
-            .into_iter()
-            .map(|ty| {
-                ty.as_function_literal()
-                    .map(|function| function.as_id())
-                    .ok_or_else(|| anyhow::anyhow!("expected an accessor function"))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?
+        let [Type::FunctionLiteral(getter), Type::FunctionLiteral(setter)] = [getter, setter]
+        else {
+            anyhow::bail!("expected accessor functions");
+        };
+        [getter.as_id(), setter.as_id()]
     };
     let events = db.take_salsa_events();
     for accessor in accessor_ids {

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::db::tests::{TestDbBuilder, setup_db};
 use crate::place::{global_symbol, typing_extensions_symbol, typing_symbol};
+use crate::types::call::bind::CallableDescription;
 use crate::types::type_alias::PEP695TypeAliasType;
 use crate::{Db, ProgramEnvironment};
 use ruff_db::files::system_path_to_file;
@@ -47,6 +48,14 @@ fn property_deprecations_do_not_infer_accessor_signatures() -> anyhow::Result<()
             .property_deprecations(&db)
             .ok_or_else(|| anyhow::anyhow!("expected a deprecated getter"))?;
         assert_eq!(deprecations.functions(&db, ast::ExprContext::Load).len(), 1);
+        assert_eq!(
+            CallableDescription::from_overload(
+                &db,
+                deprecations.functions(&db, ast::ExprContext::Load)[0],
+            )
+            .name(),
+            "getter"
+        );
         assert!(
             deprecations
                 .functions(&db, ast::ExprContext::Store)

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -1,11 +1,14 @@
 use super::*;
 use crate::db::tests::{TestDbBuilder, setup_db};
-use crate::place::{typing_extensions_symbol, typing_symbol};
+use crate::place::{global_symbol, typing_extensions_symbol, typing_symbol};
 use crate::types::type_alias::PEP695TypeAliasType;
 use crate::{Db, ProgramEnvironment};
+use ruff_db::files::system_path_to_file;
 use ruff_db::system::DbWithWritableSystem as _;
+use ruff_db::testing::assert_function_query_was_not_run_by_name;
 use ruff_python_ast as ast;
 use ruff_python_ast::PythonVersion;
+use salsa::plumbing::AsId;
 use test_case::test_case;
 use ty_python_core::program::Program;
 use ty_python_core::{ProgramFile, TestProgramDb as _};
@@ -17,6 +20,58 @@ fn member_lookup_result_size() {
         size_of::<MemberLookupResult<'_>>(),
         size_of::<Result<PlaceAndQualifiers<'_>, MemberLookupError<'_>>>(),
     );
+}
+
+#[test]
+fn property_deprecations_do_not_infer_accessor_signatures() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/accessors.py",
+        r#"
+        from typing_extensions import deprecated
+
+        @deprecated("old getter")
+        def getter(self: object) -> int: ...
+
+        def setter(self: object, value: int) -> None: ...
+        "#,
+    )?;
+    let accessor_ids = {
+        let file = system_path_to_file(&db, "/src/accessors.py")?;
+        let env = db.program_environment();
+        let file = ProgramFile::new(&db, file, env.program(&db));
+        let getter = global_symbol(&db, file, "getter").place.expect_type();
+        let setter = global_symbol(&db, file, "setter").place.expect_type();
+        let property = PropertyInstanceType::new(&db, Some(getter), Some(setter), None);
+        let deprecations = Type::PropertyInstance(property)
+            .property_deprecations(&db)
+            .ok_or_else(|| anyhow::anyhow!("expected a deprecated getter"))?;
+        assert_eq!(deprecations.functions(&db, ast::ExprContext::Load).len(), 1);
+        assert!(
+            deprecations
+                .functions(&db, ast::ExprContext::Store)
+                .is_empty()
+        );
+
+        [getter, setter]
+            .into_iter()
+            .map(|ty| {
+                ty.as_function_literal()
+                    .map(|function| function.as_id())
+                    .ok_or_else(|| anyhow::anyhow!("expected an accessor function"))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?
+    };
+    let events = db.take_salsa_events();
+    for accessor in accessor_ids {
+        assert_function_query_was_not_run_by_name(
+            &db,
+            "FunctionType < 'db >::signature_",
+            Some(accessor),
+            &events,
+        );
+    }
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

We now report deprecated property accessors when both members of an intersection provide a deprecated getter, setter, or deleter. The warning includes both messages and points to both declarations. A non-deprecated alternative still suppresses the warning for that accessor.

We retain the deprecated accessor functions separately from the descriptor types: intersecting two distinct property objects can simplify to `Never`, which previously discarded both deprecations.

Follow-up to #28134, addressing [the intersection-property review comment](https://github.com/astral-sh/ruff/pull/28134#discussion_r3913675442).
