### PR TITLE
[`flake8-tidy-imports`] Prevent fix loop between `TID254` and `TID255`

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-tidy-imports/lazy-import-immediately-resolved.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-tidy-imports/lazy-import-immediately-resolved.md
@@ -34,3 +34,27 @@ help: Convert to a lazy import
   |
 note: This is an unsafe fix and may change runtime behavior
 ```
+
+## Partially required lazy imports
+
+`TID255` still reports immediately resolved names outside `require-lazy`, even when another name in
+the same import is required to be lazy.
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TID254", "TID255"]
+flake8-tidy-imports.require-lazy = ["foo", "pkg.Base"]
+```
+
+```py
+lazy import foo as required, bar
+lazy from pkg import Base as RequiredBase, OtherBase
+
+required.value
+RequiredBase()
+bar.value  # error: [lazy-import-immediately-resolved]
+OtherBase()  # error: [lazy-import-immediately-resolved]
+```

--- a/crates/ruff_linter/resources/mdtest/flake8-tidy-imports/lazy-import-immediately-resolved.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-tidy-imports/lazy-import-immediately-resolved.md
@@ -1,0 +1,36 @@
+# `lazy-import-immediately-resolved` (`TID255`)
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TID254", "TID255"]
+flake8-tidy-imports.require-lazy = "all"
+```
+
+## Required lazy imports
+
+`TID255` ignores imports that are required to be lazy to avoid a conflict with `TID254`, even if the
+import is resolved immediately.
+
+```py
+import foo  # snapshot: lazy-import-mismatch
+
+class Bar(foo.Base): ...
+```
+
+```snapshot
+error[TID254]: Use a `lazy` import instead of an eager import
+ --> src/mdtest_snippet.py:1:8
+  |
+1 | import foo  # snapshot: lazy-import-mismatch
+  |        ^^^
+help: Convert to a lazy import
+  |
+  - import foo  # snapshot: lazy-import-mismatch
+1 + lazy import foo  # snapshot: lazy-import-mismatch
+2 |
+  |
+note: This is an unsafe fix and may change runtime behavior
+```

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_immediately_resolved.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_immediately_resolved.rs
@@ -105,7 +105,7 @@ pub(crate) fn lazy_import_immediately_resolved(checker: &Checker, name: &ExprNam
             break;
         }
 
-        if require_lazy.find(&policy).is_some() {
+        if node.range().contains_range(binding.range()) && require_lazy.find(&policy).is_some() {
             return;
         }
     }

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_immediately_resolved.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_immediately_resolved.rs
@@ -8,6 +8,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
 use crate::codes::Category;
+use crate::rules::flake8_tidy_imports::rules::BannedModuleImportPolicies;
 use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
@@ -46,6 +47,12 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// The fix is only available when the lazy import statement imports a single
 /// member, since removing `lazy` from a multi-member import would make every
 /// imported member eager, including names that may not be resolved immediately.
+///
+/// ## Options
+///
+/// The rule ignores imports required to be lazy by the following setting:
+///
+/// - [`lint.flake8-tidy-imports.require-lazy`]
 #[derive(ViolationMetadata)]
 #[violation_metadata(preview_since = "0.15.13", category = Category::Correctness)]
 pub(crate) struct LazyImportImmediatelyResolved {
@@ -89,6 +96,19 @@ pub(crate) fn lazy_import_immediately_resolved(checker: &Checker, name: &ExprNam
     let Some(import) = lazy_import_statement(binding, semantic) else {
         return;
     };
+
+    // Ignore imports that are required to be lazy.
+    let require_lazy = &checker.settings().flake8_tidy_imports.require_lazy;
+    for (policy, node) in &BannedModuleImportPolicies::new(import, checker) {
+        // An `all` selector matches a `from` import's module, not its individual members.
+        if require_lazy.includes_all() && import.is_import_from_stmt() && node.is_alias() {
+            break;
+        }
+
+        if require_lazy.find(&policy).is_some() {
+            return;
+        }
+    }
 
     let fix_range = if is_single_member_import(import) {
         lazy_import_prefix_range(import, checker.source_tokens())


### PR DESCRIPTION
Summary
--

I initially wanted to avoid emitting `TID254` when an import that was required to be lazy was
immediately resolved. However, it became clear that that approach was much more complicated while
reviewing #26027. This PR implements the easier fix of skipping `TID255` for imports that are
required to be lazy by the user's configuration, even if those imports are immediately resolved. I
think this is also a sensible route.

A close alternative would be still emitting the `TID255` diagnostic and only suppressing the fix. I
don't really feel strongly one way or the other. The diagnostic is possibly still helpful to let you
know that you're defeating your desired lazy import, but especially in an example like the one from
the issue, it would be pretty hard to avoid. This would just require moving the new check down a few
lines to implement, though.

Fixes #25418

Test Plan
--

New mdtest based on the issue
