### PR TITLE
[ty] Expose inferred name loads to semantic consumers

### DIFF
--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -18,7 +18,7 @@ use ruff_db::vendored::VendoredFileSystem;
 use salsa::{Database, Event, Setter};
 use ty_module_resolver::system_module_search_paths;
 use ty_python_core::ProgramFile;
-use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};
+use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy};
 use ty_python_semantic::dependency::DependencyMetadata;
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{
@@ -120,18 +120,24 @@ impl ProjectDatabase {
         )
     }
 
-    /// Creates a new database, substituting default values for any misconfigured settings.
-    pub fn use_defaults<S>(project_metadata: ProjectMetadata, system: S) -> Self
+    /// Creates a database that permits name-load recording for selected files.
+    ///
+    /// The strategy determines how misconfigured settings are handled. Recording remains off
+    /// until files are selected with [`ty_python_semantic::enable_place_load_recording`].
+    pub fn with_place_load_recording<S, Strategy: MisconfigurationStrategy>(
+        project_metadata: ProjectMetadata,
+        system: S,
+        strategy: &Strategy,
+    ) -> Result<Self, Strategy::Error<anyhow::Error>>
     where
         S: System + 'static + Send + Sync + RefUnwindSafe,
     {
-        let Ok(db) = Self::new(
+        Self::new(
             project_metadata,
             system,
-            PlaceLoadRecordingMode::default(),
-            &UseDefaultStrategy,
-        );
-        db
+            PlaceLoadRecordingMode::OnDemand,
+            strategy,
+        )
     }
 
     /// Permanently freezes the most heavily read inputs that are immutable during a one-shot check.
@@ -953,11 +959,13 @@ pub(crate) mod testing {
 #[cfg(test)]
 mod tests {
     use ruff_db::Db as _;
-    use ruff_db::files::{FileRootKind, system_path_to_file};
+    use ruff_db::files::{File, FileRootKind, system_path_to_file};
+    use ruff_db::parsed::parsed_module;
     use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf, TestSystem};
     use ruff_db::testing::assert_function_query_was_not_run_by_name;
     use ruff_python_trivia::textwrap::dedent;
     use ty_module_resolver::list_modules;
+    use ty_python_core::program::FallibleStrategy;
     use ty_python_semantic::Db as _;
 
     use crate::db::testing::TestDb;
@@ -983,6 +991,45 @@ result = value
         ty_python_semantic::enable_place_load_recording(&mut db, [file]);
         assert!(!ty_python_semantic::should_record_place_loads(&db, file));
         assert!(db.check_file(file).is_empty());
+    }
+
+    #[test]
+    fn place_load_recording_is_opt_in_and_additive() {
+        let system = TestSystem::default();
+        for path in ["/project/first.py", "/project/second.py"] {
+            system
+                .memory_file_system()
+                .write_file_all(
+                    path,
+                    r#"
+value = 1
+result = value
+"#,
+                )
+                .expect("write recording fixture");
+        }
+        let mut db = ProjectDatabase::with_place_load_recording(
+            ProjectMetadata::new("recording", SystemPathBuf::from("/project")),
+            system,
+            &FallibleStrategy,
+        )
+        .expect("valid test project");
+        let first = system_path_to_file(&db, "/project/first.py").expect("first fixture exists");
+        let second = system_path_to_file(&db, "/project/second.py").expect("second fixture exists");
+        let project = db.project();
+        assert!(!has_recorded_name_load(&db, first));
+        assert!(!has_recorded_name_load(&db, second));
+        assert!(db.check_file(first).is_empty());
+
+        project.enable_place_load_recording(&mut db, [first]);
+        assert!(has_recorded_name_load(&db, first));
+        assert!(!has_recorded_name_load(&db, second));
+        assert!(db.check_file(first).is_empty());
+
+        project.enable_place_load_recording(&mut db, [first, second]);
+        assert!(has_recorded_name_load(&db, first));
+        assert!(has_recorded_name_load(&db, second));
+        assert!(db.check_file(second).is_empty());
     }
 
     #[test]
@@ -1154,5 +1201,21 @@ result = value
         );
 
         Ok(())
+    }
+
+    fn has_recorded_name_load(db: &ProjectDatabase, file: File) -> bool {
+        let file = db.program_file(file);
+        let module = parsed_module(db, file.python_file(db)).load(db);
+        let name = module
+            .syntax()
+            .body
+            .last()
+            .and_then(|statement| statement.as_assign_stmt())
+            .and_then(|assignment| assignment.value.as_name_expr())
+            .expect("fixture ends with an assignment from a name");
+        ty_python_semantic::SemanticModel::new(db, file)
+            .infer_name_loads([name])
+            .get(name)
+            .is_some()
     }
 }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -632,6 +632,23 @@ impl Project {
         self.set_open_fileset(db).to(open_files);
     }
 
+    /// Enables cached name-load records for the selected files without running inference.
+    ///
+    /// The database must permit recording; construct a [`ProjectDatabase`] with
+    /// [`ProjectDatabase::with_place_load_recording`]. Otherwise this request has no effect.
+    ///
+    /// Call this before creating database snapshots or semantic models for the operation.
+    /// Recording remains enabled across requests and source edits. Already-enabled files do
+    /// not change the database; newly enabled files invalidate their unrecorded inference.
+    #[allow(dead_code, reason = "recording is exposed for IDE consumers")]
+    pub fn enable_place_load_recording(
+        self,
+        db: &mut dyn Db,
+        files: impl IntoIterator<Item = File>,
+    ) {
+        ty_python_semantic::enable_place_load_recording(db, files);
+    }
+
     /// Permanently marks the project as never having open files, so reads of the
     /// open-file state record no salsa dependency. Any later write panics.
     fn freeze_open_files(self, db: &mut dyn Db) {

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -16,6 +16,11 @@ pub use db::{
 pub(crate) use diagnostic::add_inferred_python_version_hint_to_diagnostic;
 pub use diagnostic::inferred_python_version_source_annotation;
 pub use fixes::{fix_all_diagnostics, suppress_all_diagnostics};
+#[allow(
+    dead_code,
+    reason = "definition-resolution metadata is exposed for IDE consumers"
+)]
+pub use place::definitions::DefinitionResolution;
 use ruff_db::PythonFile;
 use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
 use ruff_db::files::File;
@@ -45,17 +50,19 @@ pub use ty_site_packages::{
     SitePackagesDiscoveryError, SitePackagesPaths, SysPrefixPathOrigin,
 };
 pub use types::ide_support::{
-    ImplementationsFinder, ImportAliasResolution, ResolvedDefinition, TypeHierarchyClass,
-    contains_identifier, definitions_for_attribute, definitions_for_bin_op,
+    ImplementationsFinder, ImportAliasResolution, InferredNameLoads, ResolvedDefinition,
+    TypeHierarchyClass, contains_identifier, definitions_for_attribute, definitions_for_bin_op,
     definitions_for_imported_symbol, definitions_for_name, definitions_for_unary_op,
     map_stub_definition, type_hierarchy_prepare, type_hierarchy_subtypes,
     type_hierarchy_supertypes,
 };
 pub use types::{
-    DisplaySettings, FixtureBinding, FixtureExposure, FixtureNameSource, ProgramEnvironment,
-    TypeQualifiers, fixture_bindings_for_parameter, fixture_exposures_for_definition,
-    pytest_global_plugin_files,
+    DeferredExpressionState, DisplaySettings, FixtureBinding, FixtureExposure, FixtureNameSource,
+    InferredNameLoad, ProgramEnvironment, TypeQualifiers, fixture_bindings_for_parameter,
+    fixture_exposures_for_definition, pytest_global_plugin_files,
 };
+#[allow(dead_code, reason = "inference APIs are exposed for IDE consumers")]
+pub use types::{binding_type, ide_support::NameLoadInference};
 
 mod db;
 pub mod dependency;

--- a/crates/ty_python_semantic/src/place/definitions.rs
+++ b/crates/ty_python_semantic/src/place/definitions.rs
@@ -1,8 +1,10 @@
 use smallvec::SmallVec;
+use ty_module_resolver::Module;
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
-    BindingWithConstraintsIterator, BoundnessAnalysis, global_scope, place_table, use_def_map,
+    BindingWithConstraintsIterator, BoundnessAnalysis, Program, ProgramFile, global_scope,
+    place_table, use_def_map,
 };
 
 use crate::Db;
@@ -15,13 +17,30 @@ use crate::place_load::{ImplicitPlaceLoad, PlaceLoadSource, PlaceLoadSourceKind}
 use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::ProgramEnvironment;
 
+/// Returns the definitions that may supply the value for a module global at the end of its scope.
+pub(crate) fn definitions_for_module_global<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    module: Module<'db>,
+    name: &str,
+) -> Option<DefinitionResolution<'db>> {
+    let file = ProgramFile::new(db, module.file(db)?, program);
+    let scope = global_scope(db, file);
+    let symbol = place_table(db, scope).symbol_id(name)?;
+
+    Some(DefinitionResolution::from_bindings(
+        db,
+        use_def_map(db, scope).end_of_scope_symbol_bindings(symbol),
+    ))
+}
+
 /// A set of definitions found by name resolution along with facts about their availability.
 #[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 #[expect(
     clippy::struct_excessive_bools,
     reason = "these flags describe independent facts about the resolved definitions"
 )]
-pub(crate) struct DefinitionResolution<'db> {
+pub struct DefinitionResolution<'db> {
     definitions: SmallVec<[Definition<'db>; 2]>,
     is_complete: bool,
     may_be_unbound: bool,
@@ -35,28 +54,52 @@ pub(crate) struct DefinitionResolution<'db> {
 )]
 impl<'db> DefinitionResolution<'db> {
     /// Returns the definitions found by name resolution.
-    pub(crate) fn definitions(&self) -> &[Definition<'db>] {
+    pub fn definitions(&self) -> &[Definition<'db>] {
         &self.definitions
     }
 
     /// Returns whether every possible result is represented by a definition.
-    pub(crate) fn is_complete(&self) -> bool {
+    pub fn is_complete(&self) -> bool {
         self.is_complete
     }
 
     /// Returns whether the value is bound on every reachable control-flow path.
-    pub(crate) fn is_definitely_bound(&self) -> bool {
+    pub fn is_definitely_bound(&self) -> bool {
         !self.may_be_unbound
     }
 
     /// Returns whether a reachable deletion may leave the value unbound.
-    pub(crate) fn may_be_deleted(&self) -> bool {
+    pub fn may_be_deleted(&self) -> bool {
         self.may_be_deleted
     }
 
     /// Returns whether resolution crosses a `global` or `nonlocal` declaration.
-    pub(crate) fn crosses_scope_declaration(&self) -> bool {
+    pub fn crosses_scope_declaration(&self) -> bool {
         self.crosses_scope_declaration
+    }
+
+    /// Replaces each definition with its projected definitions.
+    ///
+    /// The result is incomplete if any definition has no projection.
+    pub(crate) fn project_definitions<I>(
+        mut self,
+        mut project: impl FnMut(Definition<'db>) -> I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = Definition<'db>>,
+    {
+        let definitions = std::mem::take(&mut self.definitions);
+
+        for definition in definitions {
+            let mut has_projection = false;
+            for projected in project(definition) {
+                has_projection = true;
+                self.push_definition(projected);
+            }
+            self.is_complete &= has_projection;
+        }
+
+        self
     }
 
     fn from_place_load_source(
@@ -313,5 +356,60 @@ impl<'db> DefinitionResolutionBuilder<'db> {
         self.resolution.crosses_scope_declaration |= crosses_scope_declaration;
         self.resolution.definitions.shrink_to_fit();
         self.resolution
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ty_python_core::ProgramFile;
+
+    use super::definitions_for_module_global;
+    use crate::SemanticModel;
+    use crate::db::tests::TestDbBuilder;
+
+    #[test]
+    fn definitions_for_module_global_retains_conditional_definitions() {
+        let db = TestDbBuilder::new()
+            .with_file(
+                "/src/pkg/__init__.py",
+                r#"
+if flag:
+    from . import first as value
+else:
+    from . import second as value
+"#,
+            )
+            .with_file(
+                "/src/pkg/first.py",
+                r#"
+"#,
+            )
+            .with_file(
+                "/src/pkg/second.py",
+                r#"
+"#,
+            )
+            .with_file(
+                "/src/use.py",
+                r#"
+import pkg
+"#,
+            )
+            .build()
+            .expect("valid TestDb setup");
+        let file = system_path_to_file(&db, "/src/use.py").expect("test file should exist");
+        let program = db.program_environment().program(&db);
+        let model = SemanticModel::new(&db, ProgramFile::new(&db, file, program));
+        let module = model
+            .resolve_module(Some("pkg"), 0)
+            .expect("test package should resolve");
+
+        let resolution = definitions_for_module_global(&db, program, module, "value")
+            .expect("module global should exist");
+
+        assert_eq!(resolution.definitions().len(), 2);
+        assert!(resolution.is_complete());
+        assert!(resolution.is_definitely_bound());
     }
 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -37,10 +37,12 @@ pub(crate) use self::diagnostic::TypeCheckDiagnostics;
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 use self::infer::infer_function_default_types;
+pub use self::infer::{DeferredExpressionState, InferredNameLoad};
 pub(crate) use self::infer::{
-    InferredDeclaration, TypeContext, infer_complete_scope_types, infer_deferred_types,
-    infer_definition_types, infer_expression_type, infer_expression_types,
+    InferredDeclaration, TypeContext, complete_inference_scope, infer_complete_scope_types,
+    infer_deferred_types, infer_definition_types, infer_expression_type, infer_expression_types,
     infer_same_file_expression_type, infer_scope_types, is_discarded_dict_key_assignment,
+    place_load_metadata_from_inference,
 };
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
@@ -231,7 +233,7 @@ pub fn check_types(db: &dyn Db, file: ProgramFile<'_>) -> Vec<Diagnostic> {
 }
 
 /// Infer the type of a binding.
-pub(crate) fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
+pub fn binding_type<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Type<'db> {
     let inference = infer_definition_types(db, definition);
     inference.binding_type(definition)
 }

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -23,12 +23,15 @@ use ty_module_resolver::{ImportingFile, Module, ResolverFile};
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::{ProgramFile, attribute_scopes, semantic_index, use_def_map};
 
+mod name_resolution;
 mod unreachable_code;
 #[path = "ide_support/unused_bindings.rs"]
 mod unused_binding_support;
 
 use crate::types::definition_resolution::{self, user_visible_definitions};
 pub use crate::types::definition_resolution::{ImportAliasResolution, ResolvedDefinition};
+#[allow(dead_code, reason = "name-load inference is exposed for IDE consumers")]
+pub use name_resolution::{InferredNameLoads, NameLoadInference};
 pub use stub_mapping::map_stub_definition;
 pub use unreachable_code::{UnreachableKind, UnreachableRange, unreachable_ranges};
 pub use unused_binding_support::{UnusedBinding, unused_bindings};

--- a/crates/ty_python_semantic/src/types/ide_support/name_resolution.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/name_resolution.rs
@@ -1,0 +1,278 @@
+//! Definition-resolution support for IDE refactors.
+
+#![allow(
+    dead_code,
+    reason = "source-backed definition resolution is retained for IDE consumers"
+)]
+
+use ruff_python_ast as ast;
+use ruff_text_size::Ranged;
+use rustc_hash::{FxHashMap, FxHashSet};
+use ty_module_resolver::Module;
+use ty_python_core::{ProgramFile, scope::ScopeId};
+
+use crate::place::definitions::{DefinitionResolution, definitions_for_module_global};
+use crate::types::{
+    InferredNameLoad, complete_inference_scope, place_load_metadata_from_inference,
+};
+use crate::{FxIndexMap, SemanticModel};
+
+use super::user_visible_definitions;
+
+/// Selects name-load records from cached inference for one file.
+pub struct NameLoadInference<'db> {
+    db: &'db dyn crate::Db,
+    program_file: ProgramFile<'db>,
+    requests_by_scope: FxIndexMap<ScopeId<'db>, FxHashSet<ruff_text_size::TextRange>>,
+}
+
+impl<'db> NameLoadInference<'db> {
+    /// Adds selected name loads from `model` to this inference run.
+    ///
+    /// Passing the submodel returned by [`SemanticModel::enter_string_annotation`] allows one run
+    /// to include both regular file nodes and names parsed from string annotations. `model` must
+    /// refer to the same program file as the model that created this inference run.
+    pub fn extend<'ast>(
+        &mut self,
+        model: &SemanticModel<'db>,
+        names: impl IntoIterator<Item = &'ast ast::ExprName>,
+    ) {
+        debug_assert_eq!(self.program_file, model.program_file());
+
+        for name in names {
+            let Some(file_scope) = model.scope(name.into()) else {
+                continue;
+            };
+            let scope = file_scope.to_scope_id(self.db, self.program_file);
+            let scope = complete_inference_scope(self.db, scope);
+            self.requests_by_scope
+                .entry(scope)
+                .or_default()
+                .insert(name.range());
+        }
+    }
+
+    /// Runs inference as needed and returns the selected name-load records.
+    pub fn finish(self) -> InferredNameLoads<'db> {
+        let mut loads = FxHashMap::default();
+        for (scope, requested) in self.requests_by_scope {
+            loads.extend(
+                place_load_metadata_from_inference(self.db, scope, &requested)
+                    .into_iter()
+                    .map(|(range, (deferred_state, resolution))| {
+                        let resolution = source_backed_resolution(self.db, resolution);
+                        let load = InferredNameLoad::new(deferred_state, resolution);
+                        (range, load)
+                    }),
+            );
+        }
+
+        InferredNameLoads { loads }
+    }
+}
+
+/// Inference results for a requested set of name loads.
+pub struct InferredNameLoads<'db> {
+    loads: FxHashMap<ruff_text_size::TextRange, InferredNameLoad<'db>>,
+}
+
+impl<'db> InferredNameLoads<'db> {
+    /// Returns the inference result for `name`, if inference visited it.
+    pub fn get(&self, name: &ast::ExprName) -> Option<&InferredNameLoad<'db>> {
+        self.loads.get(&name.range())
+    }
+}
+
+impl<'db> SemanticModel<'db> {
+    /// Selects name loads from this file's cached inference results.
+    ///
+    /// Call [`crate::enable_place_load_recording`] for this file before creating the model.
+    /// Otherwise no records are returned.
+    pub fn name_load_inference(&self) -> NameLoadInference<'db> {
+        NameLoadInference {
+            db: self.db(),
+            program_file: self.program_file(),
+            requests_by_scope: FxIndexMap::default(),
+        }
+    }
+
+    /// Infers selected name loads and returns their deferredness and definition resolution.
+    ///
+    /// Recording must already be enabled for this file; see [`Self::name_load_inference`].
+    pub fn infer_name_loads<'ast>(
+        &self,
+        names: impl IntoIterator<Item = &'ast ast::ExprName>,
+    ) -> InferredNameLoads<'db> {
+        let mut inference = self.name_load_inference();
+        inference.extend(self, names);
+        inference.finish()
+    }
+
+    /// Resolves the definitions for an explicit module global.
+    pub fn definitions_for_module_global(
+        &self,
+        module: Module<'db>,
+        name: &str,
+    ) -> Option<DefinitionResolution<'db>> {
+        definitions_for_module_global(self.db(), self.program(), module, name)
+            .map(|resolution| source_backed_resolution(self.db(), resolution))
+    }
+}
+
+pub(super) fn source_backed_resolution<'db>(
+    db: &'db dyn crate::Db,
+    resolution: DefinitionResolution<'db>,
+) -> DefinitionResolution<'db> {
+    resolution.project_definitions(|definition| user_visible_definitions(db, [definition]))
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+    use ruff_python_ast::visitor::{Visitor, walk_expr};
+    use ruff_python_ast::{self as ast};
+    use ruff_text_size::Ranged;
+    use ty_python_core::ProgramFile;
+
+    use crate::db::tests::TestDbBuilder;
+    use crate::{PlaceLoadRecordingMode, SemanticModel};
+
+    #[test]
+    fn observed_load_uses_point_in_time_bindings() {
+        let definitions = definition_texts(
+            r#"
+import first as value
+before = value
+import second as value
+"#,
+            &["value"],
+        );
+
+        assert_eq!(definitions, ["first as value"]);
+    }
+
+    #[test]
+    fn observed_loads_inside_string_annotation_are_distinct() {
+        let source = r#"
+import first
+import second
+annotation: "tuple[first.C, second.C]"
+"#;
+        let path = "/src/test.py";
+        let mut db = TestDbBuilder::new()
+            .with_place_load_recording_mode(PlaceLoadRecordingMode::OnDemand)
+            .with_file(path, source)
+            .build()
+            .expect("valid test database");
+        let file = system_path_to_file(&db, path).expect("test file should exist");
+        db.enable_place_load_recording(file);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let module = parsed_module(&db, file.python_file(&db)).load(&db);
+        let assignment = module
+            .syntax()
+            .body
+            .last()
+            .and_then(ast::Stmt::as_ann_assign_stmt)
+            .expect("last statement should be an annotated assignment");
+        let annotation = assignment
+            .annotation
+            .as_string_literal_expr()
+            .expect("assignment annotation should be a string literal");
+        let model = SemanticModel::new(&db, file);
+        let (annotation, model) = model
+            .enter_string_annotation(annotation)
+            .expect("annotation should parse as a string annotation");
+        let names = loaded_names_in_expression(annotation.expr(), &["first", "second"]);
+        let definitions = definition_texts_for_names(&db, &module, source, &model, names);
+
+        assert_eq!(definitions, ["first", "second"]);
+    }
+
+    fn definition_texts(source: &str, searched: &[&str]) -> Vec<String> {
+        let path = "/src/test.py";
+        let mut db = TestDbBuilder::new()
+            .with_place_load_recording_mode(PlaceLoadRecordingMode::OnDemand)
+            .with_file(path, source)
+            .build()
+            .expect("valid test database");
+        let file = system_path_to_file(&db, path).expect("test file should exist");
+        db.enable_place_load_recording(file);
+        let file = ProgramFile::new(&db, file, db.program_environment().program(&db));
+        let module = parsed_module(&db, file.python_file(&db)).load(&db);
+        let names = loaded_names(&module, searched);
+        let model = SemanticModel::new(&db, file);
+
+        definition_texts_for_names(&db, &module, source, &model, names)
+    }
+
+    fn definition_texts_for_names<'ast>(
+        db: &'ast dyn crate::Db,
+        module: &ParsedModuleRef,
+        source: &str,
+        model: &SemanticModel<'ast>,
+        names: Vec<&'ast ast::ExprName>,
+    ) -> Vec<String> {
+        let loads = model.infer_name_loads(names.iter().copied());
+
+        names
+            .into_iter()
+            .flat_map(|name| {
+                let load = loads.get(name);
+                assert!(
+                    load.is_some(),
+                    "inference should observe the requested name load at {:?}",
+                    name.range()
+                );
+                load.expect("asserted that inference observed this name load")
+                    .resolution()
+                    .definitions()
+            })
+            .map(|definition| {
+                let range = definition.full_range(db, module).range();
+                source[range].to_string()
+            })
+            .collect()
+    }
+
+    fn loaded_names_in_expression<'ast>(
+        expression: &'ast ast::Expr,
+        searched: &[&str],
+    ) -> Vec<&'ast ast::ExprName> {
+        let mut collector = NameCollector {
+            searched,
+            names: Vec::new(),
+        };
+        collector.visit_expr(expression);
+        collector.names
+    }
+
+    fn loaded_names<'ast>(
+        module: &'ast ParsedModuleRef,
+        searched: &[&str],
+    ) -> Vec<&'ast ast::ExprName> {
+        let mut collector = NameCollector {
+            searched,
+            names: Vec::new(),
+        };
+        collector.visit_body(&module.syntax().body);
+        collector.names
+    }
+
+    struct NameCollector<'ast, 'name> {
+        searched: &'name [&'name str],
+        names: Vec<&'ast ast::ExprName>,
+    }
+
+    impl<'ast> Visitor<'ast> for NameCollector<'ast, '_> {
+        fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+            if let ast::Expr::Name(name) = expression
+                && name.ctx.is_load()
+                && self.searched.contains(&name.id.as_str())
+            {
+                self.names.push(name);
+            }
+            walk_expr(self, expression);
+        }
+    }
+}

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -49,7 +49,7 @@ use itertools::Either;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use salsa;
 use salsa::plumbing::AsId;
 use std::borrow::Cow;
@@ -64,7 +64,8 @@ use crate::types::{
 };
 use crate::{Db, FxIndexSet};
 
-use builder::{DeferredExpressionState, TypeInferenceBuilder};
+pub use builder::DeferredExpressionState;
+use builder::TypeInferenceBuilder;
 pub(super) use comparisons::UnsupportedComparisonError;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::expression::Expression;
@@ -84,6 +85,74 @@ struct PlaceLoadMetadata<'db> {
     range: TextRange,
     deferred_state: DeferredExpressionState,
     resolution: DefinitionResolution<'db>,
+}
+
+/// Information captured while inference resolves a name load.
+pub struct InferredNameLoad<'db> {
+    deferred_state: DeferredExpressionState,
+    resolution: DefinitionResolution<'db>,
+}
+
+#[allow(dead_code, reason = "place-load metadata is exposed for IDE consumers")]
+impl<'db> InferredNameLoad<'db> {
+    pub(crate) const fn new(
+        deferred_state: DeferredExpressionState,
+        resolution: DefinitionResolution<'db>,
+    ) -> Self {
+        Self {
+            deferred_state,
+            resolution,
+        }
+    }
+
+    /// Returns the binding state selected by inference.
+    pub const fn deferred_state(&self) -> DeferredExpressionState {
+        self.deferred_state
+    }
+
+    /// Returns the definitions that can provide the loaded value.
+    pub const fn resolution(&self) -> &DefinitionResolution<'db> {
+        &self.resolution
+    }
+}
+
+pub(crate) fn place_load_metadata_from_inference<'db>(
+    db: &'db dyn Db,
+    scope: ScopeId<'db>,
+    requested: &FxHashSet<TextRange>,
+) -> FxHashMap<TextRange, (DeferredExpressionState, DefinitionResolution<'db>)> {
+    if !crate::db::should_record_place_loads(db, scope.file(db)) {
+        return FxHashMap::default();
+    }
+    infer_complete_scope_types(db, scope)
+        .extra
+        .as_deref()
+        .and_then(|extra| extra.place_load_metadata.as_deref())
+        .into_iter()
+        .flat_map(FrozenMap::iter)
+        .filter(|(_, metadata)| requested.contains(&metadata.range))
+        .map(|(_, metadata)| {
+            (
+                metadata.range,
+                (metadata.deferred_state, metadata.resolution.clone()),
+            )
+        })
+        .collect()
+}
+
+pub(crate) fn complete_inference_scope<'db>(
+    db: &'db dyn Db,
+    mut scope: ScopeId<'db>,
+) -> ScopeId<'db> {
+    while scope.accepts_type_context(db) {
+        let program_file = scope.program_file(db);
+        let index = semantic_index(db, program_file);
+        let Some(parent_scope) = index.parent_scope_id(scope.file_scope_id(db)) else {
+            break;
+        };
+        scope = parent_scope.to_scope_id(db, program_file);
+    }
+    scope
 }
 
 bitflags::bitflags! {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -12673,7 +12673,7 @@ impl<'a> Iterator for ArgumentsIter<'a> {
 
 /// The deferred state of a specific expression in an inference region.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-pub(super) enum DeferredExpressionState {
+pub enum DeferredExpressionState {
     /// The expression is not deferred.
     #[default]
     None,

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -31,7 +31,7 @@ use ty_project::{
 };
 
 use index::DocumentError;
-use ty_python_core::program::UseDefaultStrategy;
+use ty_python_core::program::{FallibleStrategy, UseDefaultStrategy};
 
 pub(crate) use self::options::InitializationOptions;
 pub use self::options::{ClientOptions, DiagnosticMode, GlobalOptions, WorkspaceOptions};
@@ -792,7 +792,11 @@ impl Session {
                     metadata.apply_override_options(override_options.clone());
                 }
 
-                ProjectDatabase::fallible(metadata, system.clone())
+                ProjectDatabase::with_place_load_recording(
+                    metadata,
+                    system.clone(),
+                    &FallibleStrategy,
+                )
             });
 
         let mut db = match project {
@@ -815,7 +819,12 @@ impl Session {
                     &UseDefaultStrategy,
                 )
                 .map(|metadata| metadata.with_use_uv(self.use_uv));
-                ProjectDatabase::use_defaults(metadata, system)
+                let Ok(db) = ProjectDatabase::with_place_load_recording(
+                    metadata,
+                    system,
+                    &UseDefaultStrategy,
+                );
+                db
             }
         };
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
