### PR TITLE
Alternate nested quotes inside format spec interpolations

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/nested_string_quote_style.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/nested_string_quote_style.py
@@ -79,3 +79,17 @@ t'{ ("implicit " "concatenation", ["more", "strings"]) }'
 # Inner implicit concatenation with escaped quotes.
 f'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
 t'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
+
+# Nested string literals inside a format spec. The field belongs to the same string as the
+# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
+# counting as a further level of nesting.
+f'{v:,.{d["n"]}f}'
+t'{v:,.{d["n"]}f}'
+f'{v:{"width"}}'
+t'{v:{"width"}}'
+
+# An interpolated string inside a format spec is still a further level of nesting, so the
+# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
+# not itself a pre-3.12 syntax error.
+f'''{v:{f"{d['n']}"}}'''
+t'''{v:{f"{d['n']}"}}'''

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/nested_string_quote_style.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/expression/nested_string_quote_style.py
@@ -80,16 +80,11 @@ t'{ ("implicit " "concatenation", ["more", "strings"]) }'
 f'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
 t'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
 
-# Nested string literals inside a format spec. The field belongs to the same string as the
-# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
-# counting as a further level of nesting.
-f'{v:,.{d["n"]}f}'
-t'{v:,.{d["n"]}f}'
-f'{v:{"width"}}'
-t'{v:{"width"}}'
+# A field in a format spec belongs to the same string as its enclosing field,
+# so its string literals follow the same rules as an ordinary interpolation.
+# Regression test for https://github.com/astral-sh/ruff/issues/28218
+f'{v:{d["n"]}}'
+t'{v:{d["n"]}}'
 
-# An interpolated string inside a format spec is still a further level of nesting, so the
-# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
-# not itself a pre-3.12 syntax error.
+# A nested f-string inside a format spec adds another level of nesting.
 f'''{v:{f"{d['n']}"}}'''
-t'''{v:{f"{d['n']}"}}'''

--- a/crates/ruff_python_formatter/src/context.rs
+++ b/crates/ruff_python_formatter/src/context.rs
@@ -153,12 +153,14 @@ impl Debug for PyFormatContext<'_> {
 
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) enum InterpolatedStringState {
-    /// The formatter is inside an f-string expression element i.e., between the
-    /// curly brace in `f"foo {x}"`.
+    /// The formatter is inside the elements of an f-string or t-string, including
+    /// literal text and interpolations. In `f"foo {x}"`, this state is active
+    /// while formatting both `foo ` and `{x}`.
     ///
-    /// The containing `FStringContext` is the surrounding f-string context.
+    /// The containing `InterpolatedStringContext` is the surrounding f-string context.
     InsideInterpolatedElement(InterpolatedStringContext),
-    /// The formatter is inside more than one nested f-string, such as in `nested` in:
+    /// The formatter is inside more than one nested interpolated string, such as
+    /// in `nested` in:
     ///
     /// ```py
     /// f"{f'''{'nested'} inner'''} outer"
@@ -170,6 +172,16 @@ pub(crate) enum InterpolatedStringState {
 }
 
 impl InterpolatedStringState {
+    /// Entering another interpolated string increases the nesting depth.
+    pub(crate) fn enter_string(self, context: InterpolatedStringContext) -> Self {
+        match self {
+            Self::Outside => Self::InsideInterpolatedElement(context),
+            Self::InsideInterpolatedElement(_) | Self::NestedInterpolatedElement(_) => {
+                Self::NestedInterpolatedElement(context)
+            }
+        }
+    }
+
     pub(crate) fn can_contain_line_breaks(self) -> Option<bool> {
         match self {
             InterpolatedStringState::InsideInterpolatedElement(context)

--- a/crates/ruff_python_formatter/src/other/f_string.rs
+++ b/crates/ruff_python_formatter/src/other/f_string.rs
@@ -1,4 +1,5 @@
 use super::interpolated_string_element::FormatInterpolatedStringElement;
+use crate::context::WithInterpolatedStringState;
 use crate::other::interpolated_string::{InterpolatedStringContext, InterpolatedStringLayout};
 use crate::prelude::*;
 use crate::string::{StringNormalizer, StringQuotes};
@@ -30,8 +31,15 @@ impl FormatNodeRule<FString> for FormatFString {
         let quotes = StringQuotes::from(string_kind);
         write!(f, [string_kind.prefix(), quotes])?;
 
-        for element in &item.elements {
-            FormatInterpolatedStringElement::new(element, context).fmt(f)?;
+        {
+            let state = f
+                .context()
+                .interpolated_string_state()
+                .enter_string(context);
+            let f = &mut WithInterpolatedStringState::new(state, &mut *f);
+            for element in &item.elements {
+                FormatInterpolatedStringElement::new(element, context).fmt(f)?;
+            }
         }
 
         // Ending quote

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -25,6 +25,7 @@ use super::interpolated_string::{InterpolatedStringContext, InterpolatedStringLa
 pub(crate) struct FormatInterpolatedStringElement<'a> {
     element: &'a InterpolatedStringElement,
     context: InterpolatedStringContext,
+    in_format_spec: bool,
 }
 
 impl<'a> FormatInterpolatedStringElement<'a> {
@@ -32,7 +33,17 @@ impl<'a> FormatInterpolatedStringElement<'a> {
         element: &'a InterpolatedStringElement,
         context: InterpolatedStringContext,
     ) -> Self {
-        Self { element, context }
+        Self {
+            element,
+            context,
+            in_format_spec: false,
+        }
+    }
+
+    /// Marks this element as belonging to the format spec of an enclosing replacement field.
+    pub(crate) fn in_format_spec(mut self) -> Self {
+        self.in_format_spec = true;
+        self
     }
 }
 
@@ -43,7 +54,12 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedStringElement<'_> {
                 FormatFStringLiteralElement::new(string_literal, self.context.flags()).fmt(f)
             }
             InterpolatedStringElement::Interpolation(expression) => {
-                FormatInterpolatedElement::new(expression, self.context).fmt(f)
+                let element = FormatInterpolatedElement::new(expression, self.context);
+                if self.in_format_spec {
+                    element.in_format_spec().fmt(f)
+                } else {
+                    element.fmt(f)
+                }
             }
         }
     }
@@ -80,6 +96,7 @@ impl Format<PyFormatContext<'_>> for FormatFStringLiteralElement<'_> {
 pub(crate) struct FormatInterpolatedElement<'a> {
     element: &'a InterpolatedElement,
     context: InterpolatedStringContext,
+    in_format_spec: bool,
 }
 
 impl<'a> FormatInterpolatedElement<'a> {
@@ -87,7 +104,17 @@ impl<'a> FormatInterpolatedElement<'a> {
         element: &'a InterpolatedElement,
         context: InterpolatedStringContext,
     ) -> Self {
-        Self { element, context }
+        Self {
+            element,
+            context,
+            in_format_spec: false,
+        }
+    }
+
+    /// Marks this replacement field as belonging to the format spec of an enclosing field.
+    pub(crate) fn in_format_spec(mut self) -> Self {
+        self.in_format_spec = true;
+        self
     }
 }
 
@@ -194,13 +221,21 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
 
             let item = format_with(|f: &mut PyFormatter| {
                 // Update the context to be inside the f-string expression element.
-                let state = match f.context().interpolated_string_state() {
-                    InterpolatedStringState::InsideInterpolatedElement(_)
-                    | InterpolatedStringState::NestedInterpolatedElement(_) => {
-                        InterpolatedStringState::NestedInterpolatedElement(context)
-                    }
-                    InterpolatedStringState::Outside => {
-                        InterpolatedStringState::InsideInterpolatedElement(context)
+                // A field in a format spec belongs to the same string as the field enclosing
+                // it, so it is not a further level of nesting: only entering another string
+                // literal is. Deepening here made pre-3.12 targets preserve the inner quotes
+                // and reuse the outer quote character, which is a syntax error before PEP 701.
+                let state = if self.in_format_spec {
+                    f.context().interpolated_string_state()
+                } else {
+                    match f.context().interpolated_string_state() {
+                        InterpolatedStringState::InsideInterpolatedElement(_)
+                        | InterpolatedStringState::NestedInterpolatedElement(_) => {
+                            InterpolatedStringState::NestedInterpolatedElement(context)
+                        }
+                        InterpolatedStringState::Outside => {
+                            InterpolatedStringState::InsideInterpolatedElement(context)
+                        }
                     }
                 };
                 let f = &mut WithInterpolatedStringState::new(state, f);
@@ -229,7 +264,9 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                     token(":").fmt(f)?;
 
                     for element in &format_spec.elements {
-                        FormatInterpolatedStringElement::new(element, context).fmt(f)?;
+                        FormatInterpolatedStringElement::new(element, context)
+                            .in_format_spec()
+                            .fmt(f)?;
                     }
                 }
 

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -41,7 +41,7 @@ impl<'a> FormatInterpolatedStringElement<'a> {
     }
 
     /// Marks this element as belonging to the format spec of an enclosing replacement field.
-    pub(crate) fn in_format_spec(mut self) -> Self {
+    fn in_format_spec(mut self) -> Self {
         self.in_format_spec = true;
         self
     }
@@ -112,7 +112,7 @@ impl<'a> FormatInterpolatedElement<'a> {
     }
 
     /// Marks this replacement field as belonging to the format spec of an enclosing field.
-    pub(crate) fn in_format_spec(mut self) -> Self {
+    fn in_format_spec(mut self) -> Self {
         self.in_format_spec = true;
         self
     }

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -25,7 +25,6 @@ use super::interpolated_string::{InterpolatedStringContext, InterpolatedStringLa
 pub(crate) struct FormatInterpolatedStringElement<'a> {
     element: &'a InterpolatedStringElement,
     context: InterpolatedStringContext,
-    in_format_spec: bool,
 }
 
 impl<'a> FormatInterpolatedStringElement<'a> {
@@ -33,17 +32,7 @@ impl<'a> FormatInterpolatedStringElement<'a> {
         element: &'a InterpolatedStringElement,
         context: InterpolatedStringContext,
     ) -> Self {
-        Self {
-            element,
-            context,
-            in_format_spec: false,
-        }
-    }
-
-    /// Marks this element as belonging to the format spec of an enclosing replacement field.
-    fn in_format_spec(mut self) -> Self {
-        self.in_format_spec = true;
-        self
+        Self { element, context }
     }
 }
 
@@ -54,12 +43,7 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedStringElement<'_> {
                 FormatFStringLiteralElement::new(string_literal, self.context.flags()).fmt(f)
             }
             InterpolatedStringElement::Interpolation(expression) => {
-                let element = FormatInterpolatedElement::new(expression, self.context);
-                if self.in_format_spec {
-                    element.in_format_spec().fmt(f)
-                } else {
-                    element.fmt(f)
-                }
+                FormatInterpolatedElement::new(expression, self.context).fmt(f)
             }
         }
     }
@@ -96,7 +80,6 @@ impl Format<PyFormatContext<'_>> for FormatFStringLiteralElement<'_> {
 pub(crate) struct FormatInterpolatedElement<'a> {
     element: &'a InterpolatedElement,
     context: InterpolatedStringContext,
-    in_format_spec: bool,
 }
 
 impl<'a> FormatInterpolatedElement<'a> {
@@ -104,17 +87,7 @@ impl<'a> FormatInterpolatedElement<'a> {
         element: &'a InterpolatedElement,
         context: InterpolatedStringContext,
     ) -> Self {
-        Self {
-            element,
-            context,
-            in_format_spec: false,
-        }
-    }
-
-    /// Marks this replacement field as belonging to the format spec of an enclosing field.
-    fn in_format_spec(mut self) -> Self {
-        self.in_format_spec = true;
-        self
+        Self { element, context }
     }
 }
 
@@ -220,22 +193,18 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                 }));
 
             let item = format_with(|f: &mut PyFormatter| {
-                // Update the context to be inside the f-string expression element.
-                // A field in a format spec belongs to the same string as the field enclosing
-                // it, so it is not a further level of nesting: only entering another string
-                // literal is. Deepening here made pre-3.12 targets preserve the inner quotes
-                // and reuse the outer quote character, which is a syntax error before PEP 701.
-                let state = if self.in_format_spec {
-                    f.context().interpolated_string_state()
-                } else {
-                    match f.context().interpolated_string_state() {
-                        InterpolatedStringState::InsideInterpolatedElement(_)
-                        | InterpolatedStringState::NestedInterpolatedElement(_) => {
-                            InterpolatedStringState::NestedInterpolatedElement(context)
-                        }
-                        InterpolatedStringState::Outside => {
-                            InterpolatedStringState::InsideInterpolatedElement(context)
-                        }
+                // Update the context for this f-string expression element.
+                // An interpolated element in a format spec belongs to the same f-string as
+                // its enclosing element, such as `{width}` in `f"{value:{width}}"`.
+                // Increasing the depth here would preserve inner quotes before Python 3.12
+                // and could reuse the outer quote character, producing invalid syntax.
+                let state = match f.context().interpolated_string_state() {
+                    InterpolatedStringState::NestedInterpolatedElement(_) => {
+                        InterpolatedStringState::NestedInterpolatedElement(context)
+                    }
+                    InterpolatedStringState::InsideInterpolatedElement(_)
+                    | InterpolatedStringState::Outside => {
+                        InterpolatedStringState::InsideInterpolatedElement(context)
                     }
                 };
                 let f = &mut WithInterpolatedStringState::new(state, f);
@@ -264,9 +233,7 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                     token(":").fmt(f)?;
 
                     for element in &format_spec.elements {
-                        FormatInterpolatedStringElement::new(element, context)
-                            .in_format_spec()
-                            .fmt(f)?;
+                        FormatInterpolatedStringElement::new(element, context).fmt(f)?;
                     }
                 }
 

--- a/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
+++ b/crates/ruff_python_formatter/src/other/interpolated_string_element.rs
@@ -193,18 +193,20 @@ impl Format<PyFormatContext<'_>> for FormatInterpolatedElement<'_> {
                 }));
 
             let item = format_with(|f: &mut PyFormatter| {
-                // Update the context for this f-string expression element.
-                // An interpolated element in a format spec belongs to the same f-string as
-                // its enclosing element, such as `{width}` in `f"{value:{width}}"`.
-                // Increasing the depth here would preserve inner quotes before Python 3.12
-                // and could reuse the outer quote character, producing invalid syntax.
                 let state = match f.context().interpolated_string_state() {
+                    InterpolatedStringState::Outside => {
+                        InterpolatedStringState::InsideInterpolatedElement(context)
+                    }
+                    // Formatting an interpolated element does not enter another f/t-string:
+                    // `{width}` in `f"{value:{width}}"` still belongs to the outer f-string.
+                    // Increasing the depth for that element would preserve its expression's
+                    // quotes before Python 3.12 and could reuse the outer quote character,
+                    // producing invalid syntax.
+                    InterpolatedStringState::InsideInterpolatedElement(_) => {
+                        InterpolatedStringState::InsideInterpolatedElement(context)
+                    }
                     InterpolatedStringState::NestedInterpolatedElement(_) => {
                         InterpolatedStringState::NestedInterpolatedElement(context)
-                    }
-                    InterpolatedStringState::InsideInterpolatedElement(_)
-                    | InterpolatedStringState::Outside => {
-                        InterpolatedStringState::InsideInterpolatedElement(context)
                     }
                 };
                 let f = &mut WithInterpolatedStringState::new(state, f);

--- a/crates/ruff_python_formatter/src/other/t_string.rs
+++ b/crates/ruff_python_formatter/src/other/t_string.rs
@@ -1,4 +1,5 @@
 use super::interpolated_string_element::FormatInterpolatedStringElement;
+use crate::context::WithInterpolatedStringState;
 use crate::other::interpolated_string::{InterpolatedStringContext, InterpolatedStringLayout};
 use crate::prelude::*;
 use crate::string::{StringNormalizer, StringQuotes};
@@ -30,8 +31,15 @@ impl FormatNodeRule<TString> for FormatTString {
         let quotes = StringQuotes::from(string_kind);
         write!(f, [string_kind.prefix(), quotes])?;
 
-        for element in &item.elements {
-            FormatInterpolatedStringElement::new(element, context).fmt(f)?;
+        {
+            let state = f
+                .context()
+                .interpolated_string_state()
+                .enter_string(context);
+            let f = &mut WithInterpolatedStringState::new(state, &mut *f);
+            for element in &item.elements {
+                FormatInterpolatedStringElement::new(element, context).fmt(f)?;
+            }
         }
 
         // Ending quote

--- a/crates/ruff_python_formatter/src/string/implicit.rs
+++ b/crates/ruff_python_formatter/src/string/implicit.rs
@@ -13,6 +13,7 @@ use ruff_text_size::{Ranged, TextRange};
 use std::borrow::Cow;
 
 use crate::comments::{leading_comments, trailing_comments};
+use crate::context::WithInterpolatedStringState;
 use crate::expression::parentheses::in_parentheses_only_soft_line_break_or_space;
 use crate::other::interpolated_string::{InterpolatedStringContext, InterpolatedStringLayout};
 use crate::other::interpolated_string_element::FormatInterpolatedElement;
@@ -332,6 +333,18 @@ impl Format<PyFormatContext<'_>> for FormatImplicitConcatenatedStringFlat<'_> {
 
                 StringLikePart::FString(FString { elements, .. })
                 | StringLikePart::TString(TString { elements, .. }) => {
+                    let context = InterpolatedStringContext::new(
+                        self.flags,
+                        InterpolatedStringLayout::from_interpolated_string_elements(
+                            elements,
+                            f.context().source(),
+                        ),
+                    );
+                    let state = f
+                        .context()
+                        .interpolated_string_state()
+                        .enter_string(context);
+                    let f = &mut WithInterpolatedStringState::new(state, &mut *f);
                     for element in elements {
                         match element {
                             InterpolatedStringElement::Literal(literal) => {
@@ -347,14 +360,6 @@ impl Format<PyFormatContext<'_>> for FormatImplicitConcatenatedStringFlat<'_> {
                             // Formatting the expression here and in the expanded version is safe **only**
                             // because we assert that the f/t-string never contains any comments.
                             InterpolatedStringElement::Interpolation(expression) => {
-                                let context = InterpolatedStringContext::new(
-                                    self.flags,
-                                    InterpolatedStringLayout::from_interpolated_string_elements(
-                                        elements,
-                                        f.context().source(),
-                                    ),
-                                );
-
                                 FormatInterpolatedElement::new(expression, context).fmt(f)?;
                             }
                         }

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__fstring.py.snap
@@ -1525,7 +1525,7 @@ f'{f"""other " """}'
 f'{1: hy "user"}'
 f'{1:hy "user"}'
 f'{1: abcd "{1}" }'
-f'{1: abcd "{'aa'}" }'
+f'{1: abcd "{"aa"}" }'
 f'{1=: "abcd {'aa'}}'
 f"{x:a{z:hy \"user\"}} '''"
 
@@ -2345,7 +2345,7 @@ f'{f"""other " """}'
 f'{1: hy "user"}'
 f'{1:hy "user"}'
 f'{1: abcd "{1}" }'
-f'{1: abcd "{'aa'}" }'
+f'{1: abcd "{"aa"}" }'
 f'{1=: "abcd {'aa'}}'
 f"{x:a{z:hy \"user\"}} '''"
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__nested_string_quote_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__nested_string_quote_style.py.snap
@@ -85,6 +85,20 @@ t'{ ("implicit " "concatenation", ["more", "strings"]) }'
 # Inner implicit concatenation with escaped quotes.
 f'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
 t'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
+
+# Nested string literals inside a format spec. The field belongs to the same string as the
+# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
+# counting as a further level of nesting.
+f'{v:,.{d["n"]}f}'
+t'{v:,.{d["n"]}f}'
+f'{v:{"width"}}'
+t'{v:{"width"}}'
+
+# An interpolated string inside a format spec is still a further level of nesting, so the
+# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
+# not itself a pre-3.12 syntax error.
+f'''{v:{f"{d['n']}"}}'''
+t'''{v:{f"{d['n']}"}}'''
 ```
 
 ## Outputs
@@ -186,6 +200,20 @@ t"{('implicit concatenation', ['more', 'strings'])}"
 # Inner implicit concatenation with escaped quotes.
 f"{('implicit concatenation', ["'single'", '"double"'])}"
 t"{('implicit concatenation', ["'single'", '"double"'])}"
+
+# Nested string literals inside a format spec. The field belongs to the same string as the
+# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
+# counting as a further level of nesting.
+f"{v:,.{d['n']}f}"
+t"{v:,.{d['n']}f}"
+f"{v:{'width'}}"
+t"{v:{'width'}}"
+
+# An interpolated string inside a format spec is still a further level of nesting, so the
+# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
+# not itself a pre-3.12 syntax error.
+f"""{v:{f"{d['n']}"}}"""
+t"""{v:{f"{d['n']}"}}"""
 ```
 
 
@@ -287,6 +315,20 @@ t"{("implicit concatenation", ["more", "strings"])}"
 # Inner implicit concatenation with escaped quotes.
 f"{("implicit concatenation", ["'single'", '"double"'])}"
 t"{("implicit concatenation", ["'single'", '"double"'])}"
+
+# Nested string literals inside a format spec. The field belongs to the same string as the
+# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
+# counting as a further level of nesting.
+f"{v:,.{d["n"]}f}"
+t"{v:,.{d["n"]}f}"
+f"{v:{"width"}}"
+t"{v:{"width"}}"
+
+# An interpolated string inside a format spec is still a further level of nesting, so the
+# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
+# not itself a pre-3.12 syntax error.
+f"""{v:{f"{d["n"]}"}}"""
+t"""{v:{f"{d["n"]}"}}"""
 ```
 
 
@@ -388,6 +430,20 @@ t"{('implicit concatenation', ['more', 'strings'])}"
 # Inner implicit concatenation with escaped quotes.
 f"{('implicit concatenation', ["'single'", '"double"'])}"
 t"{('implicit concatenation', ["'single'", '"double"'])}"
+
+# Nested string literals inside a format spec. The field belongs to the same string as the
+# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
+# counting as a further level of nesting.
+f"{v:,.{d['n']}f}"
+t"{v:,.{d['n']}f}"
+f"{v:{'width'}}"
+t"{v:{'width'}}"
+
+# An interpolated string inside a format spec is still a further level of nesting, so the
+# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
+# not itself a pre-3.12 syntax error.
+f"""{v:{f"{d['n']}"}}"""
+t"""{v:{f"{d['n']}"}}"""
 ```
 
 
@@ -515,6 +571,20 @@ t"{('implicit concatenation', ['more', 'strings'])}"
 # Inner implicit concatenation with escaped quotes.
 f"{('implicit concatenation', ["'single'", '"double"'])}"
 t"{('implicit concatenation', ["'single'", '"double"'])}"
+
+# Nested string literals inside a format spec. The field belongs to the same string as the
+# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
+# counting as a further level of nesting.
+f"{v:,.{d['n']}f}"
+t"{v:,.{d['n']}f}"
+f"{v:{'width'}}"
+t"{v:{'width'}}"
+
+# An interpolated string inside a format spec is still a further level of nesting, so the
+# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
+# not itself a pre-3.12 syntax error.
+f"""{v:{f"{d['n']}"}}"""
+t"""{v:{f"{d['n']}"}}"""
 ```
 
 

--- a/crates/ruff_python_formatter/tests/snapshots/format@expression__nested_string_quote_style.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@expression__nested_string_quote_style.py.snap
@@ -86,19 +86,14 @@ t'{ ("implicit " "concatenation", ["more", "strings"]) }'
 f'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
 t'{ ("implicit " "concatenation", ["'single'", "\"double\""]) }'
 
-# Nested string literals inside a format spec. The field belongs to the same string as the
-# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
-# counting as a further level of nesting.
-f'{v:,.{d["n"]}f}'
-t'{v:,.{d["n"]}f}'
-f'{v:{"width"}}'
-t'{v:{"width"}}'
+# A field in a format spec belongs to the same string as its enclosing field,
+# so its string literals follow the same rules as an ordinary interpolation.
+# Regression test for https://github.com/astral-sh/ruff/issues/28218
+f'{v:{d["n"]}}'
+t'{v:{d["n"]}}'
 
-# An interpolated string inside a format spec is still a further level of nesting, so the
-# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
-# not itself a pre-3.12 syntax error.
+# A nested f-string inside a format spec adds another level of nesting.
 f'''{v:{f"{d['n']}"}}'''
-t'''{v:{f"{d['n']}"}}'''
 ```
 
 ## Outputs
@@ -201,19 +196,14 @@ t"{('implicit concatenation', ['more', 'strings'])}"
 f"{('implicit concatenation', ["'single'", '"double"'])}"
 t"{('implicit concatenation', ["'single'", '"double"'])}"
 
-# Nested string literals inside a format spec. The field belongs to the same string as the
-# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
-# counting as a further level of nesting.
-f"{v:,.{d['n']}f}"
-t"{v:,.{d['n']}f}"
-f"{v:{'width'}}"
-t"{v:{'width'}}"
+# A field in a format spec belongs to the same string as its enclosing field,
+# so its string literals follow the same rules as an ordinary interpolation.
+# Regression test for https://github.com/astral-sh/ruff/issues/28218
+f"{v:{d['n']}}"
+t"{v:{d['n']}}"
 
-# An interpolated string inside a format spec is still a further level of nesting, so the
-# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
-# not itself a pre-3.12 syntax error.
+# A nested f-string inside a format spec adds another level of nesting.
 f"""{v:{f"{d['n']}"}}"""
-t"""{v:{f"{d['n']}"}}"""
 ```
 
 
@@ -316,19 +306,14 @@ t"{("implicit concatenation", ["more", "strings"])}"
 f"{("implicit concatenation", ["'single'", '"double"'])}"
 t"{("implicit concatenation", ["'single'", '"double"'])}"
 
-# Nested string literals inside a format spec. The field belongs to the same string as the
-# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
-# counting as a further level of nesting.
-f"{v:,.{d["n"]}f}"
-t"{v:,.{d["n"]}f}"
-f"{v:{"width"}}"
-t"{v:{"width"}}"
+# A field in a format spec belongs to the same string as its enclosing field,
+# so its string literals follow the same rules as an ordinary interpolation.
+# Regression test for https://github.com/astral-sh/ruff/issues/28218
+f"{v:{d["n"]}}"
+t"{v:{d["n"]}}"
 
-# An interpolated string inside a format spec is still a further level of nesting, so the
-# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
-# not itself a pre-3.12 syntax error.
+# A nested f-string inside a format spec adds another level of nesting.
 f"""{v:{f"{d["n"]}"}}"""
-t"""{v:{f"{d["n"]}"}}"""
 ```
 
 
@@ -431,19 +416,14 @@ t"{('implicit concatenation', ['more', 'strings'])}"
 f"{('implicit concatenation', ["'single'", '"double"'])}"
 t"{('implicit concatenation', ["'single'", '"double"'])}"
 
-# Nested string literals inside a format spec. The field belongs to the same string as the
-# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
-# counting as a further level of nesting.
-f"{v:,.{d['n']}f}"
-t"{v:,.{d['n']}f}"
-f"{v:{'width'}}"
-t"{v:{'width'}}"
+# A field in a format spec belongs to the same string as its enclosing field,
+# so its string literals follow the same rules as an ordinary interpolation.
+# Regression test for https://github.com/astral-sh/ruff/issues/28218
+f"{v:{d['n']}}"
+t"{v:{d['n']}}"
 
-# An interpolated string inside a format spec is still a further level of nesting, so the
-# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
-# not itself a pre-3.12 syntax error.
+# A nested f-string inside a format spec adds another level of nesting.
 f"""{v:{f"{d['n']}"}}"""
-t"""{v:{f"{d['n']}"}}"""
 ```
 
 
@@ -572,19 +552,14 @@ t"{('implicit concatenation', ['more', 'strings'])}"
 f"{('implicit concatenation', ["'single'", '"double"'])}"
 t"{('implicit concatenation', ["'single'", '"double"'])}"
 
-# Nested string literals inside a format spec. The field belongs to the same string as the
-# field enclosing it, so it follows the same rules as an ordinary interpolation rather than
-# counting as a further level of nesting.
-f"{v:,.{d['n']}f}"
-t"{v:,.{d['n']}f}"
-f"{v:{'width'}}"
-t"{v:{'width'}}"
+# A field in a format spec belongs to the same string as its enclosing field,
+# so its string literals follow the same rules as an ordinary interpolation.
+# Regression test for https://github.com/astral-sh/ruff/issues/28218
+f"{v:{d['n']}}"
+t"{v:{d['n']}}"
 
-# An interpolated string inside a format spec is still a further level of nesting, so the
-# innermost quotes are preserved before 3.12. Triple quoted outside so that the input is
-# not itself a pre-3.12 syntax error.
+# A nested f-string inside a format spec adds another level of nesting.
 f"""{v:{f"{d['n']}"}}"""
-t"""{v:{f"{d['n']}"}}"""
 ```
 
 


### PR DESCRIPTION
Fixes #28218.

When Ruff formats an f-string, it normally alternates the inner quotes so they don't conflict with the outer ones. For example, a normal interpolation like `f'x {d["k"]} y'` is formatted as `f"x {d['k']} y"`.

However, this didn't work correctly for interpolations inside a format spec. For example, `f'x {v:,.{d["n"]}f} y'` was left with `{d["n"]}` using the same quote character as the outer f-string.

Reusing the outer quote character inside an f-string is only valid starting with Python 3.12, thanks to PEP 701. With `target-version = "py311"`, this meant Ruff's formatter could produce code that its own checker would reject with:

`Cannot reuse outer quote character in f-strings on Python 3.11 (syntax was added in Python 3.12)`

The issue was caused by how Ruff tracks nesting inside interpolated strings. A field inside a format spec was incorrectly treated as an additional nesting level, even though it's still part of the same f-string and doesn't introduce another string literal.

That incorrect nesting level caused the formatter to preserve the existing quotes for Python versions before 3.12. In this case, preserving them resulted in invalid Python 3.11 syntax.

The fix is to only increase the nesting level when entering another string literal. Entering a format spec does not count as deeper string nesting, so fields inside format specs now stay at the current nesting level.
