### PR TITLE
[ty] Solve formal unions using constraint-sets

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -1699,6 +1699,58 @@ class RequiredClassSelector(Generic[T]):
 reveal_type(RequiredClassSelector(class_=MyClass))  # revealed: RequiredClassSelector[MyClass | None]
 ```
 
+## Inferring type arguments from a union `self` annotation
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import Never
+
+class Covariant[T]:
+    def __init__(self: Covariant[int | str]) -> None: ...
+
+    # Make it covariant in `T`:
+    def get(self) -> T:
+        raise NotImplementedError
+
+reveal_type(Covariant())  # revealed: Covariant[int | str]
+reveal_type(Covariant[int]())  # revealed: Covariant[int]
+reveal_type(Covariant[str]())  # revealed: Covariant[str]
+reveal_type(Covariant[Never]())  # revealed: Covariant[Never]
+
+Covariant[object]()  # error: [invalid-argument-type]
+
+class Contravariant[T]:
+    def __init__(self: Contravariant[int | str]) -> None: ...
+
+    # Make it contravariant in `T`:
+    def push(self, value: T) -> None: ...
+
+reveal_type(Contravariant())  # revealed: Contravariant[int | str]
+reveal_type(Contravariant[object]())  # revealed: Contravariant[object]
+
+Contravariant[int]()  # error: [invalid-argument-type]
+Contravariant[str]()  # error: [invalid-argument-type]
+
+class Invariant[T]:
+    def __init__(self: Invariant[int | str]) -> None: ...
+
+    # Make it invariant in `T`:
+    def get(self) -> T:
+        raise NotImplementedError
+    def push(self, value: T) -> None: ...
+
+reveal_type(Invariant())  # revealed: Invariant[int | str]
+reveal_type(Invariant[int | str]())  # revealed: Invariant[int | str]
+
+Invariant[int]()  # error: [invalid-argument-type]
+Invariant[Never]()  # error: [invalid-argument-type]
+Invariant[object]()  # error: [invalid-argument-type]
+```
+
 ## `__init__` can remap constructor generic arguments via `self` annotation
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -1751,6 +1751,27 @@ Invariant[Never]()  # error: [invalid-argument-type]
 Invariant[object]()  # error: [invalid-argument-type]
 ```
 
+## Constrained type variables in a union `self` annotation
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+class C[T: (str | None, int | None)]:
+    def __init__[U: (str, int)](self: C[U | None], value: U) -> None: ...
+    def get(self) -> T:
+        raise NotImplementedError
+
+reveal_type(C("a"))  # revealed: C[str | None]
+
+# TODO: Resolve `U` before selecting a constraint for `T`. This should infer
+# `C[int | None]` without an error.
+# error: [invalid-argument-type]
+reveal_type(C(1))  # revealed: C[str | None]
+```
+
 ## `__init__` can remap constructor generic arguments via `self` annotation
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -1772,6 +1772,35 @@ reveal_type(C("a"))  # revealed: C[str | None]
 reveal_type(C(1))  # revealed: C[str | None]
 ```
 
+## Union `self` annotations with variadic constructor parameters
+
+The `object` argument selects the `Any` constraint, even when the constructor also infers a
+`ParamSpec` or `TypeVarTuple`.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from collections.abc import Callable
+from typing import Any
+
+class WithParamSpec[T: (str | None, Any)]:
+    def __init__[**P](self: WithParamSpec[str | None], value: T, callback: Callable[P, None]) -> None: ...
+    def push(self, value: T) -> None: ...
+
+def callback() -> None: ...
+
+reveal_type(WithParamSpec(object(), callback))  # revealed: WithParamSpec[Any]
+
+class WithTypeVarTuple[T: (str | None, Any)]:
+    def __init__[*Ts](self: WithTypeVarTuple[str | None], value: T, rest: tuple[*Ts]) -> None: ...
+    def push(self, value: T) -> None: ...
+
+reveal_type(WithTypeVarTuple(object(), (1,)))  # revealed: WithTypeVarTuple[Any]
+```
+
 ## `__init__` can remap constructor generic arguments via `self` annotation
 
 ```py

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -4006,18 +4006,27 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 );
             }
             (Type::Union(union_formal), _) => {
-                // If the formal is a union and the actual is a bare inferable TypeVar in an
-                // invariant position, record the whole union as the mapping. Invariant matching is
-                // equality-like; probing individual union elements below can leave spurious
-                // partial mappings from non-matching elements. For example, while comparing
-                // `ClassSelector[T]` with `ClassSelector[CT | None]`, descending into `None`
-                // would map `T` to `None` before `CT` is solved from another argument.
                 if let Type::TypeVar(actual_typevar) = actual
                     && actual_typevar.is_inferable(db, self.inferable)
-                    && matches!(polarity, TypeVarVariance::Invariant)
                 {
-                    self.add_type_mapping(actual_typevar, formal, polarity);
-                    return Ok(());
+                    let has_variadic = self
+                        .inferable
+                        .iter(db)
+                        .any(|typevar| typevar.is_paramspec(db) || typevar.is_typevartuple(db));
+                    if has_variadic {
+                        // TODO:
+                        // Variadic contexts still solve from legacy mappings. Projecting the relation
+                        // here can choose a narrow TypeVar constraint before later arguments supply
+                        // evidence for another, such as `str | None` instead of `Any`. Preserve the
+                        // legacy union heuristics, including the whole-union mapping for invariance.
+                        if matches!(polarity, TypeVarVariance::Invariant) {
+                            self.add_type_mapping(actual_typevar, formal, polarity);
+                            return Ok(());
+                        }
+                    }
+
+                    let when = self.constraint_for_relation(formal, actual, relation_polarity);
+                    return self.infer_from_constraint_set(when);
                 }
 
                 // Second, if the formal is a union, and the actual type is assignable to precisely

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -4023,10 +4023,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             self.add_type_mapping(actual_typevar, formal, polarity);
                             return Ok(());
                         }
+                    } else {
+                        let when = self.constraint_for_relation(formal, actual, relation_polarity);
+                        return self.infer_from_constraint_set(when);
                     }
-
-                    let when = self.constraint_for_relation(formal, actual, relation_polarity);
-                    return self.infer_from_constraint_set(when);
                 }
 
                 // Second, if the formal is a union, and the actual type is assignable to precisely


### PR DESCRIPTION
## Summary

When comparing an "actual" typevar against a "formal" union, we now use the new constraint-set based solver instead of the legacy solver. The previous implementation did not respect (co)variance correctly.

```py
class Contravariant[T]:
    def __init__(self: Contravariant[int | str]) -> None: ...

    # members to make it contravariant in `T`

reveal_type(Contravariant())  # revealed: previously an error, now Contravariant[int | str]
```

closes https://github.com/astral-sh/ty/issues/3990

## Ecosystem

The two new diagnostics are correct; mypy and pyright agree with that behavior.

<details>

Reproducer:

```py
from typing import Any, Generic
from typing_extensions import TypeVar

T = TypeVar("T", default=str, covariant=True)

class KDE(Generic[T]):
    def __init__(self: "KDE[str | Any]") -> None: ...

reveal_type(KDE())
```

- Base: KDE[str]
- PR: KDE[str | Any]
- Pyright and mypy agree with the PR.

</details>

## Test Plan

New Markdown tests