### PR TITLE
[`ruff`] Avoid false positives for overloaded division (`RUF069`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF069.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF069.py
@@ -32,8 +32,8 @@ assert (y := x + 1.0) == 2.0
 [i for i in range(10) if i == 1.0]
 {i for i in range(10) if i != 2.0}
 
-assert x / 2 == 1
-assert (x / 2) == (y / 3)
+assert x / 2 == 1  # ok
+assert (x / 2) == (y / 3)  # ok
 
 # ok
 assert Path(__file__).parent / ".txt" == 1
@@ -43,7 +43,7 @@ def foo(a, b):
 
 assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
 
-assert (y := x / 2) == 1
+assert (y := x / 2) == 1  # ok
 
 assert (0.3 if x > 0 else 1) == 0.1 + 0.2
 
@@ -85,3 +85,16 @@ def _cmath():
     assert cmath.inf == 1e300 * 1e300  # ok
 
     assert cmath.infj == complex(0, 1e300 * 1e300)  # ok
+
+
+assert x / 2.0 == 1
+
+
+def _decimal_division():
+    from decimal import Decimal
+
+    a = Decimal("2")
+    b = Decimal("1")
+
+    assert a / 2 == b  # ok
+    assert 2 / a == b  # ok

--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -156,41 +156,16 @@ fn has_float(expr: &Expr, semantic: &SemanticModel) -> bool {
         ResolvedPythonType::Atom(PythonType::Number(NumberLike::Float | NumberLike::Complex)) => {
             true
         }
-        _ => {
-            match expr {
-                Expr::Call(ast::ExprCall { func, .. }) => ["float", "complex"]
-                    .iter()
-                    .any(|s| semantic.match_builtin_expr(func, s)),
-                Expr::BinOp(ast::ExprBinOp {
-                    left, right, op, ..
-                }) => {
-                    // Division always returns float in Python
-                    // https://docs.python.org/3/tutorial/introduction.html#numbers
-                    match op {
-                        ast::Operator::Div => {
-                            // Only trigger for numeric divisions, not path operations
-                            // Ex) `Path(__file__).parents[2] / "text.txt"`
-                            is_numeric_expr(left) || is_numeric_expr(right)
-                        }
-                        _ => has_float(left, semantic) || has_float(right, semantic),
-                    }
-                }
-                Expr::Named(ast::ExprNamed { value, .. }) => has_float(value, semantic),
-                _ => false,
+        _ => match expr {
+            Expr::Call(ast::ExprCall { func, .. }) => ["float", "complex"]
+                .iter()
+                .any(|s| semantic.match_builtin_expr(func, s)),
+            Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
+                has_float(left, semantic) || has_float(right, semantic)
             }
-        }
-    }
-}
-
-fn is_numeric_expr(expr: &Expr) -> bool {
-    match expr {
-        Expr::NumberLiteral(_) => true,
-        Expr::BinOp(ast::ExprBinOp { left, right, .. }) => {
-            is_numeric_expr(left) || is_numeric_expr(right)
-        }
-        Expr::UnaryOp(ast::ExprUnaryOp { operand, .. }) => is_numeric_expr(operand),
-        Expr::Named(ast::ExprNamed { value, .. }) => is_numeric_expr(value),
-        _ => false,
+            Expr::Named(ast::ExprNamed { value, .. }) => has_float(value, semantic),
+            _ => false,
+        },
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__float-equality-comparison_RUF069.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__float-equality-comparison_RUF069.py.snap
@@ -172,27 +172,7 @@ RUF069 Unreliable floating point equality comparison `i != 2.0`
 33 | {i for i in range(10) if i != 2.0}
    |                          ^^^^^^^^
 34 |
-35 | assert x / 2 == 1
-   |
-
-RUF069 Unreliable floating point equality comparison `x / 2 == 1`
-  --> RUF069.py:35:8
-   |
-33 | {i for i in range(10) if i != 2.0}
-34 |
-35 | assert x / 2 == 1
-   |        ^^^^^^^^^^
-36 | assert (x / 2) == (y / 3)
-   |
-
-RUF069 Unreliable floating point equality comparison `x / 2 == y / 3`
-  --> RUF069.py:36:9
-   |
-35 | assert x / 2 == 1
-36 | assert (x / 2) == (y / 3)
-   |         ^^^^^^^^^^^^^^^^
-37 |
-38 | # ok
+35 | assert x / 2 == 1  # ok
    |
 
 RUF069 Unreliable floating point equality comparison `a == b * float("2")`
@@ -213,24 +193,19 @@ RUF069 Unreliable floating point equality comparison `complex(0.3, 0.2) == compl
 44 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 45 |
-46 | assert (y := x / 2) == 1
-   |
-
-RUF069 Unreliable floating point equality comparison `y := x / 2 == 1`
-  --> RUF069.py:46:9
-   |
-44 | assert complex(0.3, 0.2) == complex(0.1 + 0.2, 0.1 + 0.1)
-45 |
-46 | assert (y := x / 2) == 1
-   |         ^^^^^^^^^^^^^^^^
-47 |
-48 | assert (0.3 if x > 0 else 1) == 0.1 + 0.2
+46 | assert (y := x / 2) == 1  # ok
    |
 
 RUF069 Unreliable floating point equality comparison `0.3 if x > 0 else 1 == 0.1 + 0.2`
   --> RUF069.py:48:9
    |
-46 | assert (y := x / 2) == 1
+46 | assert (y := x / 2) == 1  # ok
 47 |
 48 | assert (0.3 if x > 0 else 1) == 0.1 + 0.2
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+RUF069 Unreliable floating point equality comparison `x / 2.0 == 1`
+  --> RUF069.py:90:8
+   |
+90 | assert x / 2.0 == 1
+   |        ^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Fixes #23281.

`RUF069` currently treats division as a floating-point expression whenever either operand is syntactically numeric. This works for built-in numeric division, but Python allows `/` to be overloaded. As a result, the rule reports false positives for `Decimal` and custom numeric classes whose division returns an exact, non-float value.

This change removes the division-specific heuristic. Division now follows the same logic as other binary expressions: Ruff reports the comparison only when it can identify a float or complex value in the expression.

```python
value / 2 == expected         # No diagnostic when the type of value is unknown.
value / 2.0 == expected       # RUF069 because 2.0 is a known float.
Decimal("1") / 2 == expected  # No diagnostic for overloaded division.
```

Without type inference, Ruff cannot determine whether `value / 2` uses built-in integer division or an overloaded operator. This change therefore favors false negatives over false positives when the operand types are unknown. Explicit float and complex values remain detected. Future type inference could recover built-in integer-division cases without reintroducing false positives for overloaded operators.

The regression fixture covers direct and reverse `Decimal` division, marks unknown-type division as accepted, and verifies that a float nested inside division still triggers the rule.

## Test Plan

- `INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run -p ruff_linter ruf069`
- `INSTA_FORCE_PASS=1 INSTA_UPDATE=always MDTEST_UPDATE_SNAPSHOTS=1 cargo nextest run` (9,203 passed, 44 skipped)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo dev generate-all`
- Ran `prek` for all changed files
- Verified the `Decimal` reproduction with the Ruff CLI