### PR TITLE
[ty] Recover cycles when constructing known class instances

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -521,3 +521,91 @@ reveal_mro(GenericBase["Foo", "Bar"])
 class Foo: ...
 class Bar: ...
 ```
+
+## Known class instances with shadowed standard-library modules
+
+String members retain their types when local `typing.py` and `_collections_abc.py` modules contain
+unresolved names. Inferring the bases of `str` reaches these modules, and resolving their
+metaclasses requests `str` again for the class namespace. The consumer is checked first so that the
+local modules have not already been inferred.
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/4456>.
+
+`m.py`:
+
+```py
+reveal_type("a".encode())  # revealed: bytes
+```
+
+`typing.py`:
+
+```py
+import copyreg
+
+# error: [unresolved-reference]
+# error: [unresolved-reference]
+copyreg.pickle(ParamSpecKwargs, _pickle_pskwargs)
+# error: [unresolved-reference]
+# error: [unresolved-reference]
+Sequence = _alias(collections.abc.Sequence, 1)
+```
+
+`_collections_abc.py`:
+
+```py
+class Container(metaclass=ABCMeta): ...  # error: [unresolved-reference]
+
+# error: [unresolved-reference]
+# error: [unresolved-reference]
+class Collection(Sized, Iterable, Container): ...
+class Callable(metaclass=ABCMeta): ...  # error: [unresolved-reference]
+
+# error: [inconsistent-mro]
+# error: [unresolved-reference]
+class Sequence(Reversible, Collection): ...
+class MutableSequence(Sequence): ...
+
+MutableSequence.register(bytearray)
+```
+
+## Known class instances after checking shadowing modules
+
+String members retain their types when the local modules are checked first, as they do when the
+consumer is checked first.
+
+`_collections_abc.py`:
+
+```py
+class Container(metaclass=ABCMeta): ...  # error: [unresolved-reference]
+
+# error: [unresolved-reference]
+# error: [unresolved-reference]
+class Collection(Sized, Iterable, Container): ...
+class Callable(metaclass=ABCMeta): ...  # error: [unresolved-reference]
+
+# error: [inconsistent-mro]
+# error: [unresolved-reference]
+class Sequence(Reversible, Collection): ...
+class MutableSequence(Sequence): ...
+
+MutableSequence.register(bytearray)
+```
+
+`typing.py`:
+
+```py
+import copyreg
+
+# error: [unresolved-reference]
+# error: [unresolved-reference]
+copyreg.pickle(ParamSpecKwargs, _pickle_pskwargs)
+# error: [unresolved-reference]
+# error: [unresolved-reference]
+Sequence = _alias(collections.abc.Sequence, 1)
+```
+
+`m.py`:
+
+```py
+reveal_type("a".encode())  # revealed: bytes
+```

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -522,12 +522,13 @@ class Foo: ...
 class Bar: ...
 ```
 
-## Known class instances with shadowed standard-library modules
+## Known class instances with a shadowed typing module
 
-String members retain their types when local `typing.py` and `_collections_abc.py` modules contain
-unresolved names. Inferring the bases of `str` reaches these modules, and resolving their
-metaclasses requests `str` again for the class namespace. The consumer is checked first so that the
-local modules have not already been inferred.
+String members retain their types when a local `typing.py` introduces an inference cycle. Resolving
+`str`'s bases looks up `Sequence` in that module. Determining whether the assignment is reachable
+requires inferring `trigger`'s return annotation. Resolving `C.attribute` requires determining `C`'s
+metaclass. Checking a call to that unknown metaclass constructs a class namespace with `str` keys,
+completing the cycle. The consumer is checked before the shadowing module.
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/4456>.
 
@@ -540,68 +541,28 @@ reveal_type("a".encode())  # revealed: bytes
 `typing.py`:
 
 ```py
-import copyreg
+class C(metaclass=missing): ...  # error: [unresolved-reference]
 
-# error: [unresolved-reference]
-# error: [unresolved-reference]
-copyreg.pickle(ParamSpecKwargs, _pickle_pskwargs)
-# error: [unresolved-reference]
-# error: [unresolved-reference]
-Sequence = _alias(collections.abc.Sequence, 1)
+def trigger() -> C.attribute: ...
+
+trigger()
+Sequence = object
 ```
 
-`_collections_abc.py`:
+## Known class instances after checking the shadowing module
 
-```py
-class Container(metaclass=ABCMeta): ...  # error: [unresolved-reference]
-
-# error: [unresolved-reference]
-# error: [unresolved-reference]
-class Collection(Sized, Iterable, Container): ...
-class Callable(metaclass=ABCMeta): ...  # error: [unresolved-reference]
-
-# error: [inconsistent-mro]
-# error: [unresolved-reference]
-class Sequence(Reversible, Collection): ...
-class MutableSequence(Sequence): ...
-
-MutableSequence.register(bytearray)
-```
-
-## Known class instances after checking shadowing modules
-
-String members retain their types when the local modules are checked first, as they do when the
+String members retain their types when the shadowing module is checked first, as they do when the
 consumer is checked first.
-
-`_collections_abc.py`:
-
-```py
-class Container(metaclass=ABCMeta): ...  # error: [unresolved-reference]
-
-# error: [unresolved-reference]
-# error: [unresolved-reference]
-class Collection(Sized, Iterable, Container): ...
-class Callable(metaclass=ABCMeta): ...  # error: [unresolved-reference]
-
-# error: [inconsistent-mro]
-# error: [unresolved-reference]
-class Sequence(Reversible, Collection): ...
-class MutableSequence(Sequence): ...
-
-MutableSequence.register(bytearray)
-```
 
 `typing.py`:
 
 ```py
-import copyreg
+class C(metaclass=missing): ...  # error: [unresolved-reference]
 
-# error: [unresolved-reference]
-# error: [unresolved-reference]
-copyreg.pickle(ParamSpecKwargs, _pickle_pskwargs)
-# error: [unresolved-reference]
-# error: [unresolved-reference]
-Sequence = _alias(collections.abc.Sequence, 1)
+def trigger() -> C.attribute: ...
+
+trigger()
+Sequence = object
 ```
 
 `m.py`:

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1195,7 +1195,15 @@ impl KnownClass {
             "Use `Type::heterogeneous_tuple` or `Type::homogeneous_tuple` to create `tuple` instances"
         );
 
-        #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+        #[salsa::tracked(
+            returns(copy),
+            cycle_initial=|_, id, _| Type::divergent(id),
+            cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, argument: KnownClassArgument<'db>| {
+                let env = ProgramEnvironment::from_program(argument.program(db));
+                result.cycle_normalized(db, &env, *previous, cycle)
+            },
+            heap_size=ruff_memory_usage::heap_size,
+        )]
         fn known_class_to_instance<'db>(
             db: &'db dyn Db,
             argument: KnownClassArgument<'db>,


### PR DESCRIPTION
String member lookup can panic when a first-party `typing.py` introduces an inference cycle through class and metaclass resolution. Add cycle recovery to `known_class_to_instance` so inference can converge and checking reports the ordinary diagnostics.

Fixes astral-sh/ty#4456.

## Test plan

Add mdtests with a local `typing.py` whose function call requires resolving an unknown metaclass before a `Sequence` binding. Check the consumer both before and after the shadowing module. Both scenarios verify that `str.encode()` retains its `bytes` return type and that the unresolved metaclass produces the expected diagnostic.
