### PR TITLE
[ty] Infer legacy union members separately from their value

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -164,6 +164,37 @@ def concatenate(lines: list[str]) -> str:
     return result
 ```
 
+## Tuple nesting in a loop
+
+Repeatedly wrapping a type in `tuple[...]` can grow the tuple nesting without a fixed bound.
+Inference collapses that nesting to a recursion placeholder and still includes the initial `int`
+type.
+
+```py
+def nest_tuples(iterations: list[int]):
+    result = int
+    for _ in iterations:
+        result = tuple[result]
+    reveal_type(result)  # revealed: <class 'int'> | <class 'tuple[Divergent]'>
+```
+
+## Tuple nesting in nested loops
+
+Nested loops can each add tuple layers. Their recursion placeholders also converge to a single
+recursive tuple alongside the initial `int` type.
+
+```py
+def nest_tuples(iterations: list[int]):
+    result = int
+    for _ in iterations:
+        result = tuple[result]
+        for _ in iterations:
+            result = tuple[result]
+        for _ in iterations:
+            result = tuple[result]
+    reveal_type(result)  # revealed: <class 'int'> | <class 'tuple[Divergent]'>
+```
+
 ## Runtime union accumulation in nested loops
 
 Runtime union values can also be accumulated in loops. Their presence does not make the result a
@@ -187,6 +218,106 @@ def accumulate_unions(iterations: list[int]) -> UnionType:
         for _ in iterations:
             result |= bytes
     return result
+```
+
+## Legacy union accumulation in nested loops
+
+Repeatedly combining `int` with itself through `typing.Union` still produces `int`. Using the result
+as an annotation does not admit unrelated types, even after updates in nested loops.
+
+```py
+from typing import Union
+
+def accumulate_unions(iterations: list[int]):
+    result = int
+    for _ in iterations:
+        result = Union[result, int]
+        for _ in iterations:
+            result = Union[result, int]
+        for _ in iterations:
+            result = Union[result, int]
+
+    def consume(value: result):
+        reveal_type(value)  # revealed: int
+
+    consume(1)
+    consume("")  # error: [invalid-argument-type]
+```
+
+## Conditional legacy union accumulation in nested loops
+
+A conditional update in a nested loop does not change the meaning of `Union[int, int]`. Both paths
+produce an annotation that accepts integers and rejects strings.
+
+```py
+from typing import Union
+
+def accumulate_unions(iterations: list[int], flag: bool):
+    result = int
+    for _ in iterations:
+        result = Union[result, int]
+        for _ in iterations:
+            result = Union[result, int]
+        for _ in iterations:
+            if flag:
+                result = Union[result, int]
+
+    def consume(value: result):
+        reveal_type(value)  # revealed: int
+
+    consume(1)
+    consume("")  # error: [invalid-argument-type]
+```
+
+## Simultaneous legacy union updates in nested loops
+
+Updating two union values in one assignment preserves their concrete members without introducing
+recursion placeholders. The accumulated union accepts integers and strings, but rejects bytes.
+
+```py
+from typing import Union
+
+def accumulate_unions(iterations: list[int]):
+    a = int
+    b = str
+    for _ in iterations:
+        a, b = Union[a, b], Union[b, a]
+        for _ in iterations:
+            a, b = Union[a, b], Union[b, a]
+        for _ in iterations:
+            a, b = Union[a, b], Union[b, a]
+
+    def consume(value: a):
+        reveal_type(value)  # revealed: int | str
+
+    consume(1)
+    consume("")
+    consume(b"")  # error: [invalid-argument-type]
+```
+
+## Optional accumulation in nested loops
+
+Repeatedly applying `Optional` to `int` produces `int | None`. The resulting annotation accepts
+integers and `None`, but rejects strings.
+
+```py
+from typing import Optional
+
+def accumulate_optional(iterations: list[int]):
+    result = int
+    for _ in iterations:
+        result = Optional[result]
+        for _ in iterations:
+            result = Optional[result]
+        for _ in iterations:
+            result = Optional[result]
+
+    def consume(value: result):
+        reveal_type(value)  # revealed: int | None
+
+    consume(1)
+    consume(None)
+    consume("")  # error: [invalid-argument-type]
 ```
 
 ## Runtime unions containing unrelated recursion markers
@@ -286,8 +417,8 @@ def f(x: b):
 
 ## Conditional recursive union values
 
-A conditional expression can initially infer a union of a runtime union value and another class.
-These alternatives preserve the recursive references until the tuple alias is inferred.
+Mutually recursive aliases also converge when a conditional expression produces a union value on one
+branch.
 
 ```py
 from typing import Union
@@ -298,8 +429,8 @@ b = Union["a", "b", int] if a else str
 
 ## Mutually recursive aliases through two unions
 
-The initial recursive references also survive a chain of two unions before reaching the tuple alias.
-Inference converges without expanding the tuple on every pass through the chain.
+Aliases can form a chain through multiple unions. Inference converges without expanding the tuple on
+every pass through the chain.
 
 ```py
 from typing import Union
@@ -307,6 +438,85 @@ from typing import Union
 a = tuple["b"]
 b = Union["c", "b", int]
 c = Union["a", "c", str]
+```
+
+## Recursive tuple aliases with concrete elements
+
+Normalizing the recursive tuple element preserves the other element's type and the tuple's length.
+
+```py
+from typing import Union
+
+a = tuple[str, "b"]
+b = Union["a", "b", int]
+
+def f(x: b):
+    reveal_type(x)  # revealed: tuple[str, Divergent] | int
+```
+
+## Recursive tuple aliases containing another recursive alias
+
+A tuple element can refer to an already inferred recursive alias. Normalizing a different recursive
+element preserves that alias's tuple structure, so an integer is still invalid in its place.
+
+```py
+from typing import Union
+
+Other = tuple["Other"]
+a = tuple[Other, "b"]
+b = Union["a", "b", int]
+
+def consume(x: b):
+    reveal_type(x)  # revealed: tuple[tuple[Divergent], Divergent] | int
+
+consume((1, 1))  # error: [invalid-argument-type]
+```
+
+## Recursive aliases using legacy tuples
+
+`typing.Tuple` supports the same recursive aliases as `tuple`, including homogeneous tuples.
+
+```py
+from typing import Tuple, Union
+
+a = Tuple["b", ...]
+b = Union["a", "b", int]
+
+def f(x: b):
+    reveal_type(x)  # revealed: tuple[Divergent, ...] | int
+```
+
+## Recursive aliases using imported tuple constructors
+
+An imported alias for the built-in tuple constructor has the same behavior as `tuple`.
+
+```py
+from builtins import tuple as TupleConstructor
+from typing import Union
+
+a = TupleConstructor["b"]
+b = Union["a", "b", int]
+
+def f(x: b):
+    reveal_type(x)  # revealed: tuple[Divergent] | int
+```
+
+## Recursive generic tuple aliases
+
+A recursive generic tuple alias can be specialized without rejecting the resulting alias as an
+invalid type form. Specialized recursive generic aliases are not yet fully supported, so the type
+parameter currently falls back to a `@Todo` type.
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+Callee = tuple[T, "A"]
+A = Callee[int]
+
+def f(x: A):
+    # revealed: tuple[@Todo(specialized recursive generic type alias), Divergent]
+    reveal_type(x)
 ```
 
 ## Self-referential union aliases

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -146,6 +146,78 @@ def solve(maxiter, a, b, c, d, e):
     return stop
 ```
 
+## String accumulation in nested loops
+
+Repeated string updates in nested loops converge to `str`, without retaining recursion placeholders.
+This is a reduced regression test from Pylint's similarity report.
+
+```py
+def concatenate(lines: list[str]) -> str:
+    result = ""
+    for _ in lines:
+        result += ""
+        for _ in lines:
+            result += ""
+        for _ in lines:
+            result += "\n"
+    reveal_type(result)  # revealed: str
+    return result
+```
+
+## Runtime union accumulation in nested loops
+
+Runtime union values can also be accumulated in loops. Their presence does not make the result a
+recursive alias: each value returned here is a `UnionType`, with no unresolved recursion
+placeholders.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from types import UnionType
+
+def accumulate_unions(iterations: list[int]) -> UnionType:
+    result = int | str
+    for _ in iterations:
+        result |= bytes
+        for _ in iterations:
+            result |= bytes
+        for _ in iterations:
+            result |= bytes
+    return result
+```
+
+## Runtime unions containing unrelated recursion markers
+
+A runtime union can contain a recursion marker from an already inferred alias. That marker belongs
+to the alias, not to the loop, and does not prevent the loop's own placeholders from being removed.
+
+```toml
+[rules]
+unsound-return-statement = "error"
+```
+
+```py
+from typing import Union
+from types import UnionType
+
+D = Union["D", "D"]
+R = Union[D, int]
+reveal_type(R)  # revealed: <types.UnionType special-form 'Divergent | int'>
+
+def accumulate_unions(iterations: list[int]) -> UnionType:
+    result = R
+    for _ in iterations:
+        result |= bytes
+        for _ in iterations:
+            result |= bytes
+        for _ in iterations:
+            result |= bytes
+    return result
+```
+
 ## Self-referential bare type alias
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -336,7 +336,7 @@ from types import UnionType
 
 D = Union["D", "D"]
 R = Union[D, int]
-reveal_type(R)  # revealed: <types.UnionType special-form 'Divergent | int'>
+reveal_type(R)  # revealed: <types.UnionType special-form>
 
 def accumulate_unions(iterations: list[int]) -> UnionType:
     result = R
@@ -391,6 +391,8 @@ b = Union["a", "b", int]
 Adding another concrete member to the recursive union also converges. The union keeps both concrete
 members when its recursive part is normalized.
 
+TODO: Eliminate redundant tuple members retained from intermediate recursive expansions.
+
 ```py
 from typing import Union
 
@@ -398,7 +400,70 @@ a = tuple["b"]
 b = Union["a", "b", int, str]
 
 def f(x: b):
-    reveal_type(x)  # revealed: tuple[Divergent] | int | str
+    reveal_type(x)  # revealed: tuple[Divergent] | tuple[int | str] | int | str
+```
+
+## Chained assignments of recursive union aliases
+
+A chained assignment gives both names the same recursive union. Each alias accepts tuples and
+integers, but rejects unrelated types.
+
+```py
+from typing import Union
+
+A = tuple["B"]
+B = C = Union["A", "B", int]
+
+def consume(first: B, second: C):
+    # TODO: eliminate the redundant `tuple[int]` member.
+    reveal_type(first)  # revealed: tuple[Divergent] | tuple[int] | int
+    reveal_type(second)  # revealed: tuple[Divergent] | tuple[int] | int
+
+consume(1, (1,))
+consume(1.5, 1)  # error: [invalid-argument-type]
+consume(1, 1.5)  # error: [invalid-argument-type]
+```
+
+## Unpacking assignments of recursive union aliases
+
+A recursive union can be unpacked from a tuple without changing its members or the other unpacked
+value's type.
+
+```py
+from typing import Union
+
+A = tuple["B"]
+B, C = (Union["A", "B", int], str)
+
+reveal_type(C)  # revealed: <class 'str'>
+
+def consume(value: B):
+    # TODO: eliminate the redundant `tuple[int]` member.
+    reveal_type(value)  # revealed: tuple[Divergent] | tuple[int] | int
+
+consume(1)
+consume((1,))
+consume(1.5)  # error: [invalid-argument-type]
+```
+
+## Mutually recursive tuple and optional aliases
+
+A recursive optional alias includes `None` alongside its tuple member. The self-reference does not
+admit unrelated types.
+
+```py
+from typing import Optional
+
+A = tuple["B"]
+B = Optional["A | B"]
+
+def consume(value: B):
+    # TODO: coalesce the repeated tuple alternatives.
+    reveal_type(value)  # revealed: tuple[Divergent] | tuple[Divergent] | None
+
+consume(None)
+consume((None,))
+consume(1.5)  # error: [invalid-argument-type]
 ```
 
 ## Mutually recursive union and tuple aliases in reverse order
@@ -412,7 +477,7 @@ b = Union["a", "b", int, str]
 a = tuple["b"]
 
 def f(x: b):
-    reveal_type(x)  # revealed: tuple[Divergent] | int | str
+    reveal_type(x)  # revealed: tuple[Divergent] | tuple[int | str] | int | str
 ```
 
 ## Conditional recursive union values
@@ -451,7 +516,7 @@ a = tuple[str, "b"]
 b = Union["a", "b", int]
 
 def f(x: b):
-    reveal_type(x)  # revealed: tuple[str, Divergent] | int
+    reveal_type(x)  # revealed: tuple[str, Divergent] | tuple[str, int] | int
 ```
 
 ## Recursive tuple aliases containing another recursive alias
@@ -467,7 +532,7 @@ a = tuple[Other, "b"]
 b = Union["a", "b", int]
 
 def consume(x: b):
-    reveal_type(x)  # revealed: tuple[tuple[Divergent], Divergent] | int
+    reveal_type(x)  # revealed: tuple[tuple[Divergent], Divergent] | tuple[tuple[Divergent], int] | int
 
 consume((1, 1))  # error: [invalid-argument-type]
 ```
@@ -483,7 +548,7 @@ a = Tuple["b", ...]
 b = Union["a", "b", int]
 
 def f(x: b):
-    reveal_type(x)  # revealed: tuple[Divergent, ...] | int
+    reveal_type(x)  # revealed: tuple[Divergent, ...] | tuple[int, ...] | int
 ```
 
 ## Recursive aliases using imported tuple constructors
@@ -498,7 +563,7 @@ a = TupleConstructor["b"]
 b = Union["a", "b", int]
 
 def f(x: b):
-    reveal_type(x)  # revealed: tuple[Divergent] | int
+    reveal_type(x)  # revealed: tuple[Divergent] | tuple[int] | int
 ```
 
 ## Recursive generic tuple aliases
@@ -536,6 +601,44 @@ def f(x: One, y: Many):
 
 f("", 0)  # error: [invalid-argument-type]
 f(0, b"")  # error: [invalid-argument-type]
+```
+
+## Self-referential optional aliases
+
+Without a concrete member, a self-referential optional alias reduces to `None`:
+
+```py
+from typing import Optional
+
+Alias = Optional["Alias"]
+reveal_type(Alias)  # revealed: None
+
+def consume(value: Alias):
+    reveal_type(value)  # revealed: None
+
+consume(None)
+consume(1)  # error: [invalid-argument-type]
+```
+
+## Mutually recursive optional aliases
+
+Mutual references between optional aliases also reduce to `None` when neither adds a concrete
+member:
+
+```py
+from typing import Optional
+
+A = Optional["B"]
+B = Optional["A"]
+reveal_type(A)  # revealed: None
+reveal_type(B)  # revealed: None
+
+def consume(first: A, second: B):
+    reveal_type(first)  # revealed: None
+    reveal_type(second)  # revealed: None
+
+consume(None, None)
+consume(1, None)  # error: [invalid-argument-type]
 ```
 
 ## Self-referential legacy type variables

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -171,6 +171,91 @@ def _(x: JSONValue):
     reveal_type(x)  # revealed: Sequence[JSONValue] | float | None | Mapping[str, JSONValue]
 ```
 
+## Mutually recursive tuple and union aliases
+
+Mutually recursive tuple and union aliases converge even when the union also references itself. This
+is a regression test for <https://github.com/astral-sh/ty/issues/4443>.
+
+```py
+from typing import Union
+
+a = tuple["b"]
+b = Union["a", "b", int]
+```
+
+## Mutually recursive tuple and union aliases with multiple concrete members
+
+Adding another concrete member to the recursive union also converges. The union keeps both concrete
+members when its recursive part is normalized.
+
+```py
+from typing import Union
+
+a = tuple["b"]
+b = Union["a", "b", int, str]
+
+def f(x: b):
+    reveal_type(x)  # revealed: tuple[Divergent] | int | str
+```
+
+## Mutually recursive union and tuple aliases in reverse order
+
+The recursive union also converges when it is defined before the tuple alias.
+
+```py
+from typing import Union
+
+b = Union["a", "b", int, str]
+a = tuple["b"]
+
+def f(x: b):
+    reveal_type(x)  # revealed: tuple[Divergent] | int | str
+```
+
+## Conditional recursive union values
+
+A conditional expression can initially infer a union of a runtime union value and another class.
+These alternatives preserve the recursive references until the tuple alias is inferred.
+
+```py
+from typing import Union
+
+a = tuple["b"]
+b = Union["a", "b", int] if a else str
+```
+
+## Mutually recursive aliases through two unions
+
+The initial recursive references also survive a chain of two unions before reaching the tuple alias.
+Inference converges without expanding the tuple on every pass through the chain.
+
+```py
+from typing import Union
+
+a = tuple["b"]
+b = Union["c", "b", int]
+c = Union["a", "c", str]
+```
+
+## Self-referential union aliases
+
+A direct self-reference contributes no additional members to a union. Removing it keeps both
+single-member and multi-member unions precise.
+
+```py
+from typing import Union
+
+One = Union["One", int]
+Many = Union["Many", int, str]
+
+def f(x: One, y: Many):
+    reveal_type(x)  # revealed: int
+    reveal_type(y)  # revealed: int | str
+
+f("", 0)  # error: [invalid-argument-type]
+f(0, b"")  # error: [invalid-argument-type]
+```
+
 ## Self-referential legacy type variables
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -603,6 +603,23 @@ f("", 0)  # error: [invalid-argument-type]
 f(0, b"")  # error: [invalid-argument-type]
 ```
 
+## Recursive sequence unions
+
+A recursive alias can combine sequences of itself with strings, even though strings are also
+sequences. Inferring the alias converges and still rejects non-sequence values.
+
+```py
+from typing import Sequence, Union
+
+Values = Union[Sequence["Values"], str]
+
+def consume(value: Values): ...
+
+consume("value")
+consume(["value"])
+consume(0)  # error: [invalid-argument-type]
+```
+
 ## Self-referential optional aliases
 
 Without a concrete member, a self-referential optional alias reduces to `None`:

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -446,8 +446,7 @@ reveal_type(Pair)  # revealed: <class 'tuple[T@Pair, T@Pair]'>
 reveal_type(Sum)  # revealed: <class 'tuple[T@Sum, U@Sum]'>
 reveal_type(ObjectAndList)  # revealed: <class 'tuple[object, list[T@ObjectAndList]]'>
 reveal_type(ListOrTuple)  # revealed: <types.UnionType special-form 'list[T@ListOrTuple] | tuple[T@ListOrTuple, ...]'>
-# revealed: <types.UnionType special-form 'list[T@ListOrTupleLegacy] | tuple[T@ListOrTupleLegacy, ...]'>
-reveal_type(ListOrTupleLegacy)
+reveal_type(ListOrTupleLegacy)  # revealed: <types.UnionType special-form>
 reveal_type(MyCallable)  # revealed: <Callable special-form '(**P@MyCallable) -> T@MyCallable'>
 reveal_type(AnnotatedType)  # revealed: <special-form 'typing.Annotated[T@AnnotatedType, <metadata>]'>
 reveal_type(TransparentAlias)  # revealed: TypeVar
@@ -1208,10 +1207,26 @@ from typing import Optional
 
 MyOptionalInt = Optional[int]
 
-reveal_type(MyOptionalInt)  # revealed: <types.UnionType special-form 'int | None'>
+reveal_type(MyOptionalInt)  # revealed: <types.UnionType special-form>
 
 def _(optional_int: MyOptionalInt):
     reveal_type(optional_int)  # revealed: int | None
+```
+
+Generic optional aliases preserve their type parameter when specialized:
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+GenericOptional = Optional[T]
+
+def consume(value: GenericOptional[int]):
+    reveal_type(value)  # revealed: int | None
+
+consume(1)
+consume(None)
+consume("")  # error: [invalid-argument-type]
 ```
 
 A special case is `Optional[None]`, which is equivalent to `None`:
@@ -1223,6 +1238,47 @@ reveal_type(JustNone)  # revealed: None
 
 def _(just_none: JustNone):
     reveal_type(just_none)  # revealed: None
+```
+
+`NoneType`, including aliases and stringified references to it, receives the same treatment:
+
+```py
+from types import NoneType
+
+Alias = NoneType
+ImportedNone = Optional[NoneType]
+AliasedNone = Optional[Alias]
+StringifiedNone = Optional["NoneType"]
+
+reveal_type(ImportedNone)  # revealed: None
+reveal_type(AliasedNone)  # revealed: None
+reveal_type(StringifiedNone)  # revealed: None
+```
+
+Adding `None` to a bottom type also denotes `None` in annotations, but retains a union value:
+
+```py
+from typing import NoReturn
+from typing_extensions import Never
+
+OptionalNever = Optional[Never]
+OptionalNoReturn = Optional[NoReturn]
+
+reveal_type(OptionalNever)  # revealed: <types.UnionType special-form>
+reveal_type(OptionalNoReturn)  # revealed: <types.UnionType special-form>
+
+def _(first: OptionalNever, second: OptionalNoReturn):
+    reveal_type(first)  # revealed: None
+    reveal_type(second)  # revealed: None
+```
+
+Errors in the argument are still reported when the optional value collapses to `None`:
+
+```py
+from typing import Annotated
+
+InvalidNone = Optional[Annotated[None]]  # error: [invalid-type-form]
+reveal_type(InvalidNone)  # revealed: None
 ```
 
 Invalid uses:
@@ -1288,7 +1344,8 @@ def _(invalid: Invalid):
 
 ## `Union`
 
-We support implicit type aliases using `typing.Union`:
+We support implicit type aliases using `typing.Union`. Revealing the union value shows the special
+form, while using it as an annotation produces the union of its member types:
 
 ```py
 from typing import Union
@@ -1296,8 +1353,8 @@ from typing import Union
 IntOrStr = Union[int, str]
 IntOrStrOrBytes = Union[int, Union[str, bytes]]
 
-reveal_type(IntOrStr)  # revealed: <types.UnionType special-form 'int | str'>
-reveal_type(IntOrStrOrBytes)  # revealed: <types.UnionType special-form 'int | str | bytes'>
+reveal_type(IntOrStr)  # revealed: <types.UnionType special-form>
+reveal_type(IntOrStrOrBytes)  # revealed: <types.UnionType special-form>
 
 def _(
     int_or_str: IntOrStr,
@@ -1325,7 +1382,7 @@ An empty `typing.Union` leads to a `TypeError` at runtime, so we emit an error. 
 # error: [invalid-type-form] "`typing.Union` requires at least one type argument"
 EmptyUnion = Union[()]
 
-reveal_type(EmptyUnion)  # revealed: <types.UnionType special-form 'Never'>
+reveal_type(EmptyUnion)  # revealed: <types.UnionType special-form>
 
 def _(empty: EmptyUnion):
     reveal_type(empty)  # revealed: Never
@@ -1341,6 +1398,106 @@ def _(
     invalid: Invalid,
 ):
     reveal_type(invalid)  # revealed: str | Unknown
+```
+
+Invalid union members are diagnosed even when the alias is never used, both at module scope and
+inside a function:
+
+```py
+Unused = Union[str, 1]  # error: [invalid-type-form]
+
+def unused():
+    Unused = Union[str, 1]  # error: [invalid-type-form]
+```
+
+The same checks apply to each union nested in an unused value expression:
+
+```py
+UnusedMembers = [
+    Union[str, 1],  # error: [invalid-type-form]
+    Union[int, 2],  # error: [invalid-type-form]
+]
+```
+
+## `Union` member lookup
+
+An imported union alias uses the bindings at its definition. Reassigning a member afterward, or
+binding the same name in the importing module, does not change the alias.
+
+`aliases.py`:
+
+```py
+from typing import Union
+
+Member = int
+Alias = Union[Member, str]
+Member = bytes
+```
+
+`main.py`:
+
+```py
+from aliases import Alias
+
+Member = complex
+
+def consume(value: Alias):
+    reveal_type(value)  # revealed: int | str
+
+consume(1)
+consume("")
+consume(b"")  # error: [invalid-argument-type]
+consume(1j)  # error: [invalid-argument-type]
+```
+
+## `Union` values passed to functions
+
+A union value can be passed to an ordinary function. The assignment then has the function's return
+type, rather than declaring a union alias, and other arguments are ordinary value expressions.
+
+```py
+from typing import Union
+
+def consume(value: object, other: object) -> int:
+    return 0
+
+result = consume(Union[int, str], 42)
+reveal_type(result)  # revealed: int
+```
+
+Passing a union through a generic identity function preserves its meaning as a type expression:
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def identity(value: T) -> T:
+    return value
+
+ReturnedUnion = identity(Union[int, str])
+
+def consume_returned(value: ReturnedUnion):
+    reveal_type(value)  # revealed: int | str
+
+consume_returned(1.5)  # error: [invalid-argument-type]
+```
+
+## `Union` value identity
+
+Storing a union value in a container does not make it a different object. Separately declared
+aliases can also refer to the same union object, so we do not conclude that their values are
+distinct.
+
+```py
+from typing import Union
+
+A = Union[int, str]
+values = [A]
+reveal_type(values[0] is A)  # revealed: bool
+
+B = Union[int, str]
+reveal_type(A is B)  # revealed: bool
 ```
 
 ## `type[…]` and `Type[…]`
@@ -1374,7 +1531,7 @@ reveal_type(SubclassOfA)  # revealed: <special-form 'type[A]'>
 reveal_type(SubclassOfAny)  # revealed: <special-form 'type[Any]'>
 reveal_type(SubclassOfAOrB1)  # revealed: <special-form 'type[A | B]'>
 reveal_type(SubclassOfAOrB2)  # revealed: <types.UnionType special-form 'type[A | B]'>
-reveal_type(SubclassOfAOrB3)  # revealed: <types.UnionType special-form 'type[A | B]'>
+reveal_type(SubclassOfAOrB3)  # revealed: <types.UnionType special-form>
 reveal_type(SubclassOfG)  # revealed: <special-form 'type[G[Unknown]]'>
 reveal_type(SubclassOfGInt)  # revealed: <special-form 'type[G[int]]'>
 reveal_type(SubclassOfP)  # revealed: <special-form 'type[P]'>
@@ -1704,7 +1861,7 @@ reveal_type(SubclassOfA)  # revealed: <special-form 'type[A]'>
 reveal_type(SubclassOfAny)  # revealed: <special-form 'type[Any]'>
 reveal_type(SubclassOfAOrB1)  # revealed: <special-form 'type[A | B]'>
 reveal_type(SubclassOfAOrB2)  # revealed: <types.UnionType special-form 'type[A | B]'>
-reveal_type(SubclassOfAOrB3)  # revealed: <types.UnionType special-form 'type[A | B]'>
+reveal_type(SubclassOfAOrB3)  # revealed: <types.UnionType special-form>
 reveal_type(SubclassOfG)  # revealed: <special-form 'type[G[Unknown]]'>
 reveal_type(SubclassOfGInt)  # revealed: <special-form 'type[G[int]]'>
 reveal_type(SubclassOfP)  # revealed: <special-form 'type[P]'>

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -890,6 +890,14 @@ reveal_type(Bad4)  # revealed: type[tuple[Unknown, ...]] & type[NamedTupleLike] 
 Bad4(42, 56, 79)  # no error
 ```
 
+An invalid name argument does not prevent us from reporting a missing `fields` argument:
+
+```py
+from typing import Union
+
+InvalidName = NamedTuple(Union[int, str])  # error: [missing-argument]
+```
+
 ### Starred and double-starred arguments
 
 For `collections.namedtuple`, starred (`*args`) or double-starred (`**kwargs`) arguments cause us to

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -248,7 +248,7 @@ from typing import Union
 
 IntOrStr = Union[int, str]
 
-reveal_type(IntOrStr)  # revealed: <types.UnionType special-form 'int | str'>
+reveal_type(IntOrStr)  # revealed: <types.UnionType special-form>
 
 def _(x: int | str | bytes | memoryview | range):
     if isinstance(x, IntOrStr):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/issubclass.md
@@ -269,7 +269,7 @@ from typing import Union
 
 IntOrStr = Union[int, str]
 
-reveal_type(IntOrStr)  # revealed: <types.UnionType special-form 'int | str'>
+reveal_type(IntOrStr)  # revealed: <types.UnionType special-form>
 
 def f(x: type[int | str | bytes | range]):
     if issubclass(x, IntOrStr):

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3356,6 +3356,19 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
         cycle: &salsa::Cycle,
     ) -> Self {
+        // Initial union members can still be placeholders for other aliases. For
+        // `A = tuple["B"]` and `B = Union["A", "B", int]`, removing both markers on
+        // the first pass would start `A` at `tuple[int]`, which then grows on every pass.
+        // Let dependent aliases embed the markers in their structure before reducing
+        // these unions. Later iterations remove direct self-references normally.
+        if cycle.iteration() == 0
+            && matches!(
+                self,
+                Type::Union(_) | Type::KnownInstance(KnownInstanceType::UnionType(_))
+            )
+        {
+            return self;
+        }
         cycle.head_ids().fold(self, |ty, id| {
             ty.recursive_type_normalized_impl(db, env, Type::divergent(id), false)
                 .unwrap_or(Type::divergent(id))

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8325,11 +8325,7 @@ impl<'db> Type<'db> {
                     invalid_expressions: smallvec_inline![InvalidTypeExpression::NamedTupleSpec],
                     fallback_type: Type::unknown(),
                 }),
-                KnownInstanceType::UnionType(instance) => {
-                    // Cloning here is cheap if the result is a `Type` (which is `Copy`). It's more
-                    // expensive if there are errors.
-                    instance.union_type(db).clone()
-                }
+                KnownInstanceType::UnionType(instance) => instance.union_type(db),
                 KnownInstanceType::Literal(ty) => Ok(ty.inner(db)),
                 KnownInstanceType::Annotated(ty) => Ok(ty.inner(db)),
                 KnownInstanceType::TypeGenericAlias(instance) => {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3356,16 +3356,31 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
         cycle: &salsa::Cycle,
     ) -> Self {
-        // Initial union members can still be placeholders for other aliases. For
+        // Runtime union values can initially contain this cycle's placeholders for other aliases. For
         // `A = tuple["B"]` and `B = Union["A", "B", int]`, removing both markers on
         // the first pass would start `A` at `tuple[int]`, which then grows on every pass.
         // Let dependent aliases embed the markers in their structure before reducing
-        // these unions. Later iterations remove direct self-references normally.
+        // these values, including alternatives in a conditional expression. Other unions
+        // still need immediate normalization so loop inference does not retain placeholders.
+        // Later iterations remove direct self-references normally.
+        let has_union_placeholders = |ty: &Type<'db>| {
+            if let Type::KnownInstance(KnownInstanceType::UnionType(instance)) = ty
+                && let Ok(Type::Union(union)) = instance.union_type(db)
+            {
+                union.elements(db).iter().any(|element| {
+                    cycle
+                        .head_ids()
+                        .any(|id| element.same_divergent_marker(Type::divergent(id)))
+                })
+            } else {
+                false
+            }
+        };
         if cycle.iteration() == 0
-            && matches!(
-                self,
-                Type::Union(_) | Type::KnownInstance(KnownInstanceType::UnionType(_))
-            )
+            && match self {
+                Type::Union(union) => union.elements(db).iter().any(has_union_placeholders),
+                _ => has_union_placeholders(&self),
+            }
         {
             return self;
         }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3356,34 +3356,6 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
         cycle: &salsa::Cycle,
     ) -> Self {
-        // Runtime union values can initially contain this cycle's placeholders for other aliases. For
-        // `A = tuple["B"]` and `B = Union["A", "B", int]`, removing both markers on
-        // the first pass would start `A` at `tuple[int]`, which then grows on every pass.
-        // Let dependent aliases embed the markers in their structure before reducing
-        // these values, including alternatives in a conditional expression. Other unions
-        // still need immediate normalization so loop inference does not retain placeholders.
-        // Later iterations remove direct self-references normally.
-        let has_union_placeholders = |ty: &Type<'db>| {
-            if let Type::KnownInstance(KnownInstanceType::UnionType(instance)) = ty
-                && let Ok(Type::Union(union)) = instance.union_type(db)
-            {
-                union.elements(db).iter().any(|element| {
-                    cycle
-                        .head_ids()
-                        .any(|id| element.same_divergent_marker(Type::divergent(id)))
-                })
-            } else {
-                false
-            }
-        };
-        if cycle.iteration() == 0
-            && match self {
-                Type::Union(union) => union.elements(db).iter().any(has_union_placeholders),
-                _ => has_union_placeholders(&self),
-            }
-        {
-            return self;
-        }
         cycle.head_ids().fold(self, |ty, id| {
             ty.recursive_type_normalized_impl(db, env, Type::divergent(id), false)
                 .unwrap_or(Type::divergent(id))

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -3828,7 +3828,7 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'_, 'db> {
                 f.with_type(KnownClass::UnionType.to_class_literal(db, self.env))
                     .write_str("types.UnionType")?;
                 f.write_str(" special-form")?;
-                if let Ok(ty) = union.union_type(db) {
+                if let Some(Ok(ty)) = union.eager_union_type(db) {
                     f.write_str(" '")?;
                     ty.display(db, self.env).fmt_detailed(f)?;
                     f.write_char('\'')?;

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1453,6 +1453,39 @@ impl<'db> DefinitionInferenceExtra<'db> {
     }
 }
 
+/// Resolving a tuple alias's constructor or elements can recurse while initializing its definition.
+/// Use a separate query so that this recursion falls back to the definition's marker.
+#[salsa::tracked(returns(copy), cycle_initial=|_, _, _, cycle_recovery| Some(cycle_recovery))]
+fn infer_tuple_alias_cycle_initial<'db>(
+    db: &'db dyn Db,
+    definition: Definition<'db>,
+    cycle_recovery: Type<'db>,
+) -> Option<Type<'db>> {
+    let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+        return None;
+    };
+    if assignment.unpack().is_some() {
+        return None;
+    }
+    let program_file = definition.program_file(db);
+    let python_file = program_file.python_file(db);
+    let module = parsed_module(db, python_file).load(db);
+    let ast::Expr::Subscript(subscript) = assignment.value(&module) else {
+        return None;
+    };
+    let env = ProgramEnvironment::from_definition(definition);
+    TypeInferenceBuilder::new(
+        db,
+        &env,
+        InferenceRegion::Definition(definition),
+        python_file.file(db),
+        program_file,
+        semantic_index(db, program_file),
+        &module,
+    )
+    .infer_tuple_alias_cycle_initial(definition, subscript, cycle_recovery)
+}
+
 impl<'db> DefinitionInference<'db> {
     fn cycle_initial(
         db: &'db dyn Db,
@@ -1485,6 +1518,14 @@ impl<'db> DefinitionInference<'db> {
                     types =
                         DefinitionTypes::Binding(Type::instance(db, &env, divergent_collection));
                 }
+            } else if assignment.value(&module).is_subscript_expr()
+                && let Some(ty) = infer_tuple_alias_cycle_initial(db, definition, cycle_recovery)
+            {
+                // For `A = tuple["B"]; B = Union["A", "B", int]`, a bare marker for A would
+                // disappear along with B's direct self-reference. Starting with the tuple's shape
+                // lets recursive reduction recognize the nesting instead of adding a tuple layer
+                // on each iteration.
+                types = DefinitionTypes::Binding(ty);
             }
         } else if let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) {
             let program_file = definition.program_file(db);

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -57,6 +57,7 @@ pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet, FrozenValueMap};
 use crate::types::diagnostic::TypeCheckDiagnostics;
 use crate::types::function::{FunctionDecorators, FunctionType};
 use crate::types::generics::Specialization;
+use crate::types::known_instance::DeferredUnionType;
 use crate::types::unpacker::{UnpackResult, Unpacker};
 use crate::types::{
     ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
@@ -337,6 +338,45 @@ pub(crate) fn infer_deferred_types<'db>(
         &module,
     )
     .finish_definition(definition)
+}
+
+pub(super) fn infer_union_type<'db>(db: &'db dyn Db, union: DeferredUnionType<'db>) -> Type<'db> {
+    infer_union_types(db, union).union_type
+}
+
+// Keep AST lookup inside this query so inspecting a union's value alone does not depend on its
+// defining module's AST.
+#[salsa::tracked(
+    returns(ref),
+    cycle_initial=|db, id, union: DeferredUnionType<'db>| UnionInference {
+        union_type: Type::divergent(id),
+        inference: ExpressionInference::cycle_initial(union.definition(db).scope(db), Type::divergent(id)),
+    },
+    cycle_fn=|db, cycle, previous: &UnionInference<'db>, result: UnionInference<'db>, union: DeferredUnionType<'db>| {
+        let env = ProgramEnvironment::from_definition(union.definition(db));
+        UnionInference {
+            union_type: result.union_type.recursive_type_normalized(db, &env, cycle),
+            inference: result.inference.cycle_normalized(db, &env, &previous.inference, cycle),
+        }
+    },
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn infer_union_types<'db>(db: &'db dyn Db, union: DeferredUnionType<'db>) -> UnionInference<'db> {
+    let definition = union.definition(db);
+    let program_file = definition.program_file(db);
+    let python_file = program_file.python_file(db);
+    let module = parsed_module(db, python_file).load(db);
+    let env = ProgramEnvironment::from_definition(definition);
+    TypeInferenceBuilder::new(
+        db,
+        &env,
+        InferenceRegion::Deferred(definition),
+        python_file.file(db),
+        program_file,
+        semantic_index(db, program_file),
+        &module,
+    )
+    .finish_union_inference(union)
 }
 
 /// Infer a function's parameter defaults without retaining its annotation types.
@@ -1453,39 +1493,6 @@ impl<'db> DefinitionInferenceExtra<'db> {
     }
 }
 
-/// Resolving a tuple alias's constructor or elements can recurse while initializing its definition.
-/// Use a separate query so that this recursion falls back to the definition's marker.
-#[salsa::tracked(returns(copy), cycle_initial=|_, _, _, cycle_recovery| Some(cycle_recovery))]
-fn infer_tuple_alias_cycle_initial<'db>(
-    db: &'db dyn Db,
-    definition: Definition<'db>,
-    cycle_recovery: Type<'db>,
-) -> Option<Type<'db>> {
-    let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
-        return None;
-    };
-    if assignment.unpack().is_some() {
-        return None;
-    }
-    let program_file = definition.program_file(db);
-    let python_file = program_file.python_file(db);
-    let module = parsed_module(db, python_file).load(db);
-    let ast::Expr::Subscript(subscript) = assignment.value(&module) else {
-        return None;
-    };
-    let env = ProgramEnvironment::from_definition(definition);
-    TypeInferenceBuilder::new(
-        db,
-        &env,
-        InferenceRegion::Definition(definition),
-        python_file.file(db),
-        program_file,
-        semantic_index(db, program_file),
-        &module,
-    )
-    .infer_tuple_alias_cycle_initial(definition, subscript, cycle_recovery)
-}
-
 impl<'db> DefinitionInference<'db> {
     fn cycle_initial(
         db: &'db dyn Db,
@@ -1518,14 +1525,6 @@ impl<'db> DefinitionInference<'db> {
                     types =
                         DefinitionTypes::Binding(Type::instance(db, &env, divergent_collection));
                 }
-            } else if assignment.value(&module).is_subscript_expr()
-                && let Some(ty) = infer_tuple_alias_cycle_initial(db, definition, cycle_recovery)
-            {
-                // For `A = tuple["B"]; B = Union["A", "B", int]`, a bare marker for A would
-                // disappear along with B's direct self-reference. Starting with the tuple's shape
-                // lets recursive reduction recognize the nesting instead of adding a tuple layer
-                // on each iteration.
-                types = DefinitionTypes::Binding(ty);
             }
         } else if let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) {
             let program_file = definition.program_file(db);
@@ -1869,6 +1868,17 @@ fn widen_comparison_truthiness(
             )
         })
         .collect()
+}
+
+/// The represented type and expression metadata for a deferred `Union` or `Optional`.
+#[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+struct UnionInference<'db> {
+    /// Unlike ordinary expression inference, this type does not accumulate previous cycle
+    /// iterations: intermediate recursive expansions are not additional union alternatives.
+    union_type: Type<'db>,
+
+    /// Retain the ordinary expression-inference history and diagnostics for scope checking.
+    inference: ExpressionInference<'db>,
 }
 
 /// The inferred types for an expression region.

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -355,7 +355,7 @@ pub(super) fn infer_union_type<'db>(db: &'db dyn Db, union: DeferredUnionType<'d
     cycle_fn=|db, cycle, previous: &UnionInference<'db>, result: UnionInference<'db>, union: DeferredUnionType<'db>| {
         let env = ProgramEnvironment::from_definition(union.definition(db));
         UnionInference {
-            union_type: result.union_type.recursive_type_normalized(db, &env, cycle),
+            union_type: result.union_type.cycle_normalized(db, &env, previous.union_type, cycle),
             inference: result.inference.cycle_normalized(db, &env, &previous.inference, cycle),
         }
     },
@@ -1873,8 +1873,7 @@ fn widen_comparison_truthiness(
 /// The represented type and expression metadata for a deferred `Union` or `Optional`.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 struct UnionInference<'db> {
-    /// Unlike ordinary expression inference, this type does not accumulate previous cycle
-    /// iterations: intermediate recursive expansions are not additional union alternatives.
+    /// The represented type, separate from the union's stable value-expression type.
     union_type: Type<'db>,
 
     /// Retain the ordinary expression-inference history and diagnostics for scope checking.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4452,6 +4452,75 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         declared
     }
 
+    pub(super) fn infer_tuple_alias_cycle_initial(
+        mut self,
+        definition: Definition<'db>,
+        subscript: &ast::ExprSubscript,
+        cycle_recovery: Type<'db>,
+    ) -> Option<Type<'db>> {
+        fn contains_bare_divergent(db: &dyn Db, ty: Type<'_>) -> bool {
+            match ty {
+                Type::Divergent(_) => true,
+                Type::Union(union) => union
+                    .elements(db)
+                    .iter()
+                    .any(|ty| contains_bare_divergent(db, *ty)),
+                Type::Intersection(intersection) => intersection
+                    .positive(db)
+                    .iter()
+                    .chain(intersection.negative(db))
+                    .any(|ty| contains_bare_divergent(db, *ty)),
+                _ => false,
+            }
+        }
+
+        // The full definition inference collects diagnostics and expression metadata.
+        self.context.defuse();
+        self.context.suppress_diagnostics();
+        self.typevar_binding_context = Some(definition);
+        let origin = self.infer_expression(&subscript.value, TypeContext::default());
+        let is_tuple = match origin {
+            Type::ClassLiteral(class) => class.is_tuple(self.db()),
+            Type::SpecialForm(SpecialFormType::Tuple) => true,
+            _ => false,
+        };
+        if !is_tuple {
+            return None;
+        }
+        let inferred_tuple = self.infer_tuple_type_expression(subscript);
+        // Preserve nominal element types, even if they contain their own recursive aliases.
+        // Only bare markers (possibly in a union or intersection) are replaced with this
+        // definition's marker, so another query's approximation cannot prevent reduction of
+        // this definition's tuple nesting.
+        let normalize_element = |ty| {
+            if contains_bare_divergent(self.db(), ty) {
+                cycle_recovery
+            } else {
+                ty
+            }
+        };
+        let tuple = match inferred_tuple.tuple(self.db()) {
+            Tuple::Fixed(elements) => TupleType::heterogeneous(
+                self.db(),
+                self.program_environment(),
+                elements.iter_all_elements().map(normalize_element),
+            ),
+            Tuple::Variable(elements) => TupleType::mixed_with_segment(
+                self.db(),
+                self.program_environment(),
+                elements.iter_prefix_elements().map(normalize_element),
+                match elements.variable() {
+                    VariableSegment::Homogeneous(ty) => {
+                        VariableSegment::Homogeneous(normalize_element(ty))
+                    }
+                    segment @ VariableSegment::TypeVarTuple(_) => segment,
+                },
+                elements.iter_suffix_elements().map(normalize_element),
+            ),
+        };
+        Some(tuple.to_class_type(self.db()).into())
+    }
+
     /// Initialize a declaration cycle without discarding its annotation diagnostics or metadata.
     pub(super) fn infer_annotated_assignment_cycle_initial(
         mut self,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -29,9 +29,9 @@ use super::{
     CollectionUseConstraints, DeferredAndUndecorated, DefinitionInference,
     DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
     FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference, InferenceRegion,
-    OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra, infer_deferred_types,
-    infer_definition_types, infer_expression_types, infer_same_file_expression_type,
-    infer_unpack_types,
+    OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra, UnionInference,
+    infer_deferred_types, infer_definition_types, infer_expression_types,
+    infer_same_file_expression_type, infer_union_types, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -105,6 +105,7 @@ use crate::types::infer::{
     TypeExpressionFlags, infer_statement_types, nearest_enclosing_class,
     nearest_enclosing_function, original_class_type,
 };
+use crate::types::known_instance::DeferredUnionType;
 use crate::types::match_pattern::{ClassPatternPositionalResult, class_pattern_positional_result};
 use crate::types::narrow::NarrowingEvaluatorExtension;
 use crate::types::narrow::pattern_success_types;
@@ -1179,6 +1180,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 self.extend_definition(*definition, infer_deferred_types(self.db(), *definition));
             }
+        }
+
+        // Check local deferred unions even when no annotation uses them. Sort only these
+        // expressions so diagnostic and query evaluation order do not depend on hash order.
+        let unions: Vec<_> = self
+            .expressions
+            .iter()
+            .filter_map(|(node, ty)| {
+                let Type::KnownInstance(KnownInstanceType::UnionType(union)) = ty else {
+                    return None;
+                };
+                let union = union.deferred_union(self.db())?;
+                (union.definition(self.db()).scope(self.db()) == self.scope)
+                    .then_some((*node, union))
+            })
+            .sorted_by_key(|(node, _)| *node)
+            .map(|(_, union)| union)
+            .unique()
+            .collect();
+        for union in unions {
+            self.extend_expression(&infer_union_types(self.db(), union).inference);
         }
 
         assert!(
@@ -4450,75 +4472,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.dataclass_field_specifiers.clear();
 
         declared
-    }
-
-    pub(super) fn infer_tuple_alias_cycle_initial(
-        mut self,
-        definition: Definition<'db>,
-        subscript: &ast::ExprSubscript,
-        cycle_recovery: Type<'db>,
-    ) -> Option<Type<'db>> {
-        fn contains_bare_divergent(db: &dyn Db, ty: Type<'_>) -> bool {
-            match ty {
-                Type::Divergent(_) => true,
-                Type::Union(union) => union
-                    .elements(db)
-                    .iter()
-                    .any(|ty| contains_bare_divergent(db, *ty)),
-                Type::Intersection(intersection) => intersection
-                    .positive(db)
-                    .iter()
-                    .chain(intersection.negative(db))
-                    .any(|ty| contains_bare_divergent(db, *ty)),
-                _ => false,
-            }
-        }
-
-        // The full definition inference collects diagnostics and expression metadata.
-        self.context.defuse();
-        self.context.suppress_diagnostics();
-        self.typevar_binding_context = Some(definition);
-        let origin = self.infer_expression(&subscript.value, TypeContext::default());
-        let is_tuple = match origin {
-            Type::ClassLiteral(class) => class.is_tuple(self.db()),
-            Type::SpecialForm(SpecialFormType::Tuple) => true,
-            _ => false,
-        };
-        if !is_tuple {
-            return None;
-        }
-        let inferred_tuple = self.infer_tuple_type_expression(subscript);
-        // Preserve nominal element types, even if they contain their own recursive aliases.
-        // Only bare markers (possibly in a union or intersection) are replaced with this
-        // definition's marker, so another query's approximation cannot prevent reduction of
-        // this definition's tuple nesting.
-        let normalize_element = |ty| {
-            if contains_bare_divergent(self.db(), ty) {
-                cycle_recovery
-            } else {
-                ty
-            }
-        };
-        let tuple = match inferred_tuple.tuple(self.db()) {
-            Tuple::Fixed(elements) => TupleType::heterogeneous(
-                self.db(),
-                self.program_environment(),
-                elements.iter_all_elements().map(normalize_element),
-            ),
-            Tuple::Variable(elements) => TupleType::mixed_with_segment(
-                self.db(),
-                self.program_environment(),
-                elements.iter_prefix_elements().map(normalize_element),
-                match elements.variable() {
-                    VariableSegment::Homogeneous(ty) => {
-                        VariableSegment::Homogeneous(normalize_element(ty))
-                    }
-                    segment @ VariableSegment::TypeVarTuple(_) => segment,
-                },
-                elements.iter_suffix_elements().map(normalize_element),
-            ),
-        };
-        Some(tuple.to_class_type(self.db()).into())
     }
 
     /// Initialize a declaration cycle without discarding its annotation diagnostics or metadata.
@@ -11709,6 +11662,62 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn finish_expression(mut self) -> ExpressionInference<'db> {
         self.infer_region();
         self.into_expression_inference()
+    }
+
+    pub(super) fn finish_union_inference(
+        mut self,
+        union: DeferredUnionType<'db>,
+    ) -> UnionInference<'db> {
+        let db = self.db();
+        self.typevar_binding_context = union.typevar_binding_context(db);
+        let subscript = if let DefinitionKind::Assignment(assignment) =
+            union.definition(db).kind(db)
+            && let Some(node_index) = assignment
+                .value(self.module())
+                .node_index()
+                .load()
+                .as_u32()
+                .and_then(|base| base.checked_add(union.relative_node_index(db)))
+        {
+            <&ast::ExprSubscript>::try_from(
+                self.module().get_by_index(ast::NodeIndex::from(node_index)),
+            )
+            .ok()
+        } else {
+            None
+        };
+        let union_type = match subscript {
+            Some(subscript) if union.is_optional(db) => {
+                let ty = self.infer_type_expression(&subscript.slice);
+                UnionType::from_two_elements(
+                    db,
+                    self.program_environment(),
+                    ty,
+                    Type::none(db, self.program_environment()),
+                )
+            }
+            Some(subscript) if let ast::Expr::Tuple(elements) = subscript.slice.as_ref() => {
+                let union_type = UnionType::from_elements(
+                    db,
+                    self.program_environment(),
+                    elements
+                        .iter()
+                        .map(|element| self.infer_type_expression(element)),
+                );
+                self.store_expression_type(subscript.slice.as_ref(), union_type);
+                if elements.is_empty()
+                    && let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript)
+                {
+                    builder.into_diagnostic("`typing.Union` requires at least one type argument");
+                }
+                union_type
+            }
+            _ => Type::unknown(),
+        };
+        UnionInference {
+            union_type,
+            inference: self.into_expression_inference(),
+        }
     }
 
     /// Consume the results already collected by this builder without inferring its region.

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1,7 +1,7 @@
 use itertools::{Either, EitherOrBoth, Itertools};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span};
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast::{self as ast, ArgOrKeyword, ExprContext};
+use ruff_python_ast::{self as ast, ArgOrKeyword, ExprContext, HasNodeIndex};
 use ruff_text_size::Ranged;
 use ty_module_resolver::file_to_module;
 
@@ -19,7 +19,10 @@ use crate::types::diagnostic::{
 use crate::types::generics::{GenericContext, bind_typevar};
 use crate::types::infer::builder::annotation_expression::PEP613Policy;
 use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
-use crate::types::infer::{InferenceFlags, TypeExpressionFlags};
+use crate::types::infer::{
+    InferenceFlags, InferenceRegion, TypeExpressionFlags, infer_union_types,
+};
+use crate::types::known_instance::DeferredUnionType;
 use crate::types::special_form::AliasSpec;
 use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErrorKind};
 use crate::types::tuple::{Tuple, TupleSpecBuilder, TupleType, VariableSegment};
@@ -35,10 +38,26 @@ use crate::types::{
     UnionType, UnionTypeInstance, any_over_type, todo_type,
 };
 use crate::{Db, FxOrderSet, ProgramEnvironment};
-use ty_python_core::definition::Definition;
+use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::place::PlaceExpr;
 use ty_python_core::scope::FileScopeId;
 use ty_python_core::{SemanticIndex, place_table};
+
+/// Find a name whose definition can anchor the shared RHS of an assignment.
+fn assignment_target_definition<'db>(
+    index: &SemanticIndex<'db>,
+    target: &ast::Expr,
+) -> Option<Definition<'db>> {
+    match target {
+        ast::Expr::Name(name) => index.try_definition(name),
+        ast::Expr::Tuple(ast::ExprTuple { elts, .. })
+        | ast::Expr::List(ast::ExprList { elts, .. }) => elts
+            .iter()
+            .find_map(|target| assignment_target_definition(index, target)),
+        ast::Expr::Starred(starred) => assignment_target_definition(index, &starred.value),
+        _ => None,
+    }
+}
 
 /// Given a string literal or a union of string literals, return an iterator over the contained
 /// strings, or `None` if the type is neither.
@@ -186,6 +205,48 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_subscript_load_impl(value_ty, subscript)
     }
 
+    fn deferred_union_type(
+        &self,
+        subscript: &ast::ExprSubscript,
+        is_optional: bool,
+    ) -> Option<DeferredUnionType<'db>> {
+        if self.in_string_annotation() {
+            return None;
+        }
+        let db = self.db();
+        // Chained and unpacking assignments infer their shared RHS in an expression region.
+        // Every target definition retains that RHS, so any name target provides a stable anchor.
+        let definition = match self.region {
+            InferenceRegion::Definition(definition) => Some(definition),
+            InferenceRegion::Expression(expression, _) => {
+                expression.assigned_to(db).and_then(|assignment| {
+                    assignment
+                        .node(self.module())
+                        .targets
+                        .iter()
+                        .find_map(|target| assignment_target_definition(self.index, target))
+                })
+            }
+            _ => None,
+        }?;
+        let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
+            return None;
+        };
+        let relative_node_index = subscript
+            .node_index()
+            .load()
+            .as_u32()
+            .zip(assignment.value(self.module()).node_index().load().as_u32())
+            .and_then(|(node, base)| node.checked_sub(base))?;
+        Some(DeferredUnionType::new(
+            db,
+            definition,
+            relative_node_index,
+            self.typevar_binding_context,
+            is_optional,
+        ))
+    }
+
     fn infer_subscript_load_impl(
         &mut self,
         value_ty: Type<'db>,
@@ -320,6 +381,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ));
                     }
 
+                    if let Some(deferred) = self.deferred_union_type(subscript, true) {
+                        // Optional still resolves its members eagerly to preserve the None value
+                        // when its argument denotes None, including through an alias. Otherwise,
+                        // retain the stable wrapper without embedding those members in its value.
+                        let inference = &infer_union_types(db, deferred).inference;
+                        let argument_ty = inference.expression_type(slice.as_ref());
+                        if argument_ty.is_none(db) {
+                            // No deferred union value remains for scope checking to collect.
+                            self.extend_expression(inference);
+                            return Ok(argument_ty);
+                        }
+                        return Ok(Type::KnownInstance(KnownInstanceType::UnionType(
+                            UnionTypeInstance::deferred(db, deferred),
+                        )));
+                    }
+
                     let ty = self.infer_type_expression(slice);
 
                     // `Optional[None]` is equivalent to `None`:
@@ -341,6 +418,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
                 SpecialFormType::Union => match **slice {
                     ast::Expr::Tuple(ref tuple) => {
+                        // A stable value lets recursive references resolve the assignment before
+                        // the union's members.
+                        if let Some(deferred) = self.deferred_union_type(subscript, false) {
+                            return Ok(Type::KnownInstance(KnownInstanceType::UnionType(
+                                UnionTypeInstance::deferred(db, deferred),
+                            )));
+                        }
                         let elements = tuple.iter().map(|elt| self.infer_type_expression(elt));
 
                         let union_type = Type::KnownInstance(KnownInstanceType::UnionType(

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -1194,6 +1194,44 @@ fn redundant_elif_fix_preserves_line_endings_and_checks_cleanly() -> anyhow::Res
 }
 
 #[test]
+fn dependency_union_alias_body_change() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    let alias_source = "from typing import Union\nAlias = Union[int, str] if True else bytes";
+    db.write_files([
+        ("/src/aliases.py", alias_source),
+        (
+            "/src/main.py",
+            "from aliases import Alias\nfrom typing_extensions import reveal_type\n\
+             def consume(value: Alias): reveal_type(value)",
+        ),
+    ])?;
+    assert_revealed_type(&db, "/src/main.py", "int | str");
+
+    db.write_file("/src/aliases.py", alias_source.replace("int", "bytes"))?;
+    assert_revealed_type(&db, "/src/main.py", "bytes | str");
+
+    // Inserting expressions before the alias must not redirect its deferred body lookup.
+    let shifted_source = "from typing import Union\n\
+                          Padding = Union[float, bool]\n\
+                          Alias = Union[bytes, str] if True else bytes";
+    db.write_file("/src/aliases.py", shifted_source)?;
+    assert_revealed_type(&db, "/src/main.py", "bytes | str");
+
+    // Changing the condition moves the union's node index within the same assignment RHS.
+    let shifted_source = shifted_source.replace("if True", "if not False");
+    db.write_file("/src/aliases.py", &shifted_source)?;
+    assert_revealed_type(&db, "/src/main.py", "bytes | str");
+
+    db.write_file(
+        "/src/aliases.py",
+        shifted_source.replace("bytes", "complex"),
+    )?;
+    assert_revealed_type(&db, "/src/main.py", "complex | str");
+
+    Ok(())
+}
+
+#[test]
 fn function_inference_regions_are_disjoint() -> anyhow::Result<()> {
     let mut db = setup_db();
     db.write_dedented(

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -326,8 +326,16 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
             }
         }
         KnownInstanceType::UnionType(instance) => {
-            if let Ok(union_type) = instance.union_type(db) {
+            if let Some(Ok(union_type)) = instance.eager_union_type(db) {
                 visitor.visit_type(db, *union_type);
+            } else if instance.deferred_union(db).is_some() {
+                if visitor.should_visit_lazy_type_attributes() {
+                    if let Ok(union_type) = instance.union_type(db) {
+                        visitor.visit_type(db, union_type);
+                    }
+                } else {
+                    visitor.notify_skipped_lazy_type_attributes();
+                }
             }
         }
         KnownInstanceType::Literal(ty)
@@ -509,7 +517,7 @@ impl<'db> KnownInstanceType<'db> {
     ) -> Option<Type<'db>> {
         match self {
             Self::TypeAliasType(alias) => Some(Type::TypeAlias(alias)),
-            Self::UnionType(instance) => instance.union_type(db).as_ref().ok().copied(),
+            Self::UnionType(instance) => instance.union_type(db).ok(),
             Self::Literal(ty) | Self::Annotated(ty) | Self::LiteralStringAlias(ty) => {
                 Some(ty.inner(db))
             }
@@ -770,34 +778,110 @@ impl<'db> FieldInstance<'db> {
     }
 }
 
+/// A deferred `typing.Union[...]` or `typing.Optional[...]` expression within an assignment.
+///
+/// The node index is relative to the assignment's RHS so edits preceding the assignment do not
+/// change the value type exposed to other modules.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct DeferredUnionType<'db> {
+    #[returns(copy)]
+    pub(super) definition: Definition<'db>,
+
+    #[returns(copy)]
+    pub(super) relative_node_index: u32,
+
+    #[returns(copy)]
+    pub(super) typevar_binding_context: Option<Definition<'db>>,
+
+    #[returns(copy)]
+    pub(super) is_optional: bool,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for DeferredUnionType<'_> {}
+
 /// Contains information about a `types.UnionType` instance built from a PEP 604
 /// union or a legacy `typing.Union[…]` annotation in a value expression context,
 /// e.g. `IntOrStr = int | str` or `IntOrStr = Union[int, str]`.
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 pub struct UnionTypeInstance<'db> {
-    /// You probably don't want to access this field outside `UnionTypeInstance`
-    /// internals.
-    ///
-    /// This field is the types of the elements of this union, as they were inferred
-    /// in a value expression context. For `int | str`, this would contain
-    /// `<class 'int'>` and `<class 'str'>`. For `Union[int, str]`, this field is
-    /// `None`, as we infer the elements as type expressions.
-    ///
-    /// Use `value_expression_types` to get the corresponding value expression types.
     #[returns(ref)]
-    _value_expr_types: Option<[Type<'db>; 2]>,
+    kind: UnionTypeInstanceKind<'db>,
+}
 
-    /// The type of the full union, which can be used when this `UnionType` instance
-    /// is used in a type expression context. For `int | str`, this would contain
-    /// `Ok(int | str)`. If any of the element types could not be converted, this
-    /// contains the first encountered error.
-    #[returns(ref)]
-    pub(super) union_type: Result<Type<'db>, InvalidTypeExpressionError<'db>>,
+#[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub enum UnionTypeInstanceKind<'db> {
+    Eager {
+        /// The operand value types of a PEP 604 union. Legacy `typing.Union[...]`
+        /// expressions infer their elements as type expressions and have no value operands.
+        /// Use `value_expression_types` to obtain value types for either form.
+        value_expr_types: Option<[Type<'db>; 2]>,
+        /// The represented type, or the first error converting a value operand to a type.
+        union_type: Result<Type<'db>, InvalidTypeExpressionError<'db>>,
+    },
+    /// A `typing.Union[...]` or `typing.Optional[...]` with separately inferred elements.
+    Deferred(DeferredUnionType<'db>),
 }
 
 impl get_size2::GetSize for UnionTypeInstance<'_> {}
 
 impl<'db> UnionTypeInstance<'db> {
+    pub(super) fn new(
+        db: &'db dyn Db,
+        value_expr_types: Option<[Type<'db>; 2]>,
+        union_type: Result<Type<'db>, InvalidTypeExpressionError<'db>>,
+    ) -> Self {
+        Self::new_internal(
+            db,
+            UnionTypeInstanceKind::Eager {
+                value_expr_types,
+                union_type,
+            },
+        )
+    }
+
+    pub(super) fn deferred(db: &'db dyn Db, deferred: DeferredUnionType<'db>) -> Self {
+        Self::new_internal(db, UnionTypeInstanceKind::Deferred(deferred))
+    }
+
+    pub(super) fn deferred_union(self, db: &'db dyn Db) -> Option<DeferredUnionType<'db>> {
+        match self.kind(db) {
+            UnionTypeInstanceKind::Deferred(deferred) => Some(*deferred),
+            UnionTypeInstanceKind::Eager { .. } => None,
+        }
+    }
+
+    pub(super) fn eager_union_type(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<&'db Result<Type<'db>, InvalidTypeExpressionError<'db>>> {
+        match self.kind(db) {
+            UnionTypeInstanceKind::Eager { union_type, .. } => Some(union_type),
+            UnionTypeInstanceKind::Deferred(_) => None,
+        }
+    }
+
+    pub(super) fn union_type(
+        self,
+        db: &'db dyn Db,
+    ) -> Result<Type<'db>, InvalidTypeExpressionError<'db>> {
+        match self.kind(db) {
+            UnionTypeInstanceKind::Eager { union_type, .. } => union_type.clone(),
+            UnionTypeInstanceKind::Deferred(deferred) => {
+                Ok(super::infer::infer_union_type(db, *deferred))
+            }
+        }
+    }
+
+    fn value_operand_types(self, db: &'db dyn Db) -> Option<[Type<'db>; 2]> {
+        match self.kind(db) {
+            UnionTypeInstanceKind::Eager {
+                value_expr_types, ..
+            } => *value_expr_types,
+            UnionTypeInstanceKind::Deferred(_) => None,
+        }
+    }
+
     pub(crate) fn from_value_expression_types(
         db: &'db dyn Db,
         value_expr_types: [Type<'db>; 2],
@@ -826,7 +910,7 @@ impl<'db> UnionTypeInstance<'db> {
         // an ever-deeper value-expression tree like `((A | B) | B) | B`.
         for ty in &value_expr_types {
             if let Type::KnownInstance(KnownInstanceType::UnionType(union)) = ty
-                && let Ok(&existing_union) = union.union_type(db).as_ref()
+                && let Ok(existing_union) = union.union_type(db)
                 && existing_union == union_type
             {
                 return *ty;
@@ -848,11 +932,10 @@ impl<'db> UnionTypeInstance<'db> {
         visitor: &ApplyTypeMappingVisitor<'_, 'db>,
     ) -> Self {
         if let Ok(union_type) = self.union_type(db) {
-            UnionTypeInstance::new(
-                db,
-                self._value_expr_types(db),
-                Ok(union_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-            )
+            // Specializing a deferred union produces an eager value, even for an unchanged
+            // body. This lets cycle normalization see the current approximation of its members.
+            let mapped = union_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+            UnionTypeInstance::new(db, self.value_operand_types(db), Ok(mapped))
         } else {
             self
         }
@@ -881,10 +964,10 @@ impl<'db> UnionTypeInstance<'db> {
                 .unwrap_or_else(Type::unknown)
         };
 
-        if let Some(value_expr_types) = self._value_expr_types(db) {
-            Ok(Either::Left(value_expr_types.iter().copied()))
+        if let Some(value_expr_types) = self.value_operand_types(db) {
+            Ok(Either::Left(value_expr_types.into_iter()))
         } else {
-            match self.union_type(db).clone()? {
+            match self.union_type(db)? {
                 Type::Union(union) => Ok(Either::Right(Either::Left(
                     union.elements(db).iter().copied().map(to_class_literal),
                 ))),
@@ -902,9 +985,18 @@ impl<'db> UnionTypeInstance<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        let UnionTypeInstanceKind::Eager {
+            value_expr_types,
+            union_type,
+        } = self.kind(db)
+        else {
+            // The value of a deferred union is independent of its recursively inferred elements.
+            return Some(self);
+        };
+
         // The `Divergent` elimination rules are different within union types.
         // See `UnionType::recursive_type_normalized_impl` for details.
-        let value_expr_types = match self._value_expr_types(db).as_ref() {
+        let value_expr_types = match value_expr_types {
             Some([first, second]) if nested => Some([
                 first.recursive_type_normalized_impl(db, env, div, nested)?,
                 second.recursive_type_normalized_impl(db, env, div, nested)?,
@@ -919,7 +1011,7 @@ impl<'db> UnionTypeInstance<'db> {
             ]),
             None => None,
         };
-        let union_type = match self.union_type(db).clone() {
+        let union_type = match union_type.clone() {
             Ok(ty) if nested => Ok(ty.recursive_type_normalized_impl(db, env, div, nested)?),
             Ok(ty) => Ok(ty
                 .recursive_type_normalized_impl(db, env, div, nested)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1895,6 +1895,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (
+                Type::KnownInstance(KnownInstanceType::UnionType(source_union)),
+                Type::KnownInstance(KnownInstanceType::UnionType(target_union)),
+            ) if (source_union.deferred_union(db).is_some()
+                || target_union.deferred_union(db).is_some())
+                && !matches!(self.relation, TypeRelation::Redundancy { pure: false }) =>
+            {
+                // A deferred union's definition identifies where to infer its elements, not a
+                // distinct runtime union value. Compare represented types when a relation needs
+                // that value, but do not force elements merely to simplify a union of values.
+                self.with_recursion_guard(db, source, target, || {
+                    match (source_union.union_type(db), target_union.union_type(db)) {
+                        (Ok(source_type), Ok(target_type)) => self
+                            .as_equivalence_checker()
+                            .check_type_pair(db, source_type, target_type),
+                        _ => self.never(),
+                    }
+                })
+            }
+
+            (
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_partial)),
             )
@@ -3507,6 +3527,17 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(left)),
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(right)),
             ) => nontrivial_check(self, || self.check_property_instance_pair(db, left, right)),
+
+            (
+                Type::KnownInstance(KnownInstanceType::UnionType(left_union)),
+                Type::KnownInstance(KnownInstanceType::UnionType(right_union)),
+            ) if left_union.deferred_union(db).is_some()
+                || right_union.deferred_union(db).is_some() =>
+            {
+                // Different source definitions can produce equivalent runtime union values.
+                // Keep disjointness conservative without forcing their deferred elements.
+                self.never()
+            }
 
             (
                 Type::KnownInstance(KnownInstanceType::Sentinel(left_sentinel)),

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::db::tests::{TestDbBuilder, setup_db};
 use crate::place::{global_symbol, typing_extensions_symbol, typing_symbol};
 use crate::types::call::bind::CallableDescription;
+use crate::types::tuple::TupleType;
 use crate::types::type_alias::PEP695TypeAliasType;
 use crate::{Db, ProgramEnvironment};
 use ruff_db::files::system_path_to_file;
@@ -163,16 +164,22 @@ fn typing_vs_typeshed_no_default() {
     );
 }
 
-fn list_alias<'db>(
+fn generic_alias_with_one_argument<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
+    class: KnownClass,
     argument: Type<'db>,
 ) -> GenericAlias<'db> {
-    KnownClass::List
-        .to_specialized_class_type(db, env, &[argument])
-        .expect("`list` should accept one type argument")
+    let specialized = if class == KnownClass::Tuple {
+        TupleType::heterogeneous(db, env, [argument]).to_class_type(db)
+    } else {
+        class
+            .to_specialized_class_type(db, env, &[argument])
+            .expect("the class should accept one type argument")
+    };
+    specialized
         .into_generic_alias()
-        .expect("a specialized `list` should be a generic alias")
+        .expect("the specialized class should be a generic alias")
 }
 
 fn oscillating_generic_alias_cycle_recover<'db>(
@@ -181,6 +188,7 @@ fn oscillating_generic_alias_cycle_recover<'db>(
     previous: &Type<'db>,
     current: Type<'db>,
     program: Program<'db>,
+    _class: KnownClass,
 ) -> Type<'db> {
     let env = ProgramEnvironment::from_program(program);
     current.cycle_normalized(db, &env, *previous, cycle)
@@ -188,12 +196,16 @@ fn oscillating_generic_alias_cycle_recover<'db>(
 
 #[salsa::tracked(
     returns(copy),
-    cycle_initial=|_, id, _| Type::divergent(id),
+    cycle_initial=|_, id, _, _| Type::divergent(id),
     cycle_fn=oscillating_generic_alias_cycle_recover,
 )]
-fn oscillating_generic_alias<'db>(db: &'db dyn Db, program: Program<'db>) -> Type<'db> {
+fn oscillating_generic_alias<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    class: KnownClass,
+) -> Type<'db> {
     let env = ProgramEnvironment::from_program(program);
-    let previous = oscillating_generic_alias(db, program);
+    let previous = oscillating_generic_alias(db, program, class);
     let argument = if let Type::GenericAlias(alias) = previous
         && alias.specialization(db).types(db) == [Type::unknown()]
     {
@@ -202,13 +214,14 @@ fn oscillating_generic_alias<'db>(db: &'db dyn Db, program: Program<'db>) -> Typ
         Type::unknown()
     };
 
-    list_alias(db, &env, argument).into()
+    generic_alias_with_one_argument(db, &env, class, argument).into()
 }
 
 #[test]
 fn generic_alias_cycle_recovery_normalizes_same_origin_unknown_oscillation() {
     let db = setup_db();
-    let Type::GenericAlias(alias) = oscillating_generic_alias(&db, db.program()) else {
+    let Type::GenericAlias(alias) = oscillating_generic_alias(&db, db.program(), KnownClass::List)
+    else {
         panic!("cycle recovery should preserve the generic alias");
     };
 
@@ -216,19 +229,41 @@ fn generic_alias_cycle_recovery_normalizes_same_origin_unknown_oscillation() {
 }
 
 #[test]
-fn generic_alias_cycle_recovery_rejects_unsafe_merges() {
+fn tuple_alias_cycle_recovery_converges_on_unknown_oscillation() {
+    let db = setup_db();
+    // Specialty tuples retain both approximations rather than replacing the previous iteration.
+    let Type::Union(recovered) = oscillating_generic_alias(&db, db.program(), KnownClass::Tuple)
+    else {
+        panic!("cycle recovery should retain both tuple aliases");
+    };
+    let env = db.program_environment();
+    assert_eq!(recovered.elements(&db).len(), 2);
+    for argument in [Type::unknown(), KnownClass::Int.to_instance(&db, &env)] {
+        let alias = generic_alias_with_one_argument(&db, &env, KnownClass::Tuple, argument);
+        assert!(recovered.elements(&db).contains(&Type::GenericAlias(alias)));
+    }
+}
+
+#[test_case(KnownClass::List; "list")]
+#[test_case(KnownClass::Tuple; "tuple")]
+fn generic_alias_cycle_recovery_rejects_unsafe_merges(class: KnownClass) {
     let db = setup_db();
     let db = &db;
     let env = db.program_environment();
-    let int = list_alias(db, &env, KnownClass::Int.to_instance(db, &env));
-    let str = list_alias(db, &env, KnownClass::Str.to_instance(db, &env));
+    let int =
+        generic_alias_with_one_argument(db, &env, class, KnownClass::Int.to_instance(db, &env));
+    let str =
+        generic_alias_with_one_argument(db, &env, class, KnownClass::Str.to_instance(db, &env));
     assert!(str.merge_cycle_recovery(db, int).is_none());
 
     let generic_context = int.specialization(db).generic_context(db);
     let unknown_generic = Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
     assert!(
-        int.merge_cycle_recovery(db, list_alias(db, &env, unknown_generic))
-            .is_none()
+        int.merge_cycle_recovery(
+            db,
+            generic_alias_with_one_argument(db, &env, class, unknown_generic)
+        )
+        .is_none()
     );
 }
 


### PR DESCRIPTION
Mutually recursive tuple and union aliases can fail to converge when a `typing.Union` value embeds the changing types of its members. Represent assignment-backed `typing.Union[...]` and `typing.Optional[...]` values with stable references, and infer their members in a separate query. This lets recursive aliases converge without changing ordinary union normalization or monotonic cycle recovery.

Union members are inferred when needed to interpret or specialize the represented type. Scope checking still collects diagnostics from unused aliases. `Optional` also resolves its argument when constructing the value to preserve the existing `Optional[None]` behavior. Unspecialized deferred values display as an opaque union special form; annotations retain their member types.

Fixes astral-sh/ty#4443.

## Test plan

- Recursive-alias mdtests cover tuple and union cycles, concrete members, declaration order, conditional expressions, chained and unpacking assignments, imported tuple constructors, generic specialization, self- and mutually recursive `Optional` aliases, and unions of recursive sequences with strings.
- Loop mdtests cover repeated tuple nesting, string and runtime-union accumulation, and rejection of incompatible arguments for accumulated `Union` and `Optional` annotations.
- Alias mdtests cover generic inference, binding timing across imports and reassignment, runtime identity, diagnostics in unused aliases, malformed `NamedTuple` arguments, and `Optional` arguments involving `None`, aliases, strings, `Never`, and `NoReturn`.
- Unit tests cover incremental edits to deferred union bodies and their surrounding expressions, convergence of recursive tuple approximations, and rejection of unsafe tuple-specialization merges.
