### PR TITLE
Use the shared release smoke-test action

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -489,8 +489,8 @@ jobs:
           run: |
             apt-get update
             apt-get install -y --no-install-recommends python3 python3-pip libatomic1
-            pip3 install --upgrade --require-hashes -r /pip-requirements.txt
-            pip3 install "${PACKAGE_NAME}" --no-index --find-links /dist --force-reinstall
+            python3 -m pip install --upgrade --require-hashes -r /pip-requirements.txt
+            python3 -m pip install "${PACKAGE_NAME}" --no-index --find-links /dist --force-reinstall
             ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -60,7 +60,7 @@ jobs:
           command: sdist
           args: --out dist
       - name: "Test sdist"
-        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        uses: astral-sh/github-actions/release-smoke-test@3994daa59cb9d97f991f8196a17218a2641fce4b
         with:
           image: python:3.13-bookworm@sha256:933b46a028fd786c9c3d426ebabc237e29a15912231ea8de576e95f0e4f41a4c
           artifacts: dist
@@ -322,7 +322,7 @@ jobs:
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
-        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        uses: astral-sh/github-actions/release-smoke-test@3994daa59cb9d97f991f8196a17218a2641fce4b
         with:
           image: python:3.13-bookworm@sha256:933b46a028fd786c9c3d426ebabc237e29a15912231ea8de576e95f0e4f41a4c
           artifacts: dist
@@ -394,7 +394,7 @@ jobs:
           docker-options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"
-        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        uses: astral-sh/github-actions/release-smoke-test@3994daa59cb9d97f991f8196a17218a2641fce4b
         with:
           image: python:3.13-bookworm@sha256:933b46a028fd786c9c3d426ebabc237e29a15912231ea8de576e95f0e4f41a4c
           platform: linux/arm64
@@ -481,7 +481,7 @@ jobs:
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"
         if: ${{ matrix.platform.target != 'powerpc64le-unknown-linux-gnu' }}
-        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        uses: astral-sh/github-actions/release-smoke-test@3994daa59cb9d97f991f8196a17218a2641fce4b
         with:
           image: ${{ matrix.platform.test_image }}
           platform: ${{ matrix.platform.test_platform }}
@@ -548,7 +548,7 @@ jobs:
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        uses: astral-sh/github-actions/release-smoke-test@3994daa59cb9d97f991f8196a17218a2641fce4b
         with:
           image: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
           artifacts: dist
@@ -616,7 +616,7 @@ jobs:
           args: --release --locked --out dist --compatibility pypi
           docker-options: ${{ matrix.platform.maturin_docker_options }}
       - name: "Test wheel"
-        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        uses: astral-sh/github-actions/release-smoke-test@3994daa59cb9d97f991f8196a17218a2641fce4b
         with:
           image: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
           platform: ${{ matrix.platform.test_platform }}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -60,10 +60,17 @@ jobs:
           command: sdist
           args: --out dist
       - name: "Test sdist"
-        run: |
-          pip install dist/"${PACKAGE_NAME}"-*.tar.gz --force-reinstall
-          "${MODULE_NAME}" --help
-          python -m "${MODULE_NAME}" --help
+        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        with:
+          image: python:3.13-bookworm@sha256:933b46a028fd786c9c3d426ebabc237e29a15912231ea8de576e95f0e4f41a4c
+          artifacts: dist
+          rust-toolchain: rust-toolchain.toml
+          run: |
+            # pip builds outside /test, where the toolchain file no longer applies.
+            rustup default "$(rustup show active-toolchain | cut -d ' ' -f1)"
+            pip install /dist/"${PACKAGE_NAME}"-*.tar.gz --force-reinstall
+            "${MODULE_NAME}" --help
+            python -m "${MODULE_NAME}" --help
       - name: "Upload sdist"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -315,10 +322,14 @@ jobs:
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
-        run: |
-          pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
-          "${MODULE_NAME}" --help
-          python -m "${MODULE_NAME}" --help
+        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        with:
+          image: python:3.13-bookworm@sha256:933b46a028fd786c9c3d426ebabc237e29a15912231ea8de576e95f0e4f41a4c
+          artifacts: dist
+          run: |
+            pip install /dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
+            "${MODULE_NAME}" --help
+            python -m "${MODULE_NAME}" --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -383,10 +394,15 @@ jobs:
           docker-options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"
-        run: |
-          pip install dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
-          "${MODULE_NAME}" --help
-          python -m "${MODULE_NAME}" --help
+        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        with:
+          image: python:3.13-bookworm@sha256:933b46a028fd786c9c3d426ebabc237e29a15912231ea8de576e95f0e4f41a4c
+          platform: linux/arm64
+          artifacts: dist
+          run: |
+            pip install /dist/"${PACKAGE_NAME}"-*.whl --force-reinstall
+            "${MODULE_NAME}" --help
+            python -m "${MODULE_NAME}" --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -420,23 +436,26 @@ jobs:
       matrix:
         platform:
           - target: armv7-unknown-linux-gnueabihf
-            arch: armv7
+            test_image: arm32v7/ubuntu:20.04@sha256:d9a6ab6baaf86907ea1d46f0cbc87547920077c9c6017721faed6eeb51e9aa7e
+            test_platform: linux/arm/v7
             manylinux: 2_17
           - target: s390x-unknown-linux-gnu
-            arch: s390x
+            test_image: s390x/ubuntu:20.04@sha256:221f5f8e28d896556d0e55605cd6936450e6231544e9d83d687beae2d0e71afd
+            test_platform: linux/s390x
             manylinux: 2_17
             maturin_docker_options: -e CFLAGS_s390x_unknown_linux_gnu=-march=z10
           - target: powerpc64le-unknown-linux-gnu
-            arch: ppc64le
             manylinux: 2_17
             # see https://github.com/astral-sh/ruff/issues/10073
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: arm-unknown-linux-musleabihf
             # Use the cross container, but tag as `linux_armv6l`
             manylinux: auto
-            arch: arm
+            test_image: balenalib/rpi-raspbian:bullseye@sha256:851cfc48b26f6413a72a7f6873a7624ba2a427048976f6ab4483f72fe165d4f1
+            test_platform: linux/arm/v6
           - target: riscv64gc-unknown-linux-gnu
-            arch: riscv64
+            test_image: riscv64/ubuntu:20.04@sha256:610bedb0c5d9aeae4b45e9064e820c4e0b0f6c1d2843116b0a1ae754890951ac
+            test_platform: linux/riscv64
             # Minimum manylinux target for riscv64
             manylinux: 2_31
 
@@ -460,19 +479,18 @@ jobs:
           manylinux: ${{ matrix.platform.manylinux }}
           docker-options: ${{ matrix.platform.maturin_docker_options }}
           args: --release --locked --out dist --compatibility pypi
-      - uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
-        if: ${{ matrix.platform.arch != 'ppc64le'}}
-        name: Test wheel
+      - name: "Test wheel"
+        if: ${{ matrix.platform.target != 'powerpc64le-unknown-linux-gnu' }}
+        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
         with:
-          arch: ${{ matrix.platform.arch == 'arm' && 'armv6' || matrix.platform.arch }}
-          distro: ${{ matrix.platform.arch == 'arm' && 'bullseye' || 'ubuntu20.04' }}
-          githubToken: ${{ github.token }}
-          install: |
+          image: ${{ matrix.platform.test_image }}
+          platform: ${{ matrix.platform.test_platform }}
+          artifacts: dist
+          run: |
             apt-get update
             apt-get install -y --no-install-recommends python3 python3-pip libatomic1
-            pip3 install -U pip
-          run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
+            pip3 install --upgrade --require-hashes -r /pip-requirements.txt
+            pip3 install "${PACKAGE_NAME}" --no-index --find-links /dist --force-reinstall
             ruff --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -530,13 +548,15 @@ jobs:
           args: --release --locked --out dist --compatibility pypi
       - name: "Test wheel"
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/io -w /io --env MODULE_NAME --env PACKAGE_NAME alpine:latest sh -c "
-            apk add python3;
-            python -m venv .venv;
-            .venv/bin/pip3 install ${PACKAGE_NAME} --no-index --find-links dist/ --force-reinstall;
-            .venv/bin/${MODULE_NAME} --help;
-            "
+        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
+        with:
+          image: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          artifacts: dist
+          run: |
+            apk add python3
+            python -m venv .venv
+            .venv/bin/pip3 install "${PACKAGE_NAME}" --no-index --find-links /dist --force-reinstall
+            .venv/bin/"${MODULE_NAME}" --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -570,10 +590,10 @@ jobs:
       matrix:
         platform:
           - target: aarch64-unknown-linux-musl
-            arch: aarch64
+            test_platform: linux/arm64
             maturin_docker_options: -e JEMALLOC_SYS_WITH_LG_PAGE=16
           - target: armv7-unknown-linux-musleabihf
-            arch: armv7
+            test_platform: linux/arm/v7
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -595,18 +615,17 @@ jobs:
           manylinux: musllinux_1_2
           args: --release --locked --out dist --compatibility pypi
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-      - uses: uraimo/run-on-arch-action@f9b26e3a1a408d5fd530d20c17b9f3f4428ff8d9 # v3.1.0
-        name: Test wheel
+      - name: "Test wheel"
+        uses: astral-sh/github-actions/release-smoke-test@e6a0d38509bf35a70619cb422858000b0fb2930c
         with:
-          arch: ${{ matrix.platform.arch }}
-          distro: alpine_latest
-          githubToken: ${{ github.token }}
-          install: |
-            apk add python3
+          image: alpine:latest@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          platform: ${{ matrix.platform.test_platform }}
+          artifacts: dist
           run: |
+            apk add python3
             python -m venv .venv
-            .venv/bin/pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links dist/ --force-reinstall
-            .venv/bin/${{ env.MODULE_NAME }} --help
+            .venv/bin/pip3 install "${PACKAGE_NAME}" --no-index --find-links /dist --force-reinstall
+            .venv/bin/"${MODULE_NAME}" --help
       - name: "Upload wheels"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Linux release smoke tests currently install packages on the runner or in containers with writable workspace mounts. Run them through the shared [release-smoke-test action](https://github.com/astral-sh/github-actions/pull/1), which mounts completed artifacts read-only.

Keep the existing smoke commands and target exclusions, and pin the test images. Select the installed Rust toolchain as the container default so pip can invoke Cargo from its temporary build directories.

## Test plan

- [x] Ensure the PR's Build binaries jobs run and succeed, including sdist and wheel smoke tests using the pinned shared action on native and emulated architectures.
