### PR TITLE
Experiment with bulk Ruff cache metadata on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,7 @@ dependencies = [
  "get-size2",
  "ignore",
  "insta",
+ "libc",
  "matchit",
  "path-slash",
  "pathdiff",

--- a/crates/ruff/src/cache.rs
+++ b/crates/ruff/src/cache.rs
@@ -17,6 +17,8 @@ use rustc_hash::FxHashMap;
 use tempfile::NamedTempFile;
 
 use ruff_cache::{CacheKey, CacheKeyHasher};
+#[cfg(target_os = "macos")]
+use ruff_db::system::directory_metadata;
 use ruff_linter::package::PackageRoot;
 use ruff_linter::{VERSION, warn_user};
 use ruff_macros::CacheKey;
@@ -28,7 +30,7 @@ pub(crate) type RelativePath = Path;
 /// [`PathBuf`] that is relative to the package root in [`PackageCache`].
 pub(crate) type RelativePathBuf = PathBuf;
 
-#[derive(CacheKey)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, CacheKey)]
 pub(crate) struct FileCacheKey {
     /// Timestamp when the file was last modified before the (cached) check.
     file_last_modified: FileTime,
@@ -76,6 +78,9 @@ pub(crate) struct Cache {
     /// `package.files` but are outdated. This gets merged with `package.files`
     /// when the cache is written back to disk in [`Cache::store`].
     changes: Mutex<Vec<Change>>,
+    /// Metadata fetched before this invocation starts checking or formatting files.
+    #[cfg(target_os = "macos")]
+    initial_file_keys: Mutex<FxHashMap<PathBuf, FileCacheKey>>,
     /// The "current" timestamp used as cache for the updates of
     /// [`FileCache::last_seen`]
     #[expect(clippy::struct_field_names)]
@@ -147,10 +152,23 @@ impl Cache {
             path,
             package,
             changes: Mutex::new(Vec::new()),
+            #[cfg(target_os = "macos")]
+            initial_file_keys: Mutex::default(),
             // SAFETY: this will be truncated to the year ~2554 (so don't use
             // this code after that!).
             last_seen_cache: SystemTime::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64,
         }
+    }
+
+    /// Takes a prefetched key once, so a later check of the same path reads fresh metadata.
+    pub(crate) fn file_cache_key(&self, path: &Path) -> io::Result<FileCacheKey> {
+        #[cfg(target_os = "macos")]
+        if let Ok(mut keys) = self.initial_file_keys.lock()
+            && let Some(key) = keys.remove(path)
+        {
+            return Ok(key);
+        }
+        FileCacheKey::from_path(path)
     }
 
     /// Applies the pending changes and persists the cache to disk, if it has been changed.
@@ -420,6 +438,61 @@ where
 pub(crate) struct PackageCacheMap<'a>(FxHashMap<&'a Path, Cache>);
 
 impl<'a> PackageCacheMap<'a> {
+    /// Prefetch cache keys for directories containing several selected files.
+    ///
+    /// The ordinary walker still applies ignore and configuration rules. Bulk reads only replace
+    /// metadata lookups for the selected regular files; symlinks and unavailable entries fall back
+    /// to `FileCacheKey::from_path`. A single explicitly selected file never scans its siblings.
+    pub(crate) fn prefetch_file_keys<'p>(
+        &mut self,
+        paths: impl Iterator<Item = &'p Path>,
+        package_roots: &FxHashMap<&Path, Option<PackageRoot<'_>>>,
+    ) {
+        #[cfg(target_os = "macos")]
+        {
+            let mut directories: FxHashMap<&Path, Vec<&Path>> = FxHashMap::default();
+            for path in paths {
+                if let Some(parent) = path.parent() {
+                    directories.entry(parent).or_default().push(path);
+                }
+            }
+            let keys: Vec<_> = directories
+                .into_par_iter()
+                .filter(|(_, paths)| paths.len() > 1)
+                .flat_map_iter(|(directory, paths)| {
+                    let entries = directory_metadata::read(directory).unwrap_or_default();
+                    paths.into_iter().filter_map(move |path| {
+                        let metadata = entries.get(path.file_name()?)?;
+                        Some((
+                            path,
+                            FileCacheKey {
+                                file_last_modified: metadata.last_modified,
+                                file_permissions_mode: metadata.mode,
+                            },
+                        ))
+                    })
+                })
+                .collect();
+            for (path, key) in keys {
+                if let Some(parent) = path.parent() {
+                    let root = package_roots
+                        .get(parent)
+                        .copied()
+                        .flatten()
+                        .map(PackageRoot::path)
+                        .unwrap_or(parent);
+                    if let Some(cache) = self.0.get_mut(root)
+                        && let Ok(keys) = cache.initial_file_keys.get_mut()
+                    {
+                        keys.insert(path.to_path_buf(), key);
+                    }
+                }
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        let _ = (paths, package_roots);
+    }
+
     pub(crate) fn init(
         package_roots: &FxHashMap<&'a Path, Option<PackageRoot<'a>>>,
         resolver: &Resolver,
@@ -525,6 +598,30 @@ mod tests {
     use crate::cache::{Cache, RelativePathBuf};
     use crate::commands::format::{FormatCommandError, FormatMode, FormatResult, format_path};
     use crate::diagnostics::{Diagnostics, lint_path};
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn prefetched_keys_are_consumed_once() -> io::Result<()> {
+        let root = tempfile::tempdir()?;
+        let path = root.path().join("source.py");
+        fs::write(&path, "")?;
+        let original = FileCacheKey::from_path(&path)?;
+        let mut cache = Cache::empty(root.path().join("cache"), root.path().to_path_buf());
+        cache
+            .initial_file_keys
+            .get_mut()
+            .unwrap()
+            .insert(path.clone(), original);
+
+        assert_eq!(cache.file_cache_key(&path)?, original);
+        set_file_mtime(&path, FileTime::from_unix_time(1_000, 0))?;
+        assert_eq!(
+            cache.file_cache_key(&path)?,
+            FileCacheKey::from_path(&path)?
+        );
+        assert_ne!(cache.file_cache_key(&path)?, original);
+        Ok(())
+    }
 
     #[test_case("../ruff_linter/resources/test/fixtures", "ruff_tests/cache_same_results_ruff_linter"; "ruff_linter_fixtures")]
     #[test_case("../ruff_notebook/resources/test/fixtures", "ruff_tests/cache_same_results_ruff_notebook"; "ruff_notebook_fixtures")]

--- a/crates/ruff/src/commands/check.rs
+++ b/crates/ruff/src/commands/check.rs
@@ -74,7 +74,14 @@ pub(crate) fn check(
 
     // Load the caches.
     let caches = if cache.is_enabled() {
-        Some(PackageCacheMap::init(&package_roots, &resolver))
+        let mut caches = PackageCacheMap::init(&package_roots, &resolver);
+        if noqa.is_enabled() {
+            caches.prefetch_file_keys(
+                paths.iter().flatten().map(ResolvedFile::path),
+                &package_roots,
+            );
+        }
+        Some(caches)
     } else {
         None
     };

--- a/crates/ruff/src/commands/format.rs
+++ b/crates/ruff/src/commands/format.rs
@@ -110,7 +110,12 @@ pub(crate) fn format(
         #[cfg(debug_assertions)]
         crate::warn_user!("Detected debug build without --no-cache.");
 
-        Some(PackageCacheMap::init(&package_roots, &resolver))
+        let mut caches = PackageCacheMap::init(&package_roots, &resolver);
+        caches.prefetch_file_keys(
+            paths.iter().flatten().map(ResolvedFile::path),
+            &package_roots,
+        );
+        Some(caches)
     };
 
     let start = Instant::now();
@@ -264,7 +269,7 @@ pub(crate) fn format_path(
             .relative_path(path)
             .expect("wrong package cache for file");
 
-        if let Ok(cache_key) = FileCacheKey::from_path(path) {
+        if let Ok(cache_key) = cache.file_cache_key(path) {
             if cache.is_formatted(relative_path, &cache_key) {
                 return Ok(FormatResult::Unchanged);
             }

--- a/crates/ruff/src/diagnostics.rs
+++ b/crates/ruff/src/diagnostics.rs
@@ -26,7 +26,7 @@ use ruff_text_size::TextRange;
 use ruff_workspace::Settings;
 use rustc_hash::FxHashMap;
 
-use crate::cache::{Cache, FileCache, FileCacheKey};
+use crate::cache::{Cache, FileCache};
 
 /// A collection of [`Diagnostic`]s and additional information needed to render them.
 ///
@@ -195,7 +195,9 @@ pub(crate) fn lint_path(
                 .relative_path(path)
                 .expect("wrong package cache for file");
 
-            let cache_key = FileCacheKey::from_path(path).context("Failed to create cache key")?;
+            let cache_key = cache
+                .file_cache_key(path)
+                .context("Failed to create cache key")?;
             let cached_diagnostics = cache
                 .get(relative_path, &cache_key)
                 .is_some_and(FileCache::linted);

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -53,6 +53,9 @@ zip = { workspace = true }
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 etcetera = { workspace = true, optional = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
+
 [target.'cfg(target_arch="wasm32")'.dependencies]
 web-time = { version = "1.1.0" }
 

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -24,6 +24,8 @@ pub use self::path::{
 use crate::file_revision::FileRevision;
 
 mod command;
+#[cfg(feature = "os")]
+pub mod directory_metadata;
 mod memory_fs;
 #[cfg(feature = "os")]
 mod os;

--- a/crates/ruff_db/src/system/directory_metadata.rs
+++ b/crates/ruff_db/src/system/directory_metadata.rs
@@ -1,0 +1,41 @@
+//! Best-effort bulk metadata reads for regular files in a directory.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use filetime::FileTime;
+use rustc_hash::FxHashMap;
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+/// Metadata returned without following symbolic links.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FileMetadata {
+    pub last_modified: FileTime,
+    /// Unix mode, including the regular-file type bits.
+    pub mode: u32,
+}
+
+/// Reads regular-file metadata in batches when the platform supports it.
+///
+/// Results are a snapshot for one scan, not a persistent cache. Missing entries, including
+/// symbolic links, must be queried individually. Errors and unsupported attributes return `None`
+/// so callers retain the behavior of their ordinary metadata lookups.
+pub fn read(directory: &Path) -> Option<FxHashMap<OsString, FileMetadata>> {
+    #[cfg(target_os = "macos")]
+    {
+        match macos::read(directory) {
+            Ok(entries) => entries,
+            Err(error) => {
+                tracing::debug!("Falling back to individual file metadata reads: {error}");
+                None
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = directory;
+        None
+    }
+}

--- a/crates/ruff_db/src/system/directory_metadata/macos.rs
+++ b/crates/ruff_db/src/system/directory_metadata/macos.rs
@@ -1,0 +1,254 @@
+use std::ffi::{CStr, OsStr, OsString};
+use std::fs::OpenOptions;
+use std::io;
+use std::mem::offset_of;
+use std::os::fd::AsRawFd;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+use filetime::FileTime;
+use rustc_hash::FxHashMap;
+
+use super::FileMetadata;
+
+const ATTR_CMN_ERROR: u32 = 0x2000_0000;
+const VREG: u32 = 1;
+const REQUIRED: u32 = libc::ATTR_CMN_NAME
+    | libc::ATTR_CMN_OBJTYPE
+    | libc::ATTR_CMN_MODTIME
+    | libc::ATTR_CMN_ACCESSMASK;
+
+#[repr(align(8))]
+struct Buffer([u8; 64 * 1024]);
+
+/// Darwin's attribute packing order. Records are decoded through checked slices, never cast.
+#[repr(C)]
+struct Attributes {
+    length: u32,
+    returned: libc::attribute_set_t,
+    error: u32,
+    name: libc::attrreference_t,
+    object_type: u32,
+    modified: libc::timespec,
+    mode: u32,
+}
+
+#[expect(unsafe_code)]
+pub(super) fn read(directory: &Path) -> io::Result<Option<FxHashMap<OsString, FileMetadata>>> {
+    let directory = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(directory)?;
+    let mut attributes = libc::attrlist {
+        bitmapcount: libc::ATTR_BIT_MAP_COUNT,
+        reserved: 0,
+        commonattr: libc::ATTR_CMN_RETURNED_ATTRS | ATTR_CMN_ERROR | REQUIRED,
+        volattr: 0,
+        dirattr: 0,
+        fileattr: 0,
+        forkattr: 0,
+    };
+    let mut buffer = Buffer([0; 64 * 1024]);
+    let mut entries = FxHashMap::default();
+    loop {
+        // SAFETY: The descriptor is an open directory, the request is initialized, and the
+        // writable buffer is eight-byte aligned and has the supplied length.
+        let count = unsafe {
+            libc::getattrlistbulk(
+                directory.as_raw_fd(),
+                (&raw mut attributes).cast(),
+                buffer.0.as_mut_ptr().cast(),
+                buffer.0.len(),
+                u64::from(libc::FSOPT_PACK_INVAL_ATTRS),
+            )
+        };
+        let Ok(count) = usize::try_from(count) else {
+            return Err(io::Error::last_os_error());
+        };
+        if count == 0 {
+            return Ok(Some(entries));
+        }
+        if !decode(&buffer.0, count, &mut entries)? {
+            return Ok(None);
+        }
+    }
+}
+
+fn decode(
+    mut buffer: &[u8],
+    count: usize,
+    entries: &mut FxHashMap<OsString, FileMetadata>,
+) -> io::Result<bool> {
+    for _ in 0..count {
+        let length = u32::from_ne_bytes(bytes(buffer, offset_of!(Attributes, length))?) as usize;
+        let record = buffer.get(..length).ok_or_else(invalid_attributes)?;
+        buffer = &buffer[length..];
+        let returned =
+            u32::from_ne_bytes(bytes(record, offset_of!(Attributes, returned.commonattr))?);
+        if returned & ATTR_CMN_ERROR != 0
+            && u32::from_ne_bytes(bytes(record, offset_of!(Attributes, error))?) != 0
+        {
+            // The individual lookup will report the error if this entry is needed.
+            continue;
+        }
+        if returned & libc::ATTR_CMN_OBJTYPE == 0 {
+            return Ok(false);
+        }
+        if u32::from_ne_bytes(bytes(record, offset_of!(Attributes, object_type))?) != VREG {
+            continue;
+        }
+        if returned & REQUIRED != REQUIRED {
+            return Ok(false);
+        }
+
+        let seconds = i64::from_ne_bytes(bytes(record, offset_of!(Attributes, modified.tv_sec))?);
+        let nanos = i64::from_ne_bytes(bytes(record, offset_of!(Attributes, modified.tv_nsec))?);
+        let nanos = u32::try_from(nanos)
+            .ok()
+            .filter(|nanos| *nanos < 1_000_000_000)
+            .ok_or_else(invalid_attributes)?;
+        let mode = u32::from_ne_bytes(bytes(record, offset_of!(Attributes, mode))?);
+        entries.insert(
+            file_name(record)?.to_os_string(),
+            FileMetadata {
+                last_modified: FileTime::from_unix_time(seconds, nanos),
+                mode: (mode & !u32::from(libc::S_IFMT)) | u32::from(libc::S_IFREG),
+            },
+        );
+    }
+    Ok(true)
+}
+
+fn file_name(record: &[u8]) -> io::Result<&OsStr> {
+    let offset = i32::from_ne_bytes(bytes(record, offset_of!(Attributes, name.attr_dataoffset))?);
+    let length =
+        u32::from_ne_bytes(bytes(record, offset_of!(Attributes, name.attr_length))?) as usize;
+    let start = offset_of!(Attributes, name)
+        .checked_add_signed(offset as isize)
+        .ok_or_else(invalid_attributes)?;
+    let end = start.checked_add(length).ok_or_else(invalid_attributes)?;
+    let name = CStr::from_bytes_with_nul(record.get(start..end).ok_or_else(invalid_attributes)?)
+        .map_err(|_| invalid_attributes())?
+        .to_bytes();
+    if name.is_empty() || name == b"." || name == b".." || name.contains(&b'/') {
+        return Err(invalid_attributes());
+    }
+    Ok(OsStr::from_bytes(name))
+}
+
+fn bytes<const N: usize>(buffer: &[u8], offset: usize) -> io::Result<[u8; N]> {
+    buffer
+        .get(offset..offset + N)
+        .and_then(|bytes| bytes.try_into().ok())
+        .ok_or_else(invalid_attributes)
+}
+
+fn invalid_attributes() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "invalid bulk file attributes")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::fs;
+    use std::io;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    use filetime::{FileTime, set_file_mtime};
+    use rustc_hash::FxHashMap;
+
+    use super::{ATTR_CMN_ERROR, REQUIRED, VREG, decode, read};
+
+    #[test]
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "Compare native bulk attributes with native filesystem metadata"
+    )]
+    fn matches_individual_metadata_across_batches() -> io::Result<()> {
+        let root = tempfile::tempdir()?;
+        for index in 0..1500 {
+            let path = root.path().join(format!("file-{index:064}"));
+            fs::write(&path, "")?;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o640 | (index & 0o111)))?;
+            set_file_mtime(&path, FileTime::from_unix_time(1_700_000_000, index))?;
+        }
+        let name = OsStr::new("file-λ");
+        fs::write(root.path().join(name), "")?;
+        fs::create_dir(root.path().join("directory"))?;
+        symlink(root.path().join(name), root.path().join("link"))?;
+        symlink("missing", root.path().join("broken"))?;
+
+        let entries = read(root.path())?.expect("bulk attributes supported on the test filesystem");
+        assert_eq!(entries.len(), 1501);
+        for (name, entry) in entries {
+            let metadata = fs::metadata(root.path().join(name))?;
+            assert_eq!(
+                entry.last_modified,
+                FileTime::from_last_modification_time(&metadata)
+            );
+            assert_eq!(entry.mode, metadata.permissions().mode());
+        }
+        Ok(())
+    }
+
+    /// Encode the documented wire layout independently of `Attributes`.
+    fn record(name: &[u8]) -> Vec<u8> {
+        let length = (60 + name.len() + 1).next_multiple_of(8);
+        let fields = [
+            u32::try_from(length).unwrap(),
+            REQUIRED | ATTR_CMN_ERROR | libc::ATTR_CMN_RETURNED_ATTRS,
+            0,
+            0,
+            0,
+            0,
+            0,
+            32,
+            u32::try_from(name.len() + 1).unwrap(),
+            VREG,
+        ];
+        let mut record = fields
+            .into_iter()
+            .flat_map(u32::to_ne_bytes)
+            .collect::<Vec<_>>();
+        record.extend_from_slice(&(-1_i64).to_ne_bytes());
+        record.extend_from_slice(&123_i64.to_ne_bytes());
+        record.extend_from_slice(&0o640_u32.to_ne_bytes());
+        record.extend_from_slice(name);
+        record.resize(length, 0);
+        record
+    }
+
+    #[test]
+    fn validates_records_and_required_attributes() {
+        let valid = record(b"file");
+        let mut entries = FxHashMap::default();
+        assert!(decode(&valid, 1, &mut entries).unwrap());
+        assert_eq!(
+            entries[OsStr::new("file")].last_modified,
+            FileTime::from_unix_time(-1, 123)
+        );
+        for length in 0..valid.len() {
+            assert!(decode(&valid[..length], 1, &mut FxHashMap::default()).is_err());
+        }
+        for name in [
+            b"../outside".as_slice(),
+            b"/outside",
+            b".",
+            b"..",
+            b"",
+            b"a\0b",
+        ] {
+            assert!(decode(&record(name), 1, &mut FxHashMap::default()).is_err());
+        }
+        let mut missing = valid;
+        missing[4..8].copy_from_slice(&(REQUIRED & !libc::ATTR_CMN_MODTIME).to_ne_bytes());
+        assert!(!decode(&missing, 1, &mut FxHashMap::default()).unwrap());
+
+        let name = OsStr::from_bytes(b"file-\xff");
+        let mut entries = FxHashMap::default();
+        assert!(decode(&record(name.as_bytes()), 1, &mut entries).unwrap());
+        assert!(entries.contains_key(name));
+    }
+}


### PR DESCRIPTION
## Summary

Explore reading the modification times and permissions needed for Ruff's file-cache keys with macOS `getattrlistbulk`, following https://github.com/astral-sh/uv/pull/21344. We group selected files by parent directory after discovery and prefetch keys for directories with multiple selected files. Symlinks, unsupported attributes, and failed bulk reads retain individual metadata lookups. Prefetched keys are consumed once, and formatting still fetches fresh metadata after writing a file.

**This implementation has not demonstrated a performance improvement.** It adds a directory scan after the `ignore` walk, plus maps for the prefetched keys. A local paired run produced these median full-command times:

| Synthetic tree | Command | Main | This change |
| --- | --- | ---: | ---: |
| 100 directories × 100 Python files | Cached check | 27.5 ms | 32.1 ms |
| 100 directories × 100 Python files | Cached format check | 29.8 ms | 32.2 ms |
| 1,000 directories × 5 Python files | Cached check | 39.8 ms | 52.7 ms |
| 1,000 directories × 5 Python files | Cached format check | 40.1 ms | 53.0 ms |

These are synthetic measurements on macOS 26.6.2 using optimized development builds, with ten measured runs per binary in ABBA order after three warmups. Each file contains `value = 1`; configuration discovery is disabled to isolate cache handling, and command output matches. The machine was shared and not idle, so the magnitudes are provisional. The comparison base is `6077dc3d7d`.

The extra scan is a likely reason the reduced metadata-call count does not translate into a win here. Integrating metadata collection with the existing directory enumeration needs investigation before considering this a performance improvement.
