### PR TITLE
[ty] `lambda` functions are always truthy

### DIFF
--- a/crates/ty_python_semantic/mdtest.py.lock
+++ b/crates/ty_python_semantic/mdtest.py.lock
@@ -8,7 +8,10 @@ exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
 astral-dev-toolchain-hyperfine = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-insta = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-shear = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-codspeed = "2026-08-27T00:00:00Z"
+astral-dev-toolchain-cargo-nextest = "2026-08-27T00:00:00Z"
 astral-dev-toolchain-cargo-fuzz = "2026-09-01T00:00:00Z"
 
 [manifest]

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/truthiness.md
@@ -134,7 +134,9 @@ def _(path: Path, superclass: super):
     reveal_type(bool(superclass))  # revealed: bool
 ```
 
-### `Callable` types always have ambiguous truthiness
+### Callable objects
+
+Callable objects can define `__bool__`, so `Callable` parameters have ambiguous truthiness.
 
 ```py
 from typing import Any, Callable
@@ -144,13 +146,20 @@ def f(x: Callable[..., Any], y: Callable[[int], str]):
     reveal_type(bool(y))  # revealed: bool
 ```
 
-But certain callable objects are known to be always truthy:
+But instances of `types.FunctionType` (whether they're defined using a `def` statement or a `lambda`
+expression) are always truthy, and this is also true for bound methods:
 
 ```py
 from types import FunctionType
 
 class A:
     def method(self): ...
+
+reveal_type(bool(f))  # revealed: Literal[True]
+reveal_type(bool(lambda: False))  # revealed: Literal[True]
+
+lambda_function = lambda: False
+reveal_type(bool(lambda_function))  # revealed: Literal[True]
 
 reveal_type(bool(A().method))  # revealed: Literal[True]
 reveal_type(bool(f.__get__))  # revealed: Literal[True]

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -243,6 +243,8 @@ impl<'db> Type<'db> {
         };
 
         let truthiness = match self {
+            Type::Callable(callable) if callable.is_function_like(db) => Truthiness::AlwaysTrue,
+
             Type::Dynamic(_)
             | Type::Divergent(_)
             | Type::Never


### PR DESCRIPTION
## Summary

Function-like `Callable`s are ones where we know that the `Callable` is also an instance of `FunctionType` at runtime. Since `FunctionType` instances are always truthy, we should therefore treat function-like `Callable` types as always truthy too. This fixes a false positive in the ecosystem and will also reduce false negatives on https://github.com/astral-sh/ruff/pull/28034.

## Test Plan

mdtests