### PR TITLE
[ty] Avoid dict keyword-call panics when typing is shadowed

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -587,6 +587,28 @@ def clean(value: dict[str, int] | str | None) -> None:
             value[key] = item
 ```
 
+## `dict` keyword arguments with a shadowed `typing` module
+
+An empty first-party `typing` module hides the definitions that make `dict` generic. Calls with one
+or more named keyword arguments still check their values and recover with `Unknown`, just like
+dictionary literals.
+
+`typing.py`:
+
+```py
+```
+
+`main.py`:
+
+```py
+reveal_type(dict(a=1))  # revealed: Unknown
+reveal_type(dict(a=1, b=2))  # revealed: Unknown
+reveal_type({"a": 1})  # revealed: Unknown
+
+# error: [unresolved-reference]
+dict(a=1, b=missing)
+```
+
 ## Failed inner `OrderedDict` calls do not invalidate outer constructors
 
 Constructing an `OrderedDict` from a list containing both strings and floats is already rejected.

--- a/crates/ty_python_semantic/resources/mdtest/call/builtins.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/builtins.md
@@ -609,6 +609,61 @@ reveal_type({"a": 1})  # revealed: Unknown
 dict(a=1, b=missing)
 ```
 
+## Empty `dict` calls with a non-generic stub
+
+An empty call to a non-generic dictionary class is rejected if its constructor requires an argument.
+
+```toml
+[environment]
+typeshed = "/typeshed"
+```
+
+`/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+class object: ...
+class int: ...
+
+class dict:
+    def __init__(self, value: int) -> None: ...
+```
+
+```py
+dict(1)
+
+dict()  # error: [missing-argument] "No argument provided for required parameter `value`"
+```
+
+## `dict` keyword arguments that violate a type variable bound
+
+A custom typeshed can constrain dictionary values. A value that violates the bound is rejected, and
+later keyword values are still checked.
+
+```toml
+[environment]
+python-version = "3.12"
+typeshed = "/typeshed"
+```
+
+`/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+class object: ...
+class str: ...
+class int: ...
+
+class dict[K, V: int]:
+    def __init__(self, **kwargs: V) -> None: ...
+```
+
+```py
+dict(a=1)
+
+# error: [invalid-argument-type] "does not satisfy upper bound `int`"
+# error: [unresolved-reference]
+dict(a="oops", b=missing)
+```
+
 ## Failed inner `OrderedDict` calls do not invalidate outer constructors
 
 Constructing an `OrderedDict` from a list containing both strings and floats is already rejected.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7509,8 +7509,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Some((collection_alias, generic_context, elt_tys)) = elt_tys(collection_class) else {
             // Infer the element types without type context, and fallback to `Unknown` for
             // custom typesheds.
-            for (i, elt) in elts.iter().flatten().flatten().enumerate() {
-                infer_elt_expression(self, (i, elt, TypeContext::default()));
+            for elts in elts {
+                for (i, elt) in elts.iter().enumerate() {
+                    let Some(elt) = elt else { continue };
+                    infer_elt_expression(self, (i, elt, TypeContext::default()));
+                }
             }
 
             return None;

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -106,12 +106,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        self.infer_collection_literal(
-            KnownClass::Dict,
-            collection_expr,
-            &items,
-            &mut infer_elt_ty,
-            call_expression_tcx,
+        // Collection inference checks the values even if it cannot specialize `dict`. Return
+        // its fallback type so ordinary call inference does not infer the values again.
+        Some(
+            self.infer_collection_literal(
+                KnownClass::Dict,
+                collection_expr,
+                &items,
+                &mut infer_elt_ty,
+                call_expression_tcx,
+            )
+            .unwrap_or_else(|| {
+                KnownClass::Dict.to_specialized_instance(
+                    db,
+                    self.program_environment(),
+                    &[Type::unknown(), Type::unknown()],
+                )
+            }),
         )
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -106,23 +106,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        // Collection inference checks the values even if it cannot specialize `dict`. Return
-        // its fallback type so ordinary call inference does not infer the values again.
-        Some(
-            self.infer_collection_literal(
-                KnownClass::Dict,
-                collection_expr,
-                &items,
-                &mut infer_elt_ty,
-                call_expression_tcx,
-            )
-            .unwrap_or_else(|| {
-                KnownClass::Dict.to_specialized_instance(
-                    db,
-                    self.program_environment(),
-                    &[Type::unknown(), Type::unknown()],
-                )
-            }),
+        self.infer_collection_literal(
+            KnownClass::Dict,
+            collection_expr,
+            &items,
+            &mut infer_elt_ty,
+            call_expression_tcx,
         )
+        .or_else(|| {
+            // Empty calls still need constructor validation and have no inferred values to preserve.
+            if arguments.is_empty() {
+                return None;
+            }
+
+            // Without generic definitions, collection inference still checks all values. Return
+            // `Unknown` in that case to avoid inferring them again. Specialization failures need
+            // ordinary call checking to report argument errors.
+            KnownClass::Dict
+                .try_to_class_literal(db, self.program_environment())
+                .and_then(|class| class.generic_context(db))
+                .is_none()
+                .then(Type::unknown)
+        })
     }
 }


### PR DESCRIPTION
Calling `dict(a=1)` can panic when a first-party `typing.py` hides typeshed's generic definitions. Preserve key/value indices during fallback inference and recover with `Unknown` after checking the values, avoiding a second inference pass. Empty calls and specialization failures retain ordinary constructor validation so their diagnostics are preserved.

Fixes astral-sh/ty#4454.

## Test plan

Added mdtests for one and multiple named keywords with an empty `typing.py`, diagnostics in keyword values, empty calls to a non-generic dictionary requiring an argument, and a bounded dictionary value type that reports both an invalid argument and a later unresolved name.
