### PR TITLE
[ty] Optionally record place load and deferredness data in an inference result.

### DIFF
--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -21,7 +21,9 @@ use ty_python_core::ProgramFile;
 use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};
 use ty_python_semantic::dependency::DependencyMetadata;
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
-use ty_python_semantic::{AnalysisSettings, Db as SemanticDb, PythonVersionWithSource};
+use ty_python_semantic::{
+    AnalysisSettings, Db as SemanticDb, PlaceLoadRecordingMode, PythonVersionWithSource,
+};
 
 mod changes;
 
@@ -110,7 +112,12 @@ impl ProjectDatabase {
     where
         S: System + 'static + Send + Sync + RefUnwindSafe,
     {
-        Self::new(project_metadata, system, &FallibleStrategy)
+        Self::new(
+            project_metadata,
+            system,
+            PlaceLoadRecordingMode::default(),
+            &FallibleStrategy,
+        )
     }
 
     /// Creates a new database, substituting default values for any misconfigured settings.
@@ -118,7 +125,12 @@ impl ProjectDatabase {
     where
         S: System + 'static + Send + Sync + RefUnwindSafe,
     {
-        let Ok(db) = Self::new(project_metadata, system, &UseDefaultStrategy);
+        let Ok(db) = Self::new(
+            project_metadata,
+            system,
+            PlaceLoadRecordingMode::default(),
+            &UseDefaultStrategy,
+        );
         db
     }
 
@@ -144,6 +156,7 @@ impl ProjectDatabase {
     fn new<S, Strategy: MisconfigurationStrategy>(
         project_metadata: ProjectMetadata,
         system: S,
+        recording_mode: PlaceLoadRecordingMode,
         strategy: &Strategy,
     ) -> Result<Self, Strategy::Error<anyhow::Error>>
     where
@@ -181,6 +194,8 @@ impl ProjectDatabase {
 
         let (program_settings, program_settings_diagnostics) = strategy
             .to_anyhow(merged_options.to_program_settings(db.system(), db.vendored(), strategy))?;
+
+        ty_python_semantic::initialize_place_load_recording(&db, recording_mode);
 
         // This must be called before `from_metadata`, or the `SearchPath` root
         // will take precedence over the `Project` root, resulting in
@@ -714,7 +729,7 @@ pub(crate) mod testing {
     use ty_python_semantic::ProgramEnvironment;
     use ty_python_semantic::dependency::DependencyMetadata;
     use ty_python_semantic::lint::{LintRegistry, RuleSelection};
-    use ty_python_semantic::{AnalysisSettings, PythonVersionWithSource};
+    use ty_python_semantic::{AnalysisSettings, PlaceLoadRecordingMode, PythonVersionWithSource};
 
     use crate::db::Db;
     use crate::metadata::settings::file_settings;
@@ -755,6 +770,11 @@ pub(crate) mod testing {
                 events,
                 project: None,
             };
+
+            ty_python_semantic::initialize_place_load_recording(
+                &db,
+                PlaceLoadRecordingMode::default(),
+            );
 
             let (settings, settings_diagnostics) = project
                 .to_merged_options()

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -3,6 +3,8 @@ use crate::lint::{LintRegistry, RuleSelection};
 use crate::{AnalysisSettings, PythonVersionWithSource};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
+use rustc_hash::FxHashSet;
+use salsa::Setter;
 use ty_python_core::{Db as PythonCoreDb, ProgramFile};
 
 /// Database giving access to semantic information about a Python program.
@@ -35,6 +37,77 @@ pub trait Db: PythonCoreDb {
     fn is_open_file(&self, file: File) -> bool;
 
     fn dyn_clone(&self) -> Box<dyn Db>;
+}
+
+/// Initializes the database's permanent recording policy, with no files selected.
+///
+/// Call once when constructing a database, before running inference or creating snapshots.
+/// The input must exist even while recording is disabled: Salsa does not track the absence
+/// of a singleton, so creating it on first opt-in would not invalidate earlier inference.
+pub fn initialize_place_load_recording(db: &dyn Db, mode: PlaceLoadRecordingMode) {
+    let _ = PlaceLoadRecording::builder(mode, FxHashSet::default())
+        .mode_durability(salsa::Durability::NEVER_CHANGE)
+        .new(db);
+}
+
+/// Whether a database can retain place-load resolutions alongside inferred types.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, get_size2::GetSize)]
+pub enum PlaceLoadRecordingMode {
+    /// Never record place loads, even if a caller requests them.
+    #[default]
+    Disabled,
+    /// Allow callers to enable recording for individual files.
+    OnDemand,
+}
+
+/// Enables cached place-load records for the selected files without running inference.
+///
+/// Recording persists across requests and source edits. Newly enabled files invalidate their
+/// unrecorded inference; enabling an already-enabled file does not change the database.
+/// Has no effect when the database was constructed with [`PlaceLoadRecordingMode::Disabled`].
+pub fn enable_place_load_recording(db: &mut dyn Db, files: impl IntoIterator<Item = File>) {
+    let recording = PlaceLoadRecording::get(db);
+    if recording.mode(db) == PlaceLoadRecordingMode::Disabled {
+        return;
+    }
+
+    let enabled = recording.files(db);
+
+    let additions: FxHashSet<_> = files
+        .into_iter()
+        .filter(|file| !enabled.contains(file))
+        .collect();
+    if additions.is_empty() {
+        return;
+    }
+
+    let mut enabled = enabled.clone();
+    enabled.extend(additions);
+    enabled.shrink_to_fit();
+
+    recording.set_files(db).to(enabled);
+}
+
+#[salsa::input(singleton, heap_size=ruff_memory_usage::heap_size)]
+struct PlaceLoadRecording {
+    #[returns(copy)]
+    mode: PlaceLoadRecordingMode,
+    #[returns(ref)]
+    files: FxHashSet<File>,
+}
+
+/// Returns whether inference retains place-load resolutions for `file`.
+///
+/// Permanently disabled databases neither cache per-file flags nor depend on the selected files.
+pub fn should_record_place_loads(db: &dyn Db, file: File) -> bool {
+    PlaceLoadRecording::get(db).mode(db) == PlaceLoadRecordingMode::OnDemand
+        && should_record_place_loads_impl(db, file)
+}
+
+/// Isolates recording changes so inference for other files can retain its cached result.
+#[salsa::tracked(heap_size=ruff_memory_usage::heap_size, returns(copy))]
+fn should_record_place_loads_impl(db: &dyn Db, file: File) -> bool {
+    PlaceLoadRecording::get(db).files(db).contains(&file)
 }
 
 #[cfg(test)]
@@ -80,7 +153,7 @@ pub(crate) mod tests {
             let events = Events::default();
             let vendored = ty_vendored::file_system().clone();
             let program_settings = ProgramSettings::empty(&vendored);
-            Self {
+            let db = Self {
                 storage: salsa::Storage::new(Some(Box::new({
                     let events = events.clone();
                     move |event| {
@@ -97,7 +170,9 @@ pub(crate) mod tests {
                 analysis_settings: AnalysisSettings::default().into(),
                 open_files: rustc_hash::FxHashSet::default(),
                 program_settings,
-            }
+            };
+            initialize_place_load_recording(&db, PlaceLoadRecordingMode::default());
+            db
         }
 
         pub(crate) fn python_version(&self) -> PythonVersion {

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -8,7 +8,11 @@ use crate::suppression::{
     UNUSED_TYPE_IGNORE_COMMENT,
 };
 use crate::types::check_types;
-pub use db::Db;
+#[allow(dead_code)]
+pub use db::{
+    Db, PlaceLoadRecordingMode, enable_place_load_recording, initialize_place_load_recording,
+    should_record_place_loads,
+};
 pub(crate) use diagnostic::add_inferred_python_version_hint_to_diagnostic;
 pub use diagnostic::inferred_python_version_source_annotation;
 pub use fixes::{fix_all_diagnostics, suppress_all_diagnostics};

--- a/crates/ty_python_semantic/src/place/definitions.rs
+++ b/crates/ty_python_semantic/src/place/definitions.rs
@@ -40,6 +40,7 @@ pub(crate) fn definitions_for_module_global<'db>(
 }
 
 /// A set of definitions found by name resolution along with facts about their availability.
+#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "these flags describe independent facts about the resolved definitions"
@@ -354,6 +355,7 @@ impl<'db> DefinitionResolutionBuilder<'db> {
     ) -> DefinitionResolution<'db> {
         self.resolution.may_be_unbound = !is_definitely_bound;
         self.resolution.crosses_scope_declaration |= crosses_scope_declaration;
+        self.resolution.definitions.shrink_to_fit();
         self.resolution
     }
 }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -44,6 +44,7 @@
 //! be considered a bug.)
 
 use crate::ProgramEnvironment;
+use crate::place::definitions::DefinitionResolution;
 use itertools::Either;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
@@ -63,7 +64,7 @@ use crate::types::{
 };
 use crate::{Db, FxIndexSet};
 
-use builder::TypeInferenceBuilder;
+use builder::{DeferredExpressionState, TypeInferenceBuilder};
 pub(super) use comparisons::UnsupportedComparisonError;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::expression::Expression;
@@ -76,6 +77,14 @@ mod builder;
 mod comparisons;
 #[cfg(test)]
 mod tests;
+
+/// The place-load metadata produced alongside an expression's type when recording is enabled.
+#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+struct PlaceLoadMetadata<'db> {
+    range: TextRange,
+    deferred_state: DeferredExpressionState,
+    resolution: DefinitionResolution<'db>,
+}
 
 bitflags::bitflags! {
     /// Metadata for expressions inferred as type expressions.
@@ -233,6 +242,7 @@ pub(crate) fn function_known_decorator_flags<'db>(
 /// function-definition inference.
 #[derive(Debug, Eq, PartialEq, Default, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct FunctionDecoratorInference<'db> {
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     expression_types: FrozenMap<ExpressionNodeKey, Type<'db>>,
     bindings: Box<[(Definition<'db>, Type<'db>)]>,
     called_functions: Box<[FunctionType<'db>]>,
@@ -907,6 +917,8 @@ pub(crate) struct ScopeInference<'db> {
 
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct ScopeInferenceExtra<'db> {
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
@@ -1282,6 +1294,9 @@ impl<'db> DefinitionTypes<'db> {
 /// `Other` stores uncommon combinations that require multiple fields.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 enum DefinitionInferenceExtra<'db> {
+    /// Place-load metadata is the only extra data for some definitions.
+    PlaceLoadMetadata(FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>),
+
     /// Type qualifiers are the only extra data for most annotated definitions.
     Qualifiers(FrozenMap<ExpressionNodeKey, TypeQualifiers>),
 
@@ -1314,6 +1329,9 @@ struct DeferredAndUndecorated<'db> {
 
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct OtherDefinitionInferenceExtra<'db> {
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
+
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
@@ -1356,6 +1374,10 @@ struct OtherDefinitionInferenceExtra<'db> {
 impl<'db> DefinitionInferenceExtra<'db> {
     fn into_other(self) -> OtherDefinitionInferenceExtra<'db> {
         match self {
+            Self::PlaceLoadMetadata(place_load_metadata) => OtherDefinitionInferenceExtra {
+                place_load_metadata: Some(Box::new(place_load_metadata)),
+                ..OtherDefinitionInferenceExtra::default()
+            },
             Self::Qualifiers(qualifiers) => OtherDefinitionInferenceExtra {
                 qualifiers,
                 ..OtherDefinitionInferenceExtra::default()
@@ -1725,6 +1747,8 @@ pub(crate) struct ExpressionInference<'db> {
 /// Extra data that only exists for few inferred expression regions.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct ExpressionInferenceExtra<'db> {
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
@@ -1972,6 +1996,8 @@ pub(crate) struct StatementInferenceInner<'db> {
 
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct StatementInferenceInnerExtra<'db> {
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -25,6 +25,7 @@ use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
+use super::PlaceLoadMetadata;
 use super::{
     CollectionUseConstraints, DeferredAndUndecorated, DefinitionInference,
     DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
@@ -34,6 +35,7 @@ use super::{
     infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
+use crate::place::definitions::DefinitionResolutionBuilder;
 use crate::place::{
     ConsideredDefinitions, DefinedPlace, Definedness, LookupError, Place, PlaceAndQualifiers,
     RequiresExplicitReExport, TypeOrigin, builtins_module_scope, class_body_implicit_symbol,
@@ -312,6 +314,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// Expected types for expression nodes tracked for IDE completion.
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
+    /// Place-load metadata retained only when this file opts into recording.
+    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>,
+
     /// The scope this region is part of.
     scope: ScopeId<'db>,
 
@@ -512,6 +517,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             collection_use_constraints: FxHashMap::default(),
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
+            place_load_metadata: FxHashMap::default(),
             bindings: VecMap::default(),
             declarations: VecMap::default(),
             typevar_binding_context: None,
@@ -598,6 +604,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(extra) = &inference.extra {
             match extra.as_ref() {
+                DefinitionInferenceExtra::PlaceLoadMetadata(metadata) => {
+                    self.place_load_metadata.extend(metadata.iter().cloned());
+                }
                 DefinitionInferenceExtra::Qualifiers(qualifiers) => {
                     self.qualifiers.extend(qualifiers.iter().copied());
                 }
@@ -624,6 +633,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 DefinitionInferenceExtra::Undecorated(_)
                 | DefinitionInferenceExtra::DiscardsDictKeyAssignments => {}
                 DefinitionInferenceExtra::Other(extra) => {
+                    if let Some(place_load_metadata) = &extra.place_load_metadata {
+                        self.place_load_metadata
+                            .extend(place_load_metadata.iter().cloned());
+                    }
                     self.called_functions
                         .extend(extra.called_functions.iter().copied());
                     self.extend_cycle_recovery(extra.cycle_recovery);
@@ -673,6 +686,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if let Some(extra) = &inference.extra {
+            if let Some(place_load_metadata) = &extra.place_load_metadata {
+                self.place_load_metadata
+                    .extend(place_load_metadata.iter().cloned());
+            }
             self.called_functions
                 .extend(extra.called_functions.iter().copied());
             self.return_types_and_ranges
@@ -728,6 +745,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.extend_expression_types(inference.expressions.iter().copied());
 
         if let Some(extra) = &inference.extra {
+            if let Some(place_load_metadata) = &extra.place_load_metadata {
+                self.place_load_metadata
+                    .extend(place_load_metadata.iter().cloned());
+            }
             self.comparison_truthiness
                 .extend(extra.comparison_truthiness.iter().copied());
             self.context.extend(&extra.diagnostics);
@@ -755,6 +776,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_expression_cache_entry(&mut self, inference: &FullExpressionCacheEntry<'db>) {
+        self.place_load_metadata.extend(
+            inference
+                .place_load_metadata
+                .iter()
+                .map(|(key, metadata)| (*key, metadata.clone())),
+        );
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
@@ -805,6 +832,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.extend_expression_types(inference.expressions.iter());
 
         if let Some(extra) = &inference.extra {
+            if let Some(place_load_metadata) = &extra.place_load_metadata {
+                self.place_load_metadata
+                    .extend(place_load_metadata.iter().cloned());
+            }
             self.context.extend(&extra.diagnostics);
             self.extend_cycle_recovery(extra.cycle_recovery);
             self.string_annotations
@@ -10325,7 +10356,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ///
     /// This also returns the [`ConstraintKey`]s used by expression-level narrowing.
     fn infer_place_load(
-        &self,
+        &mut self,
         place_expr: PlaceExpr,
         expr_ref: ast::ExprRef,
     ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
@@ -10342,10 +10373,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut place = PlaceAndQualifiers::from(Place::Undefined);
         let mut failure = None;
         let mut checked_deprecated = false;
+        let mut definition_resolution = (expr_ref.is_name_expr()
+            && crate::db::should_record_place_loads(self.db(), self.file()))
+        .then(DefinitionResolutionBuilder::new);
 
         while let Some(step) = resolution.next() {
             match step {
                 PlaceLoadResolutionStep::Source(source) => {
+                    if let Some(definitions) = definition_resolution.as_mut() {
+                        definitions.add_source(self.db(), env, self.scope(), &source);
+                    }
                     if !checked_deprecated && source.is_post_lexical() {
                         // Deprecation diagnostics apply to the result of lexical name resolution,
                         // before it is combined with implicit module globals or builtins. Hence, we
@@ -10393,6 +10430,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } else {
             place
         };
+
+        if let Some(mut definitions) = definition_resolution {
+            if failure == Some(PlaceLoadFailure::NotFound) {
+                definitions.mark_incomplete();
+            }
+            self.place_load_metadata.insert(
+                expr_ref.into(),
+                PlaceLoadMetadata {
+                    range: expr_ref.range(),
+                    deferred_state: self.deferred_state,
+                    resolution: definitions.finish(
+                        place.place.is_definitely_bound(),
+                        resolution.crosses_scope_declaration(),
+                    ),
+                },
+            );
+        }
 
         let constraint_keys = resolution.into_constraints();
 
@@ -11678,6 +11732,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -11715,6 +11770,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         FullExpressionCacheEntry {
+            place_load_metadata,
             expressions,
             comparison_truthiness,
             type_expression_flags,
@@ -11741,6 +11797,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             mut collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -11769,6 +11826,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         let extra = (!diagnostics.is_empty()
+            || !place_load_metadata.is_empty()
             || !string_annotations.is_empty()
             || cycle_recovery.is_some()
             || !expected_types.is_empty()
@@ -11782,6 +11840,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             collection_use_constraints.shrink_to_fit();
             return_types_and_ranges.shrink_to_fit();
             Box::new(StatementInferenceInnerExtra {
+                place_load_metadata: (!place_load_metadata.is_empty())
+                    .then(|| Box::new(FrozenMap::from(place_load_metadata))),
                 string_annotations: FrozenSet::from(string_annotations),
                 expected_types: FrozenMap::from(expected_types),
                 called_functions: called_functions
@@ -11860,6 +11920,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred: _,
             scope: _,
             string_annotations: _,
+            place_load_metadata,
             expected_types: _,
             return_types_and_ranges: _,
             collection_use_constraints: _,
@@ -11878,6 +11939,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         FunctionDecoratorInference {
+            place_load_metadata: (!place_load_metadata.is_empty())
+                .then(|| Box::new(FrozenMap::from(place_load_metadata))),
             expression_types: FrozenMap::from(expressions),
             bindings: bindings.into_boxed_slice(),
             called_functions: called_functions
@@ -11906,6 +11969,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             mut collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -11932,6 +11996,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         let non_undecorated_extra_field_count = usize::from(!string_annotations.is_empty())
+            + usize::from(!place_load_metadata.is_empty())
             + usize::from(!expected_types.is_empty())
             + usize::from(!collection_use_constraints.is_empty())
             + usize::from(!called_functions.is_empty())
@@ -11945,6 +12010,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let extra = match (non_undecorated_extra_field_count, undecorated_type) {
             (0, None) => None,
+            (1, None) if !place_load_metadata.is_empty() => Some(Box::new(
+                DefinitionInferenceExtra::PlaceLoadMetadata(FrozenMap::from(place_load_metadata)),
+            )),
             (1, None) if !qualifiers.is_empty() => Some(Box::new(
                 DefinitionInferenceExtra::Qualifiers(FrozenMap::from(qualifiers)),
             )),
@@ -11985,6 +12053,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (_, undecorated_type) => {
                 collection_use_constraints.shrink_to_fit();
                 let extra = OtherDefinitionInferenceExtra {
+                    place_load_metadata: (!place_load_metadata.is_empty())
+                        .then(|| Box::new(FrozenMap::from(place_load_metadata))),
                     string_annotations: FrozenSet::from(string_annotations),
                     expected_types: FrozenMap::from(expected_types),
                     collection_use_constraints,
@@ -12042,6 +12112,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Self {
             context,
             string_annotations,
+            place_load_metadata,
             expected_types,
             type_expression_flags,
             mut collection_use_constraints,
@@ -12077,6 +12148,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         let extra = (!string_annotations.is_empty()
+            || !place_load_metadata.is_empty()
             || !expected_types.is_empty()
             || !diagnostics.is_empty()
             || cycle_recovery.is_some()
@@ -12086,6 +12158,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         .then(|| {
             collection_use_constraints.shrink_to_fit();
             Box::new(ScopeInferenceExtra {
+                place_load_metadata: (!place_load_metadata.is_empty())
+                    .then(|| Box::new(FrozenMap::from(place_load_metadata))),
                 string_annotations: FrozenSet::from(string_annotations),
                 qualifiers: FrozenMap::from(qualifiers),
                 expected_types: FrozenMap::from(expected_types),
@@ -12131,6 +12205,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions: _,
             comparison_truthiness: _,
             string_annotations: _,
+            place_load_metadata: _,
             expected_types: _,
             scope: _,
             bindings: _,
@@ -12194,6 +12269,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -12232,6 +12308,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         self.extend_expression_types(expressions);
+        self.place_load_metadata.extend(place_load_metadata);
         self.comparison_truthiness.extend(comparison_truthiness);
         self.context.extend(&diagnostics);
         self.extend_cycle_recovery(cycle_recovery);
@@ -12358,6 +12435,7 @@ enum ExpressionCacheEntry<'db> {
 /// Unlike [`ExpressionInference`], this type is short-lived, and avoids the cost of compaction
 /// that is otherwise performed for Salsa results.
 struct FullExpressionCacheEntry<'db> {
+    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>,
     expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
     comparison_truthiness: FxHashMap<ExpressionNodeKey, Truthiness>,
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
@@ -12383,6 +12461,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
 
     fn is_single_expression(&self, expression: ExpressionNodeKey, ty: Type<'db>) -> bool {
         self.expressions.len() == 1
+            && self.place_load_metadata.is_empty()
             && self.expressions.get(&expression) == Some(&ty)
             && self.comparison_truthiness.is_empty()
             && self.type_expression_flags.is_empty()
@@ -12400,6 +12479,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
         region: InferenceRegion<'db>,
     ) -> ExpressionInference<'db> {
         let extra = (!self.string_annotations.is_empty()
+            || !self.place_load_metadata.is_empty()
             || !self.comparison_truthiness.is_empty()
             || !self.type_expression_flags.is_empty()
             || !self.collection_use_constraints.is_empty()
@@ -12421,6 +12501,8 @@ impl<'db> FullExpressionCacheEntry<'db> {
             self.collection_use_constraints.shrink_to_fit();
             self.diagnostics.shrink_to_fit();
             Box::new(ExpressionInferenceExtra {
+                place_load_metadata: (!self.place_load_metadata.is_empty())
+                    .then(|| Box::new(FrozenMap::from(self.place_load_metadata))),
                 string_annotations: FrozenSet::from(self.string_annotations),
                 comparison_truthiness: FrozenMap::from(self.comparison_truthiness),
                 expected_types: FrozenMap::from(self.expected_types),
@@ -12590,8 +12672,8 @@ impl<'a> Iterator for ArgumentsIter<'a> {
 }
 
 /// The deferred state of a specific expression in an inference region.
-#[derive(Default, Debug, Clone, Copy)]
-enum DeferredExpressionState {
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(super) enum DeferredExpressionState {
     /// The expression is not deferred.
     #[default]
     None,

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -423,6 +423,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let decorator_inference =
             (!decorator_list.is_empty()).then(|| function_known_decorators(self.db(), definition));
         if let Some(decorator_inference) = decorator_inference.as_ref() {
+            if let Some(metadata) = &decorator_inference.place_load_metadata {
+                self.place_load_metadata.extend(metadata.iter().cloned());
+            }
             self.context.extend(decorator_inference.diagnostics());
             self.expressions
                 .extend(decorator_inference.expression_types());

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -155,7 +155,7 @@ impl CorpusDb {
     pub fn new() -> Self {
         let vendored = ty_vendored::file_system().clone();
         let program_settings = ProgramSettings::empty(&vendored);
-        Self {
+        let db = Self {
             storage: salsa::Storage::new(None),
             system: TestSystem::default(),
             vendored,
@@ -163,7 +163,12 @@ impl CorpusDb {
             files: Files::default(),
             analysis_settings: Arc::new(AnalysisSettings::default()),
             program_settings,
-        }
+        };
+        ty_python_semantic::initialize_place_load_recording(
+            &db,
+            ty_python_semantic::PlaceLoadRecordingMode::default(),
+        );
+        db
     }
 }
 

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -184,6 +184,7 @@ Memory report:
 `FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `File`                                             metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `ModuleResolveModeIngredient`                      metadata=[X.XXMB]   fields=[X.XXMB]   count=1
+`PlaceLoadRecording`                               metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Project`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `ResolverEnvironment`                              metadata=[X.XXMB]   fields=[X.XXMB]   count=1

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -51,6 +51,10 @@ impl Db {
         };
 
         db.settings = Some(Settings::new(&db, program_settings));
+        ty_python_semantic::initialize_place_load_recording(
+            &db,
+            ty_python_semantic::PlaceLoadRecordingMode::default(),
+        );
         db
     }
 

--- a/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
@@ -74,6 +74,10 @@ impl TestDb {
         };
         program_settings.search_paths.try_register_static_roots(&db);
         db.program_settings = program_settings;
+        ty_python_semantic::initialize_place_load_recording(
+            &db,
+            ty_python_semantic::PlaceLoadRecordingMode::default(),
+        );
 
         db
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This change extends the `*InferenceExtra` data types (e.g., [`ScopeInferenceExtra`](https://github.com/astral-sh/ruff/blob/e5e93233e9c5f4a4d28edb81fea54c3215e7b2e9/crates/ty_python_semantic/src/types/infer.rs#L918-L921)) with a collection of [`RecordedPlaceLoad`](https://github.com/astral-sh/ruff/blob/e5e93233e9c5f4a4d28edb81fea54c3215e7b2e9/crates/ty_python_semantic/src/types/infer.rs#L81-L87) objects which encapsulate information about a place load and its deferredness that is useful to the language server. That collection is only populated when an inference consumer explicitly enables the recording of that data. As a result, apart from a small amount of fixed overhead, ordinary type-checking should not pay the cost of the extra storage.

## Test Plan

See included tests.
<!-- How was it tested? -->
