### PR TITLE
[ty] Add support for `workspace/willRenameFiles` LSP request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,6 +4950,7 @@ dependencies = [
  "jod-thread",
  "libc",
  "lsp-server",
+ "percent-encoding",
  "regex",
  "ruff_db",
  "ruff_diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,7 @@ parking_lot = { version = "0.12.4" }
 path-absolutize = { version = "4.0.0" }
 path-slash = { version = "0.2.1" }
 pathdiff = { version = "0.2.1" }
+percent-encoding = { version = "2.3.1" }
 pep440_rs = { version = "0.7.1" }
 pretty_assertions = "1.3.0"
 proc-macro2 = { version = "1.0.79" }

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -620,7 +620,7 @@ impl Project {
     }
 
     /// Returns the open files in the project.
-    fn open_files(self, db: &dyn Db) -> &FxHashSet<File> {
+    pub fn open_files(self, db: &dyn Db) -> &FxHashSet<File> {
         self.open_fileset(db)
     }
 

--- a/crates/ty_server/Cargo.toml
+++ b/crates/ty_server/Cargo.toml
@@ -36,6 +36,7 @@ crossbeam = { workspace = true }
 jod-thread = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+percent-encoding = { workspace = true }
 rustc-hash = { workspace = true }
 salsa = { workspace = true }
 serde = { workspace = true }

--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -453,6 +453,12 @@ pub(crate) fn server_capabilities(
                 server_diagnostic_options(true),
             ))
         };
+    let rename_filter = |glob: &str, kind| {
+        types::FileOperationFilter::new(
+            Some("file".to_string()),
+            types::FileOperationPattern::new(glob.to_string(), Some(kind), None),
+        )
+    };
 
     ServerCapabilities {
         position_encoding: Some(position_encoding.into()),
@@ -546,6 +552,13 @@ pub(crate) fn server_capabilities(
                 // https://github.com/microsoft/language-server-protocol/issues/1720#issuecomment-1514732305
                 supported: Some(true),
                 change_notifications: Some(true.into()),
+            }),
+            file_operations: Some(types::FileOperationOptions {
+                will_rename: Some(types::FileOperationRegistrationOptions::new(vec![
+                    rename_filter("**/*.{py,pyi}", types::FileOperationPatternKind::File),
+                    rename_filter("**", types::FileOperationPatternKind::Folder),
+                ])),
+                ..types::FileOperationOptions::default()
             }),
             ..Default::default()
         }),

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -115,6 +115,9 @@ pub(super) fn request(req: server::Request) -> Task {
         >(
             req, BackgroundSchedule::Worker
         ),
+        requests::WillRenameFilesHandler::METHOD => background_request_task::<
+            requests::WillRenameFilesHandler,
+        >(req, BackgroundSchedule::Worker),
         requests::PrepareTypeHierarchyRequestHandler::METHOD => background_document_request_task::<
             requests::PrepareTypeHierarchyRequestHandler,
         >(

--- a/crates/ty_server/src/server/api/requests.rs
+++ b/crates/ty_server/src/server/api/requests.rs
@@ -39,6 +39,7 @@ mod shutdown;
 mod signature_help;
 mod type_hierarchy_subtypes;
 mod type_hierarchy_supertypes;
+mod will_rename_files;
 mod workspace_diagnostic;
 mod workspace_symbols;
 
@@ -69,5 +70,6 @@ pub(super) use shutdown::ShutdownHandler;
 pub(super) use signature_help::SignatureHelpRequestHandler;
 pub(super) use type_hierarchy_subtypes::TypeHierarchySubtypesRequestHandler;
 pub(super) use type_hierarchy_supertypes::TypeHierarchySupertypesRequestHandler;
+pub(super) use will_rename_files::WillRenameFilesHandler;
 pub(super) use workspace_diagnostic::WorkspaceDiagnosticRequestHandler;
 pub(super) use workspace_symbols::WorkspaceSymbolRequestHandler;

--- a/crates/ty_server/src/server/api/requests/will_rename_files.rs
+++ b/crates/ty_server/src/server/api/requests/will_rename_files.rs
@@ -1,0 +1,493 @@
+//! LSP exposure for best-effort Python file and regular-package renames.
+//!
+//! Each supported entry is analyzed in the workspace that owns both paths. A renamed folder may
+//! not contain another workspace. Candidates include indexed and open files plus every physical
+//! Python source moved with a folder. Unsupported entries and failed workspace groups or LSP
+//! documents are omitted without suppressing independent edits. The server sends one warning when
+//! it omits a request entry or cannot project an edit.
+
+use std::collections::{BTreeMap, HashMap};
+
+use lsp_server::RequestId;
+use lsp_types::{
+    FileRename, RenameFilesParams, TextEdit, Uri, WillRenameFilesRequest, WorkspaceEdit,
+};
+use percent_encoding::percent_decode_str;
+use ruff_db::Db as _;
+use ruff_db::files::{File, system_path_to_file};
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ty_ide::{PathRename, will_rename_paths};
+use ty_project::{Db as _, ProjectDatabase};
+use ty_python_semantic::should_record_place_loads;
+
+use crate::document::FileRangeExt;
+use crate::server::Action;
+use crate::server::api::traits::{
+    BackgroundRequestHandler, RequestHandler, RetriableRequestHandler,
+};
+use crate::session::SessionSnapshot;
+use crate::session::client::Client;
+
+/// Handles `workspace/willRenameFiles` for supported Python modules and packages.
+pub(crate) struct WillRenameFilesHandler;
+
+impl RequestHandler for WillRenameFilesHandler {
+    type RequestType = WillRenameFilesRequest;
+}
+
+impl BackgroundRequestHandler for WillRenameFilesHandler {
+    fn handle_request(
+        id: &RequestId,
+        snapshot: SessionSnapshot,
+        client: &Client,
+        params: RenameFilesParams,
+    ) {
+        let files = files_needing_recording(&snapshot, &params);
+        if !files.is_empty() {
+            let revision = snapshot.revision();
+            // Drop our database snapshots before the main thread changes Salsa inputs.
+            // Otherwise its cancellation could wait for this task while we queue the action.
+            drop(snapshot);
+            client.queue_action(Action::EnablePlaceLoadRecording {
+                revision,
+                files,
+                request: lsp_server::Request::new(
+                    id.clone(),
+                    Self::METHOD.as_str().to_owned(),
+                    params,
+                ),
+            });
+            return;
+        }
+
+        client.respond(id, Self::run(&snapshot, client, params));
+    }
+
+    fn run(
+        snapshot: &SessionSnapshot,
+        client: &Client,
+        params: RenameFilesParams,
+    ) -> crate::server::Result<Option<WorkspaceEdit>> {
+        let result = workspace_edit(snapshot, params);
+        if result.known_omissions {
+            client.show_warning_message(INCOMPLETE_RENAME_WARNING);
+        }
+        Ok(result.edit)
+    }
+}
+
+impl RetriableRequestHandler for WillRenameFilesHandler {
+    const RETRY_ON_CANCELLATION: bool = true;
+}
+
+const INCOMPLETE_RENAME_WARNING: &str = "ty could not safely update all affected Python code. Some imports, references, or exports may remain unchanged after this file operation.";
+
+/// Discovers recording requirements without inferring types. After the main thread enables them,
+/// the request is retried against a fresh snapshot; subsequent requests usually need no preparation.
+fn files_needing_recording(
+    snapshot: &SessionSnapshot,
+    params: &RenameFilesParams,
+) -> Vec<(usize, Vec<File>)> {
+    let Some(system) = snapshot.projects().first().map(ProjectDatabase::system) else {
+        return Vec::new();
+    };
+    let mut by_project: BTreeMap<usize, Vec<File>> = BTreeMap::new();
+    for rename in &params.files {
+        let Ok(Some(prepared)) = prepare_rename(snapshot, system, rename.clone()) else {
+            continue;
+        };
+        let owner = prepared.project;
+        if snapshot.language_services_disabled(owner) {
+            continue;
+        }
+        let db = &snapshot.projects()[owner];
+        by_project.entry(owner).or_default().extend(
+            prepared
+                .pending
+                .moved
+                .into_iter()
+                .filter_map(|path| system_path_to_file(db, &path).ok()),
+        );
+    }
+
+    by_project
+        .into_iter()
+        .filter_map(|(owner, moved)| {
+            let db = &snapshot.projects()[owner];
+            let project = db.project();
+            let mut files: Vec<_> = project
+                .files(db)
+                .into_iter()
+                .chain(project.open_files(db).iter().copied())
+                .chain(moved)
+                .filter(|file| {
+                    file.path(db)
+                        .as_system_path()
+                        .is_none_or(|path| snapshot.enclosing_project_index(path) == Some(owner))
+                })
+                .filter(|file| !should_record_place_loads(db, *file))
+                .collect();
+            files.sort_unstable();
+            files.dedup();
+            (!files.is_empty()).then_some((owner, files))
+        })
+        .collect()
+}
+
+fn workspace_edit(snapshot: &SessionSnapshot, params: RenameFilesParams) -> WorkspaceEditResult {
+    let mut omissions = Omissions::default();
+    let Some(system) = snapshot.projects().first().map(ProjectDatabase::system) else {
+        if params
+            .files
+            .iter()
+            .any(|rename| !uri_is_non_python_file(&rename.old_uri))
+        {
+            omissions.record("no project is available");
+        }
+        return WorkspaceEditResult {
+            edit: None,
+            known_omissions: omissions.any,
+        };
+    };
+    let mut groups: BTreeMap<usize, Vec<PendingRename>> = BTreeMap::new();
+
+    for rename in params.files {
+        match prepare_rename(snapshot, system, rename) {
+            Ok(Some(prepared)) => groups
+                .entry(prepared.project)
+                .or_default()
+                .push(prepared.pending),
+            Ok(None) => {}
+            Err(omission) => omission.record(&mut omissions),
+        }
+    }
+
+    let mut changes = HashMap::new();
+    for (owner, group) in groups {
+        let db = &snapshot.projects()[owner];
+        let mut moved_files = Vec::new();
+        let mut renames = Vec::new();
+        for pending in group {
+            let mut files = Vec::with_capacity(pending.moved.len());
+            let mut valid = true;
+            for path in pending.moved {
+                if snapshot.enclosing_project_index(&path) != Some(owner) {
+                    omissions.path("a moved source belongs to another workspace", &path);
+                    valid = false;
+                    break;
+                }
+                let Ok(file) = system_path_to_file(db, &path) else {
+                    omissions.path("a moved source cannot be registered", &path);
+                    valid = false;
+                    break;
+                };
+                files.push(file);
+            }
+            if valid {
+                moved_files.extend(files);
+                renames.push(pending.rename);
+            }
+        }
+        if renames.is_empty() {
+            continue;
+        }
+        let in_scope = |file: File| {
+            file.path(db)
+                .as_system_path()
+                .is_none_or(|path| snapshot.enclosing_project_index(path) == Some(owner))
+        };
+        if snapshot.language_services_disabled(owner) {
+            omissions.path(
+                "language services are disabled for the workspace",
+                snapshot.workspace_root(owner),
+            );
+            continue;
+        }
+        let project = db.project();
+        let result = will_rename_paths(
+            db,
+            &renames,
+            project
+                .files(db)
+                .into_iter()
+                .chain(project.open_files(db).iter().copied())
+                .chain(moved_files),
+            in_scope,
+        );
+        project_lsp_edits(
+            db,
+            snapshot.position_encoding(),
+            result,
+            &mut changes,
+            &mut omissions,
+        );
+    }
+    normalize_lsp_edits(&mut changes, &mut omissions);
+    WorkspaceEditResult {
+        edit: (!changes.is_empty()).then(|| WorkspaceEdit::new(Some(changes), None, None)),
+        known_omissions: omissions.any,
+    }
+}
+
+struct WorkspaceEditResult {
+    edit: Option<WorkspaceEdit>,
+    known_omissions: bool,
+}
+
+fn prepare_rename(
+    snapshot: &SessionSnapshot,
+    system: &dyn System,
+    rename: FileRename,
+) -> Result<Option<PreparedRename>, RenameOmission> {
+    let old_path = match file_uri_to_path(&rename.old_uri) {
+        Some(path) => path,
+        None if uri_is_non_python_file(&rename.old_uri) => return Ok(None),
+        None => return Err(RenameOmission::NonLocalUri(rename.old_uri)),
+    };
+
+    let directory = system.is_directory(&old_path);
+    if !directory && !matches!(old_path.extension(), Some("py" | "pyi")) {
+        return Ok(None);
+    }
+
+    let new_path =
+        file_uri_to_path(&rename.new_uri).ok_or(RenameOmission::NonLocalUri(rename.new_uri))?;
+
+    let project = snapshot
+        .enclosing_project_index(&old_path)
+        .ok_or_else(|| RenameOmission::OutsideWorkspace(old_path.clone()))?;
+    if snapshot.enclosing_project_index(&new_path) != Some(project) {
+        return Err(RenameOmission::CrossesWorkspaceOwnership { old_path, new_path });
+    }
+    if directory && snapshot.contains_other_workspace(project, &old_path) {
+        return Err(RenameOmission::ContainsAnotherWorkspace(old_path));
+    }
+
+    let moved = if directory {
+        let files = python_files_in_directory(system, &old_path)
+            .ok_or_else(|| RenameOmission::UnreadableDirectory(old_path.clone()))?;
+        if files.is_empty() {
+            return Ok(None);
+        }
+        files
+    } else {
+        if new_path.extension() != old_path.extension() {
+            return Err(RenameOmission::ChangedPythonExtension { old_path, new_path });
+        }
+        vec![old_path.clone()]
+    };
+
+    let rename = if directory {
+        PathRename::directory(old_path, new_path)
+    } else {
+        PathRename::file(old_path, new_path)
+    };
+
+    Ok(Some(PreparedRename {
+        project,
+        pending: PendingRename { rename, moved },
+    }))
+}
+
+struct PreparedRename {
+    project: usize,
+    pending: PendingRename,
+}
+
+enum RenameOmission {
+    NonLocalUri(Uri),
+    UnreadableDirectory(SystemPathBuf),
+    ChangedPythonExtension {
+        old_path: SystemPathBuf,
+        new_path: SystemPathBuf,
+    },
+    OutsideWorkspace(SystemPathBuf),
+    CrossesWorkspaceOwnership {
+        old_path: SystemPathBuf,
+        new_path: SystemPathBuf,
+    },
+    ContainsAnotherWorkspace(SystemPathBuf),
+}
+
+impl RenameOmission {
+    fn record(self, omissions: &mut Omissions) {
+        match self {
+            Self::NonLocalUri(uri) => {
+                omissions.uri("a rename URI is not a local file path", uri);
+            }
+            Self::UnreadableDirectory(path) => {
+                omissions.path("a renamed directory cannot be read completely", path);
+            }
+            Self::ChangedPythonExtension { old_path, new_path } => omissions.rename(
+                "a Python file rename changes its extension",
+                old_path,
+                new_path,
+            ),
+            Self::OutsideWorkspace(path) => {
+                omissions.path("a renamed source is outside every workspace", path);
+            }
+            Self::CrossesWorkspaceOwnership { old_path, new_path } => {
+                omissions.rename("a rename crosses workspace ownership", old_path, new_path);
+            }
+            Self::ContainsAnotherWorkspace(path) => {
+                omissions.path("a renamed directory contains another workspace", path);
+            }
+        }
+    }
+}
+
+struct PendingRename {
+    rename: PathRename,
+    moved: Vec<SystemPathBuf>,
+}
+
+fn project_lsp_edits(
+    db: &ProjectDatabase,
+    encoding: crate::PositionEncoding,
+    edits: Vec<ty_ide::FileRenameEdit>,
+    changes: &mut HashMap<Uri, Vec<TextEdit>>,
+    omissions: &mut Omissions,
+) {
+    let mut by_file: HashMap<File, Vec<_>> = HashMap::new();
+    for edit in edits {
+        by_file.entry(edit.range.file()).or_default().push(edit);
+    }
+    for edits in by_file.into_values() {
+        let mut projected = Vec::with_capacity(edits.len());
+        let mut valid = true;
+        for edit in edits {
+            let file = edit.range.file();
+            let Some(range) = edit.range.to_lsp_range(db, encoding) else {
+                omissions.path(
+                    "an edit cannot be converted to an LSP location",
+                    file.path(db),
+                );
+                valid = false;
+                break;
+            };
+            let Some(location) = range.into_location() else {
+                omissions.path(
+                    "an edit cannot be converted to an LSP location",
+                    file.path(db),
+                );
+                valid = false;
+                break;
+            };
+            projected.push((location.uri, TextEdit::new(location.range, edit.value)));
+        }
+        if valid {
+            for (uri, edit) in projected {
+                changes.entry(uri).or_default().push(edit);
+            }
+        }
+    }
+}
+
+fn normalize_lsp_edits(changes: &mut HashMap<Uri, Vec<TextEdit>>, omissions: &mut Omissions) {
+    changes.retain(|uri, edits| {
+        edits.sort_unstable_by(|left, right| {
+            left.range
+                .cmp(&right.range)
+                .then_with(|| left.new_text.cmp(&right.new_text))
+        });
+        edits.dedup();
+        let mut normalized = Vec::with_capacity(edits.len());
+        let mut pending = std::mem::take(edits).into_iter().peekable();
+        while let Some(edit) = pending.next() {
+            let mut end = edit.range.end;
+            let mut conflicting = false;
+            while let Some(next) = pending.peek()
+                && next.range.start < end
+            {
+                let Some(next) = pending.next() else {
+                    break;
+                };
+                end = end.max(next.range.end);
+                conflicting = true;
+            }
+            if conflicting {
+                omissions.uri("projected edits overlap", uri);
+            } else {
+                normalized.push(edit);
+            }
+        }
+        *edits = normalized;
+        !edits.is_empty()
+    });
+}
+
+fn python_files_in_directory(system: &dyn System, root: &SystemPath) -> Option<Vec<SystemPathBuf>> {
+    let mut files = Vec::new();
+    for entry in system.read_directory(root).ok()? {
+        let entry = entry.ok()?;
+        let file_type = entry.file_type();
+        let path = entry.into_path();
+        if file_type.is_file() && matches!(path.extension(), Some("py" | "pyi")) {
+            files.push(path);
+        } else if file_type.is_directory() {
+            files.extend(python_files_in_directory(system, &path)?);
+        }
+    }
+    Some(files)
+}
+
+fn file_uri_to_path(uri: &Uri) -> Option<SystemPathBuf> {
+    SystemPathBuf::from_path_buf(uri.to_file_path().ok()?).ok()
+}
+
+fn uri_is_non_python_file(uri: &Uri) -> bool {
+    let path: Vec<_> = percent_decode_str(uri.path()).collect();
+    let Some(name) = path.rsplit(|byte| *byte == b'/').next() else {
+        return false;
+    };
+    let Some(dot) = name.iter().rposition(|byte| *byte == b'.') else {
+        return false;
+    };
+    let extension = &name[dot + 1..];
+    extension != b"py" && extension != b"pyi"
+}
+
+#[derive(Default)]
+struct Omissions {
+    any: bool,
+}
+
+impl Omissions {
+    fn record(&mut self, reason: &'static str) {
+        tracing::debug!(reason, "Omitting part of `workspace/willRenameFiles`");
+        self.any = true;
+    }
+
+    fn path(&mut self, reason: &'static str, path: impl std::fmt::Display) {
+        tracing::debug!(
+            reason,
+            path = %path,
+            "Omitting part of `workspace/willRenameFiles`"
+        );
+        self.any = true;
+    }
+
+    fn uri(&mut self, reason: &'static str, uri: impl std::fmt::Display) {
+        tracing::debug!(
+            reason,
+            uri = %uri,
+            "Omitting part of `workspace/willRenameFiles`"
+        );
+        self.any = true;
+    }
+
+    fn rename(
+        &mut self,
+        reason: &'static str,
+        old_path: impl std::fmt::Display,
+        new_path: impl std::fmt::Display,
+    ) {
+        tracing::debug!(
+            reason,
+            old_path = %old_path,
+            new_path = %new_path,
+            "Omitting part of `workspace/willRenameFiles`"
+        );
+        self.any = true;
+    }
+}

--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -6,6 +6,7 @@ use anyhow::anyhow;
 use lsp_server::Message;
 use lsp_types::Notification;
 use lsp_types::Uri;
+use ruff_db::files::File;
 use ruff_db::system::SystemPathBuf;
 
 pub(crate) type ConnectionSender = crossbeam::channel::Sender<Message>;
@@ -141,6 +142,23 @@ impl Server {
 
                     Action::SendRequest(request) => client.send_request_raw(&self.session, request),
 
+                    Action::EnablePlaceLoadRecording {
+                        revision,
+                        files,
+                        request,
+                    } => {
+                        if self
+                            .session
+                            .request_queue()
+                            .incoming()
+                            .is_pending(&request.id)
+                        {
+                            self.session.enable_place_load_recording(revision, files);
+                            let task = api::request(request);
+                            scheduler.dispatch(task, &mut self.session, client);
+                        }
+                    }
+
                     Action::SuspendWorkspaceDiagnostics(suspended_request) => {
                         self.session.set_suspended_workspace_diagnostics_request(
                             *suspended_request,
@@ -206,6 +224,16 @@ pub(crate) enum Action {
 
     /// Retry a request that previously failed due to a salsa cancellation.
     RetryRequest(lsp_server::Request),
+
+    /// Enables recording on the main thread, then retries the waiting request.
+    EnablePlaceLoadRecording {
+        /// The session revision that owns the project indices and file handles.
+        revision: u64,
+        /// Project indices and files discovered in the same session snapshot.
+        files: Vec<(usize, Vec<File>)>,
+        /// The request to retry, including its original request identifier.
+        request: lsp_server::Request,
+    },
 
     /// Send a request from the server to the client.
     SendRequest(SendRequest),

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -848,6 +848,8 @@ impl Session {
                 untracked_files_with_pushed_diagnostics: untracked,
             },
         );
+        // Queued background work must not reuse indices or file handles from the old project set.
+        self.bump_revision();
 
         publish_settings_diagnostics(self, client, root);
     }
@@ -1339,13 +1341,20 @@ impl Session {
 
     /// Creates a snapshot of the current state of the [`Session`].
     pub(crate) fn snapshot_session(&self) -> SessionSnapshot {
+        let (project_contexts, projects) = self
+            .projects
+            .iter()
+            .map(|(root, project)| {
+                let disabled = self
+                    .workspaces
+                    .settings_for_path(root)
+                    .or_else(|| self.workspaces.settings_virtual_fallback())
+                    .is_some_and(|settings| settings.is_language_services_disabled());
+                ((root.clone(), disabled), project.db.clone())
+            })
+            .unzip();
         SessionSnapshot {
-            projects: self
-                .projects
-                .values()
-                .map(|project| &project.db)
-                .cloned()
-                .collect(),
+            projects,
             index: self.index.clone().unwrap(),
             global_settings: self.global_settings.clone(),
             position_encoding: self.position_encoding,
@@ -1353,6 +1362,28 @@ impl Session {
             resolved_client_capabilities: self.resolved_client_capabilities,
             revision: self.revision,
             client_name: self.client_name,
+            project_contexts,
+        }
+    }
+
+    /// Enables recording discovered by a background request before taking its next snapshot.
+    pub(crate) fn enable_place_load_recording(
+        &mut self,
+        revision: u64,
+        files: Vec<(usize, Vec<File>)>,
+    ) {
+        // A stale snapshot may refer to replaced databases or a different project order.
+        // Leave it untouched; the retry will discover the requirements again.
+        if self.revision != revision {
+            return;
+        }
+        for (owner, files) in files {
+            if let Some(project) = self.projects.values_mut().nth(owner) {
+                project
+                    .db
+                    .project()
+                    .enable_place_load_recording(&mut project.db, files);
+            }
         }
     }
 
@@ -1656,6 +1687,8 @@ pub(crate) struct SessionSnapshot {
     in_test: bool,
     revision: u64,
     client_name: ClientName,
+    /// Workspace roots and disabled states, in the same order as `projects`.
+    project_contexts: Vec<(SystemPathBuf, bool)>,
 
     /// IMPORTANT: It's important that the databases come last, or at least,
     /// after any `Arc` that we try to extract or mutate in-place using `Arc::into_inner`
@@ -1672,6 +1705,34 @@ pub(crate) struct SessionSnapshot {
 impl SessionSnapshot {
     pub(crate) fn projects(&self) -> &[ProjectDatabase] {
         &self.projects
+    }
+
+    /// Returns the workspace root corresponding to `project`.
+    pub(crate) fn workspace_root(&self, project: usize) -> &SystemPath {
+        &self.project_contexts[project].0
+    }
+
+    /// Returns the closest enclosing workspace, without falling back to another project.
+    pub(crate) fn enclosing_project_index(&self, path: &SystemPath) -> Option<usize> {
+        self.project_contexts
+            .iter()
+            .enumerate()
+            .filter(|(_, (root, _))| path.starts_with(root))
+            .max_by_key(|(_, (root, _))| root.as_str().len())
+            .map(|(index, _)| index)
+    }
+
+    /// Returns whether language services are disabled for the selected workspace.
+    pub(crate) fn language_services_disabled(&self, project: usize) -> bool {
+        self.project_contexts[project].1
+    }
+
+    /// Returns whether `path` contains a workspace other than `project`.
+    pub(crate) fn contains_other_workspace(&self, project: usize, path: &SystemPath) -> bool {
+        self.project_contexts
+            .iter()
+            .enumerate()
+            .any(|(index, (root, _))| index != project && root.starts_with(path))
     }
 
     pub(crate) fn index(&self) -> &Index {
@@ -2257,10 +2318,54 @@ mod tests {
     use std::sync::Arc;
 
     use anyhow::Context;
-    use ruff_db::system::{Command, CommandExecutor, OsSystem, System as _};
+    use lsp_types::Uri;
+    use ruff_db::files::system_path_to_file;
+    use ruff_db::system::{Command, CommandExecutor, OsSystem, System as _, TestSystem};
+    use ty_project::Db as _;
+    use ty_python_semantic::should_record_place_loads;
 
-    use super::Index;
+    use super::{Client, ClientName, Index, InitializationOptions, Session, WorkspaceOptions};
+    use crate::PositionEncoding;
+    use crate::capabilities::ResolvedClientCapabilities;
     use crate::system::{LSPSystem, WorkspaceTrust};
+
+    #[test]
+    fn recording_preparation_rejects_changed_workspace_order() {
+        let (mut session, client) = recording_session();
+        let original = Uri::parse("file:///z").expect("valid original workspace URI");
+        session
+            .register_workspace_folder(original.clone())
+            .expect("register original workspace");
+        session.initialize_workspace_folder(&client, &original, WorkspaceOptions::default());
+        let snapshot = session.snapshot_session();
+        let revision = snapshot.revision();
+        let file = system_path_to_file(&snapshot.projects()[0], "/z/use.py")
+            .expect("original file exists");
+        drop(snapshot);
+
+        let added = Uri::parse("file:///a").expect("valid added workspace URI");
+        session
+            .register_workspace_folder(added.clone())
+            .expect("register added workspace");
+        session.initialize_workspace_folder(&client, &added, WorkspaceOptions::default());
+
+        session.enable_place_load_recording(revision, vec![(0, vec![file])]);
+        let snapshot = session.snapshot_session();
+        assert_ne!(snapshot.revision(), revision);
+        for db in snapshot.projects() {
+            for file in &db.project().files(db) {
+                assert!(!should_record_place_loads(db, file));
+            }
+        }
+
+        let revision = snapshot.revision();
+        drop(snapshot);
+        session.enable_place_load_recording(revision, vec![(1, vec![file])]);
+        assert!(should_record_place_loads(
+            &session.snapshot_session().projects()[1],
+            file
+        ));
+    }
 
     /// Mutating the document index requires exclusive ownership after Salsa cancels the current
     /// database snapshots. A background command executor must not retain an `LSPSystem`, because
@@ -2303,5 +2408,33 @@ mod tests {
             "external commands are disabled in an untrusted workspace",
         );
         Ok(())
+    }
+
+    fn recording_session() -> (Session, Client) {
+        let system = TestSystem::default();
+        for path in ["/a/use.py", "/z/use.py"] {
+            system
+                .memory_file_system()
+                .write_file_all(
+                    path,
+                    r#"
+value = 1
+"#,
+                )
+                .expect("write workspace fixture");
+        }
+        let session = Session::new(
+            ResolvedClientCapabilities::default(),
+            PositionEncoding::default(),
+            Vec::new(),
+            InitializationOptions::default(),
+            Arc::new(system),
+            ClientName::Other,
+            true,
+        )
+        .expect("valid test session");
+        let (main_loop_sender, _) = crossbeam::channel::unbounded();
+        let (client_sender, _) = crossbeam::channel::unbounded();
+        (session, Client::new(main_loop_sender, client_sender))
     }
 }

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -46,6 +46,7 @@ mod script_preparation;
 mod semantic_tokens;
 mod signature_help;
 mod type_hierarchy;
+mod will_rename_files;
 mod workspace_folders;
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -81,6 +82,7 @@ use lsp_types::{
     WorkspaceDiagnosticParams, WorkspaceDiagnosticReport, WorkspaceDiagnosticRequest,
     WorkspaceEdit, WorkspaceFolder, WorkspaceFoldersChangeEvent, WorkspaceFoldersInitializeParams,
 };
+use lsp_types::{FileRename, WillRenameFilesRequest};
 #[cfg(feature = "test-uv")]
 use ruff_db::system::System as _;
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf, SystemVirtualPath, TestSystem};
@@ -967,6 +969,10 @@ impl TestServer {
                 work_done_progress_params: WorkDoneProgressParams::default(),
             }),
         )
+    }
+
+    pub(crate) fn will_rename_files(&mut self, files: Vec<FileRename>) -> Option<WorkspaceEdit> {
+        self.send_request_await::<WillRenameFilesRequest>(lsp_types::RenameFilesParams { files })
     }
 
     /// Send a `textDocument/diagnostic` request for the document at the given path.

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization.snap
@@ -109,6 +109,26 @@ expression: initialization_result
       "workspaceFolders": {
         "supported": true,
         "changeNotifications": true
+      },
+      "fileOperations": {
+        "willRename": {
+          "filters": [
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**/*.{py,pyi}",
+                "matches": "file"
+              }
+            },
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**",
+                "matches": "folder"
+              }
+            }
+          ]
+        }
       }
     }
   },

--- a/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__initialize__initialization_with_workspace.snap
@@ -109,6 +109,26 @@ expression: initialization_result
       "workspaceFolders": {
         "supported": true,
         "changeNotifications": true
+      },
+      "fileOperations": {
+        "willRename": {
+          "filters": [
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**/*.{py,pyi}",
+                "matches": "file"
+              }
+            },
+            {
+              "scheme": "file",
+              "pattern": {
+                "glob": "**",
+                "matches": "folder"
+              }
+            }
+          ]
+        }
       }
     }
   },

--- a/crates/ty_server/tests/e2e/will_rename_files.rs
+++ b/crates/ty_server/tests/e2e/will_rename_files.rs
@@ -1,0 +1,362 @@
+use std::{collections::HashMap, time::Duration};
+
+use lsp_types::{FileRename, MessageType, ShowMessageNotification, Uri, WorkspaceEdit};
+use ruff_db::system::SystemPath;
+use ty_server::ClientOptions;
+
+use crate::notebook::NotebookBuilder;
+use crate::{TestServer, TestServerBuilder};
+
+#[test]
+fn batch_includes_moved_and_open_sources() {
+    let sub = r#"import old_pkg
+from . import helper
+old_pkg.x
+"#;
+    let consumer = r#"import old
+from old_pkg import sub
+old.x
+"#;
+    let mut server = TestServerBuilder::new()
+        .and_then(|builder| {
+            builder.with_file("ty.toml", "[src]\nexclude = [\"old.py\", \"old_pkg/\"]\n")
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "old.py",
+                r#"import old_pkg
+old_pkg.x
+"#,
+            )
+        })
+        .and_then(|builder| builder.with_file("old_pkg/__init__.py", ""))
+        .and_then(|builder| {
+            builder.with_file(
+                "old_pkg/helper.py",
+                r#"x = 2
+"#,
+            )
+        })
+        .and_then(|builder| builder.with_file("old_pkg/sub.py", sub))
+        .and_then(|builder| builder.with_file("consumer.py", consumer))
+        .expect("test workspace should be created")
+        .build()
+        .wait_until_workspaces_are_initialized();
+    let mut notebook = NotebookBuilder::virtual_file("consumer.ipynb");
+    let cell = notebook.add_python_cell(
+        r#"import old_pkg.sub as old_pkg
+
+def f():
+    print(old_pkg.x)
+"#,
+    );
+    notebook.open(&mut server);
+    server.collect_publish_diagnostic_notifications(1);
+
+    let edit = rename_edit(&mut server, &[("old.py", "new.py"), ("old_pkg", "new_pkg")])
+        .expect("the supported batch to produce edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("consumer.py"),
+        &[
+            (0, 7, 0, 10, "new"),
+            (1, 5, 1, 12, "new_pkg"),
+            (2, 0, 2, 3, "new"),
+        ],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("old_pkg/sub.py"),
+        &[(0, 7, 0, 14, "new_pkg"), (2, 0, 2, 7, "new_pkg")],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("old.py"),
+        &[(0, 7, 0, 14, "new_pkg"), (1, 0, 1, 7, "new_pkg")],
+    );
+    assert_edits(&edit, &cell, &[(0, 7, 0, 18, "new_pkg.sub")]);
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(4));
+}
+
+#[test]
+fn unsupported_entries_do_not_suppress_independent_edits() {
+    let a = SystemPath::new("repo/a");
+    let b = SystemPath::new("repo/b");
+    let mut server = TestServerBuilder::new()
+        .and_then(|builder| builder.with_workspace(a, None))
+        .and_then(|builder| builder.with_workspace(b, None))
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/a/old.py",
+                r#"x = 1
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/a/oldns/mod.py",
+                r#"x = 2
+"#,
+            )
+        })
+        .and_then(|builder| builder.with_file("repo/a/notes.txt", "notes\n"))
+        .and_then(|builder| builder.with_file("repo/a/empty/.gitkeep", ""))
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/a/use.py",
+                r#"import old
+import oldns.mod
+old.x
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/b/old.py",
+                r#"x = 3
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/b/use.py",
+                r#"import old
+old.x
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/outside.py",
+                r#"x = 4
+"#,
+            )
+        })
+        .expect("test workspaces should be created")
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/a/notes.txt", "repo/a/new.txt"),
+            ("repo/a/empty", "repo/a/renamed_empty"),
+            (
+                "file://remote.example/%FFnotes%2Etxt",
+                "file://remote.example/%FFnew%2Etxt",
+            ),
+        ],
+    )
+    .expect("an unrelated rename should not affect the supported entry");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+    assert!(
+        server
+            .try_await_notification::<ShowMessageNotification>(Some(Duration::from_millis(10)))
+            .is_err()
+    );
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/a/oldns", "repo/a/newns"),
+        ],
+    )
+    .expect("the supported file rename to survive an unsupported namespace package");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+    assert!(
+        server
+            .try_await_notification::<ShowMessageNotification>(Some(Duration::from_millis(10)))
+            .is_err()
+    );
+
+    let edit = rename_edit(
+        &mut server,
+        &[
+            ("repo/a/old.py", "repo/a/new.py"),
+            ("repo/b/old.py", "repo/b/new.py"),
+        ],
+    )
+    .expect("independent workspaces to contribute edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/a/use.py"),
+        &[(0, 7, 0, 10, "new"), (2, 0, 2, 3, "new")],
+    );
+    assert_edits(
+        &edit,
+        &server.file_uri("repo/b/use.py"),
+        &[(0, 7, 0, 10, "new"), (1, 0, 1, 3, "new")],
+    );
+    assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(2));
+
+    for unsupported in [
+        (
+            "file://remote.example/old.py",
+            "file://remote.example/new.py",
+        ),
+        ("repo/a/old.py", "file://remote.example/new.py"),
+        ("repo/outside.py", "repo/outside_new.py"),
+        ("repo/a/old.py", "repo/b/cross.py"),
+        ("repo/a/old.py", "repo/a/new.pyi"),
+    ] {
+        let edit = rename_edit(
+            &mut server,
+            &[unsupported, ("repo/b/old.py", "repo/b/new.py")],
+        )
+        .expect("the independent file rename to survive");
+        assert_edits(
+            &edit,
+            &server.file_uri("repo/b/use.py"),
+            &[(0, 7, 0, 10, "new"), (1, 0, 1, 3, "new")],
+        );
+        assert_eq!(edit.changes.as_ref().map(HashMap::len), Some(1));
+        assert_incomplete_warning(&mut server);
+    }
+}
+
+#[test]
+fn coordinated_facets_leave_exports_unchanged() {
+    let mut server = TestServerBuilder::new()
+        .and_then(|builder| builder.with_file("pkg/__init__.py", ""))
+        .and_then(|builder| {
+            builder.with_file(
+                "pkg/old.py",
+                r#"class C: ...
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "pkg/old.pyi",
+                r#"class C: ...
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "use.py",
+                r#"from pkg import old
+__all__ = ['old']
+print(old.C)
+"#,
+            )
+        })
+        .expect("test workspace should be created")
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    let edit = rename_edit(
+        &mut server,
+        &[("pkg/old.py", "pkg/new.py"), ("pkg/old.pyi", "pkg/new.pyi")],
+    )
+    .expect("the coordinated module rename to produce edits");
+    assert_edits(
+        &edit,
+        &server.file_uri("use.py"),
+        &[(0, 16, 0, 19, "new"), (2, 6, 2, 9, "new")],
+    );
+    assert!(
+        server
+            .try_await_notification::<ShowMessageNotification>(Some(Duration::from_millis(10)))
+            .is_err()
+    );
+}
+
+#[test]
+fn disabled_workspace_reports_an_incomplete_rename() {
+    let mut server = TestServerBuilder::new()
+        .and_then(|builder| {
+            builder.with_workspace(
+                SystemPath::new("repo"),
+                Some(ClientOptions::default().with_disable_language_services(true)),
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/old.py",
+                r#"x = 1
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/old.pyi",
+                r#"x: int
+"#,
+            )
+        })
+        .and_then(|builder| {
+            builder.with_file(
+                "repo/use.py",
+                r#"import old
+old.x
+"#,
+            )
+        })
+        .expect("test workspace should be created")
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    assert!(rename_edit(&mut server, &[("repo/old.py", "repo/new.py")]).is_none());
+    assert_incomplete_warning(&mut server);
+
+    assert!(rename_edit(&mut server, &[("repo/old.pyi", "repo/new.pyi")]).is_none());
+    assert_incomplete_warning(&mut server);
+}
+
+fn assert_incomplete_warning(server: &mut TestServer) {
+    let warning = server.await_notification::<ShowMessageNotification>();
+    assert_eq!(warning.kind, MessageType::Warning);
+    assert_eq!(
+        warning.message,
+        "ty could not safely update all affected Python code. Some imports, references, or exports may remain unchanged after this file operation."
+    );
+}
+
+fn rename_edit(server: &mut TestServer, renames: &[(&str, &str)]) -> Option<WorkspaceEdit> {
+    let files = renames
+        .iter()
+        .map(|(old, new)| FileRename::new(rename_uri(server, old), rename_uri(server, new)))
+        .collect();
+    server.will_rename_files(files)
+}
+
+fn rename_uri(server: &TestServer, path: &str) -> Uri {
+    if path.contains("://") {
+        Uri::parse(path).expect("test rename URI to be valid")
+    } else {
+        server.file_uri(path)
+    }
+}
+
+fn assert_edits(edit: &WorkspaceEdit, uri: &Uri, expected: &[(u32, u32, u32, u32, &str)]) {
+    let edits = edit
+        .changes
+        .as_ref()
+        .and_then(|changes| changes.get(uri))
+        .expect("workspace edit to contain edits for the URI");
+    let actual: Vec<_> = edits
+        .iter()
+        .map(|edit| {
+            (
+                edit.range.start.line,
+                edit.range.start.character,
+                edit.range.end.line,
+                edit.range.end.character,
+                edit.new_text.as_str(),
+            )
+        })
+        .collect();
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
## Summary

This adds `workspace/willRenameFiles` support so editors can update Python imports and references before renaming files or regular package directories. The server returns edits against the original document locations; the client applies them as part of the rename.

## Approach

The handler groups renames by workspace and calls [`will_rename_paths`](https://github.com/astral-sh/ruff/blob/5610d723c9f2823896140618d9bf7874bab80546/crates/ty_ide/src/will_rename.rs#L72) with indexed files, open documents, and Python files discovered inside moved directories. It converts the resulting source edits to LSP positions and combines them into one workspace edit.

- Name-load recording is enabled only when a request needs it. A background handler discovers the required files, releases its snapshot, and asks the main thread to enable recording before retrying. Session revisions prevent stale file handles from being applied to replaced or reordered projects.
- Each rename must stay within one workspace, and a moved folder cannot contain another workspace. Open documents use the client's current contents; moved files participate even when excluded from indexing.
- Duplicate edits are removed. Overlapping edit groups and edits that cannot be converted to LSP locations are omitted while independent edits are retained.
- The server warns once for omissions detected while validating the request or preparing LSP edits. Unsupported semantic cases omitted by the IDE planner do not trigger that warning.

## Test Plan

See included tests.
