### PR TITLE
[ty] Temporarily disable tuple types in property tests

### DIFF
--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -56,6 +56,7 @@ pub(crate) enum Ty {
         neg: Vec<Ty>,
     },
     FixedLengthTuple(Vec<Ty>),
+    #[expect(dead_code, reason = "Tuple generation is temporarily disabled")]
     VariableLengthTuple(Vec<Ty>, Box<Ty>, Vec<Ty>),
     SubclassOfAny,
     SubclassOfBuiltinClass(&'static str),
@@ -544,28 +545,14 @@ fn arbitrary_type(g: &mut Gen, size: u32, fully_static: bool) -> Ty {
     if size == 0 {
         arbitrary_core_type(g, fully_static)
     } else {
-        match u32::arbitrary(g) % 6 {
+        match u32::arbitrary(g) % 4 {
             0 => arbitrary_core_type(g, fully_static),
             1 => Ty::Union(
                 (0..*g.choose(&[2, 3]).unwrap())
                     .map(|_| arbitrary_type(g, size - 1, fully_static))
                     .collect(),
             ),
-            2 => Ty::FixedLengthTuple(
-                (0..*g.choose(&[0, 1, 2]).unwrap())
-                    .map(|_| arbitrary_type(g, size - 1, fully_static))
-                    .collect(),
-            ),
-            3 => Ty::VariableLengthTuple(
-                (0..*g.choose(&[0, 1, 2]).unwrap())
-                    .map(|_| arbitrary_type(g, size - 1, fully_static))
-                    .collect(),
-                Box::new(arbitrary_type(g, size - 1, fully_static)),
-                (0..*g.choose(&[0, 1, 2]).unwrap())
-                    .map(|_| arbitrary_type(g, size - 1, fully_static))
-                    .collect(),
-            ),
-            4 => Ty::Intersection {
+            2 => Ty::Intersection {
                 pos: (0..*g.choose(&[0, 1, 2]).unwrap())
                     .map(|_| arbitrary_type(g, size - 1, fully_static))
                     .collect(),
@@ -573,13 +560,29 @@ fn arbitrary_type(g: &mut Gen, size: u32, fully_static: bool) -> Ty {
                     .map(|_| arbitrary_type(g, size - 1, fully_static))
                     .collect(),
             },
-            5 => Ty::Callable {
+            3 => Ty::Callable {
                 params: match u32::arbitrary(g) % 2 {
                     0 if !fully_static => CallableParams::GradualForm,
                     _ => CallableParams::List(arbitrary_parameter_list(g, size, fully_static)),
                 },
                 returns: Box::new(arbitrary_type(g, size - 1, fully_static)),
             },
+            // TODO: Re-enable tuple types once they are fixed, and change the modulus back to 6.
+            // See https://github.com/astral-sh/ty/issues/4263.
+            // 4 => Ty::FixedLengthTuple(
+            //     (0..*g.choose(&[0, 1, 2]).unwrap())
+            //         .map(|_| arbitrary_type(g, size - 1, fully_static))
+            //         .collect(),
+            // ),
+            // 5 => Ty::VariableLengthTuple(
+            //     (0..*g.choose(&[0, 1, 2]).unwrap())
+            //         .map(|_| arbitrary_type(g, size - 1, fully_static))
+            //         .collect(),
+            //     Box::new(arbitrary_type(g, size - 1, fully_static)),
+            //     (0..*g.choose(&[0, 1, 2]).unwrap())
+            //         .map(|_| arbitrary_type(g, size - 1, fully_static))
+            //         .collect(),
+            // ),
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Temporarily exclude fixed- and variable-length tuples from generated property-test inputs to avoid the known failures in astral-sh/ty#4263. Keep the generation code commented out so tuple coverage can be restored when the underlying bugs are fixed.
