### PR TITLE
[ty] Track completion of boolean tests

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2412,7 +2412,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     }
                     PredicateNode::SubjectElementPattern(_)
                     | PredicateNode::ExpressionCanComplete { .. }
-                    | PredicateNode::CallCanComplete(_)
                     | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::ContextManagerSuppresses { .. }
                     | PredicateNode::FinallyNormalPathImpossible { .. }
@@ -3749,23 +3748,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .get(&node.into())
             .copied()
             .unwrap_or_else(|| self.add_standalone_expression(node));
-        let node =
-            if let Some(StatementCall { call, is_await }) = StatementCall::from_expression(node) {
-                let callable =
-                    self.add_standalone_expression_impl(&call.func, ExpressionKind::Callee, None);
-                PredicateNode::CallCanComplete(CallableAndCallExpr {
-                    callable,
-                    call_expr: expression,
-                    is_await,
-                })
-            } else {
-                PredicateNode::ExpressionCanComplete {
-                    expression,
-                    context,
-                }
-            };
         let predicate = self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
-            node,
+            node: PredicateNode::ExpressionCanComplete {
+                expression,
+                context,
+            },
             is_positive: true,
         }));
         self.current_reachability_constraints_mut()
@@ -5573,11 +5560,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         let call_expr = self.add_standalone_expression(value);
 
                         let predicate = Predicate {
-                            node: PredicateNode::IsNonTerminalCall(CallableAndCallExpr {
-                                callable,
-                                call_expr,
-                                is_await,
-                            }),
+                            node: PredicateNode::IsNonTerminalCall(CallableAndCallExpr::new(
+                                self.db, callable, call_expr, is_await,
+                            )),
                             is_positive: true,
                         };
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3792,7 +3792,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             is_positive: true,
         }));
         self.current_reachability_constraints_mut()
-            .add_atom(predicate)
+            .add_boolean_atom(predicate)
     }
 
     /// Keeps short-circuit flow snapshots out of the common recursive expression-visitor frame.
@@ -4810,7 +4810,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         self.record_ambiguous_reachability();
                         let reachability_constraint = self
                             .current_reachability_constraints_mut()
-                            .add_atom(predicate_id);
+                            .add_boolean_atom(predicate_id);
                         let narrowing_constraint = self
                             .current_use_def_map_mut()
                             .narrowing_constraints
@@ -5296,7 +5296,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                         let reachability_constraint = self
                             .current_reachability_constraints_mut()
-                            .add_atom(predicate_id);
+                            .add_boolean_atom(predicate_id);
                         let narrowing_constraint = self
                             .current_use_def_map_mut()
                             .narrowing_constraints
@@ -5337,7 +5337,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         let post_finally_state = self.flow_snapshot();
                         let terminal_reachability = self
                             .current_reachability_constraints_mut()
-                            .add_atom(predicate_id);
+                            .add_boolean_atom(predicate_id);
                         let terminal_narrowing = self
                             .current_use_def_map_mut()
                             .narrowing_constraints
@@ -5611,7 +5611,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                         let reachability_constraint = self
                             .current_reachability_constraints_mut()
-                            .add_atom(predicate_id);
+                            .add_boolean_atom(predicate_id);
                         self.current_use_def_map_mut()
                             .record_non_terminal_call_constraints(
                                 reachability_constraint,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3731,6 +3731,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         if self.source_type.is_stub() || node.is_literal_expr() {
             return ScopedReachabilityConstraintId::ALWAYS_TRUE;
         }
+        // Visiting `not` already gates both outcomes on its operand completing. Its boolean
+        // result needs no additional completion predicate when an enclosing test consumes it.
+        if matches!(node, ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not) {
+            return ScopedReachabilityConstraintId::ALWAYS_TRUE;
+        }
         let expression = self
             .expressions_by_node
             .get(&node.into())

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2412,6 +2412,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     }
                     PredicateNode::SubjectElementPattern(_)
                     | PredicateNode::ExpressionCanComplete { .. }
+                    | PredicateNode::CallCanComplete(_)
                     | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::ContextManagerSuppresses { .. }
                     | PredicateNode::FinallyNormalPathImpossible { .. }
@@ -3748,11 +3749,23 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .get(&node.into())
             .copied()
             .unwrap_or_else(|| self.add_standalone_expression(node));
+        let node =
+            if let Some(StatementCall { call, is_await }) = StatementCall::from_expression(node) {
+                let callable =
+                    self.add_standalone_expression_impl(&call.func, ExpressionKind::Callee, None);
+                PredicateNode::CallCanComplete(CallableAndCallExpr {
+                    callable,
+                    call_expr: expression,
+                    is_await,
+                })
+            } else {
+                PredicateNode::ExpressionCanComplete {
+                    expression,
+                    context,
+                }
+            };
         let predicate = self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
-            node: PredicateNode::ExpressionCanComplete {
-                expression,
-                context,
-            },
+            node,
             is_positive: true,
         }));
         self.current_reachability_constraints_mut()

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3728,7 +3728,21 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         // Like terminal calls in expression statements, completion is only relevant to
         // executable files. In stubs, inferring a version guard can itself depend on the
         // guarded definitions in `builtins` or `typing`, introducing inference cycles.
-        if self.source_type.is_stub() || node.is_literal_expr() {
+        if self.source_type.is_stub() {
+            return ScopedReachabilityConstraintId::ALWAYS_TRUE;
+        }
+        // These expressions have inhabited types regardless of a lambda's return type or a
+        // comprehension's element types. Inferring those types just to establish completion
+        // can create cycles through bindings whose reachability depends on this expression.
+        if node.is_literal_expr()
+            || matches!(
+                node,
+                ast::Expr::Lambda(_)
+                    | ast::Expr::ListComp(_)
+                    | ast::Expr::SetComp(_)
+                    | ast::Expr::DictComp(_)
+            )
+        {
             return ScopedReachabilityConstraintId::ALWAYS_TRUE;
         }
         // Visiting `not` already gates both outcomes on its operand completing. Its boolean

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -48,10 +48,10 @@ use crate::place::{
     match_subject_place_expressions,
 };
 use crate::predicate::{
-    CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternPredicateKind,
-    MappingPatternEntryPredicateKind, MappingPatternPredicateKind, PatternPredicate,
-    PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
-    SequencePatternPredicateKind, StarImportPlaceholderPredicate, StatementCall,
+    BuiltinCallKind, CallableAndCallExpr, ClassPatternKeywordPredicateKind,
+    ClassPatternPredicateKind, MappingPatternEntryPredicateKind, MappingPatternPredicateKind,
+    PatternPredicate, PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral,
+    ScopedPredicateId, SequencePatternPredicateKind, StarImportPlaceholderPredicate, StatementCall,
     SubjectElementPatternPredicate,
 };
 use crate::re_exports::exported_names;
@@ -2412,7 +2412,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     }
                     PredicateNode::SubjectElementPattern(_)
                     | PredicateNode::ExpressionCanComplete { .. }
-                    | PredicateNode::BoolCallCanComplete(_)
+                    | PredicateNode::BuiltinCallCanComplete { .. }
                     | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::ContextManagerSuppresses { .. }
                     | PredicateNode::FinallyNormalPathImpossible { .. }
@@ -3772,16 +3772,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .copied()
             .unwrap_or_else(|| self.add_standalone_expression_impl(node, kind, None));
         let node = if let ast::Expr::Call(call) = node
-            && call
+            && let Some(builtin) = call
                 .func
                 .as_name_expr()
-                .is_some_and(|name| name.id == "bool")
+                .and_then(|name| BuiltinCallKind::from_name(name.id.as_str()))
         {
-            let callable =
-                self.add_standalone_expression_impl(&call.func, ExpressionKind::Callee, None);
-            PredicateNode::BoolCallCanComplete(CallableAndCallExpr::new(
-                self.db, callable, expression, false,
-            ))
+            PredicateNode::BuiltinCallCanComplete {
+                expression,
+                builtin,
+            }
         } else {
             PredicateNode::ExpressionCanComplete {
                 expression,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3742,9 +3742,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     | ast::Expr::SetComp(_)
                     | ast::Expr::DictComp(_)
             )
-            // Identity comparisons always produce a boolean, including within comparison chains.
+            // Identity and membership comparisons have inhabited result types, including chains.
             || matches!(node, ast::Expr::Compare(compare)
-                if compare.ops.iter().all(|op| matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot)))
+                if compare.ops.iter().all(|op| matches!(op,
+                    ast::CmpOp::Is | ast::CmpOp::IsNot | ast::CmpOp::In | ast::CmpOp::NotIn)))
         {
             return ScopedReachabilityConstraintId::ALWAYS_TRUE;
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3743,11 +3743,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Expr::Compare(compare) if compare.ops.len() > 1 => context,
             _ => ExpressionContext::Value,
         };
+        let kind = match context {
+            ExpressionContext::Value => ExpressionKind::BooleanTest,
+            ExpressionContext::Condition => ExpressionKind::Normal,
+        };
         let expression = self
             .expressions_by_node
             .get(&node.into())
             .copied()
-            .unwrap_or_else(|| self.add_standalone_expression(node));
+            .unwrap_or_else(|| self.add_standalone_expression_impl(node, kind, None));
         let predicate = self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
             node: PredicateNode::ExpressionCanComplete {
                 expression,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2412,6 +2412,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     }
                     PredicateNode::SubjectElementPattern(_)
                     | PredicateNode::ExpressionCanComplete { .. }
+                    | PredicateNode::BoolCallCanComplete(_)
                     | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::ContextManagerSuppresses { .. }
                     | PredicateNode::FinallyNormalPathImpossible { .. }
@@ -3770,11 +3771,25 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .get(&node.into())
             .copied()
             .unwrap_or_else(|| self.add_standalone_expression_impl(node, kind, None));
-        let predicate = self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
-            node: PredicateNode::ExpressionCanComplete {
+        let node = if let ast::Expr::Call(call) = node
+            && call
+                .func
+                .as_name_expr()
+                .is_some_and(|name| name.id == "bool")
+        {
+            let callable =
+                self.add_standalone_expression_impl(&call.func, ExpressionKind::Callee, None);
+            PredicateNode::BoolCallCanComplete(CallableAndCallExpr::new(
+                self.db, callable, expression, false,
+            ))
+        } else {
+            PredicateNode::ExpressionCanComplete {
                 expression,
                 context,
-            },
+            }
+        };
+        let predicate = self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
+            node,
             is_positive: true,
         }));
         self.current_reachability_constraints_mut()

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3736,6 +3736,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         if matches!(node, ast::Expr::UnaryOp(unary) if unary.op == ast::UnaryOp::Not) {
             return ScopedReachabilityConstraintId::ALWAYS_TRUE;
         }
+        // A single value completes if its type is inhabited. Compound conditions also need
+        // their short-circuit paths, which cannot always be recovered from the result type.
+        let context = match node {
+            ast::Expr::BoolOp(_) | ast::Expr::If(_) => context,
+            ast::Expr::Compare(compare) if compare.ops.len() > 1 => context,
+            _ => ExpressionContext::Value,
+        };
         let expression = self
             .expressions_by_node
             .get(&node.into())

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1368,17 +1368,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let merged = self.flow_snapshot();
                 self.flow_restore(snapshots.truthy);
                 self.current_use_def_map_mut()
-                    .record_reachability_constraint(completion);
+                    .record_expression_completion_constraint(completion);
                 let truthy = self.flow_snapshot();
                 self.flow_restore(snapshots.falsy);
                 self.current_use_def_map_mut()
-                    .record_reachability_constraint(completion);
+                    .record_expression_completion_constraint(completion);
                 let falsy = self.flow_snapshot();
                 self.flow_restore(merged);
                 ConditionFlowSnapshots { truthy, falsy }
             });
         self.current_use_def_map_mut()
-            .record_reachability_constraint(completion);
+            .record_expression_completion_constraint(completion);
         if let Some(snapshots) = snapshots {
             ConditionFlowSnapshot::Branches(snapshots)
         } else {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3742,6 +3742,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     | ast::Expr::SetComp(_)
                     | ast::Expr::DictComp(_)
             )
+            // Identity comparisons always produce a boolean, including within comparison chains.
+            || matches!(node, ast::Expr::Compare(compare)
+                if compare.ops.iter().all(|op| matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot)))
         {
             return ScopedReachabilityConstraintId::ALWAYS_TRUE;
         }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1345,25 +1345,41 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         &mut self,
         expr: &ast::Expr,
     ) -> Option<ConditionFlowSnapshots> {
-        match expr {
-            ast::Expr::BoolOp(_) => self
-                .condition_flow_snapshots_by_node
-                .remove(&ExpressionNodeKey::from(expr)),
-            ast::Expr::UnaryOp(unary_op) if unary_op.op == ast::UnaryOp::Not => {
-                let snapshots = self.take_condition_flow_snapshots(&unary_op.operand)?;
-                Some(ConditionFlowSnapshots {
-                    truthy: snapshots.falsy,
-                    falsy: snapshots.truthy,
-                })
-            }
-            _ => None,
-        }
+        self.condition_flow_snapshots_by_node
+            .remove(&ExpressionNodeKey::from(expr))
     }
 
     fn flow_snapshot_for_condition(&mut self, condition: &ast::Expr) -> ConditionFlowSnapshot {
-        self.record_exception_checkpoint_if(!Self::condition_evaluation_is_known_safe(condition));
+        self.flow_snapshot_for_boolean_test(condition, ExpressionContext::Condition)
+    }
 
-        if let Some(snapshots) = self.take_condition_flow_snapshots(condition) {
+    /// Both outcomes require the test to finish evaluating. Apply that requirement to any
+    /// outcome-specific bindings as well as the merged state after the expression.
+    fn flow_snapshot_for_boolean_test(
+        &mut self,
+        condition: &ast::Expr,
+        context: ExpressionContext,
+    ) -> ConditionFlowSnapshot {
+        self.record_exception_checkpoint_if(!Self::condition_evaluation_is_known_safe(condition));
+        let completion = self.expression_completion_constraint(condition, context);
+        let snapshots = self
+            .take_condition_flow_snapshots(condition)
+            .map(|snapshots| {
+                let merged = self.flow_snapshot();
+                self.flow_restore(snapshots.truthy);
+                self.current_use_def_map_mut()
+                    .record_reachability_constraint(completion);
+                let truthy = self.flow_snapshot();
+                self.flow_restore(snapshots.falsy);
+                self.current_use_def_map_mut()
+                    .record_reachability_constraint(completion);
+                let falsy = self.flow_snapshot();
+                self.flow_restore(merged);
+                ConditionFlowSnapshots { truthy, falsy }
+            });
+        self.current_use_def_map_mut()
+            .record_reachability_constraint(completion);
+        if let Some(snapshots) = snapshots {
             ConditionFlowSnapshot::Branches(snapshots)
         } else {
             ConditionFlowSnapshot::Fallback
@@ -2215,7 +2231,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         self.register_narrowing_alias_predicates(predicate_node);
 
-        let expression = self.add_standalone_expression(predicate_node);
+        let expression = self
+            .expressions_by_node
+            .get(&predicate_node.into())
+            .copied()
+            .unwrap_or_else(|| self.add_standalone_expression(predicate_node));
 
         match resolve_to_literal(predicate_node) {
             Some(literal) => PredicateOrLiteral::Literal(literal),
@@ -2314,6 +2334,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.current_use_def_map_mut()
                 .record_boolean_test_root(test.node_index().load());
         }
+        // Record reachability at the test itself, including tests in expression-only scopes such
+        // as comprehensions, where no enclosing statement records the current flow.
+        let in_type_checking_block = self.in_type_checking_block;
+        self.current_use_def_map_mut()
+            .record_range_reachability(test.range(), in_type_checking_block);
         self.visit_expr_with_context(test, context);
         self.active_boolean_test_scope = previous;
     }
@@ -2386,6 +2411,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             .pattern(pattern, module)
                     }
                     PredicateNode::SubjectElementPattern(_)
+                    | PredicateNode::ExpressionCanComplete { .. }
                     | PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::ContextManagerSuppresses { .. }
                     | PredicateNode::FinallyNormalPathImpossible { .. }
@@ -3605,13 +3631,22 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Expr::UnaryOp(unary) => {
                 if unary.op == ast::UnaryOp::Not {
                     self.visit_boolean_test(&unary.operand, context);
+                    if let Some(snapshots) = self
+                        .flow_snapshot_for_boolean_test(&unary.operand, context)
+                        .into_branches()
+                    {
+                        self.condition_flow_snapshots_by_node.insert(
+                            ExpressionNodeKey::from(expr),
+                            ConditionFlowSnapshots {
+                                truthy: snapshots.falsy,
+                                falsy: snapshots.truthy,
+                            },
+                        );
+                    }
                 } else {
                     self.visit_expr_with_context(&unary.operand, ExpressionContext::Value);
+                    self.record_exception_checkpoint();
                 }
-                self.record_exception_checkpoint_if(
-                    unary.op != ast::UnaryOp::Not
-                        || !Self::condition_evaluation_is_known_safe(&unary.operand),
-                );
             }
             ast::Expr::Compare(ast::ExprCompare {
                 left,
@@ -3683,6 +3718,35 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.flow_merge(post_body);
     }
 
+    /// Completion must gate both outcomes of a boolean test. Negating its truthiness alone
+    /// would otherwise make one path reachable even when the test never returns.
+    fn expression_completion_constraint(
+        &mut self,
+        node: &ast::Expr,
+        context: ExpressionContext,
+    ) -> ScopedReachabilityConstraintId {
+        // Like terminal calls in expression statements, completion is only relevant to
+        // executable files. In stubs, inferring a version guard can itself depend on the
+        // guarded definitions in `builtins` or `typing`, introducing inference cycles.
+        if self.source_type.is_stub() || node.is_literal_expr() {
+            return ScopedReachabilityConstraintId::ALWAYS_TRUE;
+        }
+        let expression = self
+            .expressions_by_node
+            .get(&node.into())
+            .copied()
+            .unwrap_or_else(|| self.add_standalone_expression(node));
+        let predicate = self.add_predicate(PredicateOrLiteral::Predicate(Predicate {
+            node: PredicateNode::ExpressionCanComplete {
+                expression,
+                context,
+            },
+            is_positive: true,
+        }));
+        self.current_reachability_constraints_mut()
+            .add_atom(predicate)
+    }
+
     /// Keeps short-circuit flow snapshots out of the common recursive expression-visitor frame.
     fn visit_bool_expression(&mut self, node: &'ast ast::ExprBoolOp, context: ExpressionContext) {
         let ast::ExprBoolOp { values, op, .. } = node;
@@ -3704,10 +3768,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             // Only non-final values can short-circuit this boolean operation. The final
             // value can still have its own outcome-specific flow if it is nested.
             if index < values.len() - 1 {
-                self.record_exception_checkpoint_if(!Self::condition_evaluation_is_known_safe(
-                    value,
-                ));
-                let condition_flow_snapshots = self.take_condition_flow_snapshots(value);
+                let condition_flow_snapshots = self
+                    .flow_snapshot_for_boolean_test(value, context)
+                    .into_branches();
                 let predicate = self.build_predicate(value, context);
                 let possibly_narrowed = self.compute_possibly_narrowed_places(&predicate);
                 let predicate_id = match op {

--- a/crates/ty_python_core/src/constraint_cache.rs
+++ b/crates/ty_python_core/src/constraint_cache.rs
@@ -1,0 +1,59 @@
+use std::hash::{BuildHasher, Hash};
+
+use hashbrown::HashTable;
+use hashbrown::hash_table::Entry;
+use rustc_hash::FxBuildHasher;
+
+const SHARDS: usize = 8;
+
+#[derive(Debug)]
+struct CachedOperation<T> {
+    operands: (T, T),
+    result: T,
+}
+
+/// Memoizes binary constraint operations without resizing one large hash table.
+///
+/// Growing a hash table temporarily keeps both its old and new allocations. Independent shards
+/// limit that overlap for large constraint graphs. Empty caches do not allocate any shards.
+#[derive(Debug)]
+pub(crate) struct BinaryConstraintCache<T> {
+    shards: Option<Box<[HashTable<CachedOperation<T>>; SHARDS]>>,
+}
+
+impl<T> Default for BinaryConstraintCache<T> {
+    fn default() -> Self {
+        Self { shards: None }
+    }
+}
+
+impl<T: Copy + Eq + Hash> BinaryConstraintCache<T> {
+    fn shard(hash: u64) -> usize {
+        usize::from(hash.to_le_bytes()[4]) % SHARDS
+    }
+
+    pub(crate) fn get(&self, operands: &(T, T)) -> Option<&T> {
+        let shards = self.shards.as_ref()?;
+        let hash = FxBuildHasher.hash_one(operands);
+        shards[Self::shard(hash)]
+            .find(hash, |entry| entry.operands == *operands)
+            .map(|entry| &entry.result)
+    }
+
+    pub(crate) fn insert(&mut self, operands: (T, T), result: T) {
+        let shards = self
+            .shards
+            .get_or_insert_with(|| Box::new(std::array::from_fn(|_| HashTable::new())));
+        let hash = FxBuildHasher.hash_one(operands);
+        match shards[Self::shard(hash)].entry(
+            hash,
+            |entry| entry.operands == operands,
+            |entry| FxBuildHasher.hash_one(entry.operands),
+        ) {
+            Entry::Occupied(mut entry) => entry.get_mut().result = result,
+            Entry::Vacant(entry) => {
+                entry.insert(CachedOperation { operands, result });
+            }
+        }
+    }
+}

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -78,7 +78,7 @@ use salsa;
 /// Condition context does not propagate through calls or assignment expressions: in
 /// `if f(x and False)`, the call's result controls the branch, but its argument is evaluated in
 /// value context.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub enum ExpressionContext {
     /// Produce the expression's result object for the enclosing code to use.
     Value,

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -91,6 +91,9 @@ pub enum ExpressionContext {
 pub enum ExpressionKind {
     /// An ordinary value expression, such as `1` in `self.x: int = 1`.
     Normal,
+    /// A value used as a boolean test. Inference also retains whether its type is inhabited,
+    /// so reachability can reuse that result without a separate completion query.
+    BooleanTest,
     /// The callable part of a call, such as `list[T]` in `list[T]()`.
     ///
     /// Type variables used to specialize the callable must already be bound. A constructor call

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -41,6 +41,7 @@ use use_def::{EnclosingSnapshotKey, ScopedEnclosingSnapshotId};
 pub mod ast_ids;
 pub mod ast_node_ref;
 mod builder;
+mod constraint_cache;
 mod db;
 pub mod definition;
 pub mod expression;

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -33,11 +33,14 @@
 //! `A OR (NOT A AND B)` simplifies to `A OR B`.
 
 use std::cmp::Ordering;
+use std::hash::BuildHasher;
 
+use hashbrown::hash_table::Entry;
 use ruff_index::{Idx, IndexVec};
-use rustc_hash::FxHashMap;
+use rustc_hash::FxBuildHasher;
 
 use crate::ast_ids::ScopedUseId;
+use crate::constraint_cache::BinaryConstraintCache;
 use crate::predicate::ScopedPredicateId;
 use crate::rank::{RankBitBox, RankBitBoxVec};
 use crate::scope::FileScopeId;
@@ -128,19 +131,14 @@ impl NarrowingConstraints {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct NarrowingConstraintsBuilder {
     interiors: IndexVec<ScopedNarrowingConstraint, InteriorNode>,
     interior_used: RankBitBoxVec,
-    interior_cache: FxHashMap<InteriorNode, ScopedNarrowingConstraint>,
-    and_cache: FxHashMap<
-        (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
-        ScopedNarrowingConstraint,
-    >,
-    or_cache: FxHashMap<
-        (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
-        ScopedNarrowingConstraint,
-    >,
+    // Nodes are already stored in `interiors`; keep only their IDs in the reverse table.
+    interior_cache: hashbrown::HashTable<ScopedNarrowingConstraint>,
+    and_cache: BinaryConstraintCache<ScopedNarrowingConstraint>,
+    or_cache: BinaryConstraintCache<ScopedNarrowingConstraint>,
 }
 
 impl NarrowingConstraintsBuilder {
@@ -228,10 +226,20 @@ impl NarrowingConstraintsBuilder {
             });
         }
 
-        *self.interior_cache.entry(node).or_insert_with(|| {
-            self.interior_used.push(false);
-            self.interiors.push(node)
-        })
+        let interiors = &mut self.interiors;
+        match self.interior_cache.entry(
+            FxBuildHasher.hash_one(node),
+            |id| interiors[*id] == node,
+            |id| FxBuildHasher.hash_one(interiors[*id]),
+        ) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                self.interior_used.push(false);
+                let id = interiors.push(node);
+                entry.insert(id);
+                id
+            }
+        }
     }
 
     pub(crate) fn add_atom(&mut self, predicate: ScopedPredicateId) -> ScopedNarrowingConstraint {
@@ -280,7 +288,12 @@ impl NarrowingConstraintsBuilder {
             if_uncertain: ALWAYS_FALSE,
             if_false,
         };
-        if let Some(cached) = self.interior_cache.get(&node) {
+        if let Some(cached) = self
+            .interior_cache
+            .find(FxBuildHasher.hash_one(node), |id| {
+                self.interiors[*id] == node
+            })
+        {
             return *cached;
         }
         if self.interiors.len() >= MAX_INTERIOR_NODES {

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -102,15 +102,23 @@ impl PredicateOrLiteral<'_> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+/// A stable key for call-completion queries. Creating it while building predicates lets cached
+/// queries use its ID directly, without looking up its components in Salsa's intern table again.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct CallableAndCallExpr<'db> {
+    #[returns(copy)]
     pub callable: Expression<'db>,
+    #[returns(copy)]
     pub call_expr: Expression<'db>,
     /// Whether the call is wrapped in an `await` expression. If `true`, `call_expr` refers to the
     /// `await` expression rather than the call itself. This is used to detect terminal `await`s of
     /// async functions that return `Never`.
+    #[returns(copy)]
     pub is_await: bool,
 }
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for CallableAndCallExpr<'_> {}
 
 /// A call whose completion determines whether an expression statement can continue.
 #[derive(Debug)]
@@ -168,10 +176,6 @@ pub enum PredicateNode<'db> {
         expression: Expression<'db>,
         context: ExpressionContext,
     },
-    /// Whether a call used as a boolean test can produce a result. Callable signatures can
-    /// often determine completion without inferring the arguments or selecting an overload.
-    /// Unsupported callable forms are inferred in full to detect uninhabited results.
-    CallCanComplete(CallableAndCallExpr<'db>),
     /// Whether a context manager's exit return type allows an exception to be suppressed.
     ///
     /// Resolved during type inference because the context manager's type is unavailable during

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -176,6 +176,10 @@ pub enum PredicateNode<'db> {
         expression: Expression<'db>,
         context: ExpressionContext,
     },
+    /// Whether a direct `bool(...)` call can produce a result. Resolving its callee can establish
+    /// an inhabited result without inferring argument types; shadowed names require full inference.
+    /// The interned call descriptor keeps `PredicateNode` compact.
+    BoolCallCanComplete(CallableAndCallExpr<'db>),
     /// Whether a context manager's exit return type allows an exception to be suppressed.
     ///
     /// Resolved during type inference because the context manager's type is unavailable during

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -168,6 +168,10 @@ pub enum PredicateNode<'db> {
         expression: Expression<'db>,
         context: ExpressionContext,
     },
+    /// Whether a call used as a boolean test can produce a result. Callable signatures can
+    /// often determine completion without inferring the arguments or selecting an overload.
+    /// Unsupported callable forms are inferred in full to detect uninhabited results.
+    CallCanComplete(CallableAndCallExpr<'db>),
     /// Whether a context manager's exit return type allows an exception to be suppressed.
     ///
     /// Resolved during type inference because the context manager's type is unavailable during

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -16,7 +16,7 @@ use ruff_python_ast::{self as ast, Singleton, name::Name};
 use crate::ProgramFile;
 use crate::ast_ids::ExpressionNodeKey;
 use crate::db::Db;
-use crate::expression::Expression;
+use crate::expression::{Expression, ExpressionContext};
 use crate::global_scope;
 use crate::reachability_constraints::ScopedReachabilityConstraintId;
 use crate::scope::{FileScopeId, ScopeId};
@@ -162,6 +162,12 @@ pub enum PredicateNode<'db> {
     /// A chained comparison evaluated directly as a condition. Its inferred truthiness is
     /// available without walking the expression again.
     ChainedComparisonCondition(Expression<'db>),
+    /// Whether a boolean test can produce a result. A terminal test permits neither the
+    /// truthy nor the falsy outcome, so this constraint is independent of its truthiness.
+    ExpressionCanComplete {
+        expression: Expression<'db>,
+        context: ExpressionContext,
+    },
     /// Whether a context manager's exit return type allows an exception to be suppressed.
     ///
     /// Resolved during type inference because the context manager's type is unavailable during

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -102,6 +102,39 @@ impl PredicateOrLiteral<'_> {
     }
 }
 
+/// Builtins whose call result can be established without inferring their arguments.
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+pub enum BuiltinCallKind {
+    Bool,
+    Len,
+    IsInstance,
+    IsSubclass,
+    HasAttr,
+}
+
+impl BuiltinCallKind {
+    pub(crate) fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "bool" => Some(Self::Bool),
+            "len" => Some(Self::Len),
+            "isinstance" => Some(Self::IsInstance),
+            "issubclass" => Some(Self::IsSubclass),
+            "hasattr" => Some(Self::HasAttr),
+            _ => None,
+        }
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Bool => "bool",
+            Self::Len => "len",
+            Self::IsInstance => "isinstance",
+            Self::IsSubclass => "issubclass",
+            Self::HasAttr => "hasattr",
+        }
+    }
+}
+
 /// A stable key for call-completion queries. Creating it while building predicates lets cached
 /// queries use its ID directly, without looking up its components in Salsa's intern table again.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
@@ -176,10 +209,12 @@ pub enum PredicateNode<'db> {
         expression: Expression<'db>,
         context: ExpressionContext,
     },
-    /// Whether a direct `bool(...)` call can produce a result. Resolving its callee can establish
-    /// an inhabited result without inferring argument types; shadowed names require full inference.
-    /// The interned call descriptor keeps `PredicateNode` compact.
-    BoolCallCanComplete(CallableAndCallExpr<'db>),
+    /// Whether a call to a builtin with an inhabited result type can produce a result. Resolving
+    /// its callee can avoid inferring argument types; shadowed names require full inference.
+    BuiltinCallCanComplete {
+        expression: Expression<'db>,
+        builtin: BuiltinCallKind,
+    },
     /// Whether a context manager's exit return type allows an exception to be suppressed.
     ///
     /// Resolved during type inference because the context manager's type is unavailable during

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -110,6 +110,9 @@ pub enum BuiltinCallKind {
     IsInstance,
     IsSubclass,
     HasAttr,
+    Any,
+    All,
+    Callable,
 }
 
 impl BuiltinCallKind {
@@ -120,6 +123,9 @@ impl BuiltinCallKind {
             "isinstance" => Some(Self::IsInstance),
             "issubclass" => Some(Self::IsSubclass),
             "hasattr" => Some(Self::HasAttr),
+            "any" => Some(Self::Any),
+            "all" => Some(Self::All),
+            "callable" => Some(Self::Callable),
             _ => None,
         }
     }
@@ -131,6 +137,9 @@ impl BuiltinCallKind {
             Self::IsInstance => "isinstance",
             Self::IsSubclass => "issubclass",
             Self::HasAttr => "hasattr",
+            Self::Any => "any",
+            Self::All => "all",
+            Self::Callable => "callable",
         }
     }
 }

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -374,6 +374,27 @@ impl ReachabilityConstraintsBuilder {
         &mut self,
         predicate: ScopedPredicateId,
     ) -> ScopedReachabilityConstraintId {
+        self.add_atom_with_ambiguous_branch(predicate, AMBIGUOUS)
+    }
+
+    /// Adds a predicate whose analysis always returns `true` or `false`.
+    ///
+    /// Completion checks never produce `Ambiguous`, so their ambiguous edge is unused. Giving
+    /// that edge a constant false value avoids constructing `Ambiguous AND previous` when a
+    /// completion check is added to existing control flow. A sequence of completion checks can
+    /// then share its preceding graph without copying an ambiguous version of every prefix.
+    pub(crate) fn add_boolean_atom(
+        &mut self,
+        predicate: ScopedPredicateId,
+    ) -> ScopedReachabilityConstraintId {
+        self.add_atom_with_ambiguous_branch(predicate, ALWAYS_FALSE)
+    }
+
+    fn add_atom_with_ambiguous_branch(
+        &mut self,
+        predicate: ScopedPredicateId,
+        if_ambiguous: ScopedReachabilityConstraintId,
+    ) -> ScopedReachabilityConstraintId {
         if predicate == ScopedPredicateId::ALWAYS_FALSE {
             ALWAYS_FALSE
         } else if predicate == ScopedPredicateId::ALWAYS_TRUE {
@@ -382,7 +403,7 @@ impl ReachabilityConstraintsBuilder {
             self.add_interior(InteriorNode {
                 atom: predicate,
                 if_true: ALWAYS_TRUE,
-                if_ambiguous: AMBIGUOUS,
+                if_ambiguous,
                 if_false: ALWAYS_FALSE,
             })
         }
@@ -561,5 +582,88 @@ impl ReachabilityConstraintsBuilder {
         });
         self.and_cache.insert((a, b), result);
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_index::Idx;
+
+    use super::{
+        ALWAYS_FALSE, ALWAYS_TRUE, AMBIGUOUS, ReachabilityConstraintsBuilder,
+        ScopedReachabilityConstraintId,
+    };
+    use crate::Truthiness;
+    use crate::predicate::ScopedPredicateId;
+
+    fn evaluate(
+        constraints: &ReachabilityConstraintsBuilder,
+        mut root: ScopedReachabilityConstraintId,
+        values: &[Truthiness],
+    ) -> Truthiness {
+        loop {
+            match root {
+                ALWAYS_TRUE => return Truthiness::AlwaysTrue,
+                AMBIGUOUS => return Truthiness::Ambiguous,
+                ALWAYS_FALSE => return Truthiness::AlwaysFalse,
+                _ => {
+                    let node = constraints.interiors[root];
+                    root = match values[node.atom.index()] {
+                        Truthiness::AlwaysTrue => node.if_true,
+                        Truthiness::Ambiguous => node.if_ambiguous,
+                        Truthiness::AlwaysFalse => node.if_false,
+                    };
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn boolean_gates_preserve_ambiguous_conditions() {
+        // Completion gates can precede or follow ordinary conditions in predicate order.
+        for condition_index in [0, 1] {
+            let mut constraints = ReachabilityConstraintsBuilder::default();
+            let condition = constraints.add_atom(ScopedPredicateId::new(condition_index));
+            let completion =
+                constraints.add_boolean_atom(ScopedPredicateId::new(1 - condition_index));
+            let positive = constraints.add_and_constraint(condition, completion);
+            let negative_condition = constraints.add_not_constraint(condition);
+            let negative = constraints.add_and_constraint(negative_condition, completion);
+            let merged = constraints.add_or_constraint(positive, negative);
+
+            for condition in [
+                Truthiness::AlwaysTrue,
+                Truthiness::Ambiguous,
+                Truthiness::AlwaysFalse,
+            ] {
+                for completion in [Truthiness::AlwaysTrue, Truthiness::AlwaysFalse] {
+                    let mut values = [completion; 2];
+                    values[condition_index] = condition;
+                    assert_eq!(
+                        evaluate(&constraints, positive, &values),
+                        condition.and(completion)
+                    );
+                    assert_eq!(
+                        evaluate(&constraints, negative, &values),
+                        condition.negate().and(completion)
+                    );
+                    assert_eq!(evaluate(&constraints, merged, &values), completion);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn completion_sequences_reuse_previous_graph() {
+        const COUNT: usize = 512;
+        let mut constraints = ReachabilityConstraintsBuilder::default();
+        let mut root = constraints.add_atom(ScopedPredicateId::new(0));
+        for index in 1..=COUNT {
+            let completion = constraints.add_boolean_atom(ScopedPredicateId::new(index));
+            root = constraints.add_and_constraint(root, completion);
+        }
+
+        // Each gate adds its atom and a gated root while sharing the preceding graph.
+        assert!(constraints.interiors.len() <= 2 * COUNT + 1);
     }
 }

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -3,10 +3,13 @@
 //! See [`crate::reachability_constraints`] for more details.
 
 use std::cmp::Ordering;
+use std::hash::BuildHasher;
 
+use hashbrown::hash_table::Entry;
 use ruff_index::{Idx, IndexVec};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
+use crate::constraint_cache::BinaryConstraintCache;
 use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
 use crate::predicate::ScopedPredicateId;
 use crate::rank::{RankBitBox, RankBitBoxVec};
@@ -172,26 +175,15 @@ impl ReachabilityConstraints {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct ReachabilityConstraintsBuilder {
     interiors: IndexVec<ScopedReachabilityConstraintId, InteriorNode>,
     interior_used: RankBitBoxVec,
-    interior_cache: FxHashMap<InteriorNode, ScopedReachabilityConstraintId>,
+    // Nodes are already stored in `interiors`; keep only their IDs in the reverse table.
+    interior_cache: hashbrown::HashTable<ScopedReachabilityConstraintId>,
     not_cache: FxHashMap<ScopedReachabilityConstraintId, ScopedReachabilityConstraintId>,
-    and_cache: FxHashMap<
-        (
-            ScopedReachabilityConstraintId,
-            ScopedReachabilityConstraintId,
-        ),
-        ScopedReachabilityConstraintId,
-    >,
-    or_cache: FxHashMap<
-        (
-            ScopedReachabilityConstraintId,
-            ScopedReachabilityConstraintId,
-        ),
-        ScopedReachabilityConstraintId,
-    >,
+    and_cache: BinaryConstraintCache<ScopedReachabilityConstraintId>,
+    or_cache: BinaryConstraintCache<ScopedReachabilityConstraintId>,
 }
 
 impl ReachabilityConstraintsBuilder {
@@ -351,10 +343,20 @@ impl ReachabilityConstraintsBuilder {
             return node.if_true;
         }
 
-        *self.interior_cache.entry(node).or_insert_with(|| {
-            self.interior_used.push(false);
-            self.interiors.push(node)
-        })
+        let interiors = &mut self.interiors;
+        match self.interior_cache.entry(
+            FxBuildHasher.hash_one(node),
+            |id| interiors[*id] == node,
+            |id| FxBuildHasher.hash_one(interiors[*id]),
+        ) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                self.interior_used.push(false);
+                let id = interiors.push(node);
+                entry.insert(id);
+                id
+            }
+        }
     }
 
     /// Adds a new reachability constraint that checks a single [`super::predicate::Predicate`].

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -985,6 +985,10 @@ impl<'db> UseDefMap<'db> {
         &self.constraint_tables().predicates
     }
 
+    pub fn predicate_narrowing_targets(&self) -> &PredicateNarrowingTargets {
+        &self.constraint_tables().predicate_narrowing_targets
+    }
+
     pub fn range_reachability(
         &self,
     ) -> impl Iterator<Item = (TextRange, ScopedReachabilityConstraintId)> + '_ {

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -2501,6 +2501,25 @@ impl<'db> UseDefMapBuilder<'db> {
         self.record_reachability_constraint_impl(reachability_constraint, narrowing_constraint);
     }
 
+    /// Like a statement call, evaluating a test can terminate execution without changing any
+    /// bindings. Its completion gate does not expose additional bindings to an exception handler
+    /// until control flow restores or merges another path.
+    pub(super) fn record_expression_completion_constraint(
+        &mut self,
+        reachability_constraint: ScopedReachabilityConstraintId,
+    ) {
+        if reachability_constraint == ScopedReachabilityConstraintId::ALWAYS_TRUE {
+            return;
+        }
+        let narrowing_constraint = if self.reachability_narrowing_enabled {
+            self.reachability_constraints
+                .narrowing_gate(reachability_constraint, &mut self.narrowing_constraints)
+        } else {
+            ScopedNarrowingConstraint::ALWAYS_TRUE
+        };
+        self.record_non_terminal_call_constraints(reachability_constraint, narrowing_constraint);
+    }
+
     fn record_reachability_constraint_impl(
         &mut self,
         reachability_constraint: ScopedReachabilityConstraintId,

--- a/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
+++ b/crates/ty_python_semantic/resources/mdtest/boolean/short_circuit.md
@@ -347,6 +347,26 @@ def aliased_operand(flag: bool, marker: int):
         reveal_type(marker)  # revealed: Never
 ```
 
+If the call is evaluated first, neither `and` nor `or` can reach a later operand. A conditional
+expression whose test never returns cannot select either branch. This also makes unrelated bindings
+unreachable within those operands and branches.
+
+```py
+def terminal_and(marker: int):
+    if stop() and reveal_type(marker):  # revealed: Never
+        pass
+
+def terminal_or(marker: int):
+    stop() or reveal_type(marker)  # revealed: Never
+
+def terminal_conditional(marker: int):
+    (
+        reveal_type(marker)  # revealed: Never
+        if stop()
+        else reveal_type(marker)  # revealed: Never
+    )
+```
+
 A union of aliases of `Never` still cannot produce a result.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -47,9 +47,7 @@ match {0 for _ in [0] if value} and (lambda: value) and [lambda: value for _ in 
     case captured:
         match captured:
             case []:
-                def value() -> captured:
-                    pass
-
+                value: captured = None
 ```
 
 ## Function signature

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -22,6 +22,36 @@ if not (lambda: f):  # error: [redundant-condition] "always truthy"
     f = 0
 ```
 
+## Comprehension elements depending on pattern bindings
+
+The lambdas in the match subject refer to a name rebound in the cases. Inferring their return types
+depends on the cases' reachability. Checking whether the subject completes must not require those
+return types or the comprehension's element type, since lambdas and comprehensions have inhabited
+types regardless.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+type value = int
+
+# error: [redundant-condition] "always truthy"
+match {0 for _ in [0] if value} and (lambda: value) and [lambda: value for _ in [0]]:
+    case unknown.member:  # error: [unresolved-reference]
+        pass
+    case []:
+        assert (0).missing  # error: [unresolved-attribute]
+        value = 0  # error: [invalid-assignment]
+    case captured:
+        match captured:
+            case []:
+                def value() -> captured:
+                    pass
+
+```
+
 ## Function signature
 
 Deferred annotations can result in cycles in resolving a function signature:

--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -934,6 +934,16 @@ def saved_condition(value: Comparable):
     return not (value < 1 < 0)  # no diagnostic
 ```
 
+When the chain is evaluated as a value inside a larger expression, its result can also be tested
+again before evaluating the next operand. That operand is reachable and is checked for redundancy.
+
+```py
+def value_operand(value: Comparable):
+    # error: [redundant-condition] "always truthy"
+    if bool((value < 1 < 0) and not "yes"):
+        pass
+```
+
 ## Conditional expressions used as conditions
 
 Using `a if flag else b` as a condition tests the truthiness of `a` when `flag` is true, or `b`
@@ -2704,6 +2714,166 @@ warning[redundant-condition]: An empty tuple is always falsy
   |
 6 |         case _ if empty and enabled:  # snapshot: redundant-condition
   |                   ^^^^^ Inferred type is `tuple[()]`
+```
+
+Unreachable operands do not take precedence over the complete condition. Once an earlier operand
+determines the outcome, replacing a later operand with a string literal does not hide the strict
+diagnostic.
+
+```py
+from typing import Literal
+
+def unreachable_operands(falsy: Literal[False], truthy: Literal[True], flag: bool):
+    if falsy and flag:  # error: [redundant-condition-strict] "Condition `falsy and flag` is always false"
+        pass
+    if falsy and "yes":  # error: [redundant-condition-strict] "Condition `falsy and "yes"` is always false"
+        pass
+    if truthy or flag:  # error: [redundant-condition-strict] "Condition `truthy or flag` is always true"
+        pass
+    if truthy or "":  # error: [redundant-condition-strict] "Condition `truthy or ""` is always true"
+        pass
+```
+
+The same applies to an unreachable branch of a conditional expression used as a condition.
+
+```py
+def unreachable_branches(falsy: Literal[False]):
+    if falsy if True else "yes":  # error: [redundant-condition-strict] "Condition `falsy if True else "yes"` is always false"
+        pass
+    if "yes" if False else falsy:  # error: [redundant-condition-strict] "Condition `"yes" if False else falsy` is always false"
+        pass
+```
+
+## Conditions containing expressions that never return
+
+An expression that never returns prevents later operands from being evaluated. Those operands cannot
+produce redundant-condition diagnostics, even when their inferred types have fixed truthiness. A
+conditional expression cannot select either branch if its test never returns.
+
+```py
+from typing import Never
+
+def die() -> Never:
+    raise RuntimeError
+
+def terminal_and():
+    if die() and "yes":  # no diagnostic
+        pass
+
+def terminal_or():
+    if die() or "":  # no diagnostic
+        pass
+
+def terminal_conditional():
+    if "yes" if die() else "no":  # no diagnostic
+        pass
+```
+
+A condition can still complete by short-circuiting before the call. The strict rule reports its
+fixed outcome, without reporting operands that cannot be evaluated.
+
+```py
+def short_circuit_and(flag: bool):
+    # error: [redundant-condition-strict] "Condition `flag and die() and "yes"` is always false"
+    if flag and die() and "yes":
+        pass
+
+def short_circuit_or(flag: bool):
+    # error: [redundant-condition-strict] "Condition `flag or die() or ""` is always true"
+    if flag or die() or "":
+        pass
+```
+
+Tests evaluated before the call are still checked, even when the complete condition cannot produce a
+result.
+
+```py
+def evaluated_operand():
+    if "yes" and die():  # error: [redundant-condition] "always truthy"
+        pass
+```
+
+The same evaluation order applies to independent tests inside call arguments. Neither `not`
+expression below is evaluated.
+
+```py
+def consume(value: object) -> bool:
+    return bool(value)
+
+def nested_boolean():
+    if consume(die() and not "yes"):  # no diagnostic
+        pass
+
+def nested_conditional():
+    if consume("yes" if die() else not "no"):  # no diagnostic
+        pass
+```
+
+A statement condition that never returns reaches neither outcome. Tests in the body, the `else`
+branch, and subsequent statements are unreachable.
+
+```py
+def statement_condition():
+    if die():
+        if "yes":  # no diagnostic
+            pass
+    else:
+        if "yes":  # no diagnostic
+            pass
+    if "yes":  # no diagnostic
+        pass
+
+def elif_condition(flag: bool):
+    if flag:
+        return
+    elif die():
+        if "yes":  # no diagnostic
+            pass
+    else:
+        if "yes":  # no diagnostic
+            pass
+
+def while_condition():
+    while die():
+        if "yes":  # no diagnostic
+            pass
+    else:
+        if "yes":  # no diagnostic
+            pass
+    if "yes":  # no diagnostic
+        pass
+```
+
+An assertion's message is not evaluated when its test never returns. A terminal match guard cannot
+select its case or proceed to a later case after the pattern matches.
+
+```py
+def assertion_condition():
+    assert die(), not "yes"  # no diagnostic
+    if "yes":  # no diagnostic
+        pass
+
+def match_condition(value: object):
+    match value:
+        case _ if die():
+            if "yes":  # no diagnostic
+                pass
+        case _:
+            if "yes":  # no diagnostic
+                pass
+```
+
+A terminal comprehension filter prevents later filters and the element expression from being
+evaluated. Negation also requires its operand to return, including when `not` produces a value.
+
+```py
+def comprehension_condition():
+    [not "yes" for _ in [1] if die() if not "yes"]  # no diagnostic
+
+def negated_condition():
+    not die()
+    if "yes":  # no diagnostic
+        pass
 ```
 
 ## Boolean tests inside value expressions

--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -2751,7 +2751,7 @@ produce redundant-condition diagnostics, even when their inferred types have fix
 conditional expression cannot select either branch if its test never returns.
 
 ```py
-from typing import Never
+from typing import Callable, Never
 
 def die() -> Never:
     raise RuntimeError
@@ -2809,12 +2809,13 @@ def nested_conditional():
         pass
 ```
 
-A statement condition that never returns reaches neither outcome. Tests in the body, the `else`
-branch, and subsequent statements are unreachable.
+A statement condition that never returns reaches neither outcome, including when the callable
+shadows the builtin `bool`. Tests in the body, the `else` branch, and subsequent statements are
+unreachable.
 
 ```py
-def statement_condition():
-    if die():
+def statement_condition(bool: Callable[[], Never]):
+    if bool():
         if "yes":  # no diagnostic
             pass
     else:

--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -2810,8 +2810,8 @@ def nested_conditional():
 ```
 
 A statement condition that never returns reaches neither outcome, including when the callable
-shadows the builtin `bool`. Tests in the body, the `else` branch, and subsequent statements are
-unreachable.
+shadows a builtin such as `bool` or `len`. Tests in the body, the `else` branch, and subsequent
+statements are unreachable.
 
 ```py
 def statement_condition(bool: Callable[[], Never]):
@@ -2834,8 +2834,8 @@ def elif_condition(flag: bool):
         if "yes":  # no diagnostic
             pass
 
-def while_condition():
-    while die():
+def while_condition(len: Callable[[], Never]):
+    while len():
         if "yes":  # no diagnostic
             pass
     else:

--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -2810,7 +2810,7 @@ def nested_conditional():
 ```
 
 A statement condition that never returns reaches neither outcome, including when the callable
-shadows a builtin such as `bool` or `len`. Tests in the body, the `else` branch, and subsequent
+shadows a builtin such as `bool` or `any`. Tests in the body, the `else` branch, and subsequent
 statements are unreachable.
 
 ```py
@@ -2834,8 +2834,8 @@ def elif_condition(flag: bool):
         if "yes":  # no diagnostic
             pass
 
-def while_condition(len: Callable[[], Never]):
-    while len():
+def while_condition(any: Callable[[], Never]):
+    while any():
         if "yes":  # no diagnostic
             pass
     else:

--- a/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
+++ b/crates/ty_python_semantic/resources/mdtest/terminal_statements.md
@@ -1000,8 +1000,6 @@ import sys
 def _() -> NoReturn:
     3 + sys.exit(1)
 
-# TODO: this is currently not yet supported
-# error: [invalid-return-type]
 def _() -> NoReturn:
     3 if sys.exit(1) else 4
 ```

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1850,6 +1850,7 @@ fn place_from_bindings_impl<'db>(
                             binding.place(db),
                             binding_ty,
                         )
+                        .with_reachability_cache(reachability_cache)
                     })
                     .narrow(constraint, binding_ty),
             };

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -91,10 +91,34 @@ use ty_python_core::scope::{NodeWithScopeKind, ScopeId, ScopeKind};
 use ty_python_core::symbol::{ScopedSymbolId, Symbol};
 use ty_python_core::{
     AncestorsIter, BindingWithConstraintsIterator, BindingsSnapshotId, EnclosingSnapshotResult,
-    FileScopeId, ProgramFile, SemanticIndex,
+    FileScopeId, ProgramFile, SemanticIndex, semantic_index,
 };
 
-use crate::Db;
+use crate::place::{builtins_module_scope, implicit_builtins_symbol_scope};
+use crate::{Db, ProgramEnvironment};
+
+/// Returns whether a name is supplied by standard builtins without resolving individual uses.
+/// Any visible binding or declaration, including project-level builtins, prevents this shortcut.
+pub(crate) fn definitely_has_builtin_binding(db: &dyn Db, scope: ScopeId<'_>, name: &str) -> bool {
+    let index = semantic_index(db, scope.program_file(db));
+    if index
+        .visible_ancestor_scopes(scope.file_scope_id(db))
+        .any(|(scope, _)| {
+            index
+                .place_table(scope)
+                .symbol_id(name)
+                .is_some_and(|symbol| {
+                    let symbol = index.place_table(scope).symbol(symbol);
+                    symbol.is_bound() || symbol.is_declared()
+                })
+        })
+    {
+        return false;
+    }
+    let env = ProgramEnvironment::from_scope(scope);
+    implicit_builtins_symbol_scope(db, &env, name)
+        .is_some_and(|scope| Some(scope) == builtins_module_scope(db, &env))
+}
 
 /// Returns an iterator over the steps that resolve a value for a place load.
 pub(crate) fn resolve_place_load<'db, 'ast>(

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -194,7 +194,7 @@
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
 use crate::ProgramEnvironment;
-use std::cell::{OnceCell, RefCell};
+use std::cell::RefCell;
 
 use crate::{
     Db,
@@ -547,7 +547,6 @@ const CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL: usize = 16;
 const NARROWING_EVALUATION_CHECKPOINT_INTERVAL: usize = 8;
 
 type ReachabilityCacheEntries = RefCell<Vec<Option<Truthiness>>>;
-type PredicateCacheEntries = RefCell<FxHashMap<(usize, ScopedPredicateId), Truthiness>>;
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression)
@@ -591,7 +590,9 @@ fn analyze_completion_prefix<'db>(
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) -> bool {
-    if predicates.len() <= COMPLETION_PREDICATE_PREFIX_THRESHOLD {
+    // Only predicates up to this root can contribute to its completion prefix. Earlier roots
+    // stay below the stack-depth bound even when the rest of the scope contains many predicates.
+    if root_predicate.index() < COMPLETION_PREDICATE_PREFIX_THRESHOLD {
         return false;
     }
     let scope = predicate_scope(db, &predicates[root_predicate]);
@@ -2186,8 +2187,7 @@ pub(crate) struct ReachabilityEvaluationCache<'db> {
     primary_constraints: usize,
     primary_entries: ReachabilityCacheEntries,
     other_entries: RefCell<FxHashMap<(usize, ScopedReachabilityConstraintId), Truthiness>>,
-    // Allocate this separately so regions that never evaluate a predicate keep a small cache object.
-    predicate_entries: OnceCell<Box<PredicateCacheEntries>>,
+    predicate_entries: RefCell<FxHashMap<(usize, ScopedPredicateId), Truthiness>>,
 }
 
 impl<'db> ReachabilityEvaluationCache<'db> {
@@ -2205,7 +2205,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             primary_constraints: std::ptr::from_ref(primary_constraints).addr(),
             primary_entries: RefCell::new(Vec::new()),
             other_entries: RefCell::new(FxHashMap::default()),
-            predicate_entries: OnceCell::new(),
+            predicate_entries: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -2220,14 +2220,11 @@ impl<'db> ReachabilityEvaluationCache<'db> {
     ) -> Truthiness {
         debug_assert_eq!(env.program(db), self.primary_scope.program(db));
         let key = (predicates.raw.as_ptr().addr(), id);
-        let entries = self
-            .predicate_entries
-            .get_or_init(|| Box::new(RefCell::new(FxHashMap::default())));
-        if let Some(result) = entries.borrow().get(&key).copied() {
+        if let Some(result) = self.predicate_entries.borrow().get(&key).copied() {
             return result;
         }
         let result = analyze_single(db, env, &predicates[id]);
-        entries.borrow_mut().insert(key, result);
+        self.predicate_entries.borrow_mut().insert(key, result);
         result
     }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -530,23 +530,21 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
 /// AND a new optional narrowing constraint with an accumulated one.
 fn accumulate_constraint<'db>(
     accumulated: Option<NarrowingConstraint<'db>>,
-    new: Option<NarrowingConstraint<'db>>,
+    new: Option<&NarrowingConstraint<'db>>,
 ) -> Option<NarrowingConstraint<'db>> {
     match (accumulated, new) {
         (Some(acc), Some(new_c)) => Some(new_c.merge_constraint_and(acc)),
-        (None, Some(new_c)) => Some(new_c),
+        (None, Some(new_c)) => Some(new_c.clone()),
         (Some(acc), None) => Some(acc),
         (None, None) => None,
     }
 }
 
 const COMPLETION_PREDICATE_CHUNK_SIZE: usize = 16;
-const COMPLETION_PREDICATE_PREFIX_THRESHOLD: usize = 256;
+const COMPLETION_PREDICATE_PREFIX_THRESHOLD: usize = 128;
 const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
 const CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL: usize = 16;
 const NARROWING_EVALUATION_CHECKPOINT_INTERVAL: usize = 8;
-const SMALL_SCOPE_NARROWING_CHECKPOINT_INTERVAL: usize = 16;
-const SMALL_SCOPE_NARROWING_PREDICATE_THRESHOLD: usize = 256;
 
 type ReachabilityCacheEntries = RefCell<Vec<Option<Truthiness>>>;
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
@@ -694,7 +692,7 @@ fn evaluate_reachability_constraint<'db>(
     constraints: &ReachabilityConstraints,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     id: ScopedReachabilityConstraintId,
-    cache: Option<&ReachabilityCacheEntries>,
+    cache: Option<&ReachabilityEvaluationCache<'db>>,
 ) -> Truthiness {
     if let Some(reachability) = terminal_reachability(id) {
         return reachability;
@@ -709,8 +707,9 @@ fn evaluate_reachability_constraint<'db>(
         constraints,
         predicates,
         completion_predicates,
+        predicate_cache: cache,
     }
-    .evaluate(db, id, true, cache)
+    .evaluate(db, id, true, cache.map(|cache| &cache.primary_entries))
 }
 
 /// Evaluates the normal continuation captured by a deferred `finally` predicate.
@@ -782,9 +781,10 @@ struct ReachabilityEvaluator<'a, 'db> {
     constraints: &'a ReachabilityConstraints,
     predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
     completion_predicates: Option<&'a [ScopedPredicateId]>,
+    predicate_cache: Option<&'a ReachabilityEvaluationCache<'db>>,
 }
 
-impl ReachabilityEvaluator<'_, '_> {
+impl<'db> ReachabilityEvaluator<'_, 'db> {
     /// Walks a decision diagram until it reaches a terminal or reusable checkpoint.
     ///
     /// `use_checkpoint` is false only when entering from a checkpoint query. In that case, the
@@ -795,7 +795,7 @@ impl ReachabilityEvaluator<'_, '_> {
     /// queries for short, ordinary paths.
     fn evaluate(
         &self,
-        db: &dyn Db,
+        db: &'db dyn Db,
         mut id: ScopedReachabilityConstraintId,
         mut use_checkpoint: bool,
         cache: Option<&ReachabilityCacheEntries>,
@@ -824,7 +824,11 @@ impl ReachabilityEvaluator<'_, '_> {
                 break evaluate_reachability_checkpoint(db, self.scope, id);
             }
 
-            id = match analyze_single(db, &env, &self.predicates[node.atom()]) {
+            let truthiness = match self.predicate_cache {
+                Some(cache) => cache.analyze_predicate(db, &env, self.predicates, node.atom()),
+                None => analyze_single(db, &env, &self.predicates[node.atom()]),
+            };
+            id = match truthiness {
                 Truthiness::AlwaysTrue => node.if_true(),
                 Truthiness::Ambiguous => node.if_ambiguous(),
                 Truthiness::AlwaysFalse => node.if_false(),
@@ -875,6 +879,7 @@ fn evaluate_reachability_checkpoint<'db>(
         constraints: use_def.reachability_constraints(),
         predicates,
         completion_predicates,
+        predicate_cache: None,
     }
     .evaluate(db, id, false, None)
 }
@@ -908,6 +913,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             constraints: self,
             predicates,
             completion_predicates: None,
+            predicate_cache: None,
         }
         .evaluate(db, id, true, None)
     }
@@ -1095,6 +1101,7 @@ pub(crate) struct NarrowingProjector<'a, 'db> {
     predicate_narrowing_targets: &'a PredicateNarrowingTargets,
     place: ScopedPlaceId,
     base_ty: Type<'db>,
+    predicate_cache: Option<&'a ReachabilityEvaluationCache<'db>>,
     /// Checkpoint entries retain narrowed types, so projections are specific to the binding type.
     /// Keep the current binding's type outside the per-node keys, and retain the other caches
     /// for reuse when another binding has a previously encountered type.
@@ -1124,11 +1131,21 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             predicate_narrowing_targets,
             place,
             base_ty,
+            predicate_cache: None,
             project_cache: FxHashMap::default(),
             other_project_caches: FxHashMap::default(),
             graph: ProjectedNarrowingGraph::default(),
             narrowed_cache: FxHashMap::default(),
         }
+    }
+
+    /// Shares predicate evaluations with reachability checks in the same inference region.
+    pub(crate) fn with_reachability_cache(
+        mut self,
+        cache: Option<&'a ReachabilityEvaluationCache<'db>>,
+    ) -> Self {
+        self.predicate_cache = cache;
+        self
     }
 
     /// Narrows a binding while reusing projections and shared suffixes from earlier bindings.
@@ -1195,32 +1212,23 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         narrowed
     }
 
-    /// Returns the cached positive and negative narrowing constraints for a predicate.
-    fn predicate_constraints(
-        &mut self,
-        predicate_id: ScopedPredicateId,
-    ) -> (
-        Option<NarrowingConstraint<'db>>,
-        Option<NarrowingConstraint<'db>>,
-    ) {
+    /// Caches a predicate's narrowing constraints and reports whether either polarity narrows this place.
+    fn predicate_has_constraints(&mut self, predicate_id: ScopedPredicateId) -> bool {
         if !self
             .predicate_narrowing_targets
             .contains(predicate_id, self.place)
         {
-            return (None, None);
+            return false;
         }
 
-        let db = self.db;
-        if let Some(cached) = self.graph.predicate_constraints_cache.get(&predicate_id) {
-            return cached.clone();
-        }
-
-        let constraints =
-            infer_narrowing_constraints(db, self.predicates[predicate_id], self.place);
-        self.graph
+        let (positive, negative) = self
+            .graph
             .predicate_constraints_cache
-            .insert(predicate_id, constraints.clone());
-        constraints
+            .entry(predicate_id)
+            .or_insert_with(|| {
+                infer_narrowing_constraints(self.db, self.predicates[predicate_id], self.place)
+            });
+        positive.is_some() || negative.is_some()
     }
 
     /// Interns a projected node, collapsing nodes with identical branches.
@@ -1395,9 +1403,6 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             FinishPredicate(Id),
         }
         let db = self.db;
-        // Smaller scopes need fewer checkpoints to bound repeated work. Avoid allocating
-        // a Salsa query for every short suffix while retaining denser reuse in large scopes.
-        let small_scope = self.predicates.len() <= SMALL_SCOPE_NARROWING_PREDICATE_THRESHOLD;
 
         let mut actions = SmallVec::<[Action; 8]>::new();
         actions.push(Action::Visit(root));
@@ -1412,18 +1417,14 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
                     let index = node.atom.index();
-                    let at_checkpoint = if small_scope {
-                        let position = index ^ (index / SMALL_SCOPE_NARROWING_CHECKPOINT_INTERVAL);
-                        (position + 1).is_multiple_of(SMALL_SCOPE_NARROWING_CHECKPOINT_INTERVAL)
-                    } else {
-                        let position = index ^ (index / NARROWING_EVALUATION_CHECKPOINT_INTERVAL);
-                        (position + 1).is_multiple_of(NARROWING_EVALUATION_CHECKPOINT_INTERVAL)
-                    };
+                    let checkpoint_position =
+                        index ^ (index / NARROWING_EVALUATION_CHECKPOINT_INTERVAL);
                     // Completion gates can depend on earlier narrowed uses without narrowing
                     // this place themselves. Checkpoints keep those inference dependencies from
                     // being copied into every later expression in a long chain.
                     if (id != root || use_root_checkpoint)
-                        && at_checkpoint
+                        && (checkpoint_position + 1)
+                            .is_multiple_of(NARROWING_EVALUATION_CHECKPOINT_INTERVAL)
                         && (self
                             .predicate_narrowing_targets
                             .contains(node.atom, self.place)
@@ -1482,8 +1483,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 }
                 Action::AnalyzeNonTerminal(id) => {
                     let node = self.constraints.get_interior_node(id);
-                    let predicate = self.predicates[node.atom];
-                    let branch = match analyze_single(db, self.env, &predicate) {
+                    let branch = match self.predicate_truthiness(node.atom) {
                         Truthiness::AlwaysTrue => node.if_true,
                         Truthiness::AlwaysFalse => node.if_false,
                         Truthiness::Ambiguous => {
@@ -1508,13 +1508,11 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let if_true = self.projected_node(node.if_true);
                     let if_uncertain = self.projected_node(node.if_uncertain);
                     let if_false = self.projected_node(node.if_false);
-                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
-
-                    let projected = if pos_constraint.is_none() && neg_constraint.is_none() {
+                    let projected = if !self.predicate_has_constraints(node.atom) {
                         // This node represents `if_uncertain || (P && if_true) || (!P && if_false)`.
                         // Since the predicate `P` cannot narrow this place, remove it while retaining only branches that `P` can take.
                         // Including a statically unreachable branch could erase narrowing from the reachable branch.
-                        match analyze_single(self.db, self.env, &self.predicates[node.atom]) {
+                        match self.predicate_truthiness(node.atom) {
                             Truthiness::AlwaysTrue => self.or(if_true, if_uncertain),
                             Truthiness::AlwaysFalse => self.or(if_false, if_uncertain),
                             Truthiness::Ambiguous => {
@@ -1543,6 +1541,13 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             ScopedNarrowingConstraint::ALWAYS_TRUE => ProjectedNarrowingNodeId::ALWAYS_TRUE,
             ScopedNarrowingConstraint::ALWAYS_FALSE => ProjectedNarrowingNodeId::ALWAYS_FALSE,
             _ => self.project_cache[&id],
+        }
+    }
+
+    fn predicate_truthiness(&self, id: ScopedPredicateId) -> Truthiness {
+        match self.predicate_cache {
+            Some(cache) => cache.analyze_predicate(self.db, self.env, self.predicates, id),
+            None => analyze_single(self.db, self.env, &self.predicates[id]),
         }
     }
 }
@@ -1612,25 +1617,26 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
                 }
             };
             let (pos_constraint, neg_constraint) =
-                self.graph.predicate_constraints_cache[&node.atom].clone();
+                &self.graph.predicate_constraints_cache[&node.atom];
 
             if node.if_true == ProjectedNarrowingNodeId::ALWAYS_FALSE
                 && node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_FALSE
             {
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint.as_ref());
                 self.narrow(node.if_false, false_accumulated)
             } else if node.if_false == ProjectedNarrowingNodeId::ALWAYS_FALSE
                 && node.if_uncertain == ProjectedNarrowingNodeId::ALWAYS_FALSE
             {
-                let true_accumulated = accumulate_constraint(accumulated, pos_constraint);
+                let true_accumulated = accumulate_constraint(accumulated, pos_constraint.as_ref());
                 self.narrow(node.if_true, true_accumulated)
             } else {
-                let true_accumulated = accumulate_constraint(accumulated.clone(), pos_constraint);
+                let true_accumulated =
+                    accumulate_constraint(accumulated.clone(), pos_constraint.as_ref());
                 let true_ty = self.narrow(node.if_true, true_accumulated);
 
                 let uncertain_ty = self.narrow(node.if_uncertain, accumulated.clone());
 
-                let false_accumulated = accumulate_constraint(accumulated, neg_constraint);
+                let false_accumulated = accumulate_constraint(accumulated, neg_constraint.as_ref());
                 let false_ty = self.narrow(node.if_false, false_accumulated);
 
                 let true_or_uncertain =
@@ -2179,6 +2185,7 @@ pub(crate) struct ReachabilityEvaluationCache<'db> {
     primary_constraints: usize,
     primary_entries: ReachabilityCacheEntries,
     other_entries: RefCell<FxHashMap<(usize, ScopedReachabilityConstraintId), Truthiness>>,
+    predicate_entries: RefCell<FxHashMap<(usize, ScopedPredicateId), Truthiness>>,
 }
 
 impl<'db> ReachabilityEvaluationCache<'db> {
@@ -2196,7 +2203,27 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             primary_constraints: std::ptr::from_ref(primary_constraints).addr(),
             primary_entries: RefCell::new(Vec::new()),
             other_entries: RefCell::new(FxHashMap::default()),
+            predicate_entries: RefCell::new(FxHashMap::default()),
         }
+    }
+
+    /// Reuses predicate truthiness across reachability paths and narrowing projections.
+    /// The predicate table's address distinguishes IDs from different use-def maps.
+    fn analyze_predicate(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+        id: ScopedPredicateId,
+    ) -> Truthiness {
+        debug_assert_eq!(env.program(db), self.primary_scope.program(db));
+        let key = (predicates.raw.as_ptr().addr(), id);
+        if let Some(result) = self.predicate_entries.borrow().get(&key).copied() {
+            return result;
+        }
+        let result = analyze_single(db, env, &predicates[id]);
+        self.predicate_entries.borrow_mut().insert(key, result);
+        result
     }
 
     /// Evaluates `id`, reusing a cached result when possible.
@@ -2235,7 +2262,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
                 constraints,
                 predicates,
                 id,
-                Some(&self.primary_entries),
+                Some(self),
             );
         }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -553,10 +553,7 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
         | PredicateNode::ChainedComparisonCondition(expression)
         | PredicateNode::ContextManagerSuppresses { expression, .. }
         | PredicateNode::ExpressionCanComplete { expression, .. } => expression.scope(db),
-        PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. })
-        | PredicateNode::CallCanComplete(CallableAndCallExpr { callable, .. }) => {
-            callable.scope(db)
-        }
+        PredicateNode::IsNonTerminalCall(call) => call.callable(db).scope(db),
         PredicateNode::Pattern(pattern) => pattern.scope(db),
         PredicateNode::FinallyNormalPathImpossible { scope, .. } => scope,
         PredicateNode::OrPatternAlternative(scope) => scope,
@@ -591,22 +588,13 @@ fn analyze_completion_prefix<'db>(
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) -> bool {
-    // A complete block needs at least this many preceding predicates, even if all of them
-    // concern completion. Short scopes cannot require the cached index either.
-    if predicates.len() <= COMPLETION_PREDICATE_CHUNK_SIZE
-        || root_predicate.index() + 1 < COMPLETION_PREDICATE_CHUNK_SIZE
-    {
-        return false;
-    }
     let scope = predicate_scope(db, &predicates[root_predicate]);
     let has_many_completions = predicates
         .iter()
         .filter(|predicate| {
             matches!(
                 predicate.node,
-                PredicateNode::IsNonTerminalCall(_)
-                    | PredicateNode::ExpressionCanComplete { .. }
-                    | PredicateNode::CallCanComplete(_)
+                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
             )
         })
         .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
@@ -646,9 +634,7 @@ fn completion_predicates<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Box<[Scop
         .filter_map(|(id, predicate)| {
             matches!(
                 predicate.node,
-                PredicateNode::IsNonTerminalCall(_)
-                    | PredicateNode::ExpressionCanComplete { .. }
-                    | PredicateNode::CallCanComplete(_)
+                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
             )
             .then_some(id)
         })
@@ -883,9 +869,7 @@ fn evaluate_reachability_checkpoint<'db>(
         .filter(|predicate| {
             matches!(
                 predicate.node,
-                PredicateNode::IsNonTerminalCall(_)
-                    | PredicateNode::ExpressionCanComplete { .. }
-                    | PredicateNode::CallCanComplete(_)
+                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
             )
         })
         .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
@@ -1431,7 +1415,6 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             || matches!(
                                 predicate.node,
                                 PredicateNode::ExpressionCanComplete { .. }
-                                    | PredicateNode::CallCanComplete(_)
                                     | PredicateNode::ContextManagerSuppresses { .. }
                                     | PredicateNode::FinallyNormalPathImpossible { .. }
                             ))
@@ -1468,7 +1451,6 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         predicate.node,
                         PredicateNode::IsNonTerminalCall(_)
                             | PredicateNode::ExpressionCanComplete { .. }
-                            | PredicateNode::CallCanComplete(_)
                             | PredicateNode::ContextManagerSuppresses { .. }
                             | PredicateNode::FinallyNormalPathImpossible { .. }
                     );
@@ -1798,8 +1780,8 @@ fn analyze_single_pattern_predicate_kind<'db>(
 /// dependency cannot make subsequent code unreachable.
 #[salsa::tracked(
     returns(copy),
-    cycle_initial = |_, _, _, _, _| Truthiness::AlwaysTrue,
-    cycle_fn = |_, cycle: &salsa::Cycle, previous: &Truthiness, result: Truthiness, _, _, _| {
+    cycle_initial = |_, _, _| Truthiness::AlwaysTrue,
+    cycle_fn = |_, cycle: &salsa::Cycle, previous: &Truthiness, result: Truthiness, _| {
         // A call can determine whether its own target is reachable, as with `sys.exit()` before
         // `import sys` in a loop. Expression inference can lose its previous result when it stops
         // being a cycle head, so widen the predicate itself to ensure convergence. Delay widening
@@ -1812,12 +1794,8 @@ fn analyze_single_pattern_predicate_kind<'db>(
     },
     heap_size = get_size2::GetSize::get_heap_size
 )]
-fn analyze_non_terminal_call<'db>(
-    db: &'db dyn Db,
-    callable: Expression<'db>,
-    call_expr: Expression<'db>,
-    is_await: bool,
-) -> Truthiness {
+fn analyze_non_terminal_call<'db>(db: &'db dyn Db, call: CallableAndCallExpr<'db>) -> Truthiness {
+    let callable = call.callable(db);
     let env = ProgramEnvironment::from_scope(callable.scope(db));
     // We first infer just the type of the callable. In the most likely case that the function is
     // not marked with `NoReturn`, or that it always returns `NoReturn`, doing so allows us to avoid
@@ -1827,8 +1805,8 @@ fn analyze_non_terminal_call<'db>(
     // add them on all statement-level function calls.
     let ty = infer_same_file_expression_type(db, callable, TypeContext::default());
 
-    is_non_terminal_call(db, &env, ty, is_await, || {
-        infer_same_file_expression_type(db, call_expr, TypeContext::default())
+    is_non_terminal_call(db, &env, ty, call.is_await(db), || {
+        infer_same_file_expression_type(db, call.call_expr(db), TypeContext::default())
     })
 }
 
@@ -1841,29 +1819,23 @@ pub(crate) fn is_non_terminal_call<'db>(
     is_await: bool,
     call_type: impl FnOnce() -> Type<'db>,
 ) -> Truthiness {
-    try_is_non_terminal_call(db, env, ty, is_await, call_type).unwrap_or(Truthiness::AlwaysTrue)
-}
-
-fn try_is_non_terminal_call<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    ty: Type<'db>,
-    is_await: bool,
-    call_type: impl FnOnce() -> Type<'db>,
-) -> Option<Truthiness> {
     // Short-circuit for well-known types that are known not to return `Never` when called. Without
     // the short-circuit, we've seen that threads keep blocking each other because they all try to
     // acquire Salsa's `CallableType` lock that ensures each type is only interned once. The lock is
     // so heavily congested because there are only very few dynamic types, in which case Salsa's
     // sharding the locks by value doesn't help much. See <https://github.com/astral-sh/ty/issues/968>.
     if matches!(ty, Type::Dynamic(_)) {
-        return Some(Truthiness::AlwaysTrue);
+        return Truthiness::AlwaysTrue;
     }
 
-    let callable = ty
+    let overloads_iterator = if let Some(callable) = ty
         .try_upcast_to_callable(db, env)
-        .and_then(CallableTypes::exactly_one)?;
-    let overloads_iterator = callable.signatures(db).overloads.iter();
+        .and_then(CallableTypes::exactly_one)
+    {
+        callable.signatures(db).overloads.iter()
+    } else {
+        return Truthiness::AlwaysTrue;
+    };
 
     let mut no_overloads_return_never = true;
     let mut all_overloads_return_never = true;
@@ -1877,11 +1849,11 @@ fn try_is_non_terminal_call<'db>(
     }
 
     if no_overloads_return_never && !any_overload_is_generic && !is_await {
-        Some(Truthiness::AlwaysTrue)
+        Truthiness::AlwaysTrue
     } else if all_overloads_return_never || call_type().is_equivalent_to(db, env, Type::Never) {
-        Some(Truthiness::AlwaysFalse)
+        Truthiness::AlwaysFalse
     } else {
-        Some(Truthiness::AlwaysTrue)
+        Truthiness::AlwaysTrue
     }
 }
 
@@ -1896,11 +1868,25 @@ fn analyze_non_empty_iterable(db: &dyn Db, iterable: Expression) -> Truthiness {
 
 /// Cache the whole predicate so repeated reachability walks can reuse one query result
 /// instead of looking up the expression's type and suppression behavior separately.
+/// Separate sync and async queries use the expression directly as their Salsa key.
 #[salsa::tracked(
     returns(copy),
-    cycle_initial = |_, _, _, _| false,
+    cycle_initial = |_, _, _| false,
     heap_size = get_size2::GetSize::get_heap_size
 )]
+fn sync_context_manager_suppresses<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
+    context_manager_suppresses(db, expression, false)
+}
+
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _| false,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn async_context_manager_suppresses<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
+    context_manager_suppresses(db, expression, true)
+}
+
 fn context_manager_suppresses<'db>(
     db: &'db dyn Db,
     expression: Expression<'db>,
@@ -2018,33 +2004,6 @@ fn expression_value_can_complete<'db>(db: &'db dyn Db, expression: Expression<'d
     )
 }
 
-#[salsa::tracked(
-    returns(copy),
-    cycle_initial = |_, _, _, _, _| true,
-    cycle_fn = |_, cycle: &salsa::Cycle, previous: &bool, result: bool, _, _, _| {
-        if cycle.iteration() > crate::TAINTED_CYCLES {
-            *previous || result
-        } else {
-            result
-        }
-    },
-    heap_size = get_size2::GetSize::get_heap_size
-)]
-fn expression_call_can_complete<'db>(
-    db: &'db dyn Db,
-    callable: Expression<'db>,
-    expression: Expression<'db>,
-    is_await: bool,
-) -> bool {
-    let env = ProgramEnvironment::from_scope(callable.scope(db));
-    let callable_type = infer_same_file_expression_type(db, callable, TypeContext::default());
-    let call_type = || infer_same_file_expression_type(db, expression, TypeContext::default());
-    try_is_non_terminal_call(db, &env, callable_type, is_await, call_type).map_or_else(
-        || !call_type().is_equivalent_to(db, &env, Type::Never),
-        Truthiness::is_always_true,
-    )
-}
-
 fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predicate) -> Truthiness {
     let _span = tracing::trace_span!("analyze_single", ?predicate).entered();
 
@@ -2065,13 +2024,6 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
             ExpressionContext::Value => expression_value_can_complete(db, expression),
         })
         .negate_if(!predicate.is_positive),
-        PredicateNode::CallCanComplete(call) => Truthiness::from(expression_call_can_complete(
-            db,
-            call.callable,
-            call.call_expr,
-            call.is_await,
-        ))
-        .negate_if(!predicate.is_positive),
         PredicateNode::ChainedComparisonCondition(test_expr) => {
             let inference = infer_expression_types(db, test_expr, TypeContext::default());
             let expression = test_expr.node_ref(db);
@@ -2083,8 +2035,12 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
         PredicateNode::ContextManagerSuppresses {
             expression,
             is_async,
-        } => Truthiness::from(context_manager_suppresses(db, expression, is_async))
-            .negate_if(!predicate.is_positive),
+        } => Truthiness::from(if is_async {
+            async_context_manager_suppresses(db, expression)
+        } else {
+            sync_context_manager_suppresses(db, expression)
+        })
+        .negate_if(!predicate.is_positive),
         PredicateNode::FinallyNormalPathImpossible {
             scope,
             continuation,
@@ -2092,12 +2048,9 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
             evaluate_finally_continuation(db, scope, continuation).is_always_false(),
         )
         .negate_if(!predicate.is_positive),
-        PredicateNode::IsNonTerminalCall(CallableAndCallExpr {
-            callable,
-            call_expr,
-            is_await,
-        }) => analyze_non_terminal_call(db, callable, call_expr, is_await)
-            .negate_if(!predicate.is_positive),
+        PredicateNode::IsNonTerminalCall(call) => {
+            analyze_non_terminal_call(db, call).negate_if(!predicate.is_positive)
+        }
         PredicateNode::Pattern(inner) => analyze_pattern_predicate(db, inner),
         PredicateNode::OrPatternAlternative(_) => Truthiness::Ambiguous,
         PredicateNode::SubjectElementPattern(subject_element) => {
@@ -2228,9 +2181,10 @@ impl<'db> ReachabilityEvaluationCache<'db> {
 
     /// Evaluates `id`, reusing a cached result when possible.
     ///
-    /// Trivial constraint ids return immediately and are not stored. The primary graph's identity
-    /// already determines its scope, so cache hits need no predicate or scope lookup. Other
-    /// constraints are cached by graph identity and id.
+    /// Trivial constraint ids return immediately and are not stored. For interior nodes, the
+    /// predicate determines whether the constraint belongs to the primary scope. A primary-scope
+    /// constraint from the primary graph is cached by dense index; all other constraints are cached
+    /// by graph identity and id.
     fn evaluate(
         &self,
         db: &'db dyn Db,
@@ -2245,16 +2199,16 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             _ => {}
         }
 
+        let predicate = predicates[constraints.get_interior_node(id).atom()];
         let constraints_key = std::ptr::from_ref(constraints).addr();
+        let scope = predicate_scope(db, &predicate);
 
-        if constraints_key != self.primary_constraints {
+        if scope != self.primary_scope || constraints_key != self.primary_constraints {
             let key = (constraints_key, id);
             if let Some(result) = self.other_entries.borrow().get(&key).copied() {
                 return result;
             }
 
-            let predicate = predicates[constraints.get_interior_node(id).atom()];
-            let scope = predicate_scope(db, &predicate);
             let result = evaluate_reachability_constraint(db, scope, id, None);
             self.other_entries.borrow_mut().insert(key, result);
             return result;

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -544,6 +544,8 @@ const COMPLETION_PREDICATE_CHUNK_SIZE: usize = 16;
 const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
 const CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL: usize = 16;
 const NARROWING_EVALUATION_CHECKPOINT_INTERVAL: usize = 8;
+
+type ReachabilityCacheEntries = RefCell<Vec<Option<Truthiness>>>;
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression)
@@ -696,6 +698,7 @@ fn evaluate_reachability_constraint<'db>(
     db: &'db dyn Db,
     scope: ScopeId<'db>,
     id: ScopedReachabilityConstraintId,
+    cache: Option<&ReachabilityCacheEntries>,
 ) -> Truthiness {
     if let Some(reachability) = terminal_reachability(id) {
         return reachability;
@@ -708,15 +711,13 @@ fn evaluate_reachability_constraint<'db>(
     let has_many_completions = analyze_completion_prefix(db, predicates, root_predicate);
     let completion_predicates = has_many_completions.then(|| completion_predicates(db, scope));
 
-    evaluate_reachability_path(
-        db,
+    ReachabilityEvaluator {
         scope,
         constraints,
         predicates,
         completion_predicates,
-        id,
-        true,
-    )
+    }
+    .evaluate(db, id, true, cache)
 }
 
 /// Evaluates the normal continuation captured by a deferred `finally` predicate.
@@ -740,7 +741,7 @@ fn evaluate_finally_continuation<'db>(
     scope: ScopeId<'db>,
     continuation: ScopedReachabilityConstraintId,
 ) -> Truthiness {
-    evaluate_reachability_constraint(db, scope, continuation)
+    evaluate_reachability_constraint(db, scope, continuation, None)
 }
 
 fn terminal_reachability(id: ScopedReachabilityConstraintId) -> Option<Truthiness> {
@@ -775,44 +776,75 @@ fn is_reachability_checkpoint(
         && (checkpoint_position + 1).is_multiple_of(CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL)
 }
 
-/// Walks a reachability decision diagram until it reaches a terminal or reusable checkpoint.
-///
-/// `use_checkpoint` is false only when entering from a checkpoint query. In that case, the first
-/// node is evaluated directly to prevent the query from immediately calling itself again.
-///
-/// General checkpoints are created only after traversing a genuinely long path. Their positions
-/// depend on stable predicate IDs, so adjacent roots reuse the same suffix without requiring an
-/// additional retained scope-wide index or allocating tracked queries for short, ordinary paths.
-fn evaluate_reachability_path<'db>(
-    db: &'db dyn Db,
+struct ReachabilityEvaluator<'a, 'db> {
     scope: ScopeId<'db>,
-    constraints: &ReachabilityConstraints,
-    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    completion_predicates: Option<&[ScopedPredicateId]>,
-    mut id: ScopedReachabilityConstraintId,
-    mut use_checkpoint: bool,
-) -> Truthiness {
-    let env = ProgramEnvironment::from_scope(scope);
-    let mut visited = 0;
+    constraints: &'a ReachabilityConstraints,
+    predicates: &'a IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    completion_predicates: Option<&'a [ScopedPredicateId]>,
+}
 
-    loop {
-        if let Some(reachability) = terminal_reachability(id) {
-            return reachability;
-        }
+impl ReachabilityEvaluator<'_, '_> {
+    /// Walks a decision diagram until it reaches a terminal or reusable checkpoint.
+    ///
+    /// `use_checkpoint` is false only when entering from a checkpoint query. In that case, the
+    /// first node is evaluated directly to prevent the query from immediately calling itself again.
+    ///
+    /// General checkpoints are created only after traversing a long path. Their positions depend
+    /// on stable predicate IDs, so adjacent roots reuse the same suffix without allocating tracked
+    /// queries for short, ordinary paths.
+    fn evaluate(
+        &self,
+        db: &dyn Db,
+        mut id: ScopedReachabilityConstraintId,
+        mut use_checkpoint: bool,
+        cache: Option<&ReachabilityCacheEntries>,
+    ) -> Truthiness {
+        let env = ProgramEnvironment::from_scope(self.scope);
+        let mut visited = 0;
+        let mut path = SmallVec::<[ScopedReachabilityConstraintId; 16]>::new();
 
-        let node = constraints.get_interior_node(id);
-        if use_checkpoint && is_reachability_checkpoint(completion_predicates, node.atom(), visited)
-        {
-            return evaluate_reachability_checkpoint(db, scope, id);
-        }
+        let result = loop {
+            if let Some(reachability) = terminal_reachability(id) {
+                break reachability;
+            }
 
-        id = match analyze_single(db, &env, &predicates[node.atom()]) {
-            Truthiness::AlwaysTrue => node.if_true(),
-            Truthiness::Ambiguous => node.if_ambiguous(),
-            Truthiness::AlwaysFalse => node.if_false(),
+            if let Some(cache) = cache
+                && let Some(result) = cache.borrow().get(id.index()).copied().flatten()
+            {
+                break result;
+            }
+            if cache.is_some() {
+                path.push(id);
+            }
+            let node = self.constraints.get_interior_node(id);
+            if use_checkpoint
+                && is_reachability_checkpoint(self.completion_predicates, node.atom(), visited)
+            {
+                break evaluate_reachability_checkpoint(db, self.scope, id);
+            }
+
+            id = match analyze_single(db, &env, &self.predicates[node.atom()]) {
+                Truthiness::AlwaysTrue => node.if_true(),
+                Truthiness::Ambiguous => node.if_ambiguous(),
+                Truthiness::AlwaysFalse => node.if_false(),
+            };
+            use_checkpoint = true;
+            visited += 1;
         };
-        use_checkpoint = true;
-        visited += 1;
+
+        // Every node on the evaluated path has the same result. Keep its suffixes in the
+        // inference-local cache so other bindings can reuse them without walking them again.
+        if let Some(cache) = cache {
+            let mut entries = cache.borrow_mut();
+            for id in path {
+                let index = id.index();
+                if entries.len() <= index {
+                    entries.resize(index + 1, None);
+                }
+                entries[index] = Some(result);
+            }
+        }
+        result
     }
 }
 
@@ -845,15 +877,13 @@ fn evaluate_reachability_checkpoint<'db>(
         .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
         .is_some();
     let completion_predicates = has_many_completions.then(|| completion_predicates(db, scope));
-    evaluate_reachability_path(
-        db,
+    ReachabilityEvaluator {
         scope,
-        use_def.reachability_constraints(),
+        constraints: use_def.reachability_constraints(),
         predicates,
         completion_predicates,
-        id,
-        false,
-    )
+    }
+    .evaluate(db, id, false, None)
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -880,15 +910,13 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
 
         let root_predicate = self.get_interior_node(id).atom();
         analyze_completion_prefix(db, predicates, root_predicate);
-        evaluate_reachability_path(
-            db,
-            predicate_scope(db, &predicates[root_predicate]),
-            self,
+        ReachabilityEvaluator {
+            scope: predicate_scope(db, &predicates[root_predicate]),
+            constraints: self,
             predicates,
-            None,
-            id,
-            true,
-        )
+            completion_predicates: None,
+        }
+        .evaluate(db, id, true, None)
     }
 }
 
@@ -1385,8 +1413,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             .contains(node.atom, self.place)
                             || matches!(
                                 predicate.node,
-                                PredicateNode::ExpressionCanComplete { .. }
-                                    | PredicateNode::ContextManagerSuppresses { .. }
+                                PredicateNode::ContextManagerSuppresses { .. }
                                     | PredicateNode::FinallyNormalPathImpossible { .. }
                             ))
                     {
@@ -1841,6 +1868,26 @@ fn analyze_non_empty_iterable(db: &dyn Db, iterable: Expression) -> Truthiness {
     }
 }
 
+/// Cache the whole predicate so repeated reachability walks can reuse one query result
+/// instead of looking up the expression's type and suppression behavior separately.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _, _| false,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn context_manager_suppresses<'db>(
+    db: &'db dyn Db,
+    expression: Expression<'db>,
+    is_async: bool,
+) -> bool {
+    let env = ProgramEnvironment::from_scope(expression.scope(db));
+    infer_same_file_expression_type(db, expression, TypeContext::default()).can_suppress_exceptions(
+        db,
+        &env,
+        EvaluationMode::from_is_async(is_async),
+    )
+}
+
 /// Evaluate a condition without re-testing intermediate short-circuit results.
 ///
 /// `None` means evaluation cannot produce a result, as for an operand narrowed to `Never`.
@@ -1979,11 +2026,8 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
         PredicateNode::ContextManagerSuppresses {
             expression,
             is_async,
-        } => Truthiness::from(
-            infer_same_file_expression_type(db, expression, TypeContext::default())
-                .can_suppress_exceptions(db, env, EvaluationMode::from_is_async(is_async)),
-        )
-        .negate_if(!predicate.is_positive),
+        } => Truthiness::from(context_manager_suppresses(db, expression, is_async))
+            .negate_if(!predicate.is_positive),
         PredicateNode::FinallyNormalPathImpossible {
             scope,
             continuation,
@@ -2103,7 +2147,7 @@ pub(crate) fn evaluate_reachability(
 pub(crate) struct ReachabilityEvaluationCache<'db> {
     primary_scope: ScopeId<'db>,
     primary_constraints: usize,
-    primary_entries: RefCell<Vec<Option<Truthiness>>>,
+    primary_entries: ReachabilityCacheEntries,
     other_entries: RefCell<FxHashMap<(usize, ScopedReachabilityConstraintId), Truthiness>>,
 }
 
@@ -2155,7 +2199,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
                 return result;
             }
 
-            let result = evaluate_reachability_constraint(db, scope, id);
+            let result = evaluate_reachability_constraint(db, scope, id, None);
             self.other_entries.borrow_mut().insert(key, result);
             return result;
         }
@@ -2165,13 +2209,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             return result;
         }
 
-        let result = evaluate_reachability_constraint(db, self.primary_scope, id);
-        let mut entries = self.primary_entries.borrow_mut();
-        if entries.len() <= index {
-            entries.resize(index + 1, None);
-        }
-        entries[index] = Some(result);
-        result
+        evaluate_reachability_constraint(db, self.primary_scope, id, Some(&self.primary_entries))
     }
 }
 
@@ -2359,6 +2397,7 @@ class TargetB:
                         &db,
                         scope,
                         use_def.end_of_scope_reachability(),
+                        None,
                     )
                     .may_be_true()
                 );
@@ -2373,8 +2412,13 @@ class TargetB:
             let scope = function_scope.to_scope_id(&db, program_file);
             let use_def = use_def_map(&db, scope);
             assert!(
-                evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability(),)
-                    .is_always_false()
+                evaluate_reachability_constraint(
+                    &db,
+                    scope,
+                    use_def.end_of_scope_reachability(),
+                    None
+                )
+                .is_always_false()
             );
         }
         Ok(())

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -221,7 +221,7 @@ use ty_python_core::{
     FileScopeId, NarrowingEvaluator, PredicateNarrowingTargets, ScopedDefinitionId, SemanticIndex,
     Truthiness, UseDefMap,
     definition::DefinitionState,
-    expression::{Expression, ExpressionContext},
+    expression::{Expression, ExpressionContext, ExpressionKind},
     narrowing_constraints::{NarrowingConstraints, ScopedNarrowingConstraint},
     place::ScopedPlaceId,
     place_table,
@@ -695,6 +695,8 @@ fn analyze_completion_range<'db>(db: &'db dyn Db, scope: ScopeId<'db>, level: u3
 fn evaluate_reachability_constraint<'db>(
     db: &'db dyn Db,
     scope: ScopeId<'db>,
+    constraints: &ReachabilityConstraints,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     id: ScopedReachabilityConstraintId,
     cache: Option<&ReachabilityCacheEntries>,
 ) -> Truthiness {
@@ -702,9 +704,6 @@ fn evaluate_reachability_constraint<'db>(
         return reachability;
     }
 
-    let use_def = use_def_map(db, scope);
-    let constraints = use_def.reachability_constraints();
-    let predicates = use_def.predicates();
     let root_predicate = constraints.get_interior_node(id).atom();
     let has_many_completions = analyze_completion_prefix(db, predicates, root_predicate);
     let completion_predicates = has_many_completions.then(|| completion_predicates(db, scope));
@@ -739,7 +738,15 @@ fn evaluate_finally_continuation<'db>(
     scope: ScopeId<'db>,
     continuation: ScopedReachabilityConstraintId,
 ) -> Truthiness {
-    evaluate_reachability_constraint(db, scope, continuation, None)
+    let use_def = use_def_map(db, scope);
+    evaluate_reachability_constraint(
+        db,
+        scope,
+        use_def.reachability_constraints(),
+        use_def.predicates(),
+        continuation,
+        None,
+    )
 }
 
 fn terminal_reachability(id: ScopedReachabilityConstraintId) -> Option<Truthiness> {
@@ -2021,6 +2028,11 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
             context,
         } => Truthiness::from(match context {
             ExpressionContext::Condition => analyze_condition(db, expression).is_some(),
+            ExpressionContext::Value if expression.kind(db) == ExpressionKind::BooleanTest => {
+                infer_expression_types(db, expression, TypeContext::default())
+                    .boolean_test_completion()
+                    .unwrap_or(true)
+            }
             ExpressionContext::Value => expression_value_can_complete(db, expression),
         })
         .negate_if(!predicate.is_positive),
@@ -2181,10 +2193,8 @@ impl<'db> ReachabilityEvaluationCache<'db> {
 
     /// Evaluates `id`, reusing a cached result when possible.
     ///
-    /// Trivial constraint ids return immediately and are not stored. For interior nodes, the
-    /// predicate determines whether the constraint belongs to the primary scope. A primary-scope
-    /// constraint from the primary graph is cached by dense index; all other constraints are cached
-    /// by graph identity and id.
+    /// Trivial constraint ids return immediately and are not stored. Constraints from the primary
+    /// graph are cached by dense index; all other constraints are cached by graph identity and id.
     fn evaluate(
         &self,
         db: &'db dyn Db,
@@ -2199,27 +2209,38 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             _ => {}
         }
 
-        let predicate = predicates[constraints.get_interior_node(id).atom()];
         let constraints_key = std::ptr::from_ref(constraints).addr();
-        let scope = predicate_scope(db, &predicate);
-
-        if scope != self.primary_scope || constraints_key != self.primary_constraints {
-            let key = (constraints_key, id);
-            if let Some(result) = self.other_entries.borrow().get(&key).copied() {
+        if constraints_key == self.primary_constraints {
+            if let Some(result) = self
+                .primary_entries
+                .borrow()
+                .get(id.index())
+                .copied()
+                .flatten()
+            {
                 return result;
             }
 
-            let result = evaluate_reachability_constraint(db, scope, id, None);
-            self.other_entries.borrow_mut().insert(key, result);
+            return evaluate_reachability_constraint(
+                db,
+                self.primary_scope,
+                constraints,
+                predicates,
+                id,
+                Some(&self.primary_entries),
+            );
+        }
+
+        let key = (constraints_key, id);
+        if let Some(result) = self.other_entries.borrow().get(&key).copied() {
             return result;
         }
 
-        let index = id.index();
-        if let Some(result) = self.primary_entries.borrow().get(index).copied().flatten() {
-            return result;
-        }
-
-        evaluate_reachability_constraint(db, self.primary_scope, id, Some(&self.primary_entries))
+        let predicate = predicates[constraints.get_interior_node(id).atom()];
+        let scope = predicate_scope(db, &predicate);
+        let result = evaluate_reachability_constraint(db, scope, constraints, predicates, id, None);
+        self.other_entries.borrow_mut().insert(key, result);
+        result
     }
 }
 
@@ -2406,6 +2427,8 @@ class TargetB:
                     evaluate_reachability_constraint(
                         &db,
                         scope,
+                        use_def.reachability_constraints(),
+                        use_def.predicates(),
                         use_def.end_of_scope_reachability(),
                         None,
                     )
@@ -2425,6 +2448,8 @@ class TargetB:
                 evaluate_reachability_constraint(
                     &db,
                     scope,
+                    use_def.reachability_constraints(),
+                    use_def.predicates(),
                     use_def.end_of_scope_reachability(),
                     None
                 )

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -553,7 +553,8 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
         | PredicateNode::ChainedComparisonCondition(expression)
         | PredicateNode::ContextManagerSuppresses { expression, .. }
         | PredicateNode::ExpressionCanComplete { expression, .. } => expression.scope(db),
-        PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
+        PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. })
+        | PredicateNode::CallCanComplete(CallableAndCallExpr { callable, .. }) => {
             callable.scope(db)
         }
         PredicateNode::Pattern(pattern) => pattern.scope(db),
@@ -590,13 +591,22 @@ fn analyze_completion_prefix<'db>(
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) -> bool {
+    // A complete block needs at least this many preceding predicates, even if all of them
+    // concern completion. Short scopes cannot require the cached index either.
+    if predicates.len() <= COMPLETION_PREDICATE_CHUNK_SIZE
+        || root_predicate.index() + 1 < COMPLETION_PREDICATE_CHUNK_SIZE
+    {
+        return false;
+    }
     let scope = predicate_scope(db, &predicates[root_predicate]);
     let has_many_completions = predicates
         .iter()
         .filter(|predicate| {
             matches!(
                 predicate.node,
-                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+                PredicateNode::IsNonTerminalCall(_)
+                    | PredicateNode::ExpressionCanComplete { .. }
+                    | PredicateNode::CallCanComplete(_)
             )
         })
         .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
@@ -636,7 +646,9 @@ fn completion_predicates<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Box<[Scop
         .filter_map(|(id, predicate)| {
             matches!(
                 predicate.node,
-                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+                PredicateNode::IsNonTerminalCall(_)
+                    | PredicateNode::ExpressionCanComplete { .. }
+                    | PredicateNode::CallCanComplete(_)
             )
             .then_some(id)
         })
@@ -871,7 +883,9 @@ fn evaluate_reachability_checkpoint<'db>(
         .filter(|predicate| {
             matches!(
                 predicate.node,
-                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+                PredicateNode::IsNonTerminalCall(_)
+                    | PredicateNode::ExpressionCanComplete { .. }
+                    | PredicateNode::CallCanComplete(_)
             )
         })
         .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
@@ -1417,6 +1431,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             || matches!(
                                 predicate.node,
                                 PredicateNode::ExpressionCanComplete { .. }
+                                    | PredicateNode::CallCanComplete(_)
                                     | PredicateNode::ContextManagerSuppresses { .. }
                                     | PredicateNode::FinallyNormalPathImpossible { .. }
                             ))
@@ -1453,6 +1468,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         predicate.node,
                         PredicateNode::IsNonTerminalCall(_)
                             | PredicateNode::ExpressionCanComplete { .. }
+                            | PredicateNode::CallCanComplete(_)
                             | PredicateNode::ContextManagerSuppresses { .. }
                             | PredicateNode::FinallyNormalPathImpossible { .. }
                     );
@@ -1825,23 +1841,29 @@ pub(crate) fn is_non_terminal_call<'db>(
     is_await: bool,
     call_type: impl FnOnce() -> Type<'db>,
 ) -> Truthiness {
+    try_is_non_terminal_call(db, env, ty, is_await, call_type).unwrap_or(Truthiness::AlwaysTrue)
+}
+
+fn try_is_non_terminal_call<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    ty: Type<'db>,
+    is_await: bool,
+    call_type: impl FnOnce() -> Type<'db>,
+) -> Option<Truthiness> {
     // Short-circuit for well-known types that are known not to return `Never` when called. Without
     // the short-circuit, we've seen that threads keep blocking each other because they all try to
     // acquire Salsa's `CallableType` lock that ensures each type is only interned once. The lock is
     // so heavily congested because there are only very few dynamic types, in which case Salsa's
     // sharding the locks by value doesn't help much. See <https://github.com/astral-sh/ty/issues/968>.
     if matches!(ty, Type::Dynamic(_)) {
-        return Truthiness::AlwaysTrue;
+        return Some(Truthiness::AlwaysTrue);
     }
 
-    let overloads_iterator = if let Some(callable) = ty
+    let callable = ty
         .try_upcast_to_callable(db, env)
-        .and_then(CallableTypes::exactly_one)
-    {
-        callable.signatures(db).overloads.iter()
-    } else {
-        return Truthiness::AlwaysTrue;
-    };
+        .and_then(CallableTypes::exactly_one)?;
+    let overloads_iterator = callable.signatures(db).overloads.iter();
 
     let mut no_overloads_return_never = true;
     let mut all_overloads_return_never = true;
@@ -1855,11 +1877,11 @@ pub(crate) fn is_non_terminal_call<'db>(
     }
 
     if no_overloads_return_never && !any_overload_is_generic && !is_await {
-        Truthiness::AlwaysTrue
+        Some(Truthiness::AlwaysTrue)
     } else if all_overloads_return_never || call_type().is_equivalent_to(db, env, Type::Never) {
-        Truthiness::AlwaysFalse
+        Some(Truthiness::AlwaysFalse)
     } else {
-        Truthiness::AlwaysTrue
+        Some(Truthiness::AlwaysTrue)
     }
 }
 
@@ -1996,6 +2018,33 @@ fn expression_value_can_complete<'db>(db: &'db dyn Db, expression: Expression<'d
     )
 }
 
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _, _, _| true,
+    cycle_fn = |_, cycle: &salsa::Cycle, previous: &bool, result: bool, _, _, _| {
+        if cycle.iteration() > crate::TAINTED_CYCLES {
+            *previous || result
+        } else {
+            result
+        }
+    },
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn expression_call_can_complete<'db>(
+    db: &'db dyn Db,
+    callable: Expression<'db>,
+    expression: Expression<'db>,
+    is_await: bool,
+) -> bool {
+    let env = ProgramEnvironment::from_scope(callable.scope(db));
+    let callable_type = infer_same_file_expression_type(db, callable, TypeContext::default());
+    let call_type = || infer_same_file_expression_type(db, expression, TypeContext::default());
+    try_is_non_terminal_call(db, &env, callable_type, is_await, call_type).map_or_else(
+        || !call_type().is_equivalent_to(db, &env, Type::Never),
+        Truthiness::is_always_true,
+    )
+}
+
 fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predicate) -> Truthiness {
     let _span = tracing::trace_span!("analyze_single", ?predicate).entered();
 
@@ -2015,6 +2064,13 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
             ExpressionContext::Condition => analyze_condition(db, expression).is_some(),
             ExpressionContext::Value => expression_value_can_complete(db, expression),
         })
+        .negate_if(!predicate.is_positive),
+        PredicateNode::CallCanComplete(call) => Truthiness::from(expression_call_can_complete(
+            db,
+            call.callable,
+            call.call_expr,
+            call.is_await,
+        ))
         .negate_if(!predicate.is_positive),
         PredicateNode::ChainedComparisonCondition(test_expr) => {
             let inference = infer_expression_types(db, test_expr, TypeContext::default());
@@ -2172,10 +2228,9 @@ impl<'db> ReachabilityEvaluationCache<'db> {
 
     /// Evaluates `id`, reusing a cached result when possible.
     ///
-    /// Trivial constraint ids return immediately and are not stored. For interior nodes, the
-    /// predicate determines whether the constraint belongs to the primary scope. A primary-scope
-    /// constraint from the primary graph is cached by dense index; all other constraints are cached
-    /// by graph identity and id.
+    /// Trivial constraint ids return immediately and are not stored. The primary graph's identity
+    /// already determines its scope, so cache hits need no predicate or scope lookup. Other
+    /// constraints are cached by graph identity and id.
     fn evaluate(
         &self,
         db: &'db dyn Db,
@@ -2190,16 +2245,16 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             _ => {}
         }
 
-        let predicate = predicates[constraints.get_interior_node(id).atom()];
         let constraints_key = std::ptr::from_ref(constraints).addr();
-        let scope = predicate_scope(db, &predicate);
 
-        if scope != self.primary_scope || constraints_key != self.primary_constraints {
+        if constraints_key != self.primary_constraints {
             let key = (constraints_key, id);
             if let Some(result) = self.other_entries.borrow().get(&key).copied() {
                 return result;
             }
 
+            let predicate = predicates[constraints.get_interior_node(id).atom()];
+            let scope = predicate_scope(db, &predicate);
             let result = evaluate_reachability_constraint(db, scope, id, None);
             self.other_entries.borrow_mut().insert(key, result);
             return result;

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -201,7 +201,7 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, ComparisonSoundnessPolicy, EnumClassLiteral, KnownInstanceType,
+        CallableTypes, ComparisonSoundnessPolicy, EnumClassLiteral, KnownClass, KnownInstanceType,
         NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
         definite_match_pattern_type, definite_match_pattern_type_for_subject, equality_truthiness,
         expand_type, infer_expression_types, infer_narrowing_constraints,
@@ -554,7 +554,9 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
         | PredicateNode::ChainedComparisonCondition(expression)
         | PredicateNode::ContextManagerSuppresses { expression, .. }
         | PredicateNode::ExpressionCanComplete { expression, .. } => expression.scope(db),
-        PredicateNode::IsNonTerminalCall(call) => call.callable(db).scope(db),
+        PredicateNode::IsNonTerminalCall(call) | PredicateNode::BoolCallCanComplete(call) => {
+            call.callable(db).scope(db)
+        }
         PredicateNode::Pattern(pattern) => pattern.scope(db),
         PredicateNode::FinallyNormalPathImpossible { scope, .. } => scope,
         PredicateNode::OrPatternAlternative(scope) => scope,
@@ -630,7 +632,9 @@ fn completion_predicates<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Box<[Scop
         .filter_map(|(id, predicate)| {
             matches!(
                 predicate.node,
-                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+                PredicateNode::IsNonTerminalCall(_)
+                    | PredicateNode::ExpressionCanComplete { .. }
+                    | PredicateNode::BoolCallCanComplete(_)
             )
             .then_some(id)
         })
@@ -1433,6 +1437,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             || matches!(
                                 predicate.node,
                                 PredicateNode::ExpressionCanComplete { .. }
+                                    | PredicateNode::BoolCallCanComplete(_)
                                     | PredicateNode::ContextManagerSuppresses { .. }
                                     | PredicateNode::FinallyNormalPathImpossible { .. }
                             ))
@@ -1469,6 +1474,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         predicate.node,
                         PredicateNode::IsNonTerminalCall(_)
                             | PredicateNode::ExpressionCanComplete { .. }
+                            | PredicateNode::BoolCallCanComplete(_)
                             | PredicateNode::ContextManagerSuppresses { .. }
                             | PredicateNode::FinallyNormalPathImpossible { .. }
                     );
@@ -2027,6 +2033,16 @@ fn expression_value_can_complete<'db>(db: &'db dyn Db, expression: Expression<'d
     )
 }
 
+fn inferred_expression_can_complete<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
+    if expression.kind(db) == ExpressionKind::BooleanTest {
+        infer_expression_types(db, expression, TypeContext::default())
+            .boolean_test_completion()
+            .unwrap_or(true)
+    } else {
+        expression_value_can_complete(db, expression)
+    }
+}
+
 fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predicate) -> Truthiness {
     let _span = tracing::trace_span!("analyze_single", ?predicate).entered();
 
@@ -2044,14 +2060,21 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
             context,
         } => Truthiness::from(match context {
             ExpressionContext::Condition => analyze_condition(db, expression).is_some(),
-            ExpressionContext::Value if expression.kind(db) == ExpressionKind::BooleanTest => {
-                infer_expression_types(db, expression, TypeContext::default())
-                    .boolean_test_completion()
-                    .unwrap_or(true)
-            }
-            ExpressionContext::Value => expression_value_can_complete(db, expression),
+            ExpressionContext::Value => inferred_expression_can_complete(db, expression),
         })
         .negate_if(!predicate.is_positive),
+        PredicateNode::BoolCallCanComplete(call) => {
+            let callable_type =
+                infer_same_file_expression_type(db, call.callable(db), TypeContext::default());
+            // `bool` has an inhabited return type regardless of its argument's type. Avoid
+            // pulling argument inference into reachability when the callee confirms this case.
+            Truthiness::from(
+                matches!(callable_type, Type::ClassLiteral(class)
+                    if class.is_known(db, KnownClass::Bool))
+                    || inferred_expression_can_complete(db, call.call_expr(db)),
+            )
+            .negate_if(!predicate.is_positive)
+        }
         PredicateNode::ChainedComparisonCondition(test_expr) => {
             let inference = infer_expression_types(db, test_expr, TypeContext::default());
             let expression = test_expr.node_ref(db);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -194,7 +194,7 @@
 //! [bdd]: https://en.wikipedia.org/wiki/Binary_decision_diagram
 
 use crate::ProgramEnvironment;
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 
 use crate::{
     Db,
@@ -547,6 +547,7 @@ const CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL: usize = 16;
 const NARROWING_EVALUATION_CHECKPOINT_INTERVAL: usize = 8;
 
 type ReachabilityCacheEntries = RefCell<Vec<Option<Truthiness>>>;
+type PredicateCacheEntries = RefCell<FxHashMap<(usize, ScopedPredicateId), Truthiness>>;
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression)
@@ -2185,7 +2186,8 @@ pub(crate) struct ReachabilityEvaluationCache<'db> {
     primary_constraints: usize,
     primary_entries: ReachabilityCacheEntries,
     other_entries: RefCell<FxHashMap<(usize, ScopedReachabilityConstraintId), Truthiness>>,
-    predicate_entries: RefCell<FxHashMap<(usize, ScopedPredicateId), Truthiness>>,
+    // Allocate this separately so regions that never evaluate a predicate keep a small cache object.
+    predicate_entries: OnceCell<Box<PredicateCacheEntries>>,
 }
 
 impl<'db> ReachabilityEvaluationCache<'db> {
@@ -2203,7 +2205,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
             primary_constraints: std::ptr::from_ref(primary_constraints).addr(),
             primary_entries: RefCell::new(Vec::new()),
             other_entries: RefCell::new(FxHashMap::default()),
-            predicate_entries: RefCell::new(FxHashMap::default()),
+            predicate_entries: OnceCell::new(),
         }
     }
 
@@ -2218,11 +2220,14 @@ impl<'db> ReachabilityEvaluationCache<'db> {
     ) -> Truthiness {
         debug_assert_eq!(env.program(db), self.primary_scope.program(db));
         let key = (predicates.raw.as_ptr().addr(), id);
-        if let Some(result) = self.predicate_entries.borrow().get(&key).copied() {
+        let entries = self
+            .predicate_entries
+            .get_or_init(|| Box::new(RefCell::new(FxHashMap::default())));
+        if let Some(result) = entries.borrow().get(&key).copied() {
             return result;
         }
         let result = analyze_single(db, env, &predicates[id]);
-        self.predicate_entries.borrow_mut().insert(key, result);
+        entries.borrow_mut().insert(key, result);
         result
     }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -545,6 +545,8 @@ const COMPLETION_PREDICATE_PREFIX_THRESHOLD: usize = 256;
 const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
 const CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL: usize = 16;
 const NARROWING_EVALUATION_CHECKPOINT_INTERVAL: usize = 8;
+const SMALL_SCOPE_NARROWING_CHECKPOINT_INTERVAL: usize = 16;
+const SMALL_SCOPE_NARROWING_PREDICATE_THRESHOLD: usize = 256;
 
 type ReachabilityCacheEntries = RefCell<Vec<Option<Truthiness>>>;
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
@@ -1393,6 +1395,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             FinishPredicate(Id),
         }
         let db = self.db;
+        // Smaller scopes need fewer checkpoints to bound repeated work. Avoid allocating
+        // a Salsa query for every short suffix while retaining denser reuse in large scopes.
+        let small_scope = self.predicates.len() <= SMALL_SCOPE_NARROWING_PREDICATE_THRESHOLD;
 
         let mut actions = SmallVec::<[Action; 8]>::new();
         actions.push(Action::Visit(root));
@@ -1407,14 +1412,18 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
                     let index = node.atom.index();
-                    let checkpoint_position =
-                        index ^ (index / NARROWING_EVALUATION_CHECKPOINT_INTERVAL);
+                    let at_checkpoint = if small_scope {
+                        let position = index ^ (index / SMALL_SCOPE_NARROWING_CHECKPOINT_INTERVAL);
+                        (position + 1).is_multiple_of(SMALL_SCOPE_NARROWING_CHECKPOINT_INTERVAL)
+                    } else {
+                        let position = index ^ (index / NARROWING_EVALUATION_CHECKPOINT_INTERVAL);
+                        (position + 1).is_multiple_of(NARROWING_EVALUATION_CHECKPOINT_INTERVAL)
+                    };
                     // Completion gates can depend on earlier narrowed uses without narrowing
                     // this place themselves. Checkpoints keep those inference dependencies from
                     // being copied into every later expression in a long chain.
                     if (id != root || use_root_checkpoint)
-                        && (checkpoint_position + 1)
-                            .is_multiple_of(NARROWING_EVALUATION_CHECKPOINT_INTERVAL)
+                        && at_checkpoint
                         && (self
                             .predicate_narrowing_targets
                             .contains(node.atom, self.place)
@@ -2324,6 +2333,7 @@ impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
 mod tests {
     use super::*;
     use crate::db::tests::setup_db;
+    use crate::types::infer_scope_types;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::DbWithWritableSystem as _;
     use ty_python_core::ProgramFile;
@@ -2331,20 +2341,40 @@ mod tests {
     use ty_python_core::predicate::Predicates;
     use ty_python_core::semantic_index;
 
-    /// A cached completion range returns without panicking when each class's `target` attribute
-    /// depends on the other class's `setup` method. This forces a Salsa cycle across files while
-    /// the range query itself is active, exercising that query's cycle recovery.
+    /// Each class's `target` attribute depends on the other class's `setup` method. Completion
+    /// analysis handles this cross-file cycle both at the limit for on-demand evaluation and
+    /// after prefix warming starts, using the stack size of production workers. Entering a range
+    /// directly also exercises recovery when that range query becomes the cycle head.
     #[test]
     fn completion_range_recovers_cross_file_cycle() -> anyhow::Result<()> {
-        let mut db = setup_db();
-        let calls = concat!(
-            "        other.target.ping()\n",
-            "        other.target.ping() and None\n",
-            "        None if other.target.ping() else None\n",
-        )
-        .repeat(COMPLETION_PREDICATE_PREFIX_THRESHOLD + 1);
-        let a = format!(
-            r#"from b import B
+        let handle = std::thread::Builder::new()
+            .name("completion-cycle-stack-test".into())
+            .stack_size(ruff_db::STACK_SIZE)
+            .spawn(|| -> anyhow::Result<()> {
+                for (calls, enter_range) in [
+                    (
+                        concat!(
+                            "        other.target.ping()\n",
+                            "        other.target.ping() and None\n",
+                            "        None if other.target.ping() else None\n",
+                        )
+                        .repeat(COMPLETION_PREDICATE_PREFIX_THRESHOLD + 1),
+                        true,
+                    ),
+                    (
+                        "        other.target.ping()\n"
+                            .repeat(COMPLETION_PREDICATE_PREFIX_THRESHOLD),
+                        false,
+                    ),
+                    (
+                        "        other.target.ping()\n"
+                            .repeat(COMPLETION_PREDICATE_PREFIX_THRESHOLD + 1),
+                        false,
+                    ),
+                ] {
+                    let mut db = setup_db();
+                    let a = format!(
+                        r#"from b import B
 
 class A:
     def setup(self, other: B) -> None:
@@ -2353,9 +2383,9 @@ class A:
 class TargetA:
     def ping(self) -> None: ...
 "#
-        );
-        let b = format!(
-            r#"from a import A
+                    );
+                    let b = format!(
+                        r#"from a import A
 
 class B:
     def setup(self, other: A) -> None:
@@ -2364,28 +2394,39 @@ class B:
 class TargetB:
     def ping(self) -> None: ...
 "#
-        );
-        db.write_files([("/src/a.py", a.as_str()), ("/src/b.py", b.as_str())])?;
+                    );
+                    db.write_files([("/src/a.py", a.as_str()), ("/src/b.py", b.as_str())])?;
 
-        let file = system_path_to_file(&db, "/src/a.py").unwrap();
-        let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
-        let index = semantic_index(&db, program_file);
-        let class_scope = index
-            .child_scopes(FileScopeId::global())
-            .find(|(_, scope)| scope.node().as_class().is_some())
-            .unwrap()
-            .0;
-        let setup_scope = index
-            .child_scopes(class_scope)
-            .find(|(_, scope)| scope.node().as_function().is_some())
-            .unwrap()
-            .0
-            .to_scope_id(&db, program_file);
+                    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+                    let program_file =
+                        ProgramFile::new(&db, file, db.program_environment().program(&db));
+                    let index = semantic_index(&db, program_file);
+                    let class_scope = index
+                        .child_scopes(FileScopeId::global())
+                        .find(|(_, scope)| scope.node().as_class().is_some())
+                        .unwrap()
+                        .0;
+                    let setup_scope = index
+                        .child_scopes(class_scope)
+                        .find(|(_, scope)| scope.node().as_function().is_some())
+                        .unwrap()
+                        .0
+                        .to_scope_id(&db, program_file);
 
-        // Enter the range directly so it becomes the cycle head when inferring `other.target`
-        // reaches the other module and then re-enters this scope.
-        analyze_completion_range(&db, setup_scope, 0, 0);
-        Ok(())
+                    if enter_range {
+                        // Enter the range directly so it becomes the cycle head when inferring `other.target`
+                        // reaches the other module and then re-enters this scope.
+                        analyze_completion_range(&db, setup_scope, 0, 0);
+                    } else {
+                        infer_scope_types(&db, setup_scope, TypeContext::default());
+                    }
+                }
+                Ok(())
+            })?;
+
+        handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("completion analysis thread panicked"))?
     }
 
     /// Changing an imported callable's return type from `None` to `NoReturn` invalidates cached

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -2080,8 +2080,9 @@ fn builtin_call_has_inhabited_result<'db>(
     let callable = implicit_builtins_symbol(db, &env, name)
         .place
         .ignore_possibly_undefined();
-    // These builtins keep an inhabited return type when argument inference refines it.
-    // Check annotations as well so replacement stubs retain their semantics.
+    // Inference can specialize these known functions without making their return types
+    // uninhabited. Other recognized builtins use their signatures directly. Check annotations
+    // as well so replacement stubs retain their semantics.
     match callable {
         Some(Type::ClassLiteral(class)) => class.is_known(db, KnownClass::Bool),
         Some(Type::FunctionLiteral(function))
@@ -2093,7 +2094,11 @@ fn builtin_call_has_inhabited_result<'db>(
                         | KnownFunction::IsSubclass
                         | KnownFunction::HasAttr
                 )
-            ) =>
+            ) || (matches!(
+                builtin,
+                BuiltinCallKind::Any | BuiltinCallKind::All | BuiltinCallKind::Callable
+            ) && function.known(db).is_none()
+                && function.name(db).as_str() == name) =>
         {
             let overloads = &function.signature(db).overloads;
             !overloads.is_empty()

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -541,6 +541,7 @@ fn accumulate_constraint<'db>(
 }
 
 const COMPLETION_PREDICATE_CHUNK_SIZE: usize = 16;
+const COMPLETION_PREDICATE_PREFIX_THRESHOLD: usize = 256;
 const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
 const CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL: usize = 16;
 const NARROWING_EVALUATION_CHECKPOINT_INTERVAL: usize = 8;
@@ -581,30 +582,22 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
 /// incomplete block is left for the reachability walk: it can add at most 15 nested completion
 /// queries, and analyzing it eagerly would bypass the range query's cycle recovery and could introduce a
 /// divergent inference cycle. For large scopes, keeping the complete-block pass unconditional
-/// ensures that tracked callers record the same dependencies on every thread. Small scopes do not
-/// need prefix warming to bound the Salsa stack, so their predicates are evaluated entirely on demand.
+/// ensures that tracked callers record the same dependencies on every thread. Scopes with at most
+/// [`COMPLETION_PREDICATE_PREFIX_THRESHOLD`] completion predicates are evaluated entirely on demand:
+/// their dependency chains are already bounded, and range queries would add overhead.
 fn analyze_completion_prefix<'db>(
     db: &'db dyn Db,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) -> bool {
-    let scope = predicate_scope(db, &predicates[root_predicate]);
-    let has_many_completions = predicates
-        .iter()
-        .filter(|predicate| {
-            matches!(
-                predicate.node,
-                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
-            )
-        })
-        .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
-        .is_some();
-
-    if !has_many_completions {
+    if predicates.len() <= COMPLETION_PREDICATE_PREFIX_THRESHOLD {
         return false;
     }
-
+    let scope = predicate_scope(db, &predicates[root_predicate]);
     let completion_predicates = completion_predicates(db, scope);
+    if completion_predicates.len() <= COMPLETION_PREDICATE_PREFIX_THRESHOLD {
+        return false;
+    }
     let completion_count =
         completion_predicates.partition_point(|predicate| *predicate <= root_predicate);
     let mut start = 0;
@@ -624,8 +617,9 @@ fn analyze_completion_prefix<'db>(
 
 /// Returns completion predicates for statement calls and boolean evaluation boundaries in source order.
 ///
-/// This tracked index is used only once a scope exceeds [`COMPLETION_PREDICATE_CHUNK_SIZE`], avoiding
-/// a persistent allocation for the common case of scopes with few completion predicates.
+/// Only scopes with more than [`COMPLETION_PREDICATE_PREFIX_THRESHOLD`] predicates use this
+/// tracked index. Smaller scopes need no persistent allocation; larger scopes reuse the index
+/// both to count completion predicates and to find the prefix that needs analysis.
 #[salsa::tracked(returns(deref), heap_size = get_size2::GetSize::get_heap_size)]
 fn completion_predicates<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Box<[ScopedPredicateId]> {
     use_def_map(db, scope)
@@ -871,17 +865,9 @@ fn evaluate_reachability_checkpoint<'db>(
 ) -> Truthiness {
     let use_def = use_def_map(db, scope);
     let predicates = use_def.predicates();
-    let has_many_completions = predicates
-        .iter()
-        .filter(|predicate| {
-            matches!(
-                predicate.node,
-                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
-            )
-        })
-        .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
-        .is_some();
-    let completion_predicates = has_many_completions.then(|| completion_predicates(db, scope));
+    let completion_predicates = (predicates.len() > COMPLETION_PREDICATE_PREFIX_THRESHOLD)
+        .then(|| completion_predicates(db, scope))
+        .filter(|predicates| predicates.len() > COMPLETION_PREDICATE_PREFIX_THRESHOLD);
     ReachabilityEvaluator {
         scope,
         constraints: use_def.reachability_constraints(),
@@ -2356,7 +2342,7 @@ mod tests {
             "        other.target.ping() and None\n",
             "        None if other.target.ping() else None\n",
         )
-        .repeat(COMPLETION_PREDICATE_CHUNK_SIZE + 1);
+        .repeat(COMPLETION_PREDICATE_PREFIX_THRESHOLD + 1);
         let a = format!(
             r#"from b import B
 
@@ -2417,7 +2403,7 @@ class TargetB:
             let mut db = setup_db();
             let source = format!(
                 "from dependency import callback\n\ndef f() -> None:\n{}",
-                format!("    {expression}\n").repeat(COMPLETION_PREDICATE_CHUNK_SIZE + 1)
+                format!("    {expression}\n").repeat(COMPLETION_PREDICATE_PREFIX_THRESHOLD + 1)
             );
             db.write_files([
                 ("/src/dependency.py", "def callback() -> None: ..."),

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -199,14 +199,19 @@ use std::cell::RefCell;
 use crate::{
     Db,
     dunder_all::dunder_all_names,
-    place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
+    place::{
+        DefinedPlace, Definedness, Place, RequiresExplicitReExport, implicit_builtins_symbol,
+        imported_symbol,
+    },
+    place_load::definitely_has_builtin_binding,
     types::{
-        CallableTypes, ComparisonSoundnessPolicy, EnumClassLiteral, KnownClass, KnownInstanceType,
-        NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
-        definite_match_pattern_type, definite_match_pattern_type_for_subject, equality_truthiness,
-        expand_type, infer_expression_types, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, pattern_binding_fallthrough_type,
-        sequence_pattern_type_builder, singleton_pattern_type,
+        CallableTypes, ComparisonSoundnessPolicy, EnumClassLiteral, KnownClass, KnownFunction,
+        KnownInstanceType, NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType,
+        callable_pattern_type, definite_match_pattern_type,
+        definite_match_pattern_type_for_subject, equality_truthiness, expand_type,
+        infer_expression_types, infer_narrowing_constraints, infer_same_file_expression_type,
+        mapping_pattern_type, pattern_binding_fallthrough_type, sequence_pattern_type_builder,
+        singleton_pattern_type,
     },
 };
 use ruff_db::parsed::parsed_module;
@@ -226,12 +231,12 @@ use ty_python_core::{
     place::ScopedPlaceId,
     place_table,
     predicate::{
-        CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
-        ScopedPredicateId,
+        BuiltinCallKind, CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate,
+        PredicateNode, ScopedPredicateId,
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
     scope::ScopeId,
-    use_def_map,
+    semantic_index, use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -553,10 +558,9 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
         | PredicateNode::Condition(expression)
         | PredicateNode::ChainedComparisonCondition(expression)
         | PredicateNode::ContextManagerSuppresses { expression, .. }
+        | PredicateNode::BuiltinCallCanComplete { expression, .. }
         | PredicateNode::ExpressionCanComplete { expression, .. } => expression.scope(db),
-        PredicateNode::IsNonTerminalCall(call) | PredicateNode::BoolCallCanComplete(call) => {
-            call.callable(db).scope(db)
-        }
+        PredicateNode::IsNonTerminalCall(call) => call.callable(db).scope(db),
         PredicateNode::Pattern(pattern) => pattern.scope(db),
         PredicateNode::FinallyNormalPathImpossible { scope, .. } => scope,
         PredicateNode::OrPatternAlternative(scope) => scope,
@@ -634,7 +638,7 @@ fn completion_predicates<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Box<[Scop
                 predicate.node,
                 PredicateNode::IsNonTerminalCall(_)
                     | PredicateNode::ExpressionCanComplete { .. }
-                    | PredicateNode::BoolCallCanComplete(_)
+                    | PredicateNode::BuiltinCallCanComplete { .. }
             )
             .then_some(id)
         })
@@ -1437,7 +1441,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             || matches!(
                                 predicate.node,
                                 PredicateNode::ExpressionCanComplete { .. }
-                                    | PredicateNode::BoolCallCanComplete(_)
+                                    | PredicateNode::BuiltinCallCanComplete { .. }
                                     | PredicateNode::ContextManagerSuppresses { .. }
                                     | PredicateNode::FinallyNormalPathImpossible { .. }
                             ))
@@ -1474,7 +1478,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                         predicate.node,
                         PredicateNode::IsNonTerminalCall(_)
                             | PredicateNode::ExpressionCanComplete { .. }
-                            | PredicateNode::BoolCallCanComplete(_)
+                            | PredicateNode::BuiltinCallCanComplete { .. }
                             | PredicateNode::ContextManagerSuppresses { .. }
                             | PredicateNode::FinallyNormalPathImpossible { .. }
                     );
@@ -2043,6 +2047,65 @@ fn inferred_expression_can_complete<'db>(db: &'db dyn Db, expression: Expression
     }
 }
 
+/// Resolves a builtin once per scope when no visible binding or predicate can change its type.
+/// This keeps repeated calls from adding separate callee-inference dependencies to reachability.
+#[salsa::tracked(returns(copy), cycle_initial = |_, _, _, _| false, heap_size = get_size2::GetSize::get_heap_size)]
+fn builtin_call_has_inhabited_result<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    builtin: BuiltinCallKind,
+) -> bool {
+    let name = builtin.name();
+    if !definitely_has_builtin_binding(db, scope, name) {
+        return false;
+    }
+    let index = semantic_index(db, scope.program_file(db));
+    if index
+        .visible_ancestor_scopes(scope.file_scope_id(db))
+        .any(|(scope, _)| {
+            index
+                .place_table(scope)
+                .symbol_id(name)
+                .is_some_and(|symbol| {
+                    index
+                        .use_def_map(scope)
+                        .predicate_narrowing_targets()
+                        .contains_place(symbol.into())
+                })
+        })
+    {
+        return false;
+    }
+    let env = ProgramEnvironment::from_scope(scope);
+    let callable = implicit_builtins_symbol(db, &env, name)
+        .place
+        .ignore_possibly_undefined();
+    // These builtins keep an inhabited return type when argument inference refines it.
+    // Check annotations as well so replacement stubs retain their semantics.
+    match callable {
+        Some(Type::ClassLiteral(class)) => class.is_known(db, KnownClass::Bool),
+        Some(Type::FunctionLiteral(function))
+            if matches!(
+                function.known(db),
+                Some(
+                    KnownFunction::Len
+                        | KnownFunction::IsInstance
+                        | KnownFunction::IsSubclass
+                        | KnownFunction::HasAttr
+                )
+            ) =>
+        {
+            let overloads = &function.signature(db).overloads;
+            !overloads.is_empty()
+                && overloads.iter().all(|overload| {
+                    !overload.return_ty.is_equivalent_to(db, &env, Type::Never)
+                        && !overload.return_ty.has_typevar(db, &env)
+                })
+        }
+        _ => false,
+    }
+}
+
 fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predicate) -> Truthiness {
     let _span = tracing::trace_span!("analyze_single", ?predicate).entered();
 
@@ -2063,18 +2126,14 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
             ExpressionContext::Value => inferred_expression_can_complete(db, expression),
         })
         .negate_if(!predicate.is_positive),
-        PredicateNode::BoolCallCanComplete(call) => {
-            let callable_type =
-                infer_same_file_expression_type(db, call.callable(db), TypeContext::default());
-            // `bool` has an inhabited return type regardless of its argument's type. Avoid
-            // pulling argument inference into reachability when the callee confirms this case.
-            Truthiness::from(
-                matches!(callable_type, Type::ClassLiteral(class)
-                    if class.is_known(db, KnownClass::Bool))
-                    || inferred_expression_can_complete(db, call.call_expr(db)),
-            )
-            .negate_if(!predicate.is_positive)
-        }
+        PredicateNode::BuiltinCallCanComplete {
+            expression,
+            builtin,
+        } => Truthiness::from(
+            builtin_call_has_inhabited_result(db, expression.scope(db), builtin)
+                || inferred_expression_can_complete(db, expression),
+        )
+        .negate_if(!predicate.is_positive),
         PredicateNode::ChainedComparisonCondition(test_expr) => {
             let inference = infer_expression_types(db, test_expr, TypeContext::default());
             let expression = test_expr.node_ref(db);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -221,7 +221,7 @@ use ty_python_core::{
     FileScopeId, NarrowingEvaluator, PredicateNarrowingTargets, ScopedDefinitionId, SemanticIndex,
     Truthiness, UseDefMap,
     definition::DefinitionState,
-    expression::Expression,
+    expression::{Expression, ExpressionContext},
     narrowing_constraints::{NarrowingConstraints, ScopedNarrowingConstraint},
     place::ScopedPlaceId,
     place_table,
@@ -540,7 +540,7 @@ fn accumulate_constraint<'db>(
     }
 }
 
-const NON_TERMINAL_CALL_CHUNK_SIZE: usize = 16;
+const COMPLETION_PREDICATE_CHUNK_SIZE: usize = 16;
 const REACHABILITY_EVALUATION_CHUNK_SIZE: usize = 256;
 const CONTROL_FLOW_REACHABILITY_CHECKPOINT_INTERVAL: usize = 16;
 const NARROWING_EVALUATION_CHECKPOINT_INTERVAL: usize = 8;
@@ -549,7 +549,8 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
         PredicateNode::Expression(expression)
         | PredicateNode::Condition(expression)
         | PredicateNode::ChainedComparisonCondition(expression)
-        | PredicateNode::ContextManagerSuppresses { expression, .. } => expression.scope(db),
+        | PredicateNode::ContextManagerSuppresses { expression, .. }
+        | PredicateNode::ExpressionCanComplete { expression, .. } => expression.scope(db),
         PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
             callable.scope(db)
         }
@@ -562,52 +563,58 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
     }
 }
 
-/// Infers complete preceding blocks of call predicates in source order.
+/// Infers complete preceding blocks of completion predicates in source order.
 ///
 /// Predicate IDs are assigned in source order, but the decision diagrams intentionally order
-/// predicates in reverse to reduce their size. Inferring a later call can depend on the
-/// reachability of all preceding calls, which otherwise creates a deeply recursive Salsa query
+/// predicates in reverse to reduce their size. Inferring a later expression can depend on the
+/// completion of all preceding expressions, which otherwise creates a deeply recursive Salsa query
 /// chain. Inferring the expressions in source order turns that chain into cache lookups while
 /// preserving normal reachability and narrowing during every inference.
 ///
 /// Because the prefix is based on predicate indices rather than graph reachability, branch-heavy
-/// code can warm calls from earlier source branches that this evaluation would not otherwise visit.
-/// A demand-driven graph walk could avoid that work, but would require a more complex work list. We
+/// code can warm expressions from earlier source branches that this evaluation would not otherwise
+/// visit. A demand-driven graph walk could avoid that work, but would require a more complex work list. We
 /// accept the broader eager pass because it keeps the ordering simple, and checking a scope will
 /// typically exercise most of its predicates eventually.
 ///
 /// Reentrant analysis is handled by Salsa cycle recovery on the cached-range queries. The final
-/// incomplete block is left for the reachability walk: it can add at most 15 nested call queries,
-/// and analyzing it eagerly would bypass the range query's cycle recovery and could introduce a
+/// incomplete block is left for the reachability walk: it can add at most 15 nested completion
+/// queries, and analyzing it eagerly would bypass the range query's cycle recovery and could introduce a
 /// divergent inference cycle. For large scopes, keeping the complete-block pass unconditional
 /// ensures that tracked callers record the same dependencies on every thread. Small scopes do not
-/// need prefix warming to bound the Salsa stack, so their calls are evaluated entirely on demand.
-fn analyze_non_terminal_call_prefix<'db>(
+/// need prefix warming to bound the Salsa stack, so their predicates are evaluated entirely on demand.
+fn analyze_completion_prefix<'db>(
     db: &'db dyn Db,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root_predicate: ScopedPredicateId,
 ) -> bool {
     let scope = predicate_scope(db, &predicates[root_predicate]);
-    let has_many_calls = predicates
+    let has_many_completions = predicates
         .iter()
-        .filter(|predicate| matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)))
-        .nth(NON_TERMINAL_CALL_CHUNK_SIZE)
+        .filter(|predicate| {
+            matches!(
+                predicate.node,
+                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+            )
+        })
+        .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
         .is_some();
 
-    if !has_many_calls {
+    if !has_many_completions {
         return false;
     }
 
-    let call_predicates = non_terminal_call_predicates(db, scope);
-    let call_count = call_predicates.partition_point(|predicate| *predicate <= root_predicate);
+    let completion_predicates = completion_predicates(db, scope);
+    let completion_count =
+        completion_predicates.partition_point(|predicate| *predicate <= root_predicate);
     let mut start = 0;
     // Leave the incomplete final block demand-driven. Its reverse dependency chain is bounded by
-    // the block size, and every eagerly analyzed call remains behind a recoverable range query.
-    let mut remaining = call_count / NON_TERMINAL_CALL_CHUNK_SIZE;
+    // the block size, and every eagerly analyzed predicate remains behind a recoverable range query.
+    let mut remaining = completion_count / COMPLETION_PREDICATE_CHUNK_SIZE;
     while remaining > 0 {
         let level = remaining.ilog2();
         let length = 1 << level;
-        analyze_non_terminal_call_range(db, scope, level, start >> level);
+        analyze_completion_range(db, scope, level, start >> level);
         start += length;
         remaining -= length;
     }
@@ -615,74 +622,75 @@ fn analyze_non_terminal_call_prefix<'db>(
     true
 }
 
-/// Returns the statement-call predicates for `scope` in source order.
+/// Returns completion predicates for statement calls and boolean evaluation boundaries in source order.
 ///
-/// This tracked index is used only once a scope exceeds [`NON_TERMINAL_CALL_CHUNK_SIZE`], avoiding
-/// a persistent allocation for the common case of scopes with few calls.
+/// This tracked index is used only once a scope exceeds [`COMPLETION_PREDICATE_CHUNK_SIZE`], avoiding
+/// a persistent allocation for the common case of scopes with few completion predicates.
 #[salsa::tracked(returns(deref), heap_size = get_size2::GetSize::get_heap_size)]
-fn non_terminal_call_predicates<'db>(
-    db: &'db dyn Db,
-    scope: ScopeId<'db>,
-) -> Box<[ScopedPredicateId]> {
+fn completion_predicates<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Box<[ScopedPredicateId]> {
     use_def_map(db, scope)
         .predicates()
         .iter_enumerated()
         .filter_map(|(id, predicate)| {
-            matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)).then_some(id)
+            matches!(
+                predicate.node,
+                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+            )
+            .then_some(id)
         })
         .collect()
 }
 
-fn analyze_non_terminal_calls<'db>(
+fn analyze_completion_predicates<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    call_predicates: &[ScopedPredicateId],
+    completion_predicates: &[ScopedPredicateId],
 ) {
-    for id in call_predicates {
+    for id in completion_predicates {
         analyze_single(db, env, &predicates[*id]);
     }
 }
 
-/// Analyzes a power-of-two range of call-predicate blocks in source order.
+/// Analyzes a power-of-two range of completion-predicate blocks in source order.
 ///
 /// Prefixes can be decomposed into these canonical ranges and reused by later expression-inference
 /// queries. Splitting ranges in half keeps the Salsa query stack logarithmic even when the first
-/// requested prefix contains thousands of calls. Each leaf handles multiple calls iteratively to
-/// avoid retaining a Salsa argument and query result for every individual predicate.
+/// requested prefix contains thousands of expressions. Each leaf handles multiple predicates
+/// iteratively to avoid retaining a Salsa argument and query result for every individual predicate.
 ///
-/// Analyzing a call can re-enter reachability through expression inference and request this same
-/// range. Recovery is a no-op because the range only warms call queries; any call still needed for
-/// reachability is evaluated directly by the decision-diagram walk.
+/// Analyzing an expression can re-enter reachability through inference and request this same
+/// range. Recovery is a no-op because the range only warms completion queries; any predicate still
+/// needed for reachability is evaluated directly by the decision-diagram walk.
 #[salsa::tracked(
     returns(copy),
     cycle_initial = |_, _, _, _, _| (),
     heap_size = get_size2::GetSize::get_heap_size
 )]
-fn analyze_non_terminal_call_range<'db>(
-    db: &'db dyn Db,
-    scope: ScopeId<'db>,
-    level: u32,
-    index: usize,
-) {
+fn analyze_completion_range<'db>(db: &'db dyn Db, scope: ScopeId<'db>, level: u32, index: usize) {
     if level == 0 {
         let env = ProgramEnvironment::from_scope(scope);
         let use_def = use_def_map(db, scope);
-        let call_predicates = non_terminal_call_predicates(db, scope);
-        let start = index * NON_TERMINAL_CALL_CHUNK_SIZE;
-        let end = start + NON_TERMINAL_CALL_CHUNK_SIZE;
-        analyze_non_terminal_calls(db, &env, use_def.predicates(), &call_predicates[start..end]);
+        let completion_predicates = completion_predicates(db, scope);
+        let start = index * COMPLETION_PREDICATE_CHUNK_SIZE;
+        let end = start + COMPLETION_PREDICATE_CHUNK_SIZE;
+        analyze_completion_predicates(
+            db,
+            &env,
+            use_def.predicates(),
+            &completion_predicates[start..end],
+        );
         return;
     }
 
     let child_index = index * 2;
-    analyze_non_terminal_call_range(db, scope, level - 1, child_index);
-    analyze_non_terminal_call_range(db, scope, level - 1, child_index + 1);
+    analyze_completion_range(db, scope, level - 1, child_index);
+    analyze_completion_range(db, scope, level - 1, child_index + 1);
 }
 
-/// Evaluates a reachability constraint after warming its statement-call prefix.
+/// Evaluates a reachability constraint after warming its completion-predicate prefix.
 ///
-/// Large scopes reuse canonical call ranges and sparse decision-diagram checkpoints; small scopes
+/// Large scopes reuse canonical completion ranges and sparse decision-diagram checkpoints; small scopes
 /// retain the direct evaluation path without creating either cached index.
 fn evaluate_reachability_constraint<'db>(
     db: &'db dyn Db,
@@ -697,15 +705,15 @@ fn evaluate_reachability_constraint<'db>(
     let constraints = use_def.reachability_constraints();
     let predicates = use_def.predicates();
     let root_predicate = constraints.get_interior_node(id).atom();
-    let has_many_calls = analyze_non_terminal_call_prefix(db, predicates, root_predicate);
-    let call_predicates = has_many_calls.then(|| non_terminal_call_predicates(db, scope));
+    let has_many_completions = analyze_completion_prefix(db, predicates, root_predicate);
+    let completion_predicates = has_many_completions.then(|| completion_predicates(db, scope));
 
     evaluate_reachability_path(
         db,
         scope,
         constraints,
         predicates,
-        call_predicates,
+        completion_predicates,
         id,
         true,
     )
@@ -746,16 +754,17 @@ fn terminal_reachability(id: ScopedReachabilityConstraintId) -> Option<Truthines
 
 /// Selects sparse, stable checkpoints without adding a second scope-wide predicate index.
 ///
-/// Statement calls retain their existing checkpoint spacing. Other control-flow predicates become
+/// Completion predicates share fixed checkpoint spacing. Other control-flow predicates become
 /// checkpoints only after a sufficiently long path has demonstrated that reuse is worthwhile.
 fn is_reachability_checkpoint(
-    call_predicates: Option<&[ScopedPredicateId]>,
+    completion_predicates: Option<&[ScopedPredicateId]>,
     predicate: ScopedPredicateId,
     visited: usize,
 ) -> bool {
-    if let Some(call_index) = call_predicates.and_then(|calls| calls.binary_search(&predicate).ok())
+    if let Some(completion_index) =
+        completion_predicates.and_then(|predicates| predicates.binary_search(&predicate).ok())
     {
-        return (call_index + 1).is_multiple_of(REACHABILITY_EVALUATION_CHUNK_SIZE);
+        return (completion_index + 1).is_multiple_of(REACHABILITY_EVALUATION_CHUNK_SIZE);
     }
 
     // Folding the adjacent bucket prevents regularly interleaved predicate kinds from always
@@ -779,7 +788,7 @@ fn evaluate_reachability_path<'db>(
     scope: ScopeId<'db>,
     constraints: &ReachabilityConstraints,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    call_predicates: Option<&[ScopedPredicateId]>,
+    completion_predicates: Option<&[ScopedPredicateId]>,
     mut id: ScopedReachabilityConstraintId,
     mut use_checkpoint: bool,
 ) -> Truthiness {
@@ -792,7 +801,8 @@ fn evaluate_reachability_path<'db>(
         }
 
         let node = constraints.get_interior_node(id);
-        if use_checkpoint && is_reachability_checkpoint(call_predicates, node.atom(), visited) {
+        if use_checkpoint && is_reachability_checkpoint(completion_predicates, node.atom(), visited)
+        {
             return evaluate_reachability_checkpoint(db, scope, id);
         }
 
@@ -808,7 +818,7 @@ fn evaluate_reachability_path<'db>(
 
 /// Evaluates a canonical suffix of a reachability decision diagram.
 ///
-/// Statement calls retain their existing sparse checkpoints; other predicates become checkpoints
+/// Completion predicates share sparse checkpoints; other predicates become checkpoints
 /// only after a long path demonstrates that reuse is worthwhile. This lets later statements reuse
 /// constraints accumulated by earlier statements without retaining an additional scope-wide index
 /// or a Salsa query key and memo for every constraint.
@@ -824,18 +834,23 @@ fn evaluate_reachability_checkpoint<'db>(
 ) -> Truthiness {
     let use_def = use_def_map(db, scope);
     let predicates = use_def.predicates();
-    let has_many_calls = predicates
+    let has_many_completions = predicates
         .iter()
-        .filter(|predicate| matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)))
-        .nth(NON_TERMINAL_CALL_CHUNK_SIZE)
+        .filter(|predicate| {
+            matches!(
+                predicate.node,
+                PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+            )
+        })
+        .nth(COMPLETION_PREDICATE_CHUNK_SIZE)
         .is_some();
-    let call_predicates = has_many_calls.then(|| non_terminal_call_predicates(db, scope));
+    let completion_predicates = has_many_completions.then(|| completion_predicates(db, scope));
     evaluate_reachability_path(
         db,
         scope,
         use_def.reachability_constraints(),
         predicates,
-        call_predicates,
+        completion_predicates,
         id,
         false,
     )
@@ -864,7 +879,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         }
 
         let root_predicate = self.get_interior_node(id).atom();
-        analyze_non_terminal_call_prefix(db, predicates, root_predicate);
+        analyze_completion_prefix(db, predicates, root_predicate);
         evaluate_reachability_path(
             db,
             predicate_scope(db, &predicates[root_predicate]),
@@ -1370,7 +1385,8 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             .contains(node.atom, self.place)
                             || matches!(
                                 predicate.node,
-                                PredicateNode::ContextManagerSuppresses { .. }
+                                PredicateNode::ExpressionCanComplete { .. }
+                                    | PredicateNode::ContextManagerSuppresses { .. }
                                     | PredicateNode::FinallyNormalPathImpossible { .. }
                             ))
                     {
@@ -1405,6 +1421,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let is_control_flow_gate = matches!(
                         predicate.node,
                         PredicateNode::IsNonTerminalCall(_)
+                            | PredicateNode::ExpressionCanComplete { .. }
                             | PredicateNode::ContextManagerSuppresses { .. }
                             | PredicateNode::FinallyNormalPathImpossible { .. }
                     );
@@ -1881,21 +1898,21 @@ pub(crate) fn analyze_condition_expression(
 
 #[salsa::tracked(
     returns(copy),
-    cycle_initial = |_, _, _| Truthiness::Ambiguous,
-    cycle_fn = |_, cycle: &salsa::Cycle, previous: &Truthiness, result: Truthiness, _| {
+    cycle_initial = |_, _, _| Some(Truthiness::Ambiguous),
+    cycle_fn = |_, cycle: &salsa::Cycle, previous: &Option<Truthiness>, result: Option<Truthiness>, _| {
         // A condition can control whether one of its own inputs is reachable. Expression inference
         // can lose its previous result when it ceases to be a cycle head, so its type widening alone
         // does not ensure that the condition's truthiness converges. Delay widening here to avoid
         // retaining imprecise results from the first few iterations.
         if cycle.iteration() > crate::TAINTED_CYCLES && *previous != result {
-            Truthiness::Ambiguous
+            Some(Truthiness::Ambiguous)
         } else {
             result
         }
     },
     heap_size = get_size2::GetSize::get_heap_size
 )]
-fn analyze_condition<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Truthiness {
+fn analyze_condition<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Option<Truthiness> {
     let env = ProgramEnvironment::from_scope(expression.scope(db));
     let module = parsed_module(db, expression.python_file(db)).load(db);
     let inference = infer_expression_types(db, expression, TypeContext::default());
@@ -1904,7 +1921,34 @@ fn analyze_condition<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Truth
             .comparison_truthiness(node)
             .or_else(|| inference.expression_type(node).bool_if_inhabited(db, &env))
     })
-    .unwrap_or(Truthiness::Ambiguous)
+}
+
+/// Cycle recovery assumes evaluation can complete when it depends on its own constraint.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _, _| true,
+    cycle_fn = |_, cycle: &salsa::Cycle, previous: &bool, result: bool, _, _| {
+        if cycle.iteration() > crate::TAINTED_CYCLES {
+            *previous || result
+        } else {
+            result
+        }
+    },
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn expression_can_complete<'db>(
+    db: &'db dyn Db,
+    expression: Expression<'db>,
+    context: ExpressionContext,
+) -> bool {
+    match context {
+        ExpressionContext::Condition => analyze_condition(db, expression).is_some(),
+        ExpressionContext::Value => {
+            let env = ProgramEnvironment::from_scope(expression.scope(db));
+            !infer_same_file_expression_type(db, expression, TypeContext::default())
+                .is_equivalent_to(db, &env, Type::Never)
+        }
+    }
 }
 
 fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predicate) -> Truthiness {
@@ -1916,9 +1960,14 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
                 .bool(db, env)
                 .negate_if(!predicate.is_positive)
         }
-        PredicateNode::Condition(test_expr) => {
-            analyze_condition(db, test_expr).negate_if(!predicate.is_positive)
-        }
+        PredicateNode::Condition(test_expr) => analyze_condition(db, test_expr)
+            .unwrap_or(Truthiness::Ambiguous)
+            .negate_if(!predicate.is_positive),
+        PredicateNode::ExpressionCanComplete {
+            expression,
+            context,
+        } => Truthiness::from(expression_can_complete(db, expression, context))
+            .negate_if(!predicate.is_positive),
         PredicateNode::ChainedComparisonCondition(test_expr) => {
             let inference = infer_expression_types(db, test_expr, TypeContext::default());
             let expression = test_expr.node_ref(db);
@@ -2214,10 +2263,18 @@ mod tests {
     use ty_python_core::predicate::Predicates;
     use ty_python_core::semantic_index;
 
+    /// A cached completion range returns without panicking when each class's `target` attribute
+    /// depends on the other class's `setup` method. This forces a Salsa cycle across files while
+    /// the range query itself is active, exercising that query's cycle recovery.
     #[test]
-    fn non_terminal_call_range_recovers_cross_file_cycle() -> anyhow::Result<()> {
+    fn completion_range_recovers_cross_file_cycle() -> anyhow::Result<()> {
         let mut db = setup_db();
-        let calls = "        other.target.ping()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE + 1);
+        let calls = concat!(
+            "        other.target.ping()\n",
+            "        other.target.ping() and None\n",
+            "        None if other.target.ping() else None\n",
+        )
+        .repeat(COMPLETION_PREDICATE_CHUNK_SIZE + 1);
         let a = format!(
             r#"from b import B
 
@@ -2259,50 +2316,67 @@ class TargetB:
 
         // Enter the range directly so it becomes the cycle head when inferring `other.target`
         // reaches the other module and then re-enters this scope.
-        analyze_non_terminal_call_range(&db, setup_scope, 0, 0);
+        analyze_completion_range(&db, setup_scope, 0, 0);
         Ok(())
     }
 
+    /// Changing an imported callable's return type from `None` to `NoReturn` invalidates cached
+    /// completion results. Rechecking the unchanged caller in the same database must change its
+    /// end-of-scope reachability from reachable to unreachable.
+    /// Separate fixtures exercise statement calls, boolean operands, and conditional-expression
+    /// tests so a terminal statement cannot hide a stale expression-completion result.
     #[test]
-    fn non_terminal_call_range_invalidates_when_callable_changes() -> anyhow::Result<()> {
-        let mut db = setup_db();
-        let source = format!(
-            "from dependency import callback\n\ndef f() -> None:\n{}",
-            "    callback()\n".repeat(NON_TERMINAL_CALL_CHUNK_SIZE + 1)
-        );
-        db.write_files([
-            ("/src/dependency.py", "def callback() -> None: ..."),
-            ("/src/test.py", source.as_str()),
-        ])?;
+    fn completion_range_invalidates_when_callable_changes() -> anyhow::Result<()> {
+        for expression in [
+            "callback()",
+            "callback() and None",
+            "None if callback() else None",
+        ] {
+            let mut db = setup_db();
+            let source = format!(
+                "from dependency import callback\n\ndef f() -> None:\n{}",
+                format!("    {expression}\n").repeat(COMPLETION_PREDICATE_CHUNK_SIZE + 1)
+            );
+            db.write_files([
+                ("/src/dependency.py", "def callback() -> None: ..."),
+                ("/src/test.py", source.as_str()),
+            ])?;
 
-        let file = system_path_to_file(&db, "/src/test.py").unwrap();
-        let function_scope = {
-            let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
-            let index = semantic_index(&db, program_file);
-            index.child_scopes(FileScopeId::global()).next().unwrap().0
-        };
-        {
+            let file = system_path_to_file(&db, "/src/test.py").unwrap();
+            let function_scope = {
+                let program_file =
+                    ProgramFile::new(&db, file, db.program_environment().program(&db));
+                let index = semantic_index(&db, program_file);
+                index.child_scopes(FileScopeId::global()).next().unwrap().0
+            };
+            {
+                let program_file =
+                    ProgramFile::new(&db, file, db.program_environment().program(&db));
+                let scope = function_scope.to_scope_id(&db, program_file);
+                let use_def = use_def_map(&db, scope);
+                assert!(
+                    evaluate_reachability_constraint(
+                        &db,
+                        scope,
+                        use_def.end_of_scope_reachability(),
+                    )
+                    .may_be_true()
+                );
+            }
+
+            db.write_file(
+                "/src/dependency.py",
+                "from typing import NoReturn\ndef callback() -> NoReturn: ...",
+            )?;
+
             let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
             let scope = function_scope.to_scope_id(&db, program_file);
             let use_def = use_def_map(&db, scope);
             assert!(
                 evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability(),)
-                    .may_be_true()
+                    .is_always_false()
             );
         }
-
-        db.write_file(
-            "/src/dependency.py",
-            "from typing import NoReturn\ndef callback() -> NoReturn: ...",
-        )?;
-
-        let program_file = ProgramFile::new(&db, file, db.program_environment().program(&db));
-        let scope = function_scope.to_scope_id(&db, program_file);
-        let use_def = use_def_map(&db, scope);
-        assert!(
-            evaluate_reachability_constraint(&db, scope, use_def.end_of_scope_reachability(),)
-                .is_always_false()
-        );
         Ok(())
     }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1405,6 +1405,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let index = node.atom.index();
                     let checkpoint_position =
                         index ^ (index / NARROWING_EVALUATION_CHECKPOINT_INTERVAL);
+                    // Completion gates can depend on earlier narrowed uses without narrowing
+                    // this place themselves. Checkpoints keep those inference dependencies from
+                    // being copied into every later expression in a long chain.
                     if (id != root || use_root_checkpoint)
                         && (checkpoint_position + 1)
                             .is_multiple_of(NARROWING_EVALUATION_CHECKPOINT_INTERVAL)
@@ -1413,7 +1416,8 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             .contains(node.atom, self.place)
                             || matches!(
                                 predicate.node,
-                                PredicateNode::ContextManagerSuppresses { .. }
+                                PredicateNode::ExpressionCanComplete { .. }
+                                    | PredicateNode::ContextManagerSuppresses { .. }
                                     | PredicateNode::FinallyNormalPathImpossible { .. }
                             ))
                     {
@@ -1973,8 +1977,8 @@ fn analyze_condition<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Optio
 /// Cycle recovery assumes evaluation can complete when it depends on its own constraint.
 #[salsa::tracked(
     returns(copy),
-    cycle_initial = |_, _, _, _| true,
-    cycle_fn = |_, cycle: &salsa::Cycle, previous: &bool, result: bool, _, _| {
+    cycle_initial = |_, _, _| true,
+    cycle_fn = |_, cycle: &salsa::Cycle, previous: &bool, result: bool, _| {
         if cycle.iteration() > crate::TAINTED_CYCLES {
             *previous || result
         } else {
@@ -1983,19 +1987,13 @@ fn analyze_condition<'db>(db: &'db dyn Db, expression: Expression<'db>) -> Optio
     },
     heap_size = get_size2::GetSize::get_heap_size
 )]
-fn expression_can_complete<'db>(
-    db: &'db dyn Db,
-    expression: Expression<'db>,
-    context: ExpressionContext,
-) -> bool {
-    match context {
-        ExpressionContext::Condition => analyze_condition(db, expression).is_some(),
-        ExpressionContext::Value => {
-            let env = ProgramEnvironment::from_scope(expression.scope(db));
-            !infer_same_file_expression_type(db, expression, TypeContext::default())
-                .is_equivalent_to(db, &env, Type::Never)
-        }
-    }
+fn expression_value_can_complete<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
+    let env = ProgramEnvironment::from_scope(expression.scope(db));
+    !infer_same_file_expression_type(db, expression, TypeContext::default()).is_equivalent_to(
+        db,
+        &env,
+        Type::Never,
+    )
 }
 
 fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predicate) -> Truthiness {
@@ -2013,8 +2011,11 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
         PredicateNode::ExpressionCanComplete {
             expression,
             context,
-        } => Truthiness::from(expression_can_complete(db, expression, context))
-            .negate_if(!predicate.is_positive),
+        } => Truthiness::from(match context {
+            ExpressionContext::Condition => analyze_condition(db, expression).is_some(),
+            ExpressionContext::Value => expression_value_can_complete(db, expression),
+        })
+        .negate_if(!predicate.is_positive),
         PredicateNode::ChainedComparisonCondition(test_expr) => {
             let inference = infer_expression_types(db, test_expr, TypeContext::default());
             let expression = test_expr.node_ref(db);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1108,7 +1108,11 @@ pub(crate) struct NarrowingProjector<'a, 'db> {
     place: ScopedPlaceId,
     base_ty: Type<'db>,
     /// Checkpoint entries retain narrowed types, so projections are specific to the binding type.
-    project_cache: FxHashMap<(ScopedNarrowingConstraint, Type<'db>), ProjectedNarrowingNodeId>,
+    /// Keep the current binding's type outside the per-node keys, and retain the other caches
+    /// for reuse when another binding has a previously encountered type.
+    project_cache: FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>,
+    other_project_caches:
+        FxHashMap<Type<'db>, FxHashMap<ScopedNarrowingConstraint, ProjectedNarrowingNodeId>>,
     graph: ProjectedNarrowingGraph<'db>,
     narrowed_cache: FxHashMap<(ProjectedNarrowingNodeId, Type<'db>), Type<'db>>,
 }
@@ -1133,6 +1137,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             place,
             base_ty,
             project_cache: FxHashMap::default(),
+            other_project_caches: FxHashMap::default(),
             graph: ProjectedNarrowingGraph::default(),
             narrowed_cache: FxHashMap::default(),
         }
@@ -1144,7 +1149,15 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         constraint: ScopedNarrowingConstraint,
         base_ty: Type<'db>,
     ) -> Type<'db> {
-        self.base_ty = base_ty;
+        if self.base_ty != base_ty {
+            let next = self
+                .other_project_caches
+                .remove(&base_ty)
+                .unwrap_or_default();
+            let previous = std::mem::replace(&mut self.project_cache, next);
+            self.other_project_caches.insert(self.base_ty, previous);
+            self.base_ty = base_ty;
+        }
         match constraint {
             ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
             ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
@@ -1371,12 +1384,12 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         id: ProjectedNarrowingNodeId,
         constraint: ScopedNarrowingConstraint,
     ) -> ProjectedNarrowingNodeId {
-        if let Some(cached) = self.project_cache.get(&(constraint, self.base_ty)).copied()
+        if let Some(cached) = self.project_cache.get(&constraint).copied()
             && cached != id
         {
             return cached;
         }
-        self.project_cache.remove(&(constraint, self.base_ty));
+        self.project_cache.remove(&constraint);
         self.project(constraint, false)
     }
 
@@ -1401,7 +1414,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         while let Some(action) = actions.pop() {
             match action {
                 Action::Visit(id) => {
-                    if id.is_terminal() || self.project_cache.contains_key(&(id, self.base_ty)) {
+                    if id.is_terminal() || self.project_cache.contains_key(&id) {
                         continue;
                     }
 
@@ -1451,7 +1464,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                                 projected
                             }
                         };
-                        self.project_cache.insert((id, self.base_ty), projected);
+                        self.project_cache.insert(id, projected);
                         continue;
                     }
                     let is_control_flow_gate = matches!(
@@ -1493,7 +1506,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                     let branch = self.projected_node(branch);
                     let if_uncertain = self.projected_node(node.if_uncertain);
                     let projected = self.or(branch, if_uncertain);
-                    self.project_cache.insert((id, self.base_ty), projected);
+                    self.project_cache.insert(id, projected);
                 }
                 Action::FinishPredicate(id) => {
                     let node = self.constraints.get_interior_node(id);
@@ -1522,7 +1535,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                             if_false,
                         })
                     };
-                    self.project_cache.insert((id, self.base_ty), projected);
+                    self.project_cache.insert(id, projected);
                 }
             }
         }
@@ -1534,7 +1547,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
         match id {
             ScopedNarrowingConstraint::ALWAYS_TRUE => ProjectedNarrowingNodeId::ALWAYS_TRUE,
             ScopedNarrowingConstraint::ALWAYS_FALSE => ProjectedNarrowingNodeId::ALWAYS_FALSE,
-            _ => self.project_cache[&(id, self.base_ty)],
+            _ => self.project_cache[&id],
         }
     }
 }

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -16,7 +16,7 @@ use ty_module_resolver::{
 
 use crate::Db;
 use crate::place::implicit_globals::all_implicit_module_globals;
-use crate::place::{builtins_module_scope, implicit_builtins_symbol_scope};
+use crate::place_load::definitely_has_builtin_binding;
 use crate::types::ide_support::{ImportAliasResolution, definition_for_name};
 use crate::types::list_members::{all_members, all_reachable_members};
 use crate::types::{
@@ -104,23 +104,14 @@ impl<'db> SemanticModel<'db> {
         name: &str,
         node: ast::AnyNodeRef<'_>,
     ) -> bool {
-        let index = semantic_index(self.db, self.program_file());
         let Some(scope) = self.scope(node) else {
             return false;
         };
-
-        if index.visible_ancestor_scopes(scope).any(|(scope, _)| {
-            index
-                .place_table(scope)
-                .symbol_by_name(name)
-                .is_some_and(|symbol| symbol.is_bound() || symbol.is_declared())
-        }) {
-            return false;
-        }
-
-        let env = self.program_environment();
-        implicit_builtins_symbol_scope(self.db, &env, name)
-            .is_some_and(|scope| Some(scope) == builtins_module_scope(self.db, &env))
+        definitely_has_builtin_binding(
+            self.db,
+            scope.to_scope_id(self.db, self.program_file()),
+            name,
+        )
     }
 
     /// Returns a map from symbol name to that symbol's

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -82,9 +82,10 @@ use crate::types::diagnostic::{
 pub use crate::types::display::{DisplaySettings, TypeDetail, TypeDisplayDetails};
 pub(crate) use crate::types::enums::{EnumClassLiteral, EnumComplementType, enum_metadata};
 pub(crate) use crate::types::equality::{ComparisonSoundnessPolicy, equality_truthiness};
+pub(crate) use crate::types::function::KnownFunction;
 use crate::types::function::{
     DataclassTransformerFlags, DataclassTransformerParams, FunctionDecorators, FunctionSpans,
-    FunctionType, KnownFunction, OverloadLiteral,
+    FunctionType, OverloadLiteral,
 };
 pub(crate) use crate::types::generics::GenericContext;
 use crate::types::generics::{ApplySpecialization, Specialization, bind_typevar};

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -473,8 +473,9 @@ mod tests {
         Ok(())
     }
 
+    /// An always-taken `if` branch makes both the next `elif` test and its body unreachable.
     #[test]
-    fn reports_statement_in_unreachable_elif_branch() -> anyhow::Result<()> {
+    fn reports_unreachable_elif_test_and_body() -> anyhow::Result<()> {
         let source = r#"
             if True:
                 pass
@@ -484,10 +485,12 @@ mod tests {
 
         assert_snapshot!(UnreachableTest::new().render(source)?, @r#"
         info[unreachable-code]: Code is always unreachable
-         --> src/main.py:5:5
+         --> src/main.py:4:6
           |
-        5 |     print("dead")
-          |     ^^^^^^^^^^^^^
+        4 |   elif False:
+          |  ______^
+        5 | |     print("dead")
+          | |_________________^
         "#);
         Ok(())
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -66,7 +66,7 @@ use crate::{Db, FxIndexSet};
 use builder::TypeInferenceBuilder;
 pub(super) use comparisons::UnsupportedComparisonError;
 use ty_python_core::definition::{Definition, DefinitionKind};
-use ty_python_core::expression::Expression;
+use ty_python_core::expression::{Expression, ExpressionKind};
 use ty_python_core::scope::ScopeId;
 use ty_python_core::statement::StatementInner;
 use ty_python_core::unpack::Unpack;
@@ -454,7 +454,7 @@ pub(crate) fn infer_expression_types<'db>(
     cycle_fn=|db, cycle, previous: &ExpressionInference<'db>, inference: ExpressionInference<'db>, input: InferExpression<'db>| {
         let (expression, _) = input.into_inner(db);
         let env = ProgramEnvironment::from_scope(expression.scope(db));
-        inference.cycle_normalized(db, &env, previous, cycle)
+        inference.cycle_normalized(db, &env, expression, previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -479,7 +479,7 @@ pub(super) fn infer_expression_types_impl<'db>(
 
     let env = ProgramEnvironment::from_file(program_file);
 
-    TypeInferenceBuilder::new(
+    let mut inference = TypeInferenceBuilder::new(
         db,
         &env,
         InferenceRegion::Expression(expression, tcx),
@@ -488,7 +488,15 @@ pub(super) fn infer_expression_types_impl<'db>(
         index,
         &module,
     )
-    .finish_expression()
+    .finish_expression();
+    if expression.kind(db) == ExpressionKind::BooleanTest {
+        inference.boolean_test_completion = Some(
+            !inference
+                .expression_type(expression.node_ref(db))
+                .is_equivalent_to(db, &env, Type::Never),
+        );
+    }
+    inference
 }
 
 fn expression_cycle_initial<'db>(
@@ -1796,6 +1804,9 @@ pub(crate) struct ExpressionInference<'db> {
     /// The types of every expression in this region.
     expressions: FrozenMap<ExpressionNodeKey, Type<'db>>,
 
+    /// Whether a boolean test can produce a value. Other expression regions leave this unset.
+    boolean_test_completion: Option<bool>,
+
     extra: Option<Box<ExpressionInferenceExtra<'db>>>,
 
     /// The scope this region is part of.
@@ -1864,6 +1875,7 @@ impl<'db> ExpressionInference<'db> {
     fn cycle_initial(scope: ScopeId<'db>, cycle_recovery: Type<'db>) -> Self {
         let _ = scope;
         Self {
+            boolean_test_completion: Some(true),
             extra: Some(Box::new(ExpressionInferenceExtra {
                 cycle_recovery: Some(cycle_recovery),
                 ..ExpressionInferenceExtra::default()
@@ -1878,6 +1890,7 @@ impl<'db> ExpressionInference<'db> {
         mut self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
+        expression: Expression<'db>,
         previous: &ExpressionInference<'db>,
         cycle: &salsa::Cycle,
     ) -> ExpressionInference<'db> {
@@ -1903,6 +1916,17 @@ impl<'db> ExpressionInference<'db> {
         for (expr, ty) in &mut self.expressions {
             let previous_ty = previous.expression_type(*expr);
             *ty = ty.cycle_normalized(db, env, previous_ty, cycle);
+        }
+
+        if self.boolean_test_completion.is_some() {
+            let can_complete = !self
+                .expression_type(expression.node_ref(db))
+                .is_equivalent_to(db, env, Type::Never);
+            self.boolean_test_completion = Some(
+                can_complete
+                    || (cycle.iteration() > crate::TAINTED_CYCLES
+                        && previous.boolean_test_completion == Some(true)),
+            );
         }
 
         if cycle.iteration() > crate::TAINTED_CYCLES
@@ -1962,6 +1986,10 @@ impl<'db> ExpressionInference<'db> {
             .comparison_truthiness
             .get(&expression.into())
             .copied()
+    }
+
+    pub(crate) fn boolean_test_completion(&self) -> Option<bool> {
+        self.boolean_test_completion
     }
 
     fn collection_use_constraints(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11149,7 +11149,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             operand,
         } = unary;
 
-        let operand_type = self.infer_expression(operand, TypeContext::default());
+        let operand_type = self.infer_maybe_standalone_expression(operand, TypeContext::default());
 
         self.infer_unary_expression_type(*op, operand_type, unary)
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1495,7 +1495,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.context.inference_flags |= InferenceFlags::CHECK_UNBOUND_TYPEVARS;
                 self.infer_expression_impl(expression.node_ref(self.db()).node(self.module()), tcx);
             }
-            ExpressionKind::Normal => {
+            ExpressionKind::Normal | ExpressionKind::BooleanTest => {
                 self.infer_expression_impl(expression.node_ref(self.db()).node(self.module()), tcx);
             }
             ExpressionKind::TypeExpression => {
@@ -12453,6 +12453,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
 
         ExpressionInference {
             expressions: FrozenMap::from(self.expressions),
+            boolean_test_completion: None,
             extra,
             #[cfg(debug_assertions)]
             scope: self.scope,

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
@@ -672,9 +672,7 @@ fn reachability_contains_special_cased_condition<'db>(
     let predicate = use_def.predicates()[node.atom()];
     if matches!(
         predicate.node,
-        PredicateNode::IsNonTerminalCall(_)
-            | PredicateNode::ExpressionCanComplete { .. }
-            | PredicateNode::CallCanComplete(_)
+        PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
     ) {
         // Termination does not give later values an environment-dependent origin.
         // Assume calls and boolean tests complete before collecting their guards;
@@ -721,7 +719,6 @@ fn predicate_contains_special_cased_condition<'db>(
         // definition environment-dependent merely because it is reached after that call returns.
         PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::ExpressionCanComplete { .. }
-        | PredicateNode::CallCanComplete(_)
         | PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::OrPatternAlternative(_)

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
@@ -674,7 +674,7 @@ fn reachability_contains_special_cased_condition<'db>(
         predicate.node,
         PredicateNode::IsNonTerminalCall(_)
             | PredicateNode::ExpressionCanComplete { .. }
-            | PredicateNode::BoolCallCanComplete(_)
+            | PredicateNode::BuiltinCallCanComplete { .. }
     ) {
         // Termination does not give later values an environment-dependent origin.
         // Assume calls and boolean tests complete before collecting their guards;
@@ -721,7 +721,7 @@ fn predicate_contains_special_cased_condition<'db>(
         // definition environment-dependent merely because it is reached after that call returns.
         PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::ExpressionCanComplete { .. }
-        | PredicateNode::BoolCallCanComplete(_)
+        | PredicateNode::BuiltinCallCanComplete { .. }
         | PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::OrPatternAlternative(_)

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
@@ -644,7 +644,8 @@ fn definition_contains_special_cased_condition<'db>(
 ///
 /// Successive statements often share most of their reachability graph. Cache each node's
 /// summary so checking another definition does not traverse the shared portion again.
-/// All three branches contribute, regardless of the configured environment's truthiness.
+/// All three branches contribute for environment guards, regardless of the configured
+/// environment's truthiness. Calls and boolean tests are assumed to complete.
 #[salsa::tracked(
     returns(copy),
     cycle_initial = |_, _, _, _| false,
@@ -664,9 +665,26 @@ fn reachability_contains_special_cased_condition<'db>(
         return false;
     }
 
-    let node = use_def_map(db, scope)
+    let use_def = use_def_map(db, scope);
+    let node = use_def
         .reachability_constraints()
         .get_interior_node(reachability);
+    let predicate = use_def.predicates()[node.atom()];
+    if matches!(
+        predicate.node,
+        PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+    ) {
+        // Termination does not give later values an environment-dependent origin.
+        // Assume calls and boolean tests complete before collecting their guards;
+        // merely ignoring completion predicates would still visit their failure
+        // paths, where an earlier environment guard can remain in the formula.
+        let child = if predicate.is_positive {
+            node.if_true()
+        } else {
+            node.if_false()
+        };
+        return reachability_contains_special_cased_condition(db, scope, child);
+    }
     predicate_contains_special_cased_condition(db, scope, node.atom())
         || [node.if_true(), node.if_ambiguous(), node.if_false()]
             .into_iter()
@@ -700,6 +718,7 @@ fn predicate_contains_special_cased_condition<'db>(
         // particular, a statement such as `print(sys.platform)` should not make every later
         // definition environment-dependent merely because it is reached after that call returns.
         PredicateNode::IsNonTerminalCall(_)
+        | PredicateNode::ExpressionCanComplete { .. }
         | PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::OrPatternAlternative(_)

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
@@ -672,7 +672,9 @@ fn reachability_contains_special_cased_condition<'db>(
     let predicate = use_def.predicates()[node.atom()];
     if matches!(
         predicate.node,
-        PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+        PredicateNode::IsNonTerminalCall(_)
+            | PredicateNode::ExpressionCanComplete { .. }
+            | PredicateNode::CallCanComplete(_)
     ) {
         // Termination does not give later values an environment-dependent origin.
         // Assume calls and boolean tests complete before collecting their guards;
@@ -719,6 +721,7 @@ fn predicate_contains_special_cased_condition<'db>(
         // definition environment-dependent merely because it is reached after that call returns.
         PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::ExpressionCanComplete { .. }
+        | PredicateNode::CallCanComplete(_)
         | PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::OrPatternAlternative(_)

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/exemptions.rs
@@ -672,7 +672,9 @@ fn reachability_contains_special_cased_condition<'db>(
     let predicate = use_def.predicates()[node.atom()];
     if matches!(
         predicate.node,
-        PredicateNode::IsNonTerminalCall(_) | PredicateNode::ExpressionCanComplete { .. }
+        PredicateNode::IsNonTerminalCall(_)
+            | PredicateNode::ExpressionCanComplete { .. }
+            | PredicateNode::BoolCallCanComplete(_)
     ) {
         // Termination does not give later values an environment-dependent origin.
         // Assume calls and boolean tests complete before collecting their guards;
@@ -719,6 +721,7 @@ fn predicate_contains_special_cased_condition<'db>(
         // definition environment-dependent merely because it is reached after that call returns.
         PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::ExpressionCanComplete { .. }
+        | PredicateNode::BoolCallCanComplete(_)
         | PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::OrPatternAlternative(_)

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/mod.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/mod.rs
@@ -59,7 +59,7 @@ use ty_python_core::{Truthiness, expression::ExpressionContext, predicate::State
 
 use crate::{
     lint::LintMetadata,
-    reachability::{analyze_condition_expression, is_non_terminal_call},
+    reachability::{analyze_condition_expression, is_non_terminal_call, is_range_reachable},
     types::{
         KnownClass, KnownInstanceType, Type,
         diagnostic::{REDUNDANT_CONDITION, REDUNDANT_CONDITION_STRICT},
@@ -816,6 +816,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
 
         let rule = condition.kind.rule();
+
+        // An unreachable candidate cannot suppress a diagnostic on the enclosing condition,
+        // even when its own rule is disabled or exempted.
+        if !is_range_reachable(
+            self.db(),
+            self.index,
+            self.scope().file_scope_id(self.db()),
+            test.expression.range(),
+        ) {
+            return ConditionCheckResult::CheckEnclosingCondition;
+        }
 
         if self.context.is_lint_enabled(rule) && !condition_context.exempts(self, &condition) {
             conditions.push(condition);

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -814,8 +814,12 @@ const MANY_WIDGETS: usize = 400;
 const MANY_NON_TERMINAL_CALLS: usize = 1_100;
 const FEW_NON_TERMINAL_CALLS: usize = 80;
 
+/// An attribute assigned after many calls and boolean tests retains its `Widget` type when
+/// accessed from another module. Checking the consumer first forces inference of the preceding
+/// completion predicates before their results are cached. This lookup must finish without
+/// overflowing the stack size used by production workers.
 #[test]
-fn implicit_attribute_after_many_non_terminal_calls() -> anyhow::Result<()> {
+fn implicit_attribute_after_many_completion_predicates() -> anyhow::Result<()> {
     let handle = std::thread::Builder::new()
         .name("implicit-attribute-stack-test".into())
         // Match the stack size used by ty's production worker threads.
@@ -894,8 +898,8 @@ class Inner:
                     concat!(
                         "        self.widget_{index} = Widget()\n",
                         "        self.widget_{index}.configure()\n",
-                        "        self.widget_{index}.configure()\n",
-                        "        self.widget_{index}.configure()\n",
+                        "        self.widget_{index}.configure() and None\n",
+                        "        None if self.widget_{index}.configure() else None\n",
                     ),
                     index = index,
                 )?;

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -556,6 +556,7 @@ fn comparison_truthiness_widens_across_sparse_cycle_results() -> anyhow::Result<
         (
             ExpressionInference {
                 expressions: [(expression, ty)].into_iter().collect(),
+                boolean_test_completion: None,
                 extra: truthiness.map(|truthiness| {
                     Box::new(ExpressionInferenceExtra {
                         comparison_truthiness: [(expression, truthiness)].into_iter().collect(),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -111,7 +111,7 @@ pub(crate) fn infer_narrowing_constraints<'db>(
         }
         PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::ExpressionCanComplete { .. }
-        | PredicateNode::BoolCallCanComplete(_)
+        | PredicateNode::BuiltinCallCanComplete { .. }
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::IsNonEmptyIterable(_)
@@ -1591,7 +1591,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
             PredicateNode::ContextManagerSuppresses { .. }
             | PredicateNode::ExpressionCanComplete { .. }
-            | PredicateNode::BoolCallCanComplete(_)
+            | PredicateNode::BuiltinCallCanComplete { .. }
             | PredicateNode::FinallyNormalPathImpossible { .. }
             | PredicateNode::IsNonTerminalCall(_) => return None,
             PredicateNode::IsNonEmptyIterable(_) => return None,
@@ -3310,6 +3310,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             | PredicateNode::Condition(expression)
             | PredicateNode::ChainedComparisonCondition(expression)
             | PredicateNode::ContextManagerSuppresses { expression, .. }
+            | PredicateNode::BuiltinCallCanComplete { expression, .. }
             | PredicateNode::ExpressionCanComplete { expression, .. } => expression.scope(db),
             PredicateNode::Pattern(pattern) => pattern.scope(db),
             PredicateNode::FinallyNormalPathImpossible { scope, .. } => scope,
@@ -3317,9 +3318,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             PredicateNode::SubjectElementPattern(subject_element) => {
                 subject_element.pattern.scope(db)
             }
-            PredicateNode::IsNonTerminalCall(call) | PredicateNode::BoolCallCanComplete(call) => {
-                call.callable(db).scope(db)
-            }
+            PredicateNode::IsNonTerminalCall(call) => call.callable(db).scope(db),
             PredicateNode::IsNonEmptyIterable(expression) => expression.scope(db),
             PredicateNode::StarImportPlaceholder(definition) => definition.scope(db),
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -111,6 +111,7 @@ pub(crate) fn infer_narrowing_constraints<'db>(
             (positive, None)
         }
         PredicateNode::ContextManagerSuppresses { .. }
+        | PredicateNode::ExpressionCanComplete { .. }
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::IsNonEmptyIterable(_)
@@ -1589,6 +1590,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 self.evaluate_subject_element_pattern(subject_element)
             }
             PredicateNode::ContextManagerSuppresses { .. }
+            | PredicateNode::ExpressionCanComplete { .. }
             | PredicateNode::FinallyNormalPathImpossible { .. }
             | PredicateNode::IsNonTerminalCall(_) => return None,
             PredicateNode::IsNonEmptyIterable(_) => return None,
@@ -3306,7 +3308,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             PredicateNode::Expression(expression)
             | PredicateNode::Condition(expression)
             | PredicateNode::ChainedComparisonCondition(expression)
-            | PredicateNode::ContextManagerSuppresses { expression, .. } => expression.scope(db),
+            | PredicateNode::ContextManagerSuppresses { expression, .. }
+            | PredicateNode::ExpressionCanComplete { expression, .. } => expression.scope(db),
             PredicateNode::Pattern(pattern) => pattern.scope(db),
             PredicateNode::FinallyNormalPathImpossible { scope, .. } => scope,
             PredicateNode::OrPatternAlternative(scope) => scope,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -111,6 +111,7 @@ pub(crate) fn infer_narrowing_constraints<'db>(
         }
         PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::ExpressionCanComplete { .. }
+        | PredicateNode::BoolCallCanComplete(_)
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::IsNonEmptyIterable(_)
@@ -1590,6 +1591,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
             PredicateNode::ContextManagerSuppresses { .. }
             | PredicateNode::ExpressionCanComplete { .. }
+            | PredicateNode::BoolCallCanComplete(_)
             | PredicateNode::FinallyNormalPathImpossible { .. }
             | PredicateNode::IsNonTerminalCall(_) => return None,
             PredicateNode::IsNonEmptyIterable(_) => return None,
@@ -3315,7 +3317,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             PredicateNode::SubjectElementPattern(subject_element) => {
                 subject_element.pattern.scope(db)
             }
-            PredicateNode::IsNonTerminalCall(call) => call.callable(db).scope(db),
+            PredicateNode::IsNonTerminalCall(call) | PredicateNode::BoolCallCanComplete(call) => {
+                call.callable(db).scope(db)
+            }
             PredicateNode::IsNonEmptyIterable(expression) => expression.scope(db),
             PredicateNode::StarImportPlaceholder(definition) => definition.scope(db),
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -112,6 +112,7 @@ pub(crate) fn infer_narrowing_constraints<'db>(
         }
         PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::ExpressionCanComplete { .. }
+        | PredicateNode::CallCanComplete(_)
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::IsNonEmptyIterable(_)
@@ -1591,6 +1592,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
             PredicateNode::ContextManagerSuppresses { .. }
             | PredicateNode::ExpressionCanComplete { .. }
+            | PredicateNode::CallCanComplete(_)
             | PredicateNode::FinallyNormalPathImpossible { .. }
             | PredicateNode::IsNonTerminalCall(_) => return None,
             PredicateNode::IsNonEmptyIterable(_) => return None,
@@ -3316,7 +3318,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             PredicateNode::SubjectElementPattern(subject_element) => {
                 subject_element.pattern.scope(db)
             }
-            PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
+            PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. })
+            | PredicateNode::CallCanComplete(CallableAndCallExpr { callable, .. }) => {
                 callable.scope(db)
             }
             PredicateNode::IsNonEmptyIterable(expression) => expression.scope(db),

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -30,9 +30,8 @@ use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
-    CallableAndCallExpr, ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicate,
-    PatternPredicateKind, Predicate, PredicateNode, SequencePatternPredicateKind,
-    SubjectElementPatternPredicate,
+    ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicate, PatternPredicateKind,
+    Predicate, PredicateNode, SequencePatternPredicateKind, SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::symbol::Symbol;
@@ -112,7 +111,6 @@ pub(crate) fn infer_narrowing_constraints<'db>(
         }
         PredicateNode::ContextManagerSuppresses { .. }
         | PredicateNode::ExpressionCanComplete { .. }
-        | PredicateNode::CallCanComplete(_)
         | PredicateNode::FinallyNormalPathImpossible { .. }
         | PredicateNode::IsNonTerminalCall(_)
         | PredicateNode::IsNonEmptyIterable(_)
@@ -1592,7 +1590,6 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             }
             PredicateNode::ContextManagerSuppresses { .. }
             | PredicateNode::ExpressionCanComplete { .. }
-            | PredicateNode::CallCanComplete(_)
             | PredicateNode::FinallyNormalPathImpossible { .. }
             | PredicateNode::IsNonTerminalCall(_) => return None,
             PredicateNode::IsNonEmptyIterable(_) => return None,
@@ -3318,10 +3315,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             PredicateNode::SubjectElementPattern(subject_element) => {
                 subject_element.pattern.scope(db)
             }
-            PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. })
-            | PredicateNode::CallCanComplete(CallableAndCallExpr { callable, .. }) => {
-                callable.scope(db)
-            }
+            PredicateNode::IsNonTerminalCall(call) => call.callable(db).scope(db),
             PredicateNode::IsNonEmptyIterable(expression) => expression.scope(db),
             PredicateNode::StarImportPlaceholder(definition) => definition.scope(db),
         }


### PR DESCRIPTION
Builds on #28317.

When evaluating a boolean test returns `Never`, neither its truthy nor its falsy path is reachable. Track that completion requirement separately from truthiness, and apply it consistently to statement conditions, match guards, comprehension filters, short-circuit operands, conditional expressions, and `not`. For example, both branches below are unreachable:

```python
from typing import Never

def stop() -> Never:
    raise RuntimeError

if stop():
    print("truthy")
else:
    print("falsy")
```

Redundant-condition checks use shared range reachability to skip unreachable candidates, so an unreachable literal operand cannot suppress a diagnostic on the enclosing condition. Completion predicates share the existing source-order caching and cycle recovery for terminal calls. Environment-provenance checks assume those predicates complete when collecting guards, so implicit termination does not make later constants environment-dependent.
