### PR TITLE
[`pylint`] Gate `ImportCycleError` on Python 3.15 (`PLW0133`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pylint/useless-exception-statement.md
+++ b/crates/ruff_linter/resources/mdtest/pylint/useless-exception-statement.md
@@ -1,0 +1,34 @@
+# `useless-exception-statement` (`PLW0133`)
+
+## Python 3.14
+
+```toml
+target-version = "py314"
+lint.select = ["PLW0133"]
+```
+
+`PythonFinalizationError` is available in Python 3.14, but `ImportCycleError` is not available until
+Python 3.15.
+
+```py
+import builtins
+
+builtins.PythonFinalizationError("Added in Python 3.13")  # error: [useless-exception-statement]
+builtins.ImportCycleError("Added in Python 3.15")
+```
+
+## Python 3.15
+
+```toml
+target-version = "py315"
+lint.select = ["PLW0133"]
+```
+
+Both exceptions are available in Python 3.15, so both unused exception statements are reported.
+
+```py
+import builtins
+
+builtins.PythonFinalizationError("Added in Python 3.13")  # error: [useless-exception-statement]
+builtins.ImportCycleError("Added in Python 3.15")  # error: [useless-exception-statement]
+```

--- a/crates/ruff_python_stdlib/src/builtins.rs
+++ b/crates/ruff_python_stdlib/src/builtins.rs
@@ -530,6 +530,7 @@ pub fn is_exception(name: &str, minor_version: u8) -> bool {
                 | "UserWarning"
         ) | (10.., "EncodingWarning")
             | (11.., "BaseExceptionGroup" | "ExceptionGroup")
-            | (13.., "PythonFinalizationError" | "ImportCycleError")
+            | (13.., "PythonFinalizationError")
+            | (15.., "ImportCycleError")
     )
 }


### PR DESCRIPTION
Fix PLW0133's Python version gating for `ImportCycleError`.

`ImportCycleError` was added in Python 3.15, but Ruff currently treats it as available starting in Python 3.13.

This updates the builtin exception classification so that:

- `PythonFinalizationError` remains available for Python 3.13+
- `ImportCycleError` is only considered available for Python 3.15+

Also adds regression coverage for the behavior across target Python versions.

Closes part of #28206.
