### PR TITLE
[ty] Document `CallableTypeKind` variants

### DIFF
--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -324,31 +324,277 @@ impl<'db> CallableUpcastContext<'db> {
     }
 }
 
+/// The behavior we assume for a [`CallableType`] beyond its call signatures.
+///
+/// A callable's signature alone does not determine its runtime class, attributes, truthiness,
+/// or whether it can act as a descriptor. The `CallableTypeKind` records which of these
+/// properties we know or assume. The `CallableTypeKind` is irrelevant to calls to the function
+/// and inferred types from `__call__` access; these are always inferred using the stored
+/// signature of a callable type.
+///
+/// For [`Self::FunctionLike`], [`Self::StaticMethodLike`], and [`Self::ClassMethodLike`], the
+/// LSP server emits method semantic tokens on attribute access, allowing editors to highlight
+/// these attributes as methods. We also preserve these kinds when a decorator returns a
+/// `Callable`, assuming that the decorator preserves the decorated function's descriptor behavior.
+///
+/// For example, `decorate` below returns a new function whose signature matches the original
+/// method. We give the result the [`Self::FunctionLike`] kind, so `Example().method` still
+/// binds `self`, even though the `Callable` return annotation does not guarantee that behavior:
+///
+/// ```python
+/// from collections.abc import Callable
+///
+/// def decorate[**P, R](function: Callable[P, R]) -> Callable[P, R]:
+///     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+///         return function(*args, **kwargs)
+///     return wrapper
+///
+/// class Example:
+///     @decorate
+///     def method(self, value: int) -> str:
+///         return str(value)
+///
+/// Example().method(1)  # Returns "1"; no explicit self argument is needed.
+/// ```
+///
+/// [`Self::ParamSpecValue`] is different to the other variants in that it does not describe
+/// a runtime callable object. Instead, it uses the callable representation to store parameter
+/// lists for type inference.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
 pub enum CallableTypeKind {
-    /// Represents regular callable objects.
+    /// Arbitrary callable objects, as described by a `typing.Callable` annotation.
+    ///
+    /// These can be functions, bound methods, classes, or instances with a `__call__` method.
+    /// We know their call signatures but do not assume a particular runtime class: truthiness
+    /// is ambiguous, the metatype is `type`, and member lookup exposes only `object` attributes
+    /// and `__call__`. In particular, function attributes such as `__name__` are not guaranteed.
+    ///
+    /// We do not bind a receiver when these callables are accessed as attributes. In this
+    /// example, `Calculator().add` still requires both integer arguments: accessing `add`
+    /// through the instance does not supply that instance as its first argument.
+    ///
+    /// ```python
+    /// from collections.abc import Callable
+    ///
+    /// class Add:
+    ///     def __call__(self, left: int, right: int) -> int:
+    ///         return left + right
+    ///
+    /// class Calculator:
+    ///     add: Callable[[int, int], int] = Add()
+    ///
+    /// Calculator.add(1, 2)  # Returns 3.
+    /// Calculator().add(1, 2)  # Returns 3; both arguments are still required.
+    /// ```
+    ///
+    /// As a heuristic, class-member lookup converts dunder attributes of this kind to
+    /// [`Self::FunctionLike`] if their signatures can accept parameters. See
+    /// [`Self::DunderParamSpec`] for the exception for `Callable[P, R]` attributes.
+    ///
+    /// For example, `len(Sized())` implicitly calls `__len__` on the `Sized` instance. We
+    /// treat the `Callable`-typed `__len__` as a function, so accessing `Sized().__len__`
+    /// binds the `instance` parameter and gives it the signature `() -> int`:
+    ///
+    /// ```python
+    /// from collections.abc import Callable
+    ///
+    /// def length(instance: "Sized") -> int:
+    ///     return 1
+    ///
+    /// class Sized:
+    ///     __len__: Callable[["Sized"], int] = length
+    ///
+    /// len(Sized())  # Returns 1.
+    /// ```
     Regular,
 
-    /// Represents function-like objects, like the synthesized methods of dataclasses or
-    /// `NamedTuples`. These callables act like real functions when accessed as attributes on
-    /// instances, i.e. they bind `self`.
+    /// Callable objects modeled as instances of Python's `types.FunctionType`.
+    ///
+    /// A [`Type::FunctionLiteral`] identifies a particular function definition. This kind
+    /// represents functions with the given signatures without requiring that identity. It is
+    /// also used for lambdas and synthesized methods of dataclasses and named tuples.
+    ///
+    /// We model these callables as follows:
+    ///
+    /// - These callables are always truthy.
+    /// - Member lookup uses `types.FunctionType`, exposing attributes such as `__name__`,
+    ///   `__qualname__`, `__module__`, `__code__`, `__defaults__`, and `__annotations__`.
+    ///   `__call__` retains the callable's precise signatures.
+    /// - Their metatype is the `types.FunctionType` class literal.
+    /// - They are subtypes of `types.FunctionType`. They can also satisfy a
+    ///   [`Self::Regular`] callable type with a compatible signature, but a regular callable
+    ///   cannot satisfy a function-like callable type merely by having a compatible signature.
+    /// - They use `types.FunctionType` as their owner type when constructing `super()`.
+    /// - They act as [non-data descriptors][descriptor-protocol]: access through a class leaves
+    ///   the signature unchanged, while access through an instance binds the first parameter
+    ///   to that instance. The resulting callable remains function-like.
+    ///   TODO: Model the result as a bound method. Its runtime type is `types.MethodType`,
+    ///   so retaining the `types.FunctionType` behavior listed above is inaccurate.
+    /// - Like function literals, they defer binding `typing.Self` until the receiver is known
+    ///   from the call's arguments, as illustrated below.
+    ///
+    /// In this example, `Base.identity` is function-like because of the decorator. Retrieving
+    /// it from `Base` does not fix `Self` to `Base`: the subsequent call passes a `Child`
+    /// instance, so both the receiver's type and the return type are `Child`.
+    ///
+    /// ```python
+    /// from collections.abc import Callable
+    /// from typing import Self, reveal_type
+    ///
+    /// def preserve[**P, R](function: Callable[P, R]) -> Callable[P, R]:
+    ///     return function
+    ///
+    /// class Base:
+    ///     @preserve
+    ///     def identity(self) -> Self:
+    ///         return self
+    ///
+    /// class Child(Base):
+    ///     pass
+    ///
+    /// identity = Base.identity
+    /// reveal_type(identity(Child()))  # Child
+    /// ```
+    ///
+    /// When inferring a mutable collection's element type, we generalize function literals to
+    /// function-like callables. This allows the list below to contain other functions with
+    /// compatible signatures, rather than restricting it to the single function `first`:
+    ///
+    /// ```python
+    /// def first(value: int) -> str:
+    ///     return str(value)
+    ///
+    /// def second(value: int) -> str:
+    ///     return f"{value}!"
+    ///
+    /// callbacks = [first]  # Inferred as list[(value: int) -> str].
+    /// callbacks.append(second)
+    /// ```
+    ///
+    /// [descriptor-protocol]: https://docs.python.org/3/howto/descriptor.html#descriptor-protocol
     FunctionLike,
 
-    /// Represents a `Callable[P, R]`-typed dunder attribute.
+    /// A `Callable[P, R]`-typed dunder attribute whose parameters come from a `ParamSpec`.
     ///
-    /// This is distinct from [`Self::Regular`] so that the dunder descriptor heuristic does not
-    /// turn the callable into a function-like object after `P` is specialized.
+    /// This has the runtime assumptions of [`Self::Regular`]: truthiness is ambiguous,
+    /// member lookup exposes `object` attributes, and we do not treat these callables as
+    /// descriptors. The separate kind prevents the dunder descriptor heuristic from turning
+    /// it into [`Self::FunctionLike`] after `P` is specialized: the specialized parameters
+    /// already describe the callable's arguments.
+    /// Calling [`CallableType::bind_self`] removes this marker without removing a parameter.
+    ///
+    /// In the example below, specializing `P` to `[str]` gives `callback.__call__` the signature
+    /// `(str, /) -> int`. Binding a receiver would incorrectly remove its `str` parameter:
+    ///
+    /// ```python
+    /// from collections.abc import Callable
+    ///
+    /// class Callback[**P]:
+    ///     __call__: Callable[P, int]
+    ///
+    /// class Length(Callback[[str]]):
+    ///     def __call__(self, text: str) -> int:
+    ///         return len(text)
+    ///
+    /// def invoke(callback: Callback[[str]]) -> int:
+    ///     return callback("hello")
+    ///
+    /// invoke(Length())  # Returns 5.
+    /// ```
+    ///
+    /// This variant is used to represent the callable object itself; [`Self::ParamSpecValue`]
+    /// represents the parameter list substituted for `P`.
     DunderParamSpec,
 
-    /// A callable type that represents a staticmethod. These callables do not bind `self`
-    /// when accessed as attributes on instances - they return the underlying function as-is.
+    /// A callable with the descriptor behavior of `staticmethod`.
+    ///
+    /// These are [non-data descriptors][descriptor-protocol] that return the callable unchanged
+    /// on both class and instance access, without binding a receiver.
+    ///
+    /// TODO: Distinguish the `staticmethod` descriptor from the wrapped function returned by
+    /// descriptor access. Currently, this kind is retained after access, and member lookup
+    /// and type relations lack both nominal types: truthiness is ambiguous, the metatype is
+    /// `type`, and only `object` attributes plus `__call__` are exposed.
+    ///
+    /// In the example below, `Example.method` is an always-truthy `types.FunctionType` instance
+    /// at runtime. After the `Callable`-returning decorator is applied, ty incorrectly rejects
+    /// its `__name__` attribute and the assignment, and loses precision for `type` and `bool`:
+    ///
+    /// ```python
+    /// from collections.abc import Callable
+    /// from types import FunctionType
+    /// from typing import reveal_type
+    ///
+    /// def preserve[**P, R](function: Callable[P, R]) -> Callable[P, R]:
+    ///     return function
+    ///
+    /// class Example:
+    ///     @preserve
+    ///     @staticmethod
+    ///     def method(value: int) -> str:
+    ///         return str(value)
+    ///
+    /// Example.method.__name__  # ty reports unresolved-attribute; Python returns "method".
+    /// function: FunctionType = Example.method  # ty reports invalid-assignment.
+    /// reveal_type(type(Example.method))  # ty reveals type; Python returns FunctionType.
+    /// reveal_type(bool(Example.method))  # ty reveals bool; the result is always True.
+    /// ```
+    ///
+    /// [descriptor-protocol]: https://docs.python.org/3/howto/descriptor.html#descriptor-protocol
     StaticMethodLike,
 
-    /// A callable type that we believe represents a classmethod (i.e. it will unconditionally bind
-    /// the first argument on `__get__`).
+    /// A callable with the descriptor behavior of `classmethod`.
+    ///
+    /// These are [non-data descriptors][descriptor-protocol] that bind the first parameter on
+    /// both class and instance access, using the owner when no instance is supplied.
+    ///
+    /// TODO: Distinguish the `classmethod` descriptor from the bound method returned by
+    /// descriptor access. Currently, this kind is retained after binding. Neither the
+    /// descriptor's `classmethod` type nor the bound method's `types.MethodType` is reflected
+    /// in member lookup or type relations: truthiness is ambiguous, the metatype is `type`,
+    /// and only `object` attributes plus `__call__` are exposed.
+    ///
+    /// In the example below, `Example.method` is an always-truthy `types.MethodType` instance
+    /// at runtime. After the `Callable`-returning decorator is applied, ty incorrectly rejects
+    /// its `__name__` attribute and the assignment, and loses precision for `type` and `bool`:
+    ///
+    /// ```python
+    /// from collections.abc import Callable
+    /// from types import MethodType
+    /// from typing import reveal_type
+    ///
+    /// def preserve[**P, R](function: Callable[P, R]) -> Callable[P, R]:
+    ///     return function
+    ///
+    /// class Example:
+    ///     @preserve
+    ///     @classmethod
+    ///     def method(cls, value: int) -> str:
+    ///         return str(value)
+    ///
+    /// Example.method.__name__  # ty reports unresolved-attribute; Python returns "method".
+    /// method: MethodType = Example.method  # ty reports invalid-assignment.
+    /// reveal_type(type(Example.method))  # ty reveals type; Python returns MethodType.
+    /// reveal_type(bool(Example.method))  # ty reveals bool; the result is always True.
+    /// ```
+    ///
+    /// [descriptor-protocol]: https://docs.python.org/3/howto/descriptor.html#descriptor-protocol
     ClassMethodLike,
 
-    /// Represents the value bound to a `typing.ParamSpec` type variable.
+    /// An internal representation of the value bound to a `typing.ParamSpec` type variable.
+    ///
+    /// Unlike the other variants, this does not represent a callable object in its entirety:
+    /// it represents only the parameter lists substituted for a `ParamSpec`.
+    ///
+    /// We reuse callable signatures to store the parameter lists, including overloads, with
+    /// `Unknown` return types as placeholders. Specialization extracts these parameters into
+    /// `Callable[P, R]`, `Concatenate`, or paired `P.args`/`P.kwargs` annotations while preserving
+    /// the enclosing callable's return type. A single signature is displayed as a parameter
+    /// list, without a return type.
+    ///
+    /// This kind also distinguishes gradual `...` parameter lists and their top and bottom
+    /// materializations from ordinary callable types in type-relation checks. It does not
+    /// carry the runtime `typing.ParamSpec` instance behavior of a `ParamSpec` declaration.
     ParamSpecValue,
 }
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -328,9 +328,9 @@ impl<'db> CallableUpcastContext<'db> {
 ///
 /// A callable's signature alone does not determine its runtime class, attributes, truthiness,
 /// or whether it can act as a descriptor. The `CallableTypeKind` records which of these
-/// properties we know or assume. The `CallableTypeKind` is irrelevant to calls to the function
-/// and inferred types from `__call__` access; these are always inferred using the stored
-/// signature of a callable type.
+/// properties we know or assume. Calls use the stored signature without reference to the
+/// `CallableTypeKind`. Accessing `__call__`, however, returns the original callable type,
+/// preserving both its signatures and its kind.
 ///
 /// For [`Self::FunctionLike`], [`Self::StaticMethodLike`], and [`Self::ClassMethodLike`], the
 /// LSP server emits method semantic tokens on attribute access, allowing editors to highlight


### PR DESCRIPTION
Document how `CallableTypeKind` affects truthiness, attribute lookup, nominal type relations, and descriptor behavior, with complete Python examples for decorator handling, method binding, and `ParamSpec` specialization.

Mark the current gaps in modeling bound methods and `staticmethod`/`classmethod` descriptors as TODOs, with examples showing where ty's inferred types differ from runtime behavior.

This addresses @carljm's review comment https://github.com/astral-sh/ruff/pull/28254#discussion_r3917774632 on https://github.com/astral-sh/ruff/pull/28254
