### PR TITLE
[ty] Share equivalent place tables within a file

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -44,7 +44,7 @@ use crate::expression::{Expression, ExpressionContext, ExpressionKind};
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::member::MemberExprBuilder;
 use crate::place::{
-    PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId,
+    PlaceExpr, PlaceTable, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId,
     match_subject_place_expressions,
 };
 use crate::predicate::{
@@ -3356,13 +3356,38 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         );
 
         let mut use_def_map_interner = UseDefMapInterner::default();
+        let mut interned_place_tables: FxHashMap<u64, SmallVec<[Arc<PlaceTable>; 1]>> =
+            FxHashMap::default();
+        let place_tables = self
+            .place_tables
+            .into_iter()
+            .map(|builder| {
+                let table = builder.finish();
+                // Empty tables are cheap and do not need a lookup in the interner.
+                if table.symbols().next().is_none() && table.members().next().is_none() {
+                    return Arc::new(table);
+                }
+
+                let hash = table.fingerprint();
+                if let Some(existing) = interned_place_tables.get(&hash).and_then(|candidates| {
+                    candidates
+                        .iter()
+                        .find(|candidate| candidate.as_ref() == &table)
+                }) {
+                    return Arc::clone(existing);
+                }
+
+                let table = Arc::new(table);
+                interned_place_tables
+                    .entry(hash)
+                    .or_default()
+                    .push(Arc::clone(&table));
+                table
+            })
+            .collect();
 
         SemanticIndex {
-            place_tables: self
-                .place_tables
-                .into_iter()
-                .map(|builder| Arc::new(builder.finish()))
-                .collect(),
+            place_tables,
             scopes: self.scopes.into(),
             definitions_by_node: DefinitionsByNode::from_map(self.definitions_by_node),
             expressions_by_node: self.expressions_by_node,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1,10 +1,11 @@
 use std::cell::{OnceCell, RefCell};
+use std::hash::BuildHasher;
 use std::sync::Arc;
 
 use except_handlers::{ExceptionContextStackManager, ExceptionHandlers};
 use itertools::Itertools;
 use ruff_python_ast::helpers::{Truthiness, any_over_expr, is_dotted_name};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use ruff_db::parsed::ParsedModuleRef;
 
@@ -3368,7 +3369,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     return Arc::new(table);
                 }
 
-                let hash = table.fingerprint();
+                let hash = FxBuildHasher.hash_one(&table);
                 if let Some(existing) = interned_place_tables.get(&hash).and_then(|candidates| {
                     candidates
                         .iter()

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1464,38 +1464,6 @@ y = 2
     }
 
     #[test]
-    fn equal_nonempty_place_tables_are_shared_within_a_file() {
-        let TestCase { db, file } = test_case(
-            "
-def first():
-    value = 1
-
-def second():
-    value = 2
-
-def third():
-    value = 3
-    value
-",
-        );
-        let index = semantic_index(&db, program_file(&db, file));
-        let scopes = index
-            .child_scopes(FileScopeId::global())
-            .map(|(scope, _)| scope)
-            .collect::<Vec<_>>();
-        assert_eq!(scopes.len(), 3);
-
-        assert!(Arc::ptr_eq(
-            &index.place_tables[scopes[0]],
-            &index.place_tables[scopes[1]]
-        ));
-        assert!(!Arc::ptr_eq(
-            &index.place_tables[scopes[0]],
-            &index.place_tables[scopes[2]]
-        ));
-    }
-
-    #[test]
     fn function_parameter_symbols() {
         let TestCase { db, file } = test_case(
             "

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1464,6 +1464,38 @@ y = 2
     }
 
     #[test]
+    fn equal_nonempty_place_tables_are_shared_within_a_file() {
+        let TestCase { db, file } = test_case(
+            "
+def first():
+    value = 1
+
+def second():
+    value = 2
+
+def third():
+    value = 3
+    value
+",
+        );
+        let index = semantic_index(&db, program_file(&db, file));
+        let scopes = index
+            .child_scopes(FileScopeId::global())
+            .map(|(scope, _)| scope)
+            .collect::<Vec<_>>();
+        assert_eq!(scopes.len(), 3);
+
+        assert!(Arc::ptr_eq(
+            &index.place_tables[scopes[0]],
+            &index.place_tables[scopes[1]]
+        ));
+        assert!(!Arc::ptr_eq(
+            &index.place_tables[scopes[0]],
+            &index.place_tables[scopes[2]]
+        ));
+    }
+
+    #[test]
     fn function_parameter_symbols() {
         let TestCase { db, file } = test_case(
             "

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -9,8 +9,9 @@ use crate::{Db, PossiblyNarrowedPlaces};
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_index::IndexVec;
 use ruff_python_ast as ast;
+use rustc_hash::FxHasher;
 use smallvec::SmallVec;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::iter::FusedIterator;
 
 /// Return the expressions whose existing bindings a match pattern can narrow.
@@ -190,6 +191,31 @@ pub struct PlaceTable {
 }
 
 impl PlaceTable {
+    /// Hash the ordered places and their flags, omitting the reverse-lookup indexes.
+    /// Equal tables must produce the same hash even if their indexes have different layouts.
+    pub(super) fn fingerprint(&self) -> u64 {
+        let mut hasher = FxHasher::default();
+        self.symbols.iter().len().hash(&mut hasher);
+        for symbol in self.symbols.iter() {
+            symbol.name().hash(&mut hasher);
+            symbol.is_used().hash(&mut hasher);
+            symbol.is_bound().hash(&mut hasher);
+            symbol.is_declared().hash(&mut hasher);
+            symbol.is_global().hash(&mut hasher);
+            symbol.is_nonlocal().hash(&mut hasher);
+            symbol.is_reassigned().hash(&mut hasher);
+            symbol.is_parameter().hash(&mut hasher);
+        }
+        self.members.iter().len().hash(&mut hasher);
+        for member in self.members.iter() {
+            member.expression().as_ref().hash(&mut hasher);
+            member.is_bound().hash(&mut hasher);
+            member.is_declared().hash(&mut hasher);
+            member.is_instance_attribute().hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+
     /// Iterate over the "root" expressions of the place (e.g. `x.y.z`, `x.y`, `x` for `x.y.z[0]`).
     ///
     /// Note, this iterator may skip some parents if they are not defined in the current scope.

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -9,7 +9,6 @@ use crate::{Db, PossiblyNarrowedPlaces};
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_index::IndexVec;
 use ruff_python_ast as ast;
-use rustc_hash::FxHasher;
 use smallvec::SmallVec;
 use std::hash::{Hash, Hasher};
 use std::iter::FusedIterator;
@@ -190,32 +189,31 @@ pub struct PlaceTable {
     members: MemberTable,
 }
 
-impl PlaceTable {
-    /// Hash the ordered places and their flags, omitting the reverse-lookup indexes.
-    /// Equal tables must produce the same hash even if their indexes have different layouts.
-    pub(super) fn fingerprint(&self) -> u64 {
-        let mut hasher = FxHasher::default();
-        self.symbols.iter().len().hash(&mut hasher);
+impl Hash for PlaceTable {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // The reverse-lookup indexes are also ignored by equality.
+        self.symbols.iter().len().hash(state);
         for symbol in self.symbols.iter() {
-            symbol.name().hash(&mut hasher);
-            symbol.is_used().hash(&mut hasher);
-            symbol.is_bound().hash(&mut hasher);
-            symbol.is_declared().hash(&mut hasher);
-            symbol.is_global().hash(&mut hasher);
-            symbol.is_nonlocal().hash(&mut hasher);
-            symbol.is_reassigned().hash(&mut hasher);
-            symbol.is_parameter().hash(&mut hasher);
+            symbol.name().hash(state);
+            symbol.is_used().hash(state);
+            symbol.is_bound().hash(state);
+            symbol.is_declared().hash(state);
+            symbol.is_global().hash(state);
+            symbol.is_nonlocal().hash(state);
+            symbol.is_reassigned().hash(state);
+            symbol.is_parameter().hash(state);
         }
-        self.members.iter().len().hash(&mut hasher);
+        self.members.iter().len().hash(state);
         for member in self.members.iter() {
-            member.expression().as_ref().hash(&mut hasher);
-            member.is_bound().hash(&mut hasher);
-            member.is_declared().hash(&mut hasher);
-            member.is_instance_attribute().hash(&mut hasher);
+            member.expression().as_ref().hash(state);
+            member.is_bound().hash(state);
+            member.is_declared().hash(state);
+            member.is_instance_attribute().hash(state);
         }
-        hasher.finish()
     }
+}
 
+impl PlaceTable {
     /// Iterate over the "root" expressions of the place (e.g. `x.y.z`, `x.y`, `x` for `x.y.z[0]`).
     ///
     /// Note, this iterator may skip some parents if they are not defined in the current scope.


### PR DESCRIPTION
## Summary

We retain a separate place table for each scope even when multiple scopes in a file have identical symbols and members. Share equivalent nonempty tables within the file, checking structural equality after fingerprint matching so collisions cannot merge different tables.
