### PR TITLE
[ty] Optimize recursive protocol checks for nested type variables

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -918,6 +918,43 @@ class Chain[T](Protocol):
     }
 }
 
+/// Regression benchmark for ty#4269: inherited receiver binding with nested type variables.
+///
+/// The nominal relation constrains `T` inside the source's union argument. Ignoring that
+/// evidence repeatedly expands the recursive overloads while binding `chain`.
+fn benchmark_nested_recursive_protocol_receiver(criterion: &mut Criterion) {
+    setup_rayon();
+
+    let code = r#"
+from __future__ import annotations
+
+from typing import Protocol, overload
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+    @overload
+    def chain[S, O1](self: Chain[S], o1: O1, /) -> Chain[S | O1]: ...
+    @overload
+    def chain[S, O1, O2](self: Chain[S], o1: O1, o2: O2, /) -> Chain[S | O1 | O2]: ...
+    @overload
+    def chain[S, O1, O2, O3](self: Chain[S], o1: O1, o2: O2, o3: O3, /) -> Chain[S | O1 | O2 | O3]: ...
+    def chain[S, O](self: Chain[S], *others: O) -> Chain[S | O]: ...
+
+class Concrete[T](Chain[T]): ...
+
+def check[T, S](base: Concrete[T | list[T]], *others: S) -> None:
+    base.chain(*others)
+"#;
+
+    criterion.bench_function("ty_micro[nested_recursive_protocol_receiver]", |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(code),
+            |case| assert_eq!(case.db.check().len(), 0),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Regression benchmark for ty#4269: materialized recursive protocol comparisons.
 ///
 /// Comparing the tuple-specific receiver with the gradual overload can repeatedly expand
@@ -1849,6 +1886,7 @@ criterion_group!(
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_inherited_recursive_protocol,
+    benchmark_nested_recursive_protocol_receiver,
     benchmark_materialized_recursive_protocol_overload,
     benchmark_vararg_parameter_type_accumulation,
     benchmark_typed_dict_get_large_literal_union,

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -7032,6 +7032,36 @@ def check[T](concrete: Concrete[int], symbolic: Concrete[T]) -> None:
     reveal_type(Concrete().accumulate())  # revealed: Chain[Unknown]
 ```
 
+### Nested symbolic sources with constrained protocol receivers
+
+Type variables nested inside a concrete class's specialization still contribute constraints when
+binding an inherited recursive protocol method. Tuple, union, and aliased specializations preserve
+their element types in the result.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+
+class Chain[T](Protocol):
+    def value(self) -> T: ...
+    def accumulate[S](self: Chain[S]) -> Chain[S]: ...
+
+class Concrete[T](Chain[T]): ...
+
+type Wrapped[T] = tuple[T]
+
+def check[T](nested: Concrete[tuple[T]], union: Concrete[T | list[T]], aliased: Concrete[Wrapped[T]]) -> None:
+    reveal_type(nested.accumulate())  # revealed: Chain[tuple[T@check]]
+    reveal_type(union.accumulate())  # revealed: Chain[T@check | list[T@check]]
+    reveal_type(aliased.accumulate())  # revealed: Chain[Wrapped[T@check]]
+```
+
 ### Incompatible explicit receivers on recursive protocols
 
 The `value` and `write` methods make `Chain` invariant. Calling `flatten` on `Chain[list[int]]` is
@@ -7127,6 +7157,17 @@ class Erased[T, U](Recursive[T, Any]):
     def __init__(self, callback: Callable[[U], object]) -> None: ...
 
 pair: Recursive[int, str] = Erased(lambda value: reveal_type(value))  # revealed: str
+```
+
+The same inference is needed when an erased source argument contains a nested type variable. The
+nominal relation constrains `T`, but only the recursive `value` member can infer `U` through the
+tuple.
+
+```py
+def make[T, U](callback: Callable[[U], object]) -> Erased[T, tuple[U]]:
+    raise NotImplementedError
+
+nested: Recursive[int, tuple[str]] = make(lambda value: reveal_type(value))  # revealed: str
 ```
 
 ### Overridden recursive protocol requirements

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -718,9 +718,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let source_alias = source_class.into_generic_alias()?;
 
         let source_arguments = source_alias.specialization(db).types(db);
-        if !source_arguments.iter().all(|argument| match argument {
-            Type::TypeVar(typevar) => nominally_satisfied.mentions_typevar(*typevar),
-            argument => !any_over_type_expanding_aliases(db, env, *argument, Type::is_type_var),
+        // Nested variables, such as `T` in `Concrete[T | Iterable[T]]`, can also be
+        // constrained by the nominal relation. Only variables absent from that relation
+        // require structural inference that the nominal proof cannot account for.
+        if source_arguments.iter().any(|argument| {
+            any_over_type_expanding_aliases(db, env, *argument, |nested| {
+                matches!(nested, Type::TypeVar(typevar)
+                    if !nominally_satisfied.mentions_typevar(typevar))
+            })
         }) {
             return None;
         }


### PR DESCRIPTION
Binding inherited recursive protocol methods could repeatedly expand the protocol interface when a receiver's type arguments contained nested type variables, such as `Iter[T | Iterable[T]]`. Recognize those variables when the nominal constraints already mention them, while retaining the structural implication check before skipping recursive requirements.

On [pyochain at `4b482210`](https://github.com/OutSquareCapital/pyochain/tree/4b482210241b095bbd1968b8f860a68f3d291746), the reduced `Iter(base).chain(*others)` call completes in 0.22 seconds instead of exceeding eight seconds. The full repository now completes in 4.54 seconds instead of exceeding a 20-second limit, using an optimized debug build.

Fixes [astral-sh/ty#4269](https://github.com/astral-sh/ty/issues/4269).

## Test plan

- Add mdtests for inherited receiver binding with tuple, union, and aliased type arguments, and for structural inference of a nested variable erased by protocol inheritance.
- Add a regression benchmark for overloaded recursive protocol methods on a nominal receiver with a union containing a type variable.
