### PR TITLE
[`flake8-bandit`] Fix `S113` documentation to match httpx behavior

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/request_without_timeout.rs
@@ -8,13 +8,19 @@ use crate::checkers::ast::Checker;
 use crate::codes::Category;
 
 /// ## What it does
-/// Checks for uses of the Python `requests` or `httpx` module that omit the
-/// `timeout` parameter.
+/// Checks for uses of the Python `requests` module that omit the `timeout`
+/// parameter, and for uses of the `requests` or `httpx` modules that set the
+/// `timeout` parameter to `None`.
 ///
 /// ## Why is this bad?
 /// The `timeout` parameter is used to set the maximum time to wait for a
-/// response from the server. By omitting the `timeout` parameter, the program
-/// may hang indefinitely while awaiting a response.
+/// response from the server. Without a timeout, the program may hang
+/// indefinitely while awaiting a response.
+///
+/// `requests` applies no timeout by default, so omitting the parameter leaves
+/// the request unbounded. `httpx` does apply a default timeout, so omitting
+/// the parameter is not flagged; passing `timeout=None` explicitly disables
+/// the timeout and is flagged for both modules.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
## Summary

Closes #27868.

The S113 docs say the rule flags requests and httpx calls that don't pass a timeout. That stopped being true in July 2024, when the rule learned that httpx sets a default timeout on its own, so leaving it out there won't hang anything.

This PR updates "what it does" and "why is this bad?" so they say what the rule actually does now. It also spells out why httpx is the exception. httpx comes with a default timeout, requests doesn't and will wait forever. Passing timeout=None turns that default off, which is why both get flagged in that case.

## Test Plan

Documentation only, no behavior change.
