### PR TITLE
[ty] Experiment with bulk metadata during file discovery

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -10,6 +10,8 @@ pub use path::FilePath;
 use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_ast::PySourceType;
 use ruff_text_size::{Ranged, TextRange};
+#[cfg(target_os = "macos")]
+use rustc_hash::FxHashMap;
 use salsa::plumbing::AsId;
 use salsa::{Durability, Setter};
 
@@ -19,7 +21,8 @@ use crate::files::file_root::FileRoots;
 use crate::files::private::FileStatus;
 use crate::source::SourceText;
 use crate::system::{
-    SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf, deduplicate_nested_paths,
+    Metadata, SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf,
+    deduplicate_nested_paths,
 };
 use crate::vendored::{VendoredPath, VendoredPathBuf};
 use crate::{Db, FxDashMap, vendored};
@@ -33,7 +36,15 @@ mod path;
 /// Returns `Err` if the path doesn't exist, isn't accessible, or if the path points to a directory.
 #[inline]
 pub fn system_path_to_file(db: &dyn Db, path: impl AsRef<SystemPath>) -> Result<File, FileError> {
-    let file = db.files().system(db, path.as_ref());
+    system_path_to_file_with_metadata(db, path.as_ref(), None)
+}
+
+fn system_path_to_file_with_metadata(
+    db: &dyn Db,
+    path: &SystemPath,
+    metadata: Option<Metadata>,
+) -> Result<File, FileError> {
+    let file = db.files().system_with_metadata(db, path, metadata);
 
     // It's important that `vfs.file_system` creates a `VfsFile` even for files that don't exist or don't
     // exist anymore so that Salsa can track that the caller of this function depends on the existence of
@@ -43,6 +54,44 @@ pub fn system_path_to_file(db: &dyn Db, path: impl AsRef<SystemPath>) -> Result<
         FileStatus::Exists => Ok(file),
         FileStatus::IsADirectory => Err(FileError::IsADirectory),
         FileStatus::NotFound => Err(FileError::NotFound),
+    }
+}
+
+/// Metadata batches shared by the workers in one file-discovery pass.
+///
+/// This is deliberately separate from Salsa's directory listings: editing a file changes its
+/// metadata without changing directory membership. Drop these batches at the end of the walk.
+#[derive(Default)]
+pub struct FileMetadataBatch {
+    #[cfg(target_os = "macos")]
+    directories: FxDashMap<SystemPathBuf, Option<FxHashMap<String, Metadata>>>,
+}
+
+impl FileMetadataBatch {
+    /// Interns a discovered file using its directory's metadata when available.
+    ///
+    /// Existing files retain their current inputs, including revisions supplied by the editor or
+    /// file watcher. Symlinks and failed bulk reads use the ordinary per-path lookup.
+    pub fn file(&self, db: &dyn Db, path: &SystemPath) -> Result<File, FileError> {
+        #[cfg(target_os = "macos")]
+        {
+            if db.files().try_system(db, path).is_some() {
+                return system_path_to_file(db, path);
+            }
+            let metadata = path
+                .parent()
+                .zip(path.file_name())
+                .and_then(|(parent, name)| {
+                    self.directories
+                        .entry(parent.to_path_buf())
+                        .or_insert_with(|| db.system().directory_file_metadata(parent))
+                        .as_mut()
+                        .and_then(|entries| entries.remove(name))
+                });
+            system_path_to_file_with_metadata(db, path, metadata)
+        }
+        #[cfg(not(target_os = "macos"))]
+        system_path_to_file(db, path)
     }
 }
 
@@ -106,6 +155,15 @@ impl Files {
     /// The operation always succeeds even if the path doesn't exist on disk, isn't accessible or if the path points to a directory.
     /// In these cases, a file with the appropriate [`FileStatus`] is returned.
     fn system(&self, db: &dyn Db, path: &SystemPath) -> File {
+        self.system_with_metadata(db, path, None)
+    }
+
+    fn system_with_metadata(
+        &self,
+        db: &dyn Db,
+        path: &SystemPath,
+        metadata: Option<Metadata>,
+    ) -> File {
         // All cache keys are normalized, absolute paths. However, an absolute path does not need
         // to be fully normalized for this lookup: Camino's equality and hashing ignore redundant
         // separators and `.` components, so `/foo/bar.py`, `/foo//bar.py`, and `/foo/./bar.py`
@@ -131,7 +189,7 @@ impl Files {
             .system_by_path
             .entry(absolute.clone())
             .or_insert_with(|| {
-                let metadata = db.system().path_metadata(path);
+                let metadata = metadata.map_or_else(|| db.system().path_metadata(path), Ok);
 
                 tracing::trace!("Adding file '{absolute}'");
 
@@ -727,12 +785,56 @@ mod tests {
 
     use crate::Db as _;
     use crate::file_revision::FileRevision;
-    use crate::files::{File, FileError, system_path_to_file, vendored_path_to_file};
+    use crate::files::{
+        File, FileError, FileMetadataBatch, system_path_to_file, system_path_to_file_with_metadata,
+        vendored_path_to_file,
+    };
     use crate::source::source_text;
-    use crate::system::{DbWithWritableSystem as _, SystemPath};
+    use crate::system::{DbWithWritableSystem as _, FileType, Metadata, SystemPath};
     use crate::tests::TestDb;
     use crate::vendored::VendoredFileSystemBuilder;
     use zip::CompressionMethod;
+
+    #[test]
+    fn prefetched_metadata_preserves_existing_inputs() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("test.py", "before")?;
+        let path = SystemPath::new("test.py");
+        let prefetched = Metadata::new(FileRevision::new(123), Some(0o640), FileType::File);
+        let file = system_path_to_file_with_metadata(&db, path, Some(prefetched.clone())).unwrap();
+        assert_eq!(file.revision(&db), prefetched.revision());
+        assert_eq!(file.permissions(&db), prefetched.permissions());
+
+        db.write_file(path, "after")?;
+        file.sync(&mut db);
+        let updated = file.revision(&db);
+        assert_ne!(updated, prefetched.revision());
+        assert_eq!(
+            system_path_to_file_with_metadata(&db, path, Some(prefetched)),
+            Ok(file)
+        );
+        assert_eq!(file.revision(&db), updated);
+        assert_eq!(file.read_to_string(&db)?, "after");
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_batch_falls_back_for_unavailable_entries() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("test.py", "content")?;
+        let batch = FileMetadataBatch::default();
+        let path = SystemPath::new("test.py");
+        let file = batch.file(&db, path).unwrap();
+        assert_eq!(
+            file.revision(&db),
+            db.system().path_metadata(path)?.revision()
+        );
+        assert_eq!(
+            batch.file(&db, SystemPath::new("missing.py")),
+            Err(FileError::NotFound)
+        );
+        Ok(())
+    }
 
     #[test]
     fn system_existing_file() -> crate::system::Result<()> {

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -10,6 +10,7 @@ pub use os::OsSystem;
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_ast::PySourceType;
+use rustc_hash::FxHashMap;
 use std::error::Error;
 use std::fmt;
 use std::fmt::Debug;
@@ -55,6 +56,15 @@ pub trait System: Debug + Sync + Send {
     ///
     /// This function will traverse symbolic links to query information about the destination file.
     fn path_metadata(&self, path: &SystemPath) -> Result<Metadata>;
+
+    /// Optionally reads regular-file metadata for a directory in one batch.
+    ///
+    /// Entries are keyed by filename. Missing entries, including symlinks, must use
+    /// `path_metadata`. Implementations with file overlays must omit overridden entries or return
+    /// their overlay metadata. Callers may retain the result only for the current discovery pass.
+    fn directory_file_metadata(&self, _path: &SystemPath) -> Option<FxHashMap<String, Metadata>> {
+        None
+    }
 
     /// Returns the canonical, absolute form of a path with all intermediate components normalized
     /// and symbolic links resolved.

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -14,6 +14,7 @@ use crate::system::{
 };
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};
+use rustc_hash::FxHashMap;
 use std::num::NonZeroUsize;
 use std::process::Output;
 use std::sync::Arc;
@@ -69,6 +70,20 @@ impl OsSystem {
 }
 
 impl System for OsSystem {
+    fn directory_file_metadata(&self, path: &SystemPath) -> Option<FxHashMap<String, Metadata>> {
+        super::directory_metadata::read(path.as_std_path()).map(|entries| {
+            entries
+                .into_iter()
+                .filter_map(|(name, entry)| {
+                    Some((
+                        name.into_string().ok()?,
+                        Metadata::new(entry.last_modified.into(), Some(entry.mode), FileType::File),
+                    ))
+                })
+                .collect()
+        })
+    }
+
     fn path_metadata(&self, path: &SystemPath) -> Result<Metadata> {
         let metadata = path.as_std_path().metadata()?;
         let last_modified = FileTime::from_last_modification_time(&metadata);

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -93,6 +93,10 @@ impl TestSystem {
 }
 
 impl System for TestSystem {
+    fn directory_file_metadata(&self, path: &SystemPath) -> Option<FxHashMap<String, Metadata>> {
+        self.system().directory_file_metadata(path)
+    }
+
     fn path_metadata(&self, path: &SystemPath) -> Result<Metadata> {
         self.system().path_metadata(path)
     }

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -3,7 +3,7 @@ use crate::glob::IncludeExcludeFilter;
 use crate::script::script_tag;
 use crate::{Db, GlobFilterCheckMode, IncludeResult, Project};
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
-use ruff_db::files::system_path_to_file;
+use ruff_db::files::{FileMetadataBatch, system_path_to_file};
 use ruff_db::system::walk_directory::{ErrorKind, WalkDirectoryBuilder, WalkState};
 use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
 use std::collections::BTreeSet;
@@ -178,6 +178,7 @@ impl ProjectFilesWalker {
         let exclude_scripts = project.settings(db).src().exclude_scripts;
         let files = std::sync::Mutex::new(Vec::new());
         let diagnostics = std::sync::Mutex::new(Vec::new());
+        let metadata = FileMetadataBatch::default();
 
         walker.run(|| {
             let db = Db::dyn_clone(db);
@@ -185,6 +186,7 @@ impl ProjectFilesWalker {
             let incremental_paths = &self.incremental_paths;
             let files = &files;
             let diagnostics = &diagnostics;
+            let metadata = &metadata;
             let force_exclude = filter.force_exclude();
 
             // The memory walker runs on the caller's thread, where a different database may
@@ -270,7 +272,12 @@ impl ProjectFilesWalker {
 
                                 // If this returns `Err`, then the file was deleted between now and when the walk callback was called.
                                 // We can ignore this.
-                                if let Ok(file) = system_path_to_file(&*db, entry.path()) {
+                                let file = if entry.depth() == 0 {
+                                    system_path_to_file(&*db, entry.path())
+                                } else {
+                                    metadata.file(&*db, entry.path())
+                                };
+                                if let Ok(file) = file {
                                     let is_script = script_tag(&*db, file).is_some();
                                     if entry.depth() > 0 && exclude_scripts && is_script {
                                         tracing::debug!(

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -19,6 +19,7 @@ use ruff_db::system::{
 };
 use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_ast::PySourceType;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Deserializer};
 use ty_ide::cached_vendored_path;
 
@@ -165,6 +166,16 @@ impl LSPSystem {
 }
 
 impl System for LSPSystem {
+    fn directory_file_metadata(&self, path: &SystemPath) -> Option<FxHashMap<String, Metadata>> {
+        self.native_system
+            .directory_file_metadata(path)
+            .map(|mut entries| {
+                // Open documents use editor revisions, even when the file also exists on disk.
+                entries.retain(|name, _| self.system_path_to_document(&path.join(name)).is_none());
+                entries
+            })
+    }
+
     fn path_metadata(&self, path: &SystemPath) -> Result<Metadata> {
         let document = self.system_path_to_document(path);
 


### PR DESCRIPTION
## Summary

Explore reading regular-file metadata in directory batches while indexing a ty project, using the shared macOS reader from #28300. We retain batches only for the current discovery pass and use them to initialize newly interned files. Existing file inputs remain authoritative; symlinks and unavailable entries use ordinary metadata lookups. Open editor documents retain their editor-supplied revisions, and other platforms retain the existing lookup path.

**This implementation has not demonstrated a performance improvement.** A local paired run produced these median full-command `ty check` times:

| Synthetic tree | Main | This change |
| --- | ---: | ---: |
| 100 directories × 100 Python files | 144.9 ms | 149.4 ms |
| 1,000 directories × 5 Python files | 148.9 ms | 276.7 ms |

These are synthetic measurements on macOS 26.6.2 using optimized development builds, with ten measured runs per binary in ABBA order after three warmups. Each file contains `value = 1`, and command output matches. The machine was shared and not idle, so the magnitudes are provisional. The comparison base is `6077dc3d7d`; the Ruff-specific changes in #28300 do not affect the ty binary.

This adds a scan alongside the existing walker and synchronizes access to the metadata batches. Those costs need to be removed or justified before considering this a performance improvement. File metadata is deliberately kept separate from cached directory membership so ordinary content edits retain their existing invalidation behavior.
