### PR TITLE
[ty] Converge mutually recursive tuple/Union aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -171,6 +171,18 @@ def _(x: JSONValue):
     reveal_type(x)  # revealed: Sequence[JSONValue] | float | None | Mapping[str, JSONValue]
 ```
 
+## Mutually recursive tuple and union aliases
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/4443>. Inferring these
+assignments used to panic with `infer_definition_types: execute: too many cycle iterations`.
+
+```py
+from typing import Union
+
+a = tuple["b"]
+b = Union["a", "b", int]
+```
+
 ## Self-referential legacy type variables
 
 ```py

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1187,32 +1187,49 @@ impl<'db> Specialization<'db> {
     pub(super) fn merge_cycle_recovery(self, db: &'db dyn Db, previous: Self) -> Option<Self> {
         if self.generic_context(db) != previous.generic_context(db)
             || self.materialization_kind(db) != previous.materialization_kind(db)
-            || self.tuple_inner(db) != previous.tuple_inner(db)
         {
             return None;
         }
 
-        let types: Box<[_]> = previous
-            .types(db)
-            .iter()
-            .zip(self.types(db))
-            .map(|(previous, current)| match (*previous, *current) {
-                (previous, current) if previous == current => Some(current),
-                (previous, current)
-                    if previous == Type::unknown() || current == Type::unknown() =>
-                {
-                    Some(Type::unknown())
-                }
-                _ => None,
-            })
-            .collect::<Option<Box<[_]>>>()?;
+        // Specialty tuples store their structure in `tuple_inner`. When that differs across
+        // cycle iterations (often because a recursive `typing.Union` dropped `Divergent` and
+        // the nest grew), prefer the current iteration's specialty tuple. Nest reduction then
+        // collapses `Divergent` markers. Unioning the GenericAliases instead grows without bound
+        // (ty#4443).
+        let tuple_inner = match (self.tuple_inner(db), previous.tuple_inner(db)) {
+            (None, None) => None,
+            (Some(current), Some(previous_tuple)) if current == previous_tuple => Some(current),
+            (Some(current), Some(_)) => Some(current),
+            _ => return None,
+        };
+
+        let types: Box<[_]> = if tuple_inner.is_some() {
+            // Type arguments are derived from `tuple_inner` for specialty tuples; keep them
+            // aligned with the chosen current specialization.
+            self.types(db).to_vec().into_boxed_slice()
+        } else {
+            previous
+                .types(db)
+                .iter()
+                .zip(self.types(db))
+                .map(|(previous, current)| match (*previous, *current) {
+                    (previous, current) if previous == current => Some(current),
+                    (previous, current)
+                        if previous == Type::unknown() || current == Type::unknown() =>
+                    {
+                        Some(Type::unknown())
+                    }
+                    _ => None,
+                })
+                .collect::<Option<Box<[_]>>>()?
+        };
 
         Some(Self::new(
             db,
             self.generic_context(db),
             types,
             self.materialization_kind(db),
-            self.tuple_inner(db),
+            tuple_inner,
         ))
     }
 

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -14,6 +14,7 @@ use crate::{
         dedicated::pydantic::ConfigBoolean,
         generics::{Specialization, walk_generic_context},
         newtype::NewType,
+        set_theoretic::UnionType,
         typevar::TypeVarInstance,
         variance::VarianceInferable,
         visitor,
@@ -775,14 +776,60 @@ impl<'db> UnionTypeInstance<'db> {
             None => None,
         };
         let union_type = match self.union_type(db).clone() {
-            Ok(ty) if nested => Ok(ty.recursive_type_normalized_impl(db, env, div, nested)?),
-            Ok(ty) => Ok(ty
-                .recursive_type_normalized_impl(db, env, div, nested)
-                .unwrap_or(div)),
+            Ok(ty) => {
+                // Top-level `Type::Union` normalization drops `Divergent` members
+                // (`T | Divergent == T`). That is correct for bare unions, but this
+                // `typing.Union[...]` special-form is often nested inside specialty
+                // tuples (`tuple[Union["a", "b", int]]`). Dropping `Divergent` there
+                // leaves no marker for nest reduction, so mutually recursive
+                // tuple/union aliases grow without bound (ty#4443).
+                let had_divergent_marker = union_type_has_divergent_marker(db, ty, div);
+                let normalized = if nested {
+                    ty.recursive_type_normalized_impl(db, env, div, nested)?
+                } else {
+                    ty.recursive_type_normalized_impl(db, env, div, nested)
+                        .unwrap_or(div)
+                };
+                if nested && normalized.same_divergent_marker(div) {
+                    // Collapse `UnionType[Divergent]` so enclosing specialty tuples
+                    // can nest-reduce the same way they do for bare `Divergent`.
+                    return None;
+                }
+                if !nested
+                    && had_divergent_marker
+                    && !union_type_has_divergent_marker(db, normalized, div)
+                {
+                    Ok(UnionType::from_two_elements(db, env, normalized, div))
+                } else {
+                    Ok(normalized)
+                }
+            }
             Err(err) => Err(err),
         };
 
         Some(Self::new(db, value_expr_types, union_type))
+    }
+}
+
+/// Returns `true` if `ty` is `Divergent` with `div`'s marker, or a union that still
+/// carries that marker / recursive-definition flag from cycle recovery.
+fn union_type_has_divergent_marker<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    div: Type<'db>,
+) -> bool {
+    if ty.same_divergent_marker(div) {
+        return true;
+    }
+    match ty {
+        Type::Union(union) => {
+            union.recursively_defined(db).is_yes()
+                || union
+                    .elements(db)
+                    .iter()
+                    .any(|element| union_type_has_divergent_marker(db, *element, div))
+        }
+        _ => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -813,11 +813,7 @@ impl<'db> UnionTypeInstance<'db> {
 
 /// Returns `true` if `ty` is `Divergent` with `div`'s marker, or a union that still
 /// carries that marker / recursive-definition flag from cycle recovery.
-fn union_type_has_divergent_marker<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    div: Type<'db>,
-) -> bool {
+fn union_type_has_divergent_marker<'db>(db: &'db dyn Db, ty: Type<'db>, div: Type<'db>) -> bool {
     if ty.same_divergent_marker(div) {
         return true;
     }


### PR DESCRIPTION
## Summary

- Mutually recursive aliases like `a = tuple["b"]` / `b = Union["a", "b", int]` panicked with `infer_definition_types: too many cycle iterations` (astral-sh/ty#4443).
- `typing.Union[...]` normalization dropped `Divergent` (`T | Divergent == T`), so specialty-tuple nest reduction had no marker and nests grew as `tuple[int]` → `tuple[tuple[int]|int]` → …
- Preserve `Divergent` inside the `typing.Union` special-form during cycle recovery, collapse `UnionType[Divergent]` when nested so enclosing tuples can nest-reduce, and let `Specialization::merge_cycle_recovery` keep differing `tuple_inner` instead of unioning GenericAliases.

## Test plan

- [x] `MDTEST_TEST_FILTER='Mutually recursive tuple' cargo test -p ty_python_semantic --test mdtest -- cycle/basic` (was panic, now ok)
- [x] `cargo test -p ty_python_semantic --test mdtest -- cycle/` (2 passed)
- [x] Nearby pep695 / self-referential alias mdtests still ok

Fixes astral-sh/ty#4443