### PR TITLE
[ty] Resolve dependencies within correlated inference alternatives

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -10127,6 +10127,66 @@ def swap(value: int | str) -> int | str:
     }
 
     #[test]
+    fn generic_callback_resolves_dependencies_per_alternative() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+from typing import Callable, overload
+
+class A: ...
+class B: ...
+a: A
+b: B
+
+def infer_result[T, R](callback: Callable[[T], R], consumer: Callable[[T], None]) -> R:
+    raise NotImplementedError
+
+def identity[T](value: T) -> T:
+    return value
+
+@overload
+def consume(value: A) -> None: ...
+@overload
+def consume(value: B) -> None: ...
+def consume(value: A | B) -> None: ...
+"#,
+        )?;
+        let db = &db;
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        let callable = global_symbol(db, file, "infer_result").place.expect_type();
+        let callback = global_symbol(db, file, "identity").place.expect_type();
+        let consumer = global_symbol(db, file, "consume").place.expect_type();
+        let inference = call_inference(db, callable, [callback, consumer], TypeContext::default())?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("expected correlated alternatives");
+        };
+        let a = global_symbol(db, file, "a").place.expect_type();
+        let b = global_symbol(db, file, "b").place.expect_type();
+
+        // The callback relates R to T. Each consumer overload selects a different T, and
+        // resolving R within that alternative preserves the relationship between them.
+        assert_eq!(
+            paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+            FxHashSet::from_iter([
+                [Some(Resolved(a)); 2].as_slice(),
+                [Some(Resolved(b)); 2].as_slice(),
+            ])
+        );
+        let union = UnionType::from_two_elements(db, &env, a, b);
+        assert!(
+            inference
+                .merged_specialization(db)
+                .types(db)
+                .iter()
+                .all(|ty| ty.is_equivalent_to(db, &env, union))
+        );
+        Ok(())
+    }
+
+    #[test]
     fn contextual_preference_preserves_incomplete_inference() -> anyhow::Result<()> {
         let mut db = setup_db();
         db.write_dedented(

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -10053,6 +10053,7 @@ mod tests {
 
     use crate::db::tests::{TestDb, setup_db};
     use crate::place::global_symbol;
+    use crate::types::constraints::resolution::SolutionType::Resolved;
     use crate::types::generics::TypeVarInferenceSolutions;
 
     fn call_inference<'db>(
@@ -10118,8 +10119,8 @@ def swap(value: int | str) -> int | str:
         assert_eq!(
             paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
             FxHashSet::from_iter([
-                [Some(int), Some(str)].as_slice(),
-                [Some(str), Some(int)].as_slice(),
+                [Some(Resolved(int)), Some(Resolved(str))].as_slice(),
+                [Some(Resolved(str)), Some(Resolved(int))].as_slice(),
             ])
         );
         Ok(())
@@ -10164,7 +10165,7 @@ expected: tuple[list[object], A | B, C | D | E]
         };
         assert_eq!(
             paths.iter().map(AsRef::as_ref).collect::<Vec<_>>(),
-            [[Some(Type::object()), None].as_slice()]
+            [[Some(Resolved(Type::object())), None].as_slice()]
         );
         Ok(())
     }

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -118,6 +118,7 @@ use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet, ProgramEnvironment};
 
 pub(crate) mod paths;
 pub(crate) mod projection;
+pub(crate) mod resolution;
 mod sequents;
 mod solutions;
 mod support;

--- a/crates/ty_python_semantic/src/types/constraints/projection.rs
+++ b/crates/ty_python_semantic/src/types/constraints/projection.rs
@@ -15,6 +15,7 @@ pub(crate) struct SolutionBudget {
     /// Interior and terminal visits, shared by preprocessing and path collection.
     pub(crate) visits: usize,
     /// Set-theoretic terms contributed to the result, including terms exposed by aliases.
+    /// Also bounds storage when retaining alternatives.
     pub(crate) type_terms: usize,
 }
 

--- a/crates/ty_python_semantic/src/types/constraints/resolution.rs
+++ b/crates/ty_python_semantic/src/types/constraints/resolution.rs
@@ -1,0 +1,451 @@
+//! Resolve dependencies between the selected bindings of one solution alternative.
+
+use std::cell::{Cell, RefCell};
+
+use rustc_hash::FxHashMap;
+
+use super::TypeVarSolution;
+use crate::types::cyclic::CycleDetector;
+use crate::types::function::FunctionType;
+use crate::types::generics::{ApplySpecialization, GenericContext};
+use crate::types::known_instance::walk_known_instance_type;
+use crate::types::signatures::{Signature, walk_signature};
+use crate::types::typevar::{BoundTypeVarIdentity, TypeVarSet};
+use crate::types::visitor::{TypeKind, TypeVisitor, walk_non_atomic_type};
+use crate::types::{
+    BoundTypeVarInstance, CallableType, KnownInstanceType, Type, TypeAliasType, TypeContext,
+    TypeMapping,
+};
+use crate::{Db, FxOrderMap, ProgramEnvironment};
+
+/// Whether a selected type is independent of the other inferable variables in its alternative.
+///
+/// This does not describe budget completeness or apply defaults to variables without evidence.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(crate) enum SolutionType<'db> {
+    Resolved(Type<'db>),
+    /// The original selected type, retained when dependencies are missing, cyclic, or cannot be
+    /// substituted through a type form that preserves captured references.
+    Unresolved(Type<'db>),
+}
+
+/// Resolves only dependencies with selected, acyclic solutions. The result has the same order as
+/// `solution`; references outside `inferable` retain their original bound-variable identity.
+pub(crate) fn resolve_solution<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    inferable: TypeVarSet<'db>,
+    solution: &[TypeVarSolution<'db>],
+) -> Box<[SolutionType<'db>]> {
+    let resolver = Resolver {
+        env,
+        inferable,
+        solution,
+        indices: solution
+            .iter()
+            .enumerate()
+            .map(|(index, binding)| (binding.bound_typevar.identity(db), index))
+            .collect(),
+        resolved: CycleDetector::new(None),
+    };
+    solution
+        .iter()
+        .enumerate()
+        .map(|(index, binding)| {
+            resolver.resolve(db, index).map_or(
+                SolutionType::Unresolved(binding.solution),
+                SolutionType::Resolved,
+            )
+        })
+        .collect()
+}
+
+struct ResolveBinding;
+
+struct Resolver<'a, 'db> {
+    env: &'a ProgramEnvironment<'db>,
+    inferable: TypeVarSet<'db>,
+    solution: &'a [TypeVarSolution<'db>],
+    indices: FxHashMap<BoundTypeVarIdentity<'db>, usize>,
+    resolved: CycleDetector<'db, ResolveBinding, Type<'db>, Option<Type<'db>>, 3>,
+}
+
+impl<'db> Resolver<'_, 'db> {
+    fn resolve(&self, db: &'db dyn Db, index: usize) -> Option<Type<'db>> {
+        let binding = &self.solution[index];
+        self.resolved
+            .visit(db, Type::TypeVar(binding.bound_typevar), || {
+                let original = binding.solution;
+                let replacements = RefCell::new(FxOrderMap::default());
+                if !Dependencies::check(db, self.env, self.inferable, original, |dependency| {
+                    let Some(&index) = self.indices.get(&dependency.identity(db)) else {
+                        return false;
+                    };
+                    let Some(ty) = self.resolve(db, index) else {
+                        return false;
+                    };
+                    replacements.borrow_mut().insert(index, ty);
+                    true
+                }) {
+                    return None;
+                }
+                let replacements = replacements.into_inner();
+                if replacements.is_empty() {
+                    return Some(original);
+                }
+
+                // Every replacement is already closed. One simultaneous substitution therefore
+                // suffices, and never substitutes a cycle with an arbitrary representative.
+                let context = GenericContext::from_typevar_instances(
+                    db,
+                    self.env,
+                    replacements
+                        .keys()
+                        .map(|index| self.solution[*index].bound_typevar),
+                );
+                let types: Vec<_> = replacements.values().copied().collect();
+                let mapped = original.apply_type_mapping(
+                    db,
+                    self.env,
+                    &TypeMapping::ApplySpecialization(ApplySpecialization::Partial {
+                        generic_context: context,
+                        types: &types,
+                        skip: None,
+                    }),
+                    TypeContext::default(),
+                );
+                // Some type forms preserve captured variables when specialized. For example, an
+                // alias changes its explicit arguments but can retain a free variable in its body.
+                // Verify closure on the actual result without performing further substitutions.
+                Dependencies::check(db, self.env, self.inferable, mapped, |_| false)
+                    .then_some(mapped)
+            })
+    }
+}
+
+struct VisitDependencies;
+
+/// Visits occurrences of inferable variables, leaving their declarations' bounds and defaults alone.
+struct Dependencies<'a, 'db> {
+    env: &'a ProgramEnvironment<'db>,
+    inferable: TypeVarSet<'db>,
+    query: &'a dyn Fn(BoundTypeVarInstance<'db>) -> bool,
+    satisfied: Cell<bool>,
+    visited: CycleDetector<'db, VisitDependencies, Type<'db>, (), 3>,
+}
+
+impl<'db> Dependencies<'_, 'db> {
+    fn check(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        inferable: TypeVarSet<'db>,
+        ty: Type<'db>,
+        query: impl Fn(BoundTypeVarInstance<'db>) -> bool,
+    ) -> bool {
+        let visitor = Dependencies {
+            env,
+            inferable,
+            query: &query,
+            satisfied: Cell::new(true),
+            visited: CycleDetector::new(()),
+        };
+        visitor.visit_type(db, ty);
+        visitor.satisfied.get()
+    }
+
+    fn signature(&self, db: &'db dyn Db, signature: &Signature<'db>) {
+        walk_signature(db, signature, self);
+        for parameter in signature.parameters() {
+            if let Some(default) = parameter.eager_default_type() {
+                self.visit_type(db, default);
+            }
+        }
+    }
+}
+
+impl<'db> TypeVisitor<'db> for Dependencies<'_, 'db> {
+    fn program_environment(&self) -> &ProgramEnvironment<'db> {
+        self.env
+    }
+
+    fn should_visit_lazy_type_attributes(&self) -> bool {
+        false
+    }
+
+    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+        if !self.satisfied.get() {
+            return;
+        }
+        // Recursive specialization can introduce dependencies in an alias's changing arguments.
+        // Inspect them even when the recursion guard skips another visit to the alias's body.
+        if let Type::TypeAlias(alias) = ty
+            && let Some(specialization) = alias.specialization(db)
+        {
+            for argument in specialization.types(db) {
+                self.visit_type(db, *argument);
+            }
+        }
+        if let Type::TypeVar(typevar) = ty {
+            if typevar.is_inferable(db, self.inferable) {
+                self.satisfied.set((self.query)(typevar));
+            }
+        } else if let TypeKind::NonAtomic(non_atomic) = TypeKind::from(ty) {
+            // Revisiting a recursive structural type adds no new dependencies. Binding cycles
+            // are handled separately by Resolver, where their fallback is unresolved.
+            self.visited
+                .visit(db, ty, || walk_non_atomic_type(db, non_atomic, self));
+        }
+    }
+
+    // Generic declarations are not dependencies of their specialized arguments. Actual typevar
+    // occurrences enter through `visit_type`, and their bounds and defaults remain untouched.
+    fn visit_bound_type_var_type(&self, _db: &'db dyn Db, _typevar: BoundTypeVarInstance<'db>) {}
+
+    fn visit_type_alias_type(&self, db: &'db dyn Db, alias: TypeAliasType<'db>) {
+        self.visit_type(db, alias.value_type(db));
+    }
+
+    fn visit_function_type(&self, db: &'db dyn Db, function: FunctionType<'db>) {
+        for signature in &function.signature(db).overloads {
+            self.signature(db, signature);
+        }
+        if function.literal(db).has_separate_implementation(db) {
+            for callable in function.implementation_callables(db).iter() {
+                self.visit_callable_type(db, *callable);
+            }
+        }
+    }
+
+    fn visit_callable_type(&self, db: &'db dyn Db, callable: CallableType<'db>) {
+        for signature in &callable.signatures(db).overloads {
+            self.signature(db, signature);
+        }
+    }
+
+    fn visit_known_instance_type(&self, db: &'db dyn Db, known: KnownInstanceType<'db>) {
+        match known {
+            KnownInstanceType::TypeAliasType(alias) => {
+                self.visit_type(db, Type::TypeAlias(alias));
+            }
+            KnownInstanceType::FunctoolsPartial(partial)
+            | KnownInstanceType::FunctoolsPartialCall(partial) => {
+                self.visit_type(db, partial.wrapped(db).inner(db));
+                self.visit_callable_type(db, partial.partial(db));
+            }
+            _ => walk_known_instance_type(db, known, self),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::DbWithWritableSystem;
+    use ruff_python_ast::name::Name;
+    use ty_python_core::ProgramFile;
+
+    use super::{SolutionType, resolve_solution};
+    use crate::db::tests::{TestDb, setup_db};
+    use crate::place::global_symbol;
+    use crate::types::constraints::TypeVarSolution;
+    use crate::types::tuple::TupleType;
+    use crate::types::typevar::TypeVarSet;
+    use crate::types::{
+        BoundTypeVarInstance, KnownClass, KnownInstanceType, Type, TypeVarVariance,
+    };
+
+    fn create_typevar<'db>(db: &'db TestDb, name: &str) -> BoundTypeVarInstance<'db> {
+        BoundTypeVarInstance::synthetic(
+            db,
+            &db.program_environment(),
+            Name::new(name),
+            TypeVarVariance::Invariant,
+        )
+    }
+
+    fn binding<'db>(
+        bound_typevar: BoundTypeVarInstance<'db>,
+        solution: Type<'db>,
+    ) -> TypeVarSolution<'db> {
+        TypeVarSolution {
+            bound_typevar,
+            solution,
+        }
+    }
+
+    #[test]
+    fn captured_alias_dependency_is_not_closed_by_its_argument() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+            class C[U]:
+                type Alias[V] = tuple[V, U]
+                type RecursiveAlias[V] = int | list[C.RecursiveAlias[tuple[V, U]]]
+            "#,
+        )?;
+        let db = &db;
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        let class = global_symbol(db, file, "C")
+            .place
+            .expect_type()
+            .as_class_literal()
+            .ok_or_else(|| anyhow::anyhow!("expected C"))?;
+        let u = class
+            .generic_context(db)
+            .and_then(|context| context.variables(db).next())
+            .ok_or_else(|| anyhow::anyhow!("expected C's U"))?;
+        let t = create_typevar(db, "T");
+        let int = KnownClass::Int.to_instance(db, &env);
+        // RecursiveAlias first exposes U in a recursive specialization's argument.
+        for (name, argument) in [("Alias", Type::TypeVar(u)), ("RecursiveAlias", int)] {
+            let alias = Type::instance(db, &env, class.identity_specialization(db))
+                .member(db, &env, name)
+                .place
+                .expect_type();
+            let Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) = alias else {
+                anyhow::bail!("expected a type alias, got {alias:?}");
+            };
+            let alias =
+                alias.apply_specialization(db, |context| context.specialize(db, vec![argument]));
+            for alias in [
+                Type::TypeAlias(alias),
+                Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)),
+            ] {
+                let resolved = resolve_solution(
+                    db,
+                    &env,
+                    TypeVarSet::from_typevars(db, [t, u]),
+                    &[binding(t, alias), binding(u, int)],
+                );
+                assert_eq!(
+                    resolved.as_ref(),
+                    [SolutionType::Unresolved(alias), SolutionType::Resolved(int)],
+                    "{name}"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn closed_recursive_alias_retains_its_identity() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+            type Tree = int | list[Tree]
+            value: Tree
+            type Growing[V] = V | list[Growing[list[V]]]
+            growing: Growing[int]
+            "#,
+        )?;
+        let db = &db;
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        let t = create_typevar(db, "T");
+        let u = create_typevar(db, "U");
+        let int = KnownClass::Int.to_instance(db, &env);
+        for name in ["value", "growing"] {
+            let tree = global_symbol(db, file, name).place.expect_type();
+            let resolved = resolve_solution(
+                db,
+                &env,
+                TypeVarSet::from_typevars(db, [t]),
+                &[binding(t, tree)],
+            );
+            assert_eq!(resolved.as_ref(), [SolutionType::Resolved(tree)]);
+
+            // A closed recursive alias does not prevent resolving an independent tuple element.
+            let pair = Type::tuple(TupleType::heterogeneous(db, &env, [tree, Type::TypeVar(u)]));
+            let expected = Type::tuple(TupleType::heterogeneous(db, &env, [tree, int]));
+            let resolved = resolve_solution(
+                db,
+                &env,
+                TypeVarSet::from_typevars(db, [t, u]),
+                &[binding(t, pair), binding(u, int)],
+            );
+            assert_eq!(
+                resolved.as_ref(),
+                [
+                    SolutionType::Resolved(expected),
+                    SolutionType::Resolved(int)
+                ]
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn partial_resolves_dependencies_in_its_wrapped_callable() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+            from typing import Callable
+
+            def wrapped[U](value: U) -> int: ...
+            reduced: Callable[[], int]
+            "#,
+        )?;
+        let db = &db;
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        let wrapped = global_symbol(db, file, "wrapped").place.expect_type();
+        let u = wrapped
+            .as_function_literal()
+            .and_then(|function| function.signature(db).overloads.first()?.generic_context)
+            .and_then(|context| context.variables(db).next())
+            .ok_or_else(|| anyhow::anyhow!("expected wrapped's U"))?;
+        let reduced = global_symbol(db, file, "reduced")
+            .place
+            .expect_type()
+            .as_callable()
+            .ok_or_else(|| anyhow::anyhow!("expected reduced callable"))?;
+        let Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) =
+            reduced.into_precise_functools_partial_instance(db, wrapped)
+        else {
+            anyhow::bail!("expected a precise partial instance");
+        };
+        let t = create_typevar(db, "T");
+        let int = KnownClass::Int.to_instance(db, &env);
+
+        // Binding the parameter removes U from the reduced signature, but .func still exposes it.
+        for partial in [
+            KnownInstanceType::FunctoolsPartial(partial),
+            KnownInstanceType::FunctoolsPartialCall(partial),
+        ] {
+            let resolved = resolve_solution(
+                db,
+                &env,
+                TypeVarSet::from_typevars(db, [t, u]),
+                &[binding(t, Type::KnownInstance(partial)), binding(u, int)],
+            );
+            let [
+                SolutionType::Resolved(Type::KnownInstance(
+                    KnownInstanceType::FunctoolsPartial(mapped)
+                    | KnownInstanceType::FunctoolsPartialCall(mapped),
+                )),
+                SolutionType::Resolved(resolved_u),
+            ] = resolved.as_ref()
+            else {
+                anyhow::bail!("expected resolved partial and U");
+            };
+            let parameter = mapped
+                .wrapped(db)
+                .inner(db)
+                .as_function_literal()
+                .and_then(|function| function.signature(db).overloads.first())
+                .and_then(|signature| signature.parameters().iter().next())
+                .ok_or_else(|| anyhow::anyhow!("expected wrapped callable's parameter"))?;
+            assert_eq!(parameter.annotated_type(), int);
+            assert_eq!(mapped.partial(db), reduced);
+            assert_eq!(*resolved_u, int);
+        }
+        Ok(())
+    }
+}

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -5126,51 +5126,6 @@ mod tests {
     }
 
     #[test]
-    fn inference_resolves_dependencies_per_alternative() -> anyhow::Result<()> {
-        let db = setup_db();
-        let db = &db;
-        let env = db.program_environment();
-        let typevars @ [t, u] = create_typevars(db, ["T", "U"]);
-        let context = GenericContext::from_typevar_instances(db, &env, typevars);
-        let constraints = ConstraintSetBuilder::new();
-        let int = KnownClass::Int.to_instance(db, &env);
-        let str = KnownClass::Str.to_instance(db, &env);
-        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
-        builder.record_constraint_set(exact_alternatives(
-            db,
-            &constraints,
-            typevars,
-            [[int, str], [str, int]],
-        ));
-
-        // Both paths select T = U, but each has its own concrete binding for U.
-        let inference = builder
-            .build_inference_with(|typevar, _| {
-                (typevar == t).then_some(PathBoundSolution::Solved(Type::TypeVar(u)))
-            })
-            .map_err(|()| anyhow::anyhow!("expected satisfiable dependency chains"))?;
-        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
-            anyhow::bail!("expected two resolved alternatives");
-        };
-        assert_eq!(
-            paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
-            FxHashSet::from_iter([
-                [Some(Resolved(int)); 2].as_slice(),
-                [Some(Resolved(str)); 2].as_slice(),
-            ])
-        );
-        assert_eq!(inference.merged_types(db)[0], Some(Type::TypeVar(u)));
-        assert!(
-            inference.merged_types(db)[1].is_some_and(|ty| ty.is_equivalent_to(
-                db,
-                &env,
-                UnionType::from_two_elements(db, &env, int, str),
-            ))
-        );
-        Ok(())
-    }
-
-    #[test]
     fn resolved_single_path_preserves_merged_projection() -> anyhow::Result<()> {
         let db = setup_db();
         let db = &db;

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -12,6 +12,7 @@ use crate::types::callable::walk_callable_type;
 use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::projection::{ProjectionError, SolutionBudget, SolutionProjection};
+use crate::types::constraints::resolution::{SolutionType, resolve_solution};
 use crate::types::constraints::{
     Constraint, ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, PathBound,
     PathBoundSolution, PathBounds, SolutionPaths, Solutions, TypeVarSolution,
@@ -2520,24 +2521,28 @@ impl<'db> TypeVarInference<'db> {
 /// `list[int] | None` with `list[T]`. A complete solve of the resulting constraints does not imply
 /// that the original argument is assignable to the parameter.
 ///
-/// Each alternative stores types in the generic context's variable order, like `merged_types`,
-/// with `None` when no evidence selects a type. Completeness means all retained paths were solved
-/// without budget-exhaustion fallback, not that every variable has an inferred type. Defaults for
-/// variables without evidence are applied only when a consumer creates a specialization.
+/// Each alternative stores bindings in the generic context's variable order, with `None` when
+/// no evidence selects a type. References to inferable variables are resolved within each path,
+/// without applying defaults. A binding is unresolved if it depends on missing evidence or a
+/// cycle; references to outer, non-inferable variables preserve their identity.
+///
+/// Completeness means all retained paths were solved without budget-exhaustion fallback, not
+/// that every variable has a resolved binding. Defaults are applied only when a consumer creates
+/// a specialization.
 ///
 /// If a retained path exhausts its budget, the family is incomplete even if its siblings were
 /// solved without fallback. Such a family cannot be treated as an exhaustive account of the
 /// constraint set's specializations.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) enum TypeVarInferenceSolutions<'db> {
-    /// The sole solution is already stored in `merged_types`.
+    /// The sole solution is already stored in `merged_types`, and every present binding is resolved.
     Single,
-    /// Two or more correlated alternatives, none relying on budget-exhaustion fallback.
-    /// A variable may still be `None` if the constraints provide no evidence for its type.
-    Alternatives(Box<[Box<[Option<Type<'db>>]>]>),
+    /// Correlated alternatives, none relying on budget-exhaustion fallback. A sole solution is
+    /// retained here when it has unresolved bindings or differs from the merged projection.
+    Alternatives(Box<[Box<[Option<SolutionType<'db>>]>]>),
     /// Retained alternatives, including fallback bindings from budget-exhausted solutions.
     /// Siblings solved without fallback are kept, but the family as a whole is incomplete.
-    Incomplete(Box<[Box<[Option<Type<'db>>]>]>),
+    Incomplete(Box<[Box<[Option<SolutionType<'db>>]>]>),
     /// Only a compatibility or diagnostic mapping is available, not correlated solutions.
     Unavailable(TypeVarInferenceFallback),
 }
@@ -2547,7 +2552,6 @@ pub(crate) enum TypeVarInferenceFallback {
     Unconstrained,
     Variadic,
     Unsatisfiable,
-    ExpandingCycle,
     BudgetExceeded,
 }
 
@@ -2817,7 +2821,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
         let inference =
             self.compatibility_inference_with(TypeVarInferenceFallback::Unsatisfiable, &mut choose);
-        self.finish_inference(inference)
+        self.finish_inference(inference, SolutionBudget::default())
     }
 
     /// Builds a recovery mapping from the already accumulated per-relation solutions. This must
@@ -2899,7 +2903,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
                     // Solving charges only present bindings, but context-aligned alternatives
                     // also allocate slots for unsolved variables. Bound those slots before
-                    // allocating any arrays; a complete single solution reuses `merged_types`.
+                    // allocating any arrays. A complete single solution can reuse `merged_types`;
+                    // `finish_inference` checks its storage budget if resolution changes it.
                     let solutions = if matches!(&solutions, SolutionPaths::Complete(paths) if paths.len() == 1)
                         || solutions
                             .as_slice()
@@ -2920,7 +2925,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             })
         })?;
-        Ok(self.finish_inference(inference))
+        Ok(self.finish_inference(inference, budget))
     }
 
     fn merge_solution(
@@ -3015,17 +3020,19 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
         }
 
-        // TODO: Replace this fallback with expanding-cycle detection in the constraint-set
-        // solution layer.
+        // `merged_types` is consumed by `specialize_recursive`, which substitutes bindings
+        // repeatedly. For `T = list[U], U = T`, each pass adds another `list` layer.
+        // Use the legacy type map (or `Unknown` if unavailable) for `merged_types` to avoid
+        // that infinite loop. Keep the individual alternatives in `solutions`: their
+        // dependency resolver marks `T` and `U` unresolved while preserving independent bindings.
         if types
             .iter()
             .any(|(identity, ty)| self.has_expanding_cycle(generic_context, types, *identity, *ty))
         {
-            // Recursive specialization cannot reach a fixed point when a cycle grows through an
-            // embedded generic type, such as `SupportsAdd[T, S]`.
-            return Ok(
-                self.compatibility_inference_with(TypeVarInferenceFallback::ExpandingCycle, choose)
-            );
+            inference.merged_types = self
+                .solve_hash_map_with(generic_context, &mut |typevar, bounds| {
+                    choose(typevar, bounds).and_then(PathBoundSolution::as_type)
+                });
         }
 
         Ok(inference)
@@ -3034,6 +3041,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     fn finish_inference(
         &self,
         inference: PendingInference<'db, SolutionPaths<'db>>,
+        budget: SolutionBudget,
     ) -> TypeVarInference<'db> {
         let db = self.db;
         let generic_context = self.generic_context;
@@ -3049,40 +3057,56 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
         };
         let complete = matches!(solutions, SolutionPaths::Complete(_));
-        if complete && solutions.as_slice().len() == 1 {
-            return self.typevar_inference(&types, TypeVarInferenceSolutions::Single);
-        }
+        let single = complete && solutions.as_slice().len() == 1;
 
         // The compatibility projection must be cleaned after merging, independently of these
         // alternatives: a bare `U` survives on one path, but is removed from a merged `U | int`.
         let mut paths = Vec::with_capacity(solutions.as_slice().len());
-        for path in solutions.into_vec() {
+        for mut path in solutions.into_vec() {
+            path.retain_mut(|binding| {
+                if !generic_context.contains(db, binding.bound_typevar.identity(db)) {
+                    return false;
+                }
+                binding.solution = self.remove_inferable_typevar_artifacts_from_solution(
+                    binding.bound_typevar,
+                    binding.solution,
+                );
+                true
+            });
+            let resolved = resolve_solution(db, self.env, self.inferable, &path);
             let path_types: FxHashMap<_, _> = path
-                .into_iter()
-                .filter_map(|binding| {
-                    let identity = binding.bound_typevar.identity(db);
-                    generic_context.contains(db, identity).then(|| {
-                        (
-                            identity,
-                            self.remove_inferable_typevar_artifacts_from_solution(
-                                binding.bound_typevar,
-                                binding.solution,
-                            ),
-                        )
-                    })
-                })
+                .iter()
+                .zip(resolved)
+                .map(|(binding, ty)| (binding.bound_typevar.identity(db), ty))
                 .collect();
-            if path_types.iter().any(|(identity, ty)| {
-                self.has_expanding_cycle(generic_context, &path_types, *identity, *ty)
-            }) {
+            if single
+                && generic_context.variables_inner(db).keys().all(|identity| {
+                    match (path_types.get(identity), types.get(identity)) {
+                        (None, None) => true,
+                        (Some(SolutionType::Resolved(resolved)), Some(merged)) => {
+                            resolved == merged
+                        }
+                        _ => false,
+                    }
+                })
+            {
+                return self.typevar_inference(&types, TypeVarInferenceSolutions::Single);
+            }
+            if single && generic_context.len(db) > budget.type_terms {
                 return self.typevar_inference(
                     &types,
                     TypeVarInferenceSolutions::Unavailable(
-                        TypeVarInferenceFallback::ExpandingCycle,
+                        TypeVarInferenceFallback::BudgetExceeded,
                     ),
                 );
             }
-            paths.push(self.types_in_context_order(&path_types));
+            paths.push(
+                generic_context
+                    .variables_inner(db)
+                    .keys()
+                    .map(|identity| path_types.get(identity).copied())
+                    .collect(),
+            );
         }
 
         let paths = paths.into_boxed_slice();
@@ -4629,6 +4653,8 @@ impl<'db> SpecializationError<'db> {
 mod tests {
     use super::*;
 
+    use crate::types::constraints::resolution::SolutionType::{Resolved, Unresolved};
+
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::DbWithWritableSystem;
     use ruff_python_ast::name::Name;
@@ -4702,8 +4728,8 @@ mod tests {
             assert_eq!(
                 paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
                 FxHashSet::from_iter([
-                    [Some(int), Some(str)].as_slice(),
-                    [Some(str), Some(int)].as_slice(),
+                    [Some(Resolved(int)), Some(Resolved(str))].as_slice(),
+                    [Some(Resolved(str)), Some(Resolved(int))].as_slice(),
                 ])
             );
 
@@ -4753,8 +4779,8 @@ mod tests {
                 assert_eq!(
                     paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
                     FxHashSet::from_iter([
-                        [Some(int), Some(str)].as_slice(),
-                        [fallback, Some(int)].as_slice(),
+                        [Some(Resolved(int)), Some(Resolved(str))].as_slice(),
+                        [fallback.map(Resolved), Some(Resolved(int))].as_slice(),
                     ])
                 );
 
@@ -4792,8 +4818,8 @@ mod tests {
             int,
         ));
 
-        // A complete single solution reuses the merged array, so its unsolved slots do not
-        // require any additional storage budget.
+        // A single solution whose present bindings are already resolved reuses the merged
+        // array, so its unsolved slots do not require any additional storage budget.
         let inference = builder
             .solve_pending_with(
                 SolutionBudget {
@@ -4971,8 +4997,8 @@ mod tests {
                 assert_eq!(
                     paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
                     FxHashSet::from_iter([
-                        [None, Some(int)].as_slice(),
-                        [None, Some(str)].as_slice(),
+                        [None, Some(Resolved(int))].as_slice(),
+                        [None, Some(Resolved(str))].as_slice(),
                     ])
                 );
             }
@@ -5023,8 +5049,8 @@ mod tests {
         assert_eq!(
             paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
             FxHashSet::from_iter([
-                [Some(Type::TypeVar(u)), None].as_slice(),
-                [Some(int), None].as_slice(),
+                [Some(Unresolved(Type::TypeVar(u))), None].as_slice(),
+                [Some(Resolved(int)), None].as_slice(),
             ])
         );
         assert_eq!(inference.merged_types(db), [Some(int), None]);
@@ -5032,7 +5058,7 @@ mod tests {
     }
 
     #[test]
-    fn inference_detects_expanding_cycles_hidden_by_merging() -> anyhow::Result<()> {
+    fn inference_preserves_expanding_cycles_hidden_by_merging() -> anyhow::Result<()> {
         let db = setup_db();
         let db = &db;
         let env = db.program_environment();
@@ -5062,13 +5088,284 @@ mod tests {
                 Some(PathBoundSolution::Solved(ty))
             })
             .map_err(|()| anyhow::anyhow!("an expanding cycle should recover"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("expected complete alternatives with an unresolved cycle");
+        };
         assert_eq!(
-            inference.solutions(db),
-            &TypeVarInferenceSolutions::Unavailable(TypeVarInferenceFallback::ExpandingCycle)
+            paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+            FxHashSet::from_iter([
+                [
+                    Some(Unresolved(list_of_u)),
+                    Some(Unresolved(Type::TypeVar(t)))
+                ]
+                .as_slice(),
+                [
+                    Some(Resolved(Type::object())),
+                    Some(Resolved(Type::object()))
+                ]
+                .as_slice(),
+            ])
         );
         assert_eq!(
             inference.merged_types(db),
             [Some(Type::object()), Some(Type::object())]
+        );
+        Ok(())
+    }
+
+    fn function_context<'db>(db: &'db TestDb, name: &str) -> anyhow::Result<GenericContext<'db>> {
+        let env = db.program_environment();
+        let file = system_path_to_file(db, "/src/a.py")?;
+        let file = ProgramFile::new(db, file, env.program(db));
+        global_symbol(db, file, name)
+            .place
+            .expect_type()
+            .as_function_literal()
+            .and_then(|function| function.signature(db).overloads.first()?.generic_context)
+            .ok_or_else(|| anyhow::anyhow!("expected generic function {name}"))
+    }
+
+    #[test]
+    fn inference_resolves_dependencies_per_alternative() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars @ [t, u] = create_typevars(db, ["T", "U"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        builder.record_constraint_set(exact_alternatives(
+            db,
+            &constraints,
+            typevars,
+            [[int, str], [str, int]],
+        ));
+
+        // Both paths select T = U, but each has its own concrete binding for U.
+        let inference = builder
+            .build_inference_with(|typevar, _| {
+                (typevar == t).then_some(PathBoundSolution::Solved(Type::TypeVar(u)))
+            })
+            .map_err(|()| anyhow::anyhow!("expected satisfiable dependency chains"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("expected two resolved alternatives");
+        };
+        assert_eq!(
+            paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+            FxHashSet::from_iter([
+                [Some(Resolved(int)); 2].as_slice(),
+                [Some(Resolved(str)); 2].as_slice(),
+            ])
+        );
+        assert_eq!(inference.merged_types(db)[0], Some(Type::TypeVar(u)));
+        assert!(
+            inference.merged_types(db)[1].is_some_and(|ty| ty.is_equivalent_to(
+                db,
+                &env,
+                UnionType::from_two_elements(db, &env, int, str),
+            ))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolved_single_path_preserves_merged_projection() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars @ [t, u] = create_typevars(db, ["T", "U"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        builder.record_constraint_set(exact_alternatives(db, &constraints, typevars, [[int, int]]));
+
+        let inference = builder
+            .build_inference_with(|typevar, _| {
+                (typevar == t).then_some(PathBoundSolution::Solved(Type::TypeVar(u)))
+            })
+            .map_err(|()| anyhow::anyhow!("expected a satisfiable dependency chain"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("resolved bindings differ from the merged projection");
+        };
+        assert_eq!(paths.len(), 1);
+        assert_eq!(&*paths[0], [Some(Resolved(int)); 2]);
+        assert_eq!(
+            inference.merged_types(db),
+            [Some(Type::TypeVar(u)), Some(int)]
+        );
+        assert_eq!(inference.merged_specialization(db).types(db), [int, int]);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_dependency_does_not_use_declared_default() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented("/src/a.py", "def f[T, U = int](): ...")?;
+        let db = &db;
+        let env = db.program_environment();
+        let context = function_context(db, "f")?;
+        let (t, u) = context
+            .variables(db)
+            .collect_tuple()
+            .ok_or_else(|| anyhow::anyhow!("expected two type variables"))?;
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        builder.record_constraint_set(ConstraintSet::constrain_typevar(
+            db,
+            &env,
+            &constraints,
+            t,
+            int,
+            int,
+        ));
+
+        let inference = builder
+            .build_inference_with(|typevar, _| {
+                (typevar == t).then_some(PathBoundSolution::Solved(Type::TypeVar(u)))
+            })
+            .map_err(|()| anyhow::anyhow!("a missing dependency remains satisfiable"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("expected a retained unresolved dependency");
+        };
+        assert_eq!(u.default_type(db), Some(int));
+        assert_eq!(paths.len(), 1);
+        assert_eq!(&*paths[0], [Some(Unresolved(Type::TypeVar(u))), None]);
+        assert_eq!(inference.merged_types(db), [Some(Type::TypeVar(u)), None]);
+        Ok(())
+    }
+
+    #[test]
+    fn unanchored_dependency_cycle_remains_unresolved() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars @ [t, u] = create_typevars(db, ["T", "U"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        builder.record_constraint_set(exact_alternatives(db, &constraints, typevars, [[int, int]]));
+
+        let inference = builder
+            .build_inference_with(|typevar, _| {
+                Some(PathBoundSolution::Solved(Type::TypeVar(if typevar == t {
+                    u
+                } else {
+                    t
+                })))
+            })
+            .map_err(|()| anyhow::anyhow!("an unanchored cycle remains satisfiable"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("expected a retained unresolved cycle");
+        };
+        assert_eq!(paths.len(), 1);
+        assert_eq!(
+            &*paths[0],
+            [
+                Some(Unresolved(Type::TypeVar(u))),
+                Some(Unresolved(Type::TypeVar(t))),
+            ]
+        );
+        assert_eq!(
+            inference.merged_types(db),
+            [Some(Type::TypeVar(u)), Some(Type::TypeVar(t))]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn merged_cycle_recovery_preserves_unresolved_alternative() -> anyhow::Result<()> {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let typevars @ [t, u, _] = create_typevars(db, ["T", "U", "V"]);
+        let context = GenericContext::from_typevar_instances(db, &env, typevars);
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let list_of_u = KnownClass::List.to_specialized_instance(db, &env, &[Type::TypeVar(u)]);
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        builder.record_constraint_set(exact_alternatives(db, &constraints, typevars, [[int; 3]]));
+
+        // The merged specialization needs recovery for T = list[U], U = T. That does not
+        // discard the original alternative or the independent, resolved binding V = int.
+        let inference = builder
+            .build_inference_with(|variable, _| {
+                if variable == t {
+                    Some(PathBoundSolution::Solved(list_of_u))
+                } else if variable == u {
+                    Some(PathBoundSolution::Solved(Type::TypeVar(t)))
+                } else {
+                    None
+                }
+            })
+            .map_err(|()| anyhow::anyhow!("a cyclic alternative remains satisfiable"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("expected a retained cyclic alternative");
+        };
+        assert_eq!(paths.len(), 1);
+        assert_eq!(
+            &*paths[0],
+            [
+                Some(Unresolved(list_of_u)),
+                Some(Unresolved(Type::TypeVar(t))),
+                Some(Resolved(int))
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn outer_typevar_with_same_name_remains_resolved() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_dedented(
+            "/src/a.py",
+            r#"
+            def inner[T, U](): ...
+            def outer[T = str](): ...
+            "#,
+        )?;
+        let db = &db;
+        let env = db.program_environment();
+        let context = function_context(db, "inner")?;
+        let (t, u) = context
+            .variables(db)
+            .collect_tuple()
+            .ok_or_else(|| anyhow::anyhow!("expected two type variables"))?;
+        let outer = function_context(db, "outer")?
+            .variables(db)
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("expected an outer type variable"))?;
+        let constraints = ConstraintSetBuilder::new();
+        let int = KnownClass::Int.to_instance(db, &env);
+        let str = KnownClass::Str.to_instance(db, &env);
+        let mut builder = SpecializationBuilder::new(db, &env, &constraints, context);
+        builder.record_constraint_set(exact_alternatives(
+            db,
+            &constraints,
+            [t, u],
+            [[int, str], [str, int]],
+        ));
+
+        let inference = builder
+            .build_inference_with(|typevar, _| {
+                (typevar == t).then_some(PathBoundSolution::Solved(Type::TypeVar(outer)))
+            })
+            .map_err(|()| anyhow::anyhow!("an outer dependency remains satisfiable"))?;
+        let TypeVarInferenceSolutions::Alternatives(paths) = inference.solutions(db) else {
+            anyhow::bail!("expected resolved alternatives containing the outer type variable");
+        };
+        assert_ne!(t.identity(db), outer.identity(db));
+        assert_eq!(outer.default_type(db), Some(str));
+        assert_eq!(
+            paths.iter().map(AsRef::as_ref).collect::<FxHashSet<_>>(),
+            FxHashSet::from_iter([
+                [Some(Resolved(Type::TypeVar(outer))), Some(Resolved(int)),].as_slice(),
+                [Some(Resolved(Type::TypeVar(outer))), Some(Resolved(str)),].as_slice(),
+            ])
         );
         Ok(())
     }


### PR DESCRIPTION
Retained inference-solution alternatives currently expose selected bindings without saying whether those bindings still depend on other inferable type variables. The intersection-inference work for [ty#3557](https://github.com/astral-sh/ty/issues/3557) needs to inspect each alternative before applying defaults. Currently, its conservative check has to fall back to the union-merged result even when a dependency could be resolved from another binding in the same alternative.

For example, this call produces dependent bindings (covered by the new call-inference unit test):

```python
from typing import Callable, overload

class A: ...
class B: ...

def infer_result[T, R](callback: Callable[[T], R], consumer: Callable[[T], None]) -> R:
    raise NotImplementedError

def identity[T](value: T) -> T:
    return value

@overload
def consume(value: A) -> None: ...
@overload
def consume(value: B) -> None: ...
def consume(value: A | B) -> None: ...

result = infer_result(identity, consume)
```

The consumer overloads select `T = A` or `T = B`, while the identity callback relates `R` to `T`:

| Alternative | Selected bindings | After resolving dependencies |
| --- | --- | --- |
| First | `T = A, R = T` | `T = A, R = A` |
| Second | `T = B, R = T` | `T = B, R = B` |

The unresolved `R = T` prevents the conservative intersection consumer from using these alternatives. Resolving them supplies the separate return types `A` and `B`, which can support the more precise result `A & B` once both specializations validate against the whole call.

The existing merged-specialization path already substitutes dependencies, but it does so only after merging alternatives and filling defaults, producing `A | B`; it cannot provide these separate, evidence-only results.

Resolve dependencies within each alternative and distinguish resolved bindings from unresolved ones. `T = U, U = A` resolves to `T = A`, while `T = U` with no binding for `U` remains unresolved even if `U` has a declared default. Cycles and captured references that specialization cannot replace also retain their original bindings, alongside any independent resolved bindings. References to non-inferable variables preserve their identities.

This changes the correlated-solution API. Existing call inference continues to use the merged specialization and returns `A | B` for this example. Producing `A & B` also requires the intersection consumer to use these resolved bindings and accept the generic callback during subtype revalidation; that separate validation limitation is not addressed here.

## Test plan

Add a call-inference unit test for the generic callback and overloaded consumer above, asserting independently resolved alternatives and the unchanged merged specialization. Add unit coverage for single alternatives whose resolved bindings differ from the merged projection, missing dependencies with declared defaults, dependency cycles with independent bindings, and non-inferable variables with matching names. Cover captured dependencies in ordinary and recursive aliases, preservation of closed recursive aliases, and dependencies exposed by a partial's wrapped callable. Update existing correlated-inference assertions for the resolved/unresolved representation.
