### PR TITLE
[ty] Reject missing attributes on `type[]` aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/generic_alias.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/generic_alias.md
@@ -1,4 +1,6 @@
-# GenericAlias in type expressions
+# Generic aliases
+
+## Type expressions
 
 We recognize if a `types.GenericAlias` instance is created by specializing a generic class. We don't
 explicitly mention it in our type display, but `list[int]` in the example below is a `GenericAlias`
@@ -37,4 +39,63 @@ However, using such a `GenericAlias` instance in a type expression is currently 
 # error: [invalid-type-form] "Variable of type `GenericAlias` is not allowed in a parameter annotation"
 def _(strings: Strings) -> None:
     reveal_type(strings)  # revealed: Unknown
+```
+
+## Attributes of `type` aliases
+
+The alias objects `type[Any]` and `typing.Type[Any]` delegate attribute access to their origin,
+`type`. They do not have arbitrary attributes, even though their type argument is dynamic.
+
+```py
+from typing import Any, Type, TypeAlias
+
+Modern: TypeAlias = type[Any]
+Legacy: TypeAlias = Type[Any]
+
+Modern.missing  # error: [unresolved-attribute]
+Legacy.missing  # error: [unresolved-attribute]
+
+reveal_type(Modern.__name__)  # revealed: str
+reveal_type(Legacy.__name__)  # revealed: str
+```
+
+Attributes belonging to the alias itself remain accessible.
+
+```py
+reveal_type(Modern.__args__)  # revealed: tuple[Any, ...]
+reveal_type(Legacy.__args__)  # revealed: tuple[Any, ...]
+Modern.__origin__
+Legacy.__origin__
+Modern.__mro_entries__((object,))
+```
+
+The origin is `type` regardless of the type argument. Attributes of `int` are not available on the
+alias object `type[int]`.
+
+```py
+Integers = type[int]
+LegacyIntegers = Type[int]
+
+Integers.bit_length  # error: [unresolved-attribute]
+LegacyIntegers.bit_length  # error: [unresolved-attribute]
+```
+
+When these aliases are used as annotations, their inhabitants can be arbitrary class objects.
+Accessing an unknown attribute through such a parameter remains valid.
+
+```py
+def dynamic_class(modern: Modern, legacy: Legacy) -> None:
+    reveal_type(modern.missing)  # revealed: Any
+    reveal_type(legacy.missing)  # revealed: Any
+```
+
+## Attributes of arbitrary `GenericAlias` instances
+
+When the origin is unknown, we allow arbitrary attribute access through a `GenericAlias` instance.
+
+```py
+from types import GenericAlias
+
+def unknown_origin(alias: GenericAlias) -> None:
+    reveal_type(alias.missing)  # revealed: Any
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7538,6 +7538,17 @@ impl<'db> Type<'db> {
                 return MemberLookupResult::from(Place::Undefined);
             }
 
+            if matches!(
+                self,
+                Type::KnownInstance(KnownInstanceType::TypeGenericAlias(_))
+            ) {
+                // `GenericAlias.__getattr__` delegates to `__origin__`. For `type[T]`, the
+                // origin is always `type`, not `T`, even when `T` is `Any`.
+                return KnownClass::Type
+                    .to_class_literal(db, env)
+                    .member_lookup_with_policy_and_receiver(db, env, name, policy, None);
+            }
+
             let name_type = Type::string_literal(db, name);
             match self.try_call_dunder(
                 db,


### PR DESCRIPTION
## Summary

Previously, we allowed arbitrary attribute access on the alias objects `type[T]` and `typing.Type[T]`. We now resolve missing attributes against their known origin, `type`, instead of using the unrestricted `GenericAlias.__getattr__` fallback.

```python
from typing import Any, Type, TypeAlias

Modern: TypeAlias = type[Any]
Legacy: TypeAlias = Type[Any]

# Before: no errors. After: unresolved-attribute on each line.
Modern.missing
Legacy.missing

def example(cls: type[Any]) -> None:
    cls.missing  # Before and after: OK.
```

The alias object has a known origin, whereas `cls` can refer to any class with its own attributes. Attributes defined on the alias itself, such as `__args__` and `__origin__`, remain accessible. The origin is `type` regardless of the type argument, so attributes of `int`, such as `bit_length`, are not available on the alias object `type[int]`.

Mypy 2.1.0, pyright 1.1.410, and pyrefly 1.3.0-dev.1 with the `default` preset agree with the behavior shown above: they reject both missing alias attributes and allow the access through `cls`.

This reports the two missing errors in [`specialtypes_type`](https://github.com/python/typing/blob/cf943ccbea5596ef969eec6e2260097ff697b7ba/conformance/tests/specialtypes_type.py#L143-L146), reducing its discrepancies from 11 to 9. The file remains Partial because its remaining nine discrepancies reflect an intentional choice in ty: we interpret bare `type` as `type[object]`, whereas the conformance suite expects `type[Any]`. The other 144 conformance files are unchanged.
