### PR TITLE
[ty] Report deprecations for implicit constructor calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -1156,6 +1156,94 @@ def check(integer: C[int], string: C[str]):
     string.method("one")  # error: [deprecated] "string method"
 ```
 
+## Deprecated constructors
+
+Calling a class implicitly invokes its constructor methods. A deprecated `__init__` or `__new__`
+produces a warning even when the class itself is not deprecated.
+
+```py
+from typing_extensions import Self, deprecated
+
+class OldInit:
+    @deprecated("old init")
+    def __init__(self) -> None: ...
+
+class OldNew:
+    @deprecated("old new")
+    def __new__(cls) -> Self:
+        return super().__new__(cls)
+
+OldInit()  # error: [deprecated] "old init"
+OldNew()  # error: [deprecated] "old new"
+```
+
+Explicit references and calls still report the constructor's deprecation only once.
+
+```py
+OldInit.__init__  # error: [deprecated] "old init"
+OldNew.__new__(OldNew)  # error: [deprecated] "old new"
+```
+
+An active `__new__` does not hide a deprecated `__init__`, including an inherited initializer.
+
+```py
+class NewWithOldInit(OldInit):
+    def __new__(cls) -> Self:
+        return super().__new__(cls)
+
+NewWithOldInit()  # error: [deprecated] "old init"
+```
+
+If both constructor methods are deprecated, one warning includes both messages.
+
+```py
+class Both(OldNew, OldInit): ...
+
+# snapshot: deprecated
+Both()
+```
+
+```snapshot
+warning[deprecated]: Use of deprecated functions
+  --> src/mdtest_snippet.py:24:1
+   |
+24 | Both()
+   | ^^^^ old new; old init
+   |
+  ::: src/mdtest_snippet.py:5:9
+   |
+ 5 |     def __init__(self) -> None: ...
+   |         -------- old init
+ 6 |
+ 7 | class OldNew:
+ 8 |     @deprecated("old new")
+ 9 |     def __new__(cls) -> Self:
+   |         ------- old new
+```
+
+When `__new__` returns an unrelated type, `__init__` does not run and produces no warning.
+
+```py
+class ReturnsInt(OldInit):
+    def __new__(cls) -> int:
+        return 0
+
+ReturnsInt()
+```
+
+A deprecated metaclass `__call__` also warns when invoked implicitly by constructing a class.
+
+```py
+class Meta(type):
+    @deprecated("metaclass call")
+    def __call__(cls) -> int:
+        return 0
+
+class WithMeta(metaclass=Meta): ...
+
+WithMeta()  # error: [deprecated] "metaclass call"
+```
+
 ## Calls to an inherited deprecated method
 
 When both union members inherit the same deprecated method, a call reports that method once.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -893,14 +893,32 @@ impl<'db> Bindings<'db> {
         self.implicit_dunder_init_is_possibly_unbound
     }
 
-    /// Returns the deprecated functions invoked by each union alternative, including active
-    /// downstream constructor methods. An intersection
-    /// only reports deprecations if every member that could implement the call is deprecated.
+    /// Returns the deprecated functions invoked by each union alternative, including downstream
+    /// constructor methods. An intersection only reports deprecations if every member that could
+    /// implement the call is deprecated.
     /// The same source can appear in multiple alternatives; callers deduplicate per expression.
+    ///
+    /// For call-site diagnostics, finalize argument inference first so skipped constructor
+    /// methods have been removed. For example, this call does not invoke the deprecated initializer:
+    ///
+    /// ```python
+    /// from typing_extensions import deprecated
+    ///
+    /// class C:
+    ///     def __new__(cls) -> int:
+    ///         return 0
+    ///
+    ///     @deprecated("old initializer")
+    ///     def __init__(self) -> None: ...
+    ///
+    /// C()  # No initializer deprecation: `__new__` returns an unrelated type.
+    /// ```
     pub(crate) fn deprecated_functions(
         &self,
         db: &'db dyn Db,
     ) -> impl Iterator<Item = (&CallableBinding<'db>, OverloadLiteral<'db>)> {
+        /// Append deprecations without discarding earlier union alternatives when a
+        /// non-deprecated intersection member suppresses the current alternative's warnings.
         fn collect<'a, 'db>(
             db: &'db dyn Db,
             bindings: &'a Bindings<'db>,
@@ -916,7 +934,6 @@ impl<'db> Bindings<'db> {
                             .deprecated_functions(db)
                             .map(|function| (callable, function)),
                     );
-                    // Finalized bindings retain only downstream constructors that can run.
                     if let Some(constructor) = item.as_constructor()
                         && let Some(downstream) = constructor.downstream_constructor()
                     {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -893,28 +893,47 @@ impl<'db> Bindings<'db> {
         self.implicit_dunder_init_is_possibly_unbound
     }
 
-    /// Returns the deprecated functions invoked by each union alternative. An intersection
+    /// Returns the deprecated functions invoked by each union alternative, including active
+    /// downstream constructor methods. An intersection
     /// only reports deprecations if every member that could implement the call is deprecated.
     /// The same source can appear in multiple alternatives; callers deduplicate per expression.
     pub(crate) fn deprecated_functions(
         &self,
         db: &'db dyn Db,
     ) -> impl Iterator<Item = (&CallableBinding<'db>, OverloadLiteral<'db>)> {
-        self.elements
-            .iter()
-            .map(BindingsElement::callables)
-            .filter(move |callables| {
-                callables
-                    .clone()
-                    .all(|callable| callable.deprecated_functions(db).next().is_some())
-            })
-            .flat_map(move |callables| {
-                callables.flat_map(move |callable| {
-                    callable
-                        .deprecated_functions(db)
-                        .map(move |function| (callable, function))
-                })
-            })
+        fn collect<'a, 'db>(
+            db: &'db dyn Db,
+            bindings: &'a Bindings<'db>,
+            functions: &mut SmallVec<[(&'a CallableBinding<'db>, OverloadLiteral<'db>); 1]>,
+        ) {
+            for element in &bindings.elements {
+                let start = functions.len();
+                for item in &element.items {
+                    let item_start = functions.len();
+                    let callable = item.callable();
+                    functions.extend(
+                        callable
+                            .deprecated_functions(db)
+                            .map(|function| (callable, function)),
+                    );
+                    // Finalized bindings retain only downstream constructors that can run.
+                    if let Some(constructor) = item.as_constructor()
+                        && let Some(downstream) = constructor.downstream_constructor()
+                    {
+                        collect(db, downstream, functions);
+                    }
+                    if functions.len() == item_start {
+                        // This intersection member provides a non-deprecated alternative.
+                        functions.truncate(start);
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut functions = SmallVec::new();
+        collect(db, self, &mut functions);
+        functions.into_iter()
     }
 
     /// Returns an iterator over all `CallableBinding`s, flattening the two-level structure.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9512,9 +9512,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings
                 .deprecated_functions(db)
                 // Explicit function references already report implementation deprecations.
-                // Calling an instance instead references the object, not its `__call__` method.
-                .filter(|(binding, function)| {
-                    function.is_overload(db) || binding.callable_type != binding.signature_type
+                // Other calls reference an object or class, not the implicitly invoked method.
+                .filter(|(_, function)| {
+                    function.is_overload(db)
+                        || !matches!(
+                            callable_type,
+                            Type::FunctionLiteral(_) | Type::BoundMethod(_)
+                        )
                 })
                 .map(|(_, function)| function),
         );

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -9507,20 +9507,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
+        // Explicit function references already report implementation deprecations.
+        // Other calls reference an object or class, not the implicitly invoked method.
+        let is_function_reference = matches!(
+            callable_type,
+            Type::FunctionLiteral(_) | Type::BoundMethod(_)
+        );
         self.report_deprecated_functions(
             func.as_ref(),
             bindings
                 .deprecated_functions(db)
-                // Explicit function references already report implementation deprecations.
-                // Other calls reference an object or class, not the implicitly invoked method.
-                .filter(|(_, function)| {
-                    function.is_overload(db)
-                        || !matches!(
-                            callable_type,
-                            Type::FunctionLiteral(_) | Type::BoundMethod(_)
-                        )
-                })
-                .map(|(_, function)| function),
+                .map(|(_, function)| function)
+                .filter(|function| function.is_overload(db) || !is_function_reference),
         );
 
         if let Some(class) = class {


### PR DESCRIPTION
## Summary

We now report deprecations on implicitly invoked `__init__`, `__new__`, and metaclass `__call__` methods. Previously, calling a class could miss a constructor's deprecation even though an explicit reference to that method reported it:

```python
from typing_extensions import deprecated

class C:
    @deprecated("Use another constructor")
    def __init__(self) -> None: ...

C()  # Now reports the deprecated initializer.
```

We collect deprecations throughout the active constructor chain, including inherited initializers. If `__new__` returns an unrelated type, the skipped initializer produces no warning. Multiple deprecated constructor methods produce one diagnostic, and explicit method references continue to report only once.

Follow-up to #28134, addressing [the implicit-constructor review comment](https://github.com/astral-sh/ruff/pull/28134#discussion_r3913844052).
