### PR TITLE
[ty] Don't consider removed return types of paramspec values

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -96,7 +96,9 @@ pub use crate::types::method::{BoundMethodType, KnownBoundMethodType, WrapperDes
 use crate::types::mro::{MroIterator, StaticMroError};
 pub(crate) use crate::types::narrow::{NarrowingConstraint, infer_narrowing_constraints};
 use crate::types::newtype::NewType;
-use crate::types::signatures::{ConcatenateTail, walk_signature};
+use crate::types::signatures::{
+    ConcatenateTail, walk_signature, walk_signature_without_return_type,
+};
 pub(crate) use crate::types::signatures::{Parameter, Parameters};
 use crate::types::special_form::TypeQualifier;
 use crate::types::tuple::TupleSpec;

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -15,7 +15,7 @@ use crate::{
         known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
         signatures::{CallableSignature, PartialSignatureApplication},
-        visitor, walk_signature,
+        visitor, walk_signature, walk_signature_without_return_type,
     },
 };
 use ty_python_core::definition::Definition;
@@ -418,8 +418,16 @@ pub(super) fn walk_callable_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     ty: CallableType<'db>,
     visitor: &V,
 ) {
-    for signature in &ty.signatures(db).overloads {
-        walk_signature(db, signature, visitor);
+    if ty.is_paramspec_value(db) {
+        // We normalize the callables that represent the value assigned to a ParamSpec by removing
+        // their return values. A missing return value is usually treated as `Unknown`
+        for signature in &ty.signatures(db).overloads {
+            walk_signature_without_return_type(db, signature, visitor);
+        }
+    } else {
+        for signature in &ty.signatures(db).overloads {
+            walk_signature(db, signature, visitor);
+        }
     }
 }
 
@@ -474,6 +482,10 @@ impl<'db> CallableType<'db> {
             CallableSignature::single(Signature::new(parameters, Type::unknown())),
             CallableTypeKind::ParamSpecValue,
         )
+    }
+
+    fn is_paramspec_value(self, db: &'db dyn Db) -> bool {
+        self.kind(db) == CallableTypeKind::ParamSpecValue
     }
 
     /// Create a callable type which accepts any parameters and returns an `Unknown` type.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -678,6 +678,18 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     signature: &Signature<'db>,
     visitor: &V,
 ) {
+    walk_signature_without_return_type(db, signature, visitor);
+    visitor.visit_type(db, signature.return_ty);
+}
+
+pub(super) fn walk_signature_without_return_type<
+    'db,
+    V: super::visitor::TypeVisitor<'db> + ?Sized,
+>(
+    db: &'db dyn Db,
+    signature: &Signature<'db>,
+    visitor: &V,
+) {
     if let Some(generic_context) = &signature.generic_context {
         walk_generic_context(db, *generic_context, visitor);
     }
@@ -689,7 +701,6 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     for parameter in &signature.parameters {
         visitor.visit_type(db, parameter.annotated_type());
     }
-    visitor.visit_type(db, signature.return_ty);
 }
 
 /// Describes how a `functools.partial(...)` call binds one overload's parameters.

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -953,8 +953,7 @@ mod tests {
                 Parameter::positional_only(None).with_annotated_type(Type::object())
             ]),
         );
-        // XXX: should pass
-        assert!(!dynamic_content(&db, &env, paramspec_value).is_absent());
+        assert!(dynamic_content(&db, &env, paramspec_value).is_absent());
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -939,9 +939,23 @@ mod tests {
 
     use crate::db::tests::setup_db;
     use crate::place::global_symbol;
-    use crate::types::{DynamicType, SpecialFormType, Type};
+    use crate::types::{DynamicType, Parameter, Parameters, SpecialFormType, Type};
 
-    use super::{CollectedTypes, materialization_is_noop};
+    use super::{CollectedTypes, dynamic_content, materialization_is_noop};
+
+    #[test]
+    fn fully_static_paramspec_value_has_no_dynamic_content() {
+        let db = setup_db();
+        let env = db.program_environment();
+        let paramspec_value = Type::paramspec_value_callable(
+            &db,
+            Parameters::standard([
+                Parameter::positional_only(None).with_annotated_type(Type::object())
+            ]),
+        );
+        // XXX: should pass
+        assert!(!dynamic_content(&db, &env, paramspec_value).is_absent());
+    }
 
     #[test]
     fn materialization_noop_checks_hidden_function_types() -> anyhow::Result<()> {


### PR DESCRIPTION
We use callable types to represent the values that a `ParamSpec` can specialize to. They only bind the parameters of a signature, though, not its return type annotation. So we normalize `paramspec_value` callables by removing their return type.

Internally, missing return types are treated the same as `Unknown`. This means we were erroneously considering _all_ `paramspec_value` callables to be dynamic, since they contained a dynamic return type, even if all of the parameter annotations were fully static.

To fix this, I updated our default `TypeVisitor` `walk_callable` logic to skip the return type entirely for `paramspec_value` callables, since they are genuinely missing, not just implicitly `Unknown`. (I think we use to model this separately, by storing the return type as an `Option<Type>`, but going back to that seemed to be a deeper change than was warranted.)