### PR TITLE
[`ruff`] Recognize `re.prefixmatch` (`RUF039`, `RUF055`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/ruff/unnecessary-regular-expression.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/unnecessary-regular-expression.md
@@ -1,0 +1,39 @@
+# `unnecessary-regular-expression` (`RUF055`)
+
+```toml
+target-version = "py315"
+lint.preview = true
+lint.select = ["RUF055"]
+```
+
+## `re.prefixmatch`
+
+`re.prefixmatch` anchors its pattern at the start of the string, so a plain string pattern used in
+a truth-value context can be replaced with `str.startswith`.
+
+```py
+import re
+
+source = "abc"
+
+if re.prefixmatch("abc", source):  # snapshot: unnecessary-regular-expression
+    pass
+
+# A match object used outside a truth-value context cannot be replaced.
+re.prefixmatch("abc", source)
+```
+
+```snapshot
+error[RUF055]: Plain string pattern passed to `re` function
+ --> src/mdtest_snippet.py:5:4
+  |
+5 | if re.prefixmatch("abc", source):  # snapshot: unnecessary-regular-expression
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Replace with `source.startswith("abc")`
+  |
+4 |
+  - if re.prefixmatch("abc", source):  # snapshot: unnecessary-regular-expression
+5 + if source.startswith("abc"):  # snapshot: unnecessary-regular-expression
+6 |     pass
+  |
+```

--- a/crates/ruff_linter/resources/mdtest/ruff/unraw-re-pattern.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/unraw-re-pattern.md
@@ -1,0 +1,50 @@
+# `unraw-re-pattern` (`RUF039`)
+
+```toml
+target-version = "py315"
+lint.preview = true
+lint.select = ["RUF039"]
+```
+
+## `prefixmatch`
+
+`re.prefixmatch`, added in Python 3.15, and `regex.prefixmatch` take a regular expression pattern as
+their first argument.
+
+```py
+import re
+import regex
+
+re.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+regex.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+```
+
+```snapshot
+error[RUF039]: First argument to `re.prefixmatch()` is not raw string
+ --> src/mdtest_snippet.py:4:16
+  |
+4 | re.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+  |                ^^^^
+help: Replace with raw string
+  |
+3 |
+  - re.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+4 + re.prefixmatch(r"\t", "abc")  # snapshot: unraw-re-pattern
+5 | regex.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+
+error[RUF039]: First argument to `regex.prefixmatch()` is not raw string
+ --> src/mdtest_snippet.py:5:19
+  |
+5 | regex.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+  |                   ^^^^
+help: Replace with raw string
+  |
+4 | re.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+  - regex.prefixmatch("\t", "abc")  # snapshot: unraw-re-pattern
+5 + regex.prefixmatch(r"\t", "abc")  # snapshot: unraw-re-pattern
+  |
+note: This is an unsafe fix and may change runtime behavior
+```

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -40,13 +40,14 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 ///
 /// - `re.sub`
 /// - `re.match`
+/// - `re.prefixmatch`
 /// - `re.search`
 /// - `re.fullmatch`
 /// - `re.split`
 ///
 /// For `re.sub`, the `repl` (replacement) argument must also be a string literal,
-/// not a function. For `re.match`, `re.search`, and `re.fullmatch`, the return
-/// value must also be used only for its truth value.
+/// not a function. For `re.match`, `re.prefixmatch`, `re.search`, and `re.fullmatch`,
+/// the return value must also be used only for its truth value.
 ///
 /// ## Fix safety
 ///
@@ -252,7 +253,7 @@ impl<'a> ReFunc<'a> {
                     range,
                 })
             }
-            ("match", 2) if in_truthy_context => Some(ReFunc {
+            ("match" | "prefixmatch", 2) if in_truthy_context => Some(ReFunc {
                 kind: ReFuncKind::Match,
                 pattern: call.arguments.find_argument_value("pattern", 0)?,
                 string: call.arguments.find_argument_value("string", 1)?,

--- a/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unraw_re_pattern.rs
@@ -18,7 +18,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// their first arguments are not raw strings:
 ///
 /// - For `regex` and `re`: `compile`, `findall`, `finditer`,
-///   `fullmatch`, `match`, `search`, `split`, `sub`, `subn`.
+///   `fullmatch`, `match`, `prefixmatch`, `search`, `split`, `sub`, `subn`.
 /// - `regex`-specific: `splititer`, `subf`, `subfn`, `template`.
 ///
 /// ## Why is this bad?
@@ -97,8 +97,8 @@ enum RegexModule {
 impl RegexModule {
     fn is_function_taking_pattern(self, name: &str) -> bool {
         match name {
-            "compile" | "findall" | "finditer" | "fullmatch" | "match" | "search" | "split"
-            | "sub" | "subn" => true,
+            "compile" | "findall" | "finditer" | "fullmatch" | "match" | "prefixmatch"
+            | "search" | "split" | "sub" | "subn" => true,
             "splititer" | "subf" | "subfn" | "template" => self == Self::Regex,
             _ => false,
         }


### PR DESCRIPTION
## Summary

Adds support for Python 3.15’s `re.prefixmatch` to:

- `unraw-re-pattern` (`RUF039`)
- `unnecessary-regular-expression` (`RUF055`)

`RUF055` treats `re.prefixmatch` like `re.match`, replacing plain string patterns with `str.startswith` when the result is used in a truth-value context.

Recognition is independent of the configured target version, while the mdtests use Python 3.15 where the API is available.

Closes part of #28206.

## Test Plan

- `cargo nextest run -p ruff_mdtest --test mdtest`
- `cargo nextest run -p ruff_linter rules::ruff::tests`
- `cargo dev generate-all`
- Ran `prek` on all changed files