### PR TITLE
[ty] Narrow types with ordered length comparisons

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/len.md
@@ -377,16 +377,17 @@ def _(value: tuple[str] | tuple[int, *tuple[bytes, ...], int]):
 
 ## Ordered length comparisons with string and bytes literals
 
-String and bytes literals encode their lengths, so ordered comparisons can select between them:
+String and bytes literals encode their lengths, so ordered comparisons can select between them.
+String lengths count Unicode code points:
 
 ```py
 from typing import Literal
 
-def _(text: Literal["a", "ab"], data: Literal[b"", b"a"]):
+def _(text: Literal["é", "ab"], data: Literal[b"", b"a"]):
     if len(text) >= 2:
         reveal_type(text)  # revealed: Literal["ab"]
     else:
-        reveal_type(text)  # revealed: Literal["a"]
+        reveal_type(text)  # revealed: Literal["é"]
 
     if 0 < len(data):
         reveal_type(data)  # revealed: Literal[b"a"]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/len.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/len.md
@@ -317,6 +317,150 @@ def never_prefix[*Ts](value: tuple[Never, *Ts]) -> str:
     return ""
 ```
 
+## Ordered length comparisons
+
+Ordered length comparisons select the compatible tuple alternatives in both branches. A length check
+can establish that an index is valid, including when `len` appears on the right:
+
+```py
+def _(value: tuple[int] | tuple[int, int]):
+    if len(value) > 1:
+        reveal_type(value)  # revealed: tuple[int, int]
+        reveal_type(value[1])  # revealed: int
+    else:
+        reveal_type(value)  # revealed: tuple[int]
+
+    if 2 <= len(value):
+        reveal_type(value)  # revealed: tuple[int, int]
+    else:
+        reveal_type(value)  # revealed: tuple[int]
+
+    if len(value) < 2:
+        reveal_type(value)  # revealed: tuple[int]
+    else:
+        reveal_type(value)  # revealed: tuple[int, int]
+
+    if 1 >= len(value):
+        reveal_type(value)  # revealed: tuple[int]
+    else:
+        reveal_type(value)  # revealed: tuple[int, int]
+```
+
+## Ordered length comparisons with variable tuples
+
+A variable-length tuple remains possible when some of its lengths satisfy the comparison. Its
+required elements can rule it out when the comparison requires a shorter tuple:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+def _(value: tuple[str] | tuple[int, *tuple[bytes, ...], int]):
+    if len(value) > 2:
+        reveal_type(value)  # revealed: tuple[int, *tuple[bytes, ...], int]
+    else:
+        reveal_type(value)  # revealed: tuple[str] | tuple[int, *tuple[bytes, ...], int]
+
+    if len(value) < 2:
+        reveal_type(value)  # revealed: tuple[str]
+    else:
+        reveal_type(value)  # revealed: tuple[int, *tuple[bytes, ...], int]
+
+    if len(value) <= 1:
+        reveal_type(value)  # revealed: tuple[str]
+
+    if len(value) > 1_000_000_000:
+        reveal_type(value)  # revealed: tuple[int, *tuple[bytes, ...], int]
+```
+
+## Ordered length comparisons with string and bytes literals
+
+String and bytes literals encode their lengths, so ordered comparisons can select between them:
+
+```py
+from typing import Literal
+
+def _(text: Literal["a", "ab"], data: Literal[b"", b"a"]):
+    if len(text) >= 2:
+        reveal_type(text)  # revealed: Literal["ab"]
+    else:
+        reveal_type(text)  # revealed: Literal["a"]
+
+    if 0 < len(data):
+        reveal_type(data)  # revealed: Literal[b"a"]
+    else:
+        reveal_type(data)  # revealed: Literal[b""]
+```
+
+## Ordered length comparisons with custom lengths
+
+A custom type is excluded only when none of its declared lengths satisfy the comparison. A list
+remains possible in either branch because its type does not encode its length:
+
+```py
+from typing import Literal
+
+class Short:
+    def __len__(self) -> Literal[1, 2]:
+        return 1
+
+class Long:
+    def __len__(self) -> Literal[3]:
+        return 3
+
+def _(value: Short | Long | list[int]):
+    if len(value) > 2:
+        reveal_type(value)  # revealed: Long | list[int]
+    else:
+        reveal_type(value)  # revealed: Short | list[int]
+
+    if len(value) < 2:
+        reveal_type(value)  # revealed: Short | list[int]
+    else:
+        reveal_type(value)  # revealed: Short | Long | list[int]
+```
+
+## Ordered length comparisons with type variables
+
+Filtering a type variable's upper bound preserves the type variable, so the narrowed value can still
+be returned with its original type:
+
+```py
+from typing import TypeVar
+
+TupleValue = TypeVar("TupleValue", bound=tuple[int] | tuple[str, str])
+
+def identity(value: TupleValue) -> TupleValue:
+    if len(value) >= 2:
+        reveal_type(value)  # revealed: TupleValue@identity & tuple[str, str]
+        return value
+    else:
+        reveal_type(value)  # revealed: TupleValue@identity & tuple[int]
+        return value
+```
+
+## Ordered length comparisons at zero
+
+Lengths are nonnegative, and boolean literals compare as their integer values. Zero separates empty
+tuples from nonempty tuples, while a negative upper bound excludes both alternatives:
+
+```py
+from typing_extensions import assert_never
+
+def _(value: tuple[()] | tuple[int]):
+    if len(value) <= False:
+        reveal_type(value)  # revealed: tuple[()]
+    else:
+        reveal_type(value)  # revealed: tuple[int]
+
+    if len(value) < -1:
+        assert_never(value)
+    else:
+        reveal_type(value)  # revealed: tuple[()] | tuple[int]
+```
+
 ## Regression tests
 
 Length constraints must not become stale after mutating a value that does not encode its length:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6087,6 +6087,16 @@ impl<'db> Type<'db> {
             }
         }
 
+        if let Type::LiteralValue(literal) = self
+            && let Some(length) = match literal.kind() {
+                LiteralValueTypeKind::String(string) => Some(string.python_len(db)),
+                LiteralValueTypeKind::Bytes(bytes) => Some(bytes.python_len(db)),
+                _ => None,
+            }
+        {
+            return i64::try_from(length).ok().map(Type::int_literal);
+        }
+
         let return_ty = match self.try_call_dunder(
             db,
             env,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry};
 
 use crate::place::loop_header_reachability;
@@ -1490,6 +1491,63 @@ fn necessary_sequence_pattern_type<'db>(
 enum NominalAttributeComparison {
     Equality,
     Identity,
+}
+
+/// A comparison with an integer length, expressed as a required or excluded ordering.
+/// For example, `<=` excludes `Ordering::Greater`.
+#[derive(Clone, Copy)]
+struct LengthComparison {
+    ordering: Ordering,
+    is_positive: bool,
+}
+
+impl LengthComparison {
+    fn from_op(op: ast::CmpOp, is_positive: bool) -> Option<Self> {
+        let (ordering, matches_ordering) = match op {
+            ast::CmpOp::Eq => (Ordering::Equal, true),
+            ast::CmpOp::NotEq => (Ordering::Equal, false),
+            ast::CmpOp::Lt => (Ordering::Less, true),
+            ast::CmpOp::LtE => (Ordering::Greater, false),
+            ast::CmpOp::Gt => (Ordering::Greater, true),
+            ast::CmpOp::GtE => (Ordering::Less, false),
+            _ => return None,
+        };
+        Some(Self {
+            ordering,
+            is_positive: matches_ordering == is_positive,
+        })
+    }
+
+    fn reflected(self) -> Self {
+        Self {
+            ordering: self.ordering.reverse(),
+            ..self
+        }
+    }
+
+    fn is_equality(self) -> bool {
+        self.ordering == Ordering::Equal && self.is_positive
+    }
+
+    fn matches(self, actual: i128, expected: i64) -> bool {
+        (actual.cmp(&i128::from(expected)) == self.ordering) == self.is_positive
+    }
+
+    fn matches_tuple_length(self, actual: TupleLength, expected: i64) -> bool {
+        match actual {
+            TupleLength::Fixed(actual) => self.matches(actual as i128, expected),
+            TupleLength::Variable(..) => {
+                let minimum = actual.minimum() as i128;
+                let expected = i128::from(expected);
+                match (self.ordering, self.is_positive) {
+                    (Ordering::Equal, true) | (Ordering::Greater, false) => minimum <= expected,
+                    (Ordering::Less, true) => minimum < expected,
+                    // An unbounded tuple can exceed any upper bound or differ from any exact length.
+                    _ => true,
+                }
+            }
+        }
+    }
 }
 
 struct NarrowingConstraintsBuilder<'db, 'ast> {
@@ -3383,26 +3441,26 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    /// Filter a type based on an equality or inequality comparison against an exact length.
+    /// Filter a type based on a comparison against an integer length.
     ///
-    /// Exact tuple types are specialized to the observed length. Other types that encode their
-    /// possible lengths are filtered. Unknown-length types are left unchanged because persisting
-    /// an observed length would become stale after mutation.
-    fn narrow_type_by_exact_len(
+    /// Equality comparisons specialize exact tuple types to the observed length. Other comparisons
+    /// filter types that encode their possible lengths. Unknown-length types are left unchanged
+    /// because persisting an observed length would become stale after mutation.
+    fn narrow_type_by_len_comparison(
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         ty: Type<'db>,
-        length: usize,
-        is_equality: bool,
+        length: i64,
+        comparison: LengthComparison,
     ) -> Type<'db> {
         let resolved = ty.resolve_type_alias(db);
 
         let narrowed = match resolved {
             Type::Union(union) => union.map(db, env, |element| {
-                Self::narrow_type_by_exact_len(db, env, *element, length, is_equality)
+                Self::narrow_type_by_len_comparison(db, env, *element, length, comparison)
             }),
             Type::Intersection(intersection) => intersection.map_positive(db, env, |element| {
-                Self::narrow_type_by_exact_len(db, env, *element, length, is_equality)
+                Self::narrow_type_by_len_comparison(db, env, *element, length, comparison)
             }),
             Type::TypeVar(typevar) => {
                 let Some(bound_or_constraints) = typevar.typevar(db).bound_or_constraints(db, env)
@@ -3413,19 +3471,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let upper_bound = bound_or_constraints.as_type(db, env);
                 let narrowed_upper_bound = match bound_or_constraints {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        Self::narrow_type_by_exact_len(db, env, bound, length, is_equality)
+                        Self::narrow_type_by_len_comparison(db, env, bound, length, comparison)
                     }
                     TypeVarBoundOrConstraints::Constraints(constraints) => {
                         UnionType::from_elements(
                             db,
                             env,
                             constraints.elements(db).iter().map(|constraint| {
-                                Self::narrow_type_by_exact_len(
+                                Self::narrow_type_by_len_comparison(
                                     db,
                                     env,
                                     *constraint,
                                     length,
-                                    is_equality,
+                                    comparison,
                                 )
                             }),
                         )
@@ -3439,7 +3497,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             }
             _ => {
-                if is_equality && let Some(tuple) = resolved.exact_tuple_instance_spec(db) {
+                if comparison.is_equality()
+                    && let Ok(length) = usize::try_from(length)
+                    && let Some(tuple) = resolved.exact_tuple_instance_spec(db)
+                {
                     match tuple.resize(db, env, TupleLength::Fixed(length)) {
                         Ok(resized) => {
                             let narrowed = Type::tuple(TupleType::new(db, env, &resized));
@@ -3460,8 +3521,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     let satisfies_comparison = |length_type: Type<'db>| {
                         length_type
                             .as_int_literal()
-                            .and_then(|actual| usize::try_from(actual).ok())
-                            .is_some_and(|actual| (actual == length) == is_equality)
+                            .is_some_and(|actual| comparison.matches(i128::from(actual), length))
                     };
                     let comparison_possible = resolved
                         .len(db, env)
@@ -3474,19 +3534,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         })
                         .or_else(|| {
                             tuple_length
-                                .and_then(TupleLength::into_fixed_length)
-                                .map(|actual| (actual == length) == is_equality)
+                                .map(|actual| comparison.matches_tuple_length(actual, length))
                         });
 
-                    match comparison_possible {
-                        Some(false) => Type::Never,
-                        None if is_equality
-                            && tuple_length
-                                .is_some_and(|tuple_length| length < tuple_length.minimum()) =>
-                        {
-                            Type::Never
-                        }
-                        _ => resolved,
+                    if comparison_possible == Some(false) {
+                        Type::Never
+                    } else {
+                        resolved
                     }
                 }
             }
@@ -3926,6 +3980,60 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
+        if let [op] = &**ops
+            && let Some(comparison) = LengthComparison::from_op(*op, is_positive)
+        {
+            let mut narrow_len_call =
+                |call: &ast::ExprCall, length_type: Type<'db>, comparison: LengthComparison| {
+                    let Type::FunctionLiteral(function_type) =
+                        inference.expression_type(&*call.func)
+                    else {
+                        return;
+                    };
+                    if function_type.known(db) != Some(KnownFunction::Len)
+                        || !call.arguments.keywords.is_empty()
+                    {
+                        return;
+                    }
+                    let [arg] = &*call.arguments.args else {
+                        return;
+                    };
+                    let Some(length) = length_type.resolve_type_alias(db).as_int_like_literal()
+                    else {
+                        return;
+                    };
+                    let Some(target) = PlaceExpr::try_from_expr(arg) else {
+                        return;
+                    };
+
+                    let arg_type = inference.expression_type(arg);
+                    let narrowed = Self::narrow_type_by_len_comparison(
+                        db, &self.env, arg_type, length, comparison,
+                    );
+                    if narrowed != arg_type {
+                        insert_narrowing_constraint(
+                            &mut constraints,
+                            self.expect_place(&target),
+                            NarrowingConstraint::replacement(narrowed),
+                        );
+                    }
+                };
+
+            // E.g., `len(items) == 2`
+            if let ast::Expr::Call(call) = left.expression_value() {
+                narrow_len_call(call, inference.expression_type(&comparators[0]), comparison);
+            }
+
+            // E.g., `2 == len(items)`
+            if let ast::Expr::Call(call) = comparators[0].expression_value() {
+                narrow_len_call(
+                    call,
+                    inference.expression_type(&**left),
+                    comparison.reflected(),
+                );
+            }
+        }
+
         // Narrow tagged unions of `TypedDict`s with `Literal` keys, for example:
         //
         //     class Foo(TypedDict):
@@ -3942,52 +4050,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             // For `==`, we use equality semantics on the `if` branch (is_positive=true).
             // For `!=`, we use equality semantics on the `else` branch (is_positive=false).
             let is_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
-
-            let mut narrow_len_call = |call: &ast::ExprCall, length_type: Type<'db>| {
-                let Type::FunctionLiteral(function_type) = inference.expression_type(&*call.func)
-                else {
-                    return;
-                };
-                if function_type.known(db) != Some(KnownFunction::Len)
-                    || !call.arguments.keywords.is_empty()
-                {
-                    return;
-                }
-                let [arg] = &*call.arguments.args else {
-                    return;
-                };
-                let Some(length_literal) = length_type.resolve_type_alias(db).as_int_like_literal()
-                else {
-                    return;
-                };
-                let Ok(length) = usize::try_from(length_literal) else {
-                    return;
-                };
-                let Some(target) = PlaceExpr::try_from_expr(arg) else {
-                    return;
-                };
-
-                let arg_type = inference.expression_type(arg);
-                let narrowed =
-                    Self::narrow_type_by_exact_len(db, &self.env, arg_type, length, is_equality);
-                if narrowed != arg_type {
-                    insert_narrowing_constraint(
-                        &mut constraints,
-                        self.expect_place(&target),
-                        NarrowingConstraint::replacement(narrowed),
-                    );
-                }
-            };
-
-            // E.g., `len(items) == 2`
-            if let ast::Expr::Call(call) = left.expression_value() {
-                narrow_len_call(call, inference.expression_type(&comparators[0]));
-            }
-
-            // E.g., `2 == len(items)`
-            if let ast::Expr::Call(call) = comparators[0].expression_value() {
-                narrow_len_call(call, inference.expression_type(&**left));
-            }
 
             let mut narrow_subscript = |subscript: &ast::ExprSubscript, other_type: Type<'db>| {
                 let value_type = inference.expression_type(&*subscript.value);


### PR DESCRIPTION
Length guards such as `len(values) > 1` leave `tuple[int] | tuple[int, int]` unnarrowed, causing a spurious `index-out-of-bounds` error for `values[1]`. Extend the existing length filtering to `<`, `<=`, `>`, and `>=`, including reversed operands and both branches.

The filtering uses encoded lengths and tuple minimum lengths. Equality comparisons retain their tuple specialization, and types with unknown lengths remain unchanged. Read string and bytes literal lengths directly to avoid resolving `__len__` for every member of large literal unions.

Closes https://github.com/astral-sh/ty/issues/4451.

## Test plan

Added mdtests covering the guarded indexed access, all four ordered operators, reversed operands, both branches, fixed and variable tuples, string and bytes literals, custom length declarations, and type-variable identity. Boundary cases cover Unicode character lengths, zero, boolean and negative cutoffs, and large lower bounds on variable tuples.
