### PR TITLE
[ty] Preserve nominal subtyping for top-materialized protocols

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1096,6 +1096,7 @@ overrides:
 
 ```py
 class InvalidOverride(Bounded[str]):
+    # TODO: this should be an invalid-override error (https://github.com/astral-sh/ty/issues/2156)
     read = None
 
 static_assert(is_subtype_of(InvalidOverride, Bounded[str]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1039,23 +1039,7 @@ static_assert(not is_subtype_of(Top[Bounded[Any]], EquivalentBounded[Any]))
 static_assert(not is_subtype_of(Top[Bounded[Any]], Bottom[EquivalentBounded[Any]]))
 ```
 
-Explicit inheritance establishes subtyping even when a subclass overrides a member incompatibly.
-Taking the top materialization of the base protocol weakens its requirements, so this nominal
-relationship still holds:
-
-```py
-class BoundedSub(Bounded[str]):
-    read = None
-
-static_assert(is_subtype_of(BoundedSub, Bounded[str]))
-static_assert(is_subtype_of(BoundedSub, Top[Bounded[str]]))
-static_assert(is_subtype_of(BoundedSub, Top[Bounded[Any]]))
-static_assert(not is_subtype_of(BoundedSub, Bottom[Bounded[str]]))
-static_assert(not is_subtype_of(BoundedSub, Bottom[Bounded[Any]]))
-static_assert(not is_subtype_of(BoundedSub, Top[EquivalentBounded[Any]]))
-```
-
-Protocols with constrained type parameters also lie between their bottom and top materializations:
+The same relations also hold when the type parameter has constraints:
 
 ```py
 class Constrained[T: (str, bytes)](Protocol):
@@ -1105,6 +1089,21 @@ static_assert(is_subtype_of(Bottom[Cell[Any]], Top[EquivalentCell[Any]]))
 static_assert(not is_subtype_of(Cell[Any], Bottom[EquivalentCell[Any]]))
 static_assert(not is_subtype_of(Top[Cell[Any]], EquivalentCell[Any]))
 static_assert(not is_subtype_of(Top[Cell[Any]], Bottom[EquivalentCell[Any]]))
+```
+
+If a class inherits from the protocol explicitly, we treat it as a subtype, even if it has invalid
+overrides:
+
+```py
+class InvalidOverride(Bounded[str]):
+    read = None
+
+static_assert(is_subtype_of(InvalidOverride, Bounded[str]))
+static_assert(is_subtype_of(InvalidOverride, Top[Bounded[str]]))
+static_assert(is_subtype_of(InvalidOverride, Top[Bounded[Any]]))
+static_assert(not is_subtype_of(InvalidOverride, Bottom[Bounded[str]]))
+static_assert(not is_subtype_of(InvalidOverride, Bottom[Bounded[Any]]))
+static_assert(not is_subtype_of(InvalidOverride, Top[EquivalentBounded[Any]]))
 ```
 
 ## Callable

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -1039,7 +1039,23 @@ static_assert(not is_subtype_of(Top[Bounded[Any]], EquivalentBounded[Any]))
 static_assert(not is_subtype_of(Top[Bounded[Any]], Bottom[EquivalentBounded[Any]]))
 ```
 
-The same relations also hold when the type parameter has constraints:
+Explicit inheritance establishes subtyping even when a subclass overrides a member incompatibly.
+Taking the top materialization of the base protocol weakens its requirements, so this nominal
+relationship still holds:
+
+```py
+class BoundedSub(Bounded[str]):
+    read = None
+
+static_assert(is_subtype_of(BoundedSub, Bounded[str]))
+static_assert(is_subtype_of(BoundedSub, Top[Bounded[str]]))
+static_assert(is_subtype_of(BoundedSub, Top[Bounded[Any]]))
+static_assert(not is_subtype_of(BoundedSub, Bottom[Bounded[str]]))
+static_assert(not is_subtype_of(BoundedSub, Bottom[Bounded[Any]]))
+static_assert(not is_subtype_of(BoundedSub, Top[EquivalentBounded[Any]]))
+```
+
+Protocols with constrained type parameters also lie between their bottom and top materializations:
 
 ```py
 class Constrained[T: (str, bytes)](Protocol):

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -502,9 +502,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // Explicit protocol inheritance is nominal, but materializing a protocol can change
-        // the requirements represented by that same class. The nominal shortcut is therefore
-        // valid only when materialization leaves the target's members unchanged.
+        // Explicit protocol inheritance establishes subtyping even when a subclass overrides
+        // members incompatibly. This also holds for a top-materialized base protocol, whose
+        // requirements are weaker. Other materializations can invalidate the nominal shortcut.
         let mut result = self.never();
         let source_protocol = ty.as_protocol_instance();
 
@@ -558,14 +558,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             let env = self.env;
             // `result` combines nominal and structural ways to satisfy the protocol. Including the
-            // nominal constraints directly is safe when materialization leaves the required members
-            // unchanged, or when the nominal relation has no solutions to add to `result`.
+            // nominal constraints directly is safe when the target's requirements are unchanged or
+            // weakened by top materialization, and the source's requirements are unchanged. It is
+            // also safe when the nominal relation has no solutions to add to `result`.
             //
             // Check that inexpensive case first: comparing every requirement of an unrelated
             // recursive protocol can expand its interface before structural member ordering gets
             // a chance to reject an incompatible finite member.
             let can_use_nominal_result_directly = nominally_satisfied.is_never_satisfied(db, env)
-                || (!protocol.materialization_changes_requirements(db, env, protocol)
+                || ((protocol.materialization_kind(db) == Some(MaterializationKind::Top)
+                    || !protocol.materialization_changes_requirements(db, env, protocol))
                     && !source_protocol.is_some_and(|source| {
                         source.materialization_changes_requirements(db, env, protocol)
                     }));

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -503,8 +503,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
         // Explicit protocol inheritance establishes subtyping even when a subclass overrides
-        // members incompatibly. This also holds for a top-materialized base protocol, whose
-        // requirements are weaker. Other materializations can invalidate the nominal shortcut.
+        // members incompatibly.
         let mut result = self.never();
         let source_protocol = ty.as_protocol_instance();
 


### PR DESCRIPTION
## Summary

Fix the subtype check in [Alex's example](https://github.com/astral-sh/ruff/pull/28246#pullrequestreview-5090210909): we treat `InvalidOverride` as a subtype, even though it overrides `read` incompatibly.

```python
class Bounded[T: str](Protocol):
    def read(self) -> T: ...
    def other(self) -> Any: ...

class InvalidOverride(Bounded[str]):
    read = None

static_assert(is_subtype_of(InvalidOverride, Top[Bounded[Any]]))
```

## Test strategy

New Markdown tests