### PR TITLE
[ty] Preserve outer type variables during `ParamSpec` inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1947,8 +1947,10 @@ reveal_type(identity(1))  # revealed: Any
 This also applies to type variables from an enclosing scope:
 
 ```py
-def _[T](callback: Callable[[T], T]) -> None:
-    reveal_type(decorate(callback))  # revealed: Wrapper[(T@_, /)]
+def _[T](callback: Callable[[T], T], value: T) -> None:
+    f = decorate(callback)
+    reveal_type(f)  # revealed: Wrapper[(T@_, /)]
+    reveal_type(f(value))  # revealed: Any
 ```
 
 The same applies when the return type is an alias for `Any`:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1920,6 +1920,87 @@ reveal_type(c.generic_method(100))  # revealed: Literal[100]
 reveal_type(c.generic_method([1, 2, 3]))  # revealed: list[int]
 ```
 
+### Callables inferred against gradual return types
+
+A decorator accepting `Callable[P, Any]` preserves any type variables scoped to the callable,
+instead of eagerly specializing them to `Any`:
+
+```py
+from collections.abc import Callable
+from typing import Any, overload
+
+class Wrapper[**P]:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Any:
+        raise NotImplementedError
+
+def decorate[**P](callback: Callable[P, Any]) -> Wrapper[P]:
+    raise NotImplementedError
+
+@decorate
+def identity[T](value: T) -> T:
+    return value
+
+reveal_type(identity)  # revealed: Wrapper[(value: T@identity)]
+reveal_type(identity(1))  # revealed: Any
+```
+
+This also applies to type variables from an enclosing scope:
+
+```py
+def _[T](callback: Callable[[T], T]) -> None:
+    reveal_type(decorate(callback))  # revealed: Wrapper[(T@_, /)]
+```
+
+The same applies when the return type is an alias for `Any`:
+
+```py
+type Anything = Any
+
+def decorate_alias[**P](callback: Callable[P, Anything]) -> Wrapper[P]:
+    raise NotImplementedError
+
+def _[T](callback: Callable[[T], T]) -> None:
+    reveal_type(decorate_alias(callback))  # revealed: Wrapper[(T@_, /)]
+```
+
+Type variables shared by multiple overloads are preserved as well:
+
+```py
+def _[T](value: T) -> None:
+    @overload
+    def callback(value: T) -> T: ...
+    @overload
+    def callback(value: T, count: int) -> T: ...
+    def callback(value: T, count: int = 1) -> T:
+        return value
+
+    # revealed: Wrapper[Overload[(value: T@_) -> Unknown, (value: T@_, count: int) -> Unknown]]
+    reveal_type(decorate(callback))
+```
+
+A local return type variable is inferred from the argument, even when it appears in a nested
+callable with a `ParamSpec`:
+
+```py
+def make[**P, R](consume: Callable[[Callable[P, R]], None]) -> Callable[P, R]:
+    raise NotImplementedError
+
+def _[**P](consume: Callable[[Callable[P, Any]], None]) -> None:
+    reveal_type(make(consume))  # revealed: (**P@_) -> Any
+```
+
+The inferred return type also takes precedence over a type parameter default:
+
+```py
+def make_with_default[**P, R = bytes](consume: Callable[[Callable[P, R]], None]) -> Callable[P, R]:
+    raise NotImplementedError
+
+def _[**P](consume: Callable[[Callable[P, Any]], None], *args: P.args, **kwargs: P.kwargs) -> str:
+    callback = make_with_default(consume)
+    reveal_type(callback)  # revealed: (**P@_) -> Any
+    return callback(*args, **kwargs)
+```
+
 ## Callable protocols with `ParamSpec` and class constructors
 
 When a class is passed to a function expecting a callable protocol with `ParamSpec`, the `ParamSpec`

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -20,7 +20,7 @@ use itertools::{Either, EitherOrBoth, Itertools};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec_inline};
 
-use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
+use super::{DynamicType, Type, TypeVarVariance, UnionType, any_over_type, semantic_index};
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension, OwnedConstraintSet,
@@ -2267,9 +2267,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         self.without_context_collection(|| {
                             source_overloads
                                 .iter()
-                                .map(|signature| signature.return_ty)
-                                .when_any(db, self.constraints, |source_return| {
-                                    self.check_type_pair(db, source_return, target_return)
+                                .when_any(db, self.constraints, |signature| {
+                                    self.check_paramspec_return_pair(db, signature, target_return)
                                 })
                         })
                     };
@@ -2448,6 +2447,35 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // this branch and the result is not memoized.
         self.signature_relation_visitor
             .visit(&key, || self.always(), work)
+    }
+
+    fn check_paramspec_return_pair(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        if self.relation.is_assignability()
+            && self.typevar_evaluation == TypeVarEvaluation::Lazy
+            && target.resolve_type_alias(db).is_dynamic()
+            && let Type::TypeVar(typevar) = source.return_ty.resolve_type_alias(db)
+            && source.parameters().iter().any(|parameter| {
+                any_over_type(db, self.env, parameter.annotated_type(), false, |ty| {
+                    matches!(ty, Type::TypeVar(other) if other.is_same_typevar_as(db, typevar))
+                })
+            })
+        {
+            // Comparing the generic callable `(value: T) -> T` against the declared type
+            // `Callable[P, Any]` contributes the constraint `T <= Any`, despite the gradual return
+            // type not constraining the callable-scoped type variable, so we ignore the constraints
+            // in this case.
+            //
+            // TODO: Remove this special case once `ParamSpec` inference correctly handles captured
+            // type variables when solving return-type constraints.
+            self.always()
+        } else {
+            self.check_type_pair(db, source.return_ty, target)
+        }
     }
 
     fn check_signature_pair_inner(
@@ -2685,7 +2713,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Avoid returning early after checking the return types in case there is a `ParamSpec` type
         // variable in either signature to ensure that the `ParamSpec` binding is still applied even
         // if the return types are incompatible.
-        let return_type_constraints = self.check_type_pair(db, source.return_ty, target.return_ty);
+        let return_type_constraints = if target_parameters.as_paramspec_with_prefix().is_some() {
+            self.check_paramspec_return_pair(db, source, target.return_ty)
+        } else {
+            self.check_type_pair(db, source.return_ty, target.return_ty)
+        };
         let return_type_checks = !result
             .intersect(db, self.constraints, return_type_constraints)
             .is_never_satisfied(db, env);


### PR DESCRIPTION
When inferring a callable against a declared callable type with a `ParamSpec`, constraints from the outer assignability check may leak their way into the inferred `ParamSpec` type. This can happen particularly with callables with a declared return types of `Any`. For example:
```py
from typing import Callable, Any

class Wrapper[**P]:
    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Any:
        raise NotImplementedError

def decorate[**P](callback: Callable[P, Any]) -> Wrapper[P]:
    raise NotImplementedError

def _[T](callback: Callable[[T], T]) -> None:
    reveal_type(decorate(callback))  # revealed: Wrapper[((T@_, /)) | ((Any, /))]
```

On https://github.com/astral-sh/ruff/pull/26873, the same problem arises with callable-scoped type variables.

This PR adds a very narrow short-circuit to ignore the gradual constraint in this particular case. The more principled fix probably resolves around [the quantification of signature-local variables](https://github.com/astral-sh/ruff/blob/3070999871911cf59dca7ecd9e453d984314924c/crates/ty_python_semantic/src/types/signatures.rs#L2402) which [`ParamSpec` inference currently bypasses](https://github.com/astral-sh/ruff/blob/3070999871911cf59dca7ecd9e453d984314924c/crates/ty_python_semantic/src/types/signatures.rs#L2273), as the naive quantification would lose constraints that should correctly be applied to the inferred `ParamSpec`.

cc @dhruvmanila