### PR TITLE
[ty] Index source-range reachability

### DIFF
--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -105,7 +105,7 @@ impl ScopedReachabilityConstraintId {
         self.0 >= SMALLEST_TERMINAL.0
     }
 
-    fn as_u32(self) -> u32 {
+    pub(crate) fn as_u32(self) -> u32 {
         self.0
     }
 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -275,12 +275,14 @@ use crate::{
 
 mod exception_checkpoint;
 mod place_state;
+mod range_reachability;
 
 pub(super) use exception_checkpoint::ExceptionCheckpointKey;
 use exception_checkpoint::{ExceptionCheckpointSnapshot, ExceptionCheckpointState};
 pub use place_state::LiveBinding;
 pub use place_state::ScopedDefinitionId;
 pub(super) use place_state::{FutureDefinitions, PreviousDefinitions};
+use range_reachability::RangeReachability;
 
 /// Summarizes whether the live control-flow paths leave a symbol bound.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -783,7 +785,7 @@ pub struct UseDefMap<'db> {
     /// Tracks the reachability constraint for statements and certain sub-expressions
     /// (e.g. ternary branches, boolean operator operands), keyed by their text range.
     /// Used to suppress diagnostics in unreachable code.
-    range_reachability: Box<[(TextRange, RangeInfo)]>,
+    range_reachability: RangeReachability,
 
     /// If the definition is a binding (only) -- `x = 1` for example -- then we need
     /// [`Declarations`] to know whether this binding is permitted by the live declarations.
@@ -865,20 +867,72 @@ impl UseDefMapInterner {
 }
 
 /// Information about a given range of source code.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, get_size2::GetSize)]
-struct RangeInfo {
-    reachability: ScopedReachabilityConstraintId,
-    in_type_checking_block: bool,
+#[derive(Copy, Clone, PartialEq, Eq, get_size2::GetSize)]
+struct RangeInfo(u32);
+
+impl RangeInfo {
+    // Keep the TYPE_CHECKING flag in the high bit so a range and its metadata occupy 12 bytes.
+    // Reserve the three largest 31-bit values for terminals, whose original IDs use all 32 bits.
+    const IN_TYPE_CHECKING_BLOCK: u32 = 1 << 31;
+    const CONSTRAINT_MASK: u32 = !Self::IN_TYPE_CHECKING_BLOCK;
+    const ALWAYS_TRUE: u32 = Self::CONSTRAINT_MASK;
+    const AMBIGUOUS: u32 = Self::CONSTRAINT_MASK - 1;
+    const ALWAYS_FALSE: u32 = Self::CONSTRAINT_MASK - 2;
+
+    fn new(reachability: ScopedReachabilityConstraintId, in_type_checking_block: bool) -> Self {
+        let reachability = match reachability {
+            ScopedReachabilityConstraintId::ALWAYS_TRUE => Self::ALWAYS_TRUE,
+            ScopedReachabilityConstraintId::AMBIGUOUS => Self::AMBIGUOUS,
+            ScopedReachabilityConstraintId::ALWAYS_FALSE => Self::ALWAYS_FALSE,
+            id => {
+                let id = id.as_u32();
+                assert!(
+                    id < Self::ALWAYS_FALSE,
+                    "reachability constraint IDs must fit in 31 bits without aliasing terminals"
+                );
+                id
+            }
+        };
+        Self(
+            reachability
+                | if in_type_checking_block {
+                    Self::IN_TYPE_CHECKING_BLOCK
+                } else {
+                    0
+                },
+        )
+    }
+
+    fn reachability(self) -> ScopedReachabilityConstraintId {
+        match self.0 & Self::CONSTRAINT_MASK {
+            Self::ALWAYS_TRUE => ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            Self::AMBIGUOUS => ScopedReachabilityConstraintId::AMBIGUOUS,
+            Self::ALWAYS_FALSE => ScopedReachabilityConstraintId::ALWAYS_FALSE,
+            id => ScopedReachabilityConstraintId::new(id as usize),
+        }
+    }
+
+    fn in_type_checking_block(self) -> bool {
+        self.0 & Self::IN_TYPE_CHECKING_BLOCK != 0
+    }
+}
+
+impl std::fmt::Debug for RangeInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RangeInfo")
+            .field("reachability", &self.reachability())
+            .field("in_type_checking_block", &self.in_type_checking_block())
+            .finish()
+    }
 }
 
 impl Default for RangeInfo {
     fn default() -> Self {
-        Self {
-            reachability: ScopedReachabilityConstraintId::ALWAYS_TRUE,
-            in_type_checking_block: false,
-        }
+        Self::new(ScopedReachabilityConstraintId::ALWAYS_TRUE, false)
     }
 }
+
+static_assertions::assert_eq_size!((TextRange, RangeInfo), [u32; 3]);
 
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize)]
 struct MultiBindingsByUse(ThinVec<(ScopedUseId, Box<[Bindings]>)>);
@@ -937,7 +991,19 @@ impl<'db> UseDefMap<'db> {
     ) -> impl Iterator<Item = (TextRange, ScopedReachabilityConstraintId)> + '_ {
         self.range_reachability
             .iter()
-            .map(|&(range, RangeInfo { reachability, .. })| (range, reachability))
+            .map(|&(range, info)| (range, info.reachability()))
+    }
+
+    /// Whether any part of `range` is reachable under the supplied constraint evaluator.
+    /// The ranges are disjoint, so only segments overlapping the query need to be examined.
+    pub fn is_range_reachable(
+        &self,
+        range: TextRange,
+        mut is_reachable: impl FnMut(ScopedReachabilityConstraintId) -> bool,
+    ) -> bool {
+        !self
+            .range_reachability
+            .all_in_range(range, |info| !is_reachable(info.reachability()))
     }
 
     pub fn end_of_scope_reachability(&self) -> ScopedReachabilityConstraintId {
@@ -1059,11 +1125,7 @@ impl<'db> UseDefMap<'db> {
 
     pub(crate) fn is_range_in_type_checking_block(&self, range: TextRange) -> bool {
         self.range_reachability
-            .iter()
-            .take_while(|(entry_range, _)| entry_range.start() <= range.start())
-            .any(|&(entry_range, block)| {
-                block.in_type_checking_block && entry_range.contains_range(range)
-            })
+            .all_in_range(range, RangeInfo::in_type_checking_block)
     }
 
     /// Return `true` if `node` is one of the tests recorded in
@@ -2713,10 +2775,7 @@ impl<'db> UseDefMapBuilder<'db> {
         range: TextRange,
         is_type_checking_block: bool,
     ) {
-        let this_range_info = RangeInfo {
-            reachability: self.reachability,
-            in_type_checking_block: is_type_checking_block,
-        };
+        let this_range_info = RangeInfo::new(self.reachability, is_type_checking_block);
 
         // If the last entry has the same reachability constraint and the same
         // "in-TYPE_CHECKING" status, extend it to cover this range too, collapsing
@@ -3057,10 +3116,10 @@ impl<'db> UseDefMapBuilder<'db> {
         // Keep default entries while building so they remain barriers between non-contiguous
         // ranges with the same metadata. Once construction is complete, absence represents the
         // default of reachable code outside a `TYPE_CHECKING` block.
-        self.range_reachability
-            .retain(|(_, info)| *info != RangeInfo::default());
-        for &(_, RangeInfo { reachability, .. }) in &self.range_reachability {
-            self.reachability_constraints.mark_used(reachability);
+        let range_reachability =
+            RangeReachability::new(self.range_reachability, &mut self.reachability_constraints);
+        for &(_, info) in range_reachability.iter() {
+            self.reachability_constraints.mark_used(info.reachability());
         }
         for enclosing_snapshot in &enclosing_snapshots {
             // Bindings are already marked above.
@@ -3117,7 +3176,7 @@ impl<'db> UseDefMapBuilder<'db> {
             constraint_tables,
             interned_bindings: Arc::new(interned_bindings),
             interned_declarations: Arc::new(interned_declarations),
-            range_reachability: self.range_reachability.into_boxed_slice(),
+            range_reachability,
             symbol_states,
             definitions_by_definition,
             extra,

--- a/crates/ty_python_core/src/use_def/range_reachability.rs
+++ b/crates/ty_python_core/src/use_def/range_reachability.rs
@@ -1,0 +1,274 @@
+use ruff_text_size::{TextRange, TextSize};
+
+use crate::reachability_constraints::ReachabilityConstraintsBuilder;
+
+use super::RangeInfo;
+
+/// Disjoint source ranges in increasing order, with default metadata omitted.
+///
+/// Statements and their subexpressions are recorded separately during indexing. Normalize their
+/// overlapping ranges once so lookups can skip unrelated source code with a binary search.
+#[derive(Debug, Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+pub(super) struct RangeReachability(Box<[(TextRange, RangeInfo)]>);
+
+impl RangeReachability {
+    pub(super) fn new(
+        ranges: Vec<(TextRange, RangeInfo)>,
+        constraints: &mut ReachabilityConstraintsBuilder,
+    ) -> Self {
+        let range_count = ranges.len();
+        let mut events = Vec::with_capacity(range_count * 2);
+        for (index, (range, info)) in ranges.into_iter().enumerate() {
+            if !range.is_empty() && info != RangeInfo::default() {
+                events.push((range.start(), index, info));
+                events.push((range.end(), index, RangeInfo::default()));
+            }
+        }
+        if events.is_empty() {
+            return Self::default();
+        }
+
+        let mut active = ActiveRanges::new(range_count);
+        // Remove expired ranges before adding new ones, so ranges that only touch never create
+        // temporary conjunctions while the active constraints are updated.
+        events.sort_unstable_by_key(|(offset, _, info)| (*offset, *info != RangeInfo::default()));
+        let mut normalized: Vec<(TextRange, RangeInfo)> = Vec::new();
+        let mut previous_offset = TextSize::default();
+
+        for boundary in events.chunk_by(|left, right| left.0 == right.0) {
+            let offset = boundary[0].0;
+            let info = active.combined();
+            if previous_offset < offset && info != RangeInfo::default() {
+                let range = TextRange::new(previous_offset, offset);
+                if let Some((last_range, last_info)) = normalized.last_mut()
+                    && last_range.end() == range.start()
+                    && *last_info == info
+                {
+                    *last_range = last_range.cover(range);
+                } else {
+                    normalized.push((range, info));
+                }
+            }
+
+            for &(_, index, info) in boundary {
+                active.update(constraints, index, info);
+            }
+            previous_offset = offset;
+        }
+
+        Self(normalized.into_boxed_slice())
+    }
+
+    pub(super) fn iter(&self) -> impl Iterator<Item = &(TextRange, RangeInfo)> {
+        self.0.iter()
+    }
+
+    /// Whether every part of `range` satisfies `predicate`, including gaps with default metadata.
+    /// Empty ranges use the metadata at their offset.
+    pub(super) fn all_in_range(
+        &self,
+        range: TextRange,
+        mut predicate: impl FnMut(RangeInfo) -> bool,
+    ) -> bool {
+        let start = self
+            .0
+            .partition_point(|(entry, _)| entry.end() <= range.start());
+        if range.is_empty() {
+            let info = self
+                .0
+                .get(start)
+                .filter(|(entry, _)| entry.contains(range.start()))
+                .map(|(_, info)| *info)
+                .unwrap_or_default();
+            return predicate(info);
+        }
+
+        let mut covered_until = range.start();
+        for &(entry, info) in &self.0[start..] {
+            if entry.start() >= range.end() {
+                break;
+            }
+            if covered_until < entry.start() && !predicate(RangeInfo::default()) {
+                return false;
+            }
+            if !predicate(info) {
+                return false;
+            }
+            covered_until = entry.end();
+            if covered_until >= range.end() {
+                return true;
+            }
+        }
+
+        predicate(RangeInfo::default())
+    }
+}
+
+/// A balanced reduction tree for the ranges active at a sweep boundary.
+///
+/// Adding or removing a range only recomputes its ancestors. Repeatedly folding all active ranges
+/// would make normalization quadratic for deeply nested statements and expressions.
+struct ActiveRanges {
+    values: Vec<RangeInfo>,
+    leaf_start: usize,
+}
+
+impl ActiveRanges {
+    fn new(len: usize) -> Self {
+        let leaf_start = len.next_power_of_two();
+        Self {
+            values: vec![RangeInfo::default(); leaf_start * 2],
+            leaf_start,
+        }
+    }
+
+    fn combined(&self) -> RangeInfo {
+        self.values[1]
+    }
+
+    fn update(
+        &mut self,
+        constraints: &mut ReachabilityConstraintsBuilder,
+        index: usize,
+        info: RangeInfo,
+    ) {
+        let mut index = self.leaf_start + index;
+        self.values[index] = info;
+        while index > 1 {
+            index /= 2;
+            let left = self.values[index * 2];
+            let right = self.values[index * 2 + 1];
+            let info = RangeInfo::new(
+                constraints.add_and_constraint(left.reachability(), right.reachability()),
+                left.in_type_checking_block() || right.in_type_checking_block(),
+            );
+            if self.values[index] == info {
+                break;
+            }
+            self.values[index] = info;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_index::Idx;
+
+    use super::*;
+    use crate::predicate::ScopedPredicateId;
+    use crate::reachability_constraints::ScopedReachabilityConstraintId;
+
+    fn range(start: u32, end: u32) -> TextRange {
+        TextRange::new(TextSize::new(start), TextSize::new(end))
+    }
+
+    #[test]
+    fn metadata_round_trips() {
+        for reachability in [
+            ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            ScopedReachabilityConstraintId::AMBIGUOUS,
+            ScopedReachabilityConstraintId::ALWAYS_FALSE,
+            ScopedReachabilityConstraintId::new(0),
+            ScopedReachabilityConstraintId::new(512 * 1024),
+            ScopedReachabilityConstraintId::new((1 << 31) - 4),
+        ] {
+            for in_type_checking_block in [false, true] {
+                let info = RangeInfo::new(reachability, in_type_checking_block);
+                assert_eq!(info.reachability(), reachability);
+                assert_eq!(info.in_type_checking_block(), in_type_checking_block);
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "reachability constraint IDs must fit in 31 bits without aliasing terminals"
+    )]
+    fn metadata_rejects_id_that_would_alias_terminal() {
+        RangeInfo::new(ScopedReachabilityConstraintId::new((1 << 31) - 3), false);
+    }
+
+    /// Normalization produces sorted, disjoint segments. Overlaps conjoin reachability and
+    /// inherit `TYPE_CHECKING` status from either input; touching segments with equal metadata
+    /// merge. Duplicate, default, and empty inputs do not add segments to the result.
+    #[test]
+    fn overlapping_ranges_combine_and_coalesce() {
+        let mut constraints = ReachabilityConstraintsBuilder::default();
+        let first = constraints.add_atom(ScopedPredicateId::new(2));
+        let second = constraints.add_atom(ScopedPredicateId::new(3));
+        let both = constraints.add_and_constraint(first, second);
+        let first_info = RangeInfo::new(first, false);
+        let second_info = RangeInfo::new(second, true);
+        let ranges = RangeReachability::new(
+            vec![
+                (range(4, 12), first_info),
+                (range(0, 8), second_info),
+                (range(12, 14), first_info),
+                (range(0, 8), second_info),
+                (range(20, 22), RangeInfo::default()),
+                (range(25, 25), first_info),
+            ],
+            &mut constraints,
+        );
+
+        assert_eq!(
+            ranges.0.as_ref(),
+            &[
+                (range(0, 4), second_info),
+                (range(4, 8), RangeInfo::new(both, true)),
+                (range(8, 14), first_info),
+            ]
+        );
+    }
+
+    /// Queries agree with a pointwise scan of the original ranges, including queries that cross
+    /// metadata changes or uncovered gaps. Every point must satisfy the predicate, with default
+    /// metadata used in gaps. Empty queries use the metadata at their offset, so an interval's
+    /// start is included and its end is excluded.
+    #[test]
+    fn range_queries_include_every_segment_and_default_gap() {
+        let unreachable = RangeInfo::new(ScopedReachabilityConstraintId::ALWAYS_FALSE, false);
+        let type_checking = RangeInfo::new(ScopedReachabilityConstraintId::ALWAYS_TRUE, true);
+        let original = [
+            (range(2, 12), unreachable),
+            (range(4, 8), type_checking),
+            (range(16, 20), unreachable),
+        ];
+        let mut constraints = ReachabilityConstraintsBuilder::default();
+        let ranges = RangeReachability::new(original.to_vec(), &mut constraints);
+
+        for start in 0..22 {
+            for end in start + 1..=22 {
+                let expected_unreachable = (start..end).all(|offset| {
+                    original.iter().any(|(range, info)| {
+                        range.contains(TextSize::new(offset))
+                            && info.reachability() == ScopedReachabilityConstraintId::ALWAYS_FALSE
+                    })
+                });
+                let expected_type_checking = (start..end).all(|offset| {
+                    original.iter().any(|(range, info)| {
+                        range.contains(TextSize::new(offset)) && info.in_type_checking_block()
+                    })
+                });
+                assert_eq!(
+                    ranges.all_in_range(range(start, end), |info| info.reachability()
+                        == ScopedReachabilityConstraintId::ALWAYS_FALSE),
+                    expected_unreachable,
+                    "{start}..{end}",
+                );
+                assert_eq!(
+                    ranges.all_in_range(range(start, end), RangeInfo::in_type_checking_block),
+                    expected_type_checking,
+                    "{start}..{end}",
+                );
+            }
+        }
+
+        assert!(ranges.all_in_range(range(4, 4), RangeInfo::in_type_checking_block));
+        assert!(!ranges.all_in_range(range(8, 8), RangeInfo::in_type_checking_block));
+        assert!(
+            RangeReachability::default()
+                .all_in_range(range(0, 1), |info| info == RangeInfo::default())
+        );
+    }
+}

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -2035,11 +2035,7 @@ pub(crate) fn is_range_reachable<'db>(
 ) -> bool {
     index.ancestor_scopes(scope_id).all(|(scope_id, _)| {
         let use_def = index.use_def_map(scope_id);
-        !use_def
-            .range_reachability()
-            .any(|(entry_range, constraint)| {
-                entry_range.contains_range(range) && !is_reachable(db, use_def, constraint)
-            })
+        use_def.is_range_reachable(range, |constraint| is_reachable(db, use_def, constraint))
     })
 }
 

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -75,7 +75,7 @@ fn merge_overlapping_ranges(mut ranges: Vec<UnreachableRange>) -> Box<[Unreachab
     ranges
         .into_iter()
         .coalesce(|mut previous, range| {
-            if range.range.start() < previous.range.end() {
+            if range.range.start() <= previous.range.end() {
                 previous.range = TextRange::new(
                     previous.range.start(),
                     previous.range.end().max(range.range.end()),


### PR DESCRIPTION
`is_range_reachable` is called when deciding whether to suppress a diagnostic in unreachable code, as well as for IDE features and unreachable-code annotations on redundant conditions. Previously, each query linearly scanned the stored statement and expression ranges in the current scope and its ancestors. Many range queries in a large scope could therefore make the range-lookup work quadratic.

This PR normalizes overlapping ranges into sorted, disjoint segments when building the use-def map. Overlapping reachability constraints are combined with AND, `TYPE_CHECKING` metadata is combined with OR, and adjacent segments with identical metadata are merged. Queries can then binary-search for the first relevant segment and inspect only the segments overlapping the requested range.

For each scope, excluding the cost of evaluating reachability constraints:

| | Before | After |
| --- | --- | --- |
| One range query | O(n) worst case, scanning up to all n stored ranges | O(log s + k), where s is the number of normalized segments and k is the number overlapping the query |
| q queries each overlapping O(1) segments | O(qn) worst case | O(q log s) |

There are O(n) normalized segments. A query still checks enclosing scopes, so its total cost is the sum across the scopes visited. Queries spanning many segments can still take linear time; a small diagnostic range typically overlaps only one segment. In particular, O(n) such queries go from O(n²) range-lookup work to O(n log n).

Normalization sorts the range boundaries and uses a balanced reduction tree to update the active metadata, taking O(n log n) sorting/tree work once per use-def map, plus the cost of combining reachability constraints. Queries account for coverage across multiple segments and for gaps with default metadata. Unreachable-code hints continue to merge touching segments into a single span. Packing each segment's metadata into a `u32` keeps a range and its metadata at 12 bytes.

The [CI memory report](https://github.com/astral-sh/ruff/pull/28317#issuecomment-5542833704) also shows a small reduction in measured memory usage across all four projects: 0.02–0.03% overall, ranging from 9.28 kB for Flake8 to 110.77 kB for Prefect. Almost all of the savings are in `semantic_index`.

<details>
<summary>Example: many reachability ranges followed by many suppressed diagnostics</summary>

This generator writes a deliberately large function with 20,000 separate unreachable branches, followed by another unreachable branch containing 500,000 invalid binary operations:

```python
# /// script
# requires-python = ">=3.11"
# dependencies = []
# ///

from pathlib import Path

Path("example.py").write_text(
    "def f() -> None:\n"
    + "    if False:\n        pass\n" * 20_000
    + "    if False:\n"
    + "        1 + 'x'\n" * 500_000
)
```

Checking `example.py` produces no diagnostics because all the invalid operations are unreachable. However, deciding to suppress each diagnostic still requires a reachability query. Previously, each of those queries scanned past all 20,000 earlier ranges before finding the range covering the final branch: roughly ten billion range-containment checks in total. The new lookup binary-searches directly to the final segment.

With single-threaded `profiling` builds on ARM64 macOS, targeting Python 3.12, the median of three checks was:

| Revision | Time |
| --- | ---: |
| Parent (`3fc132c2d0`) | 3.39 s |
| This PR (`aa3e13f2f1`) | 0.92 s |

That is about a 3.7× improvement for this synthetic stress case. The asymptotic improvement described above applies to the range lookups; other parts of type checking still contribute to the total runtime.

</details>
