### PR TITLE
[ty] Normalize recursive collection-use constraints

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -338,6 +338,31 @@ fn benchmark_tuple_implicit_instance_attributes(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmark for <https://github.com/astral-sh/ty/issues/4466>.
+///
+/// Uses of empty dictionaries in a nested conditional constrain their initializers. Without
+/// normalization, these constraints gain another layer of dictionary types on each cycle iteration.
+fn benchmark_recursive_collection_use_constraints(criterion: &mut Criterion) {
+    setup_rayon();
+
+    criterion.bench_function("ty_micro[recursive_collection_use_constraints]", |b| {
+        b.iter_batched_ref(
+            || {
+                setup_micro_case(
+                    r#"
+                    def f(flag: bool):
+                        x = {}
+                        y = {}
+                        return {"a": x, "b": {"c": y} if flag else {"d": {"e": y}}}
+                    "#,
+                )
+            },
+            |case| assert_eq!(case.db.check().len(), 0),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 fn benchmark_complex_constrained_attributes_1(criterion: &mut Criterion) {
     setup_rayon();
 
@@ -1871,6 +1896,7 @@ criterion_group!(
     benchmark_many_string_assignments,
     benchmark_many_tuple_assignments,
     benchmark_tuple_implicit_instance_attributes,
+    benchmark_recursive_collection_use_constraints,
     benchmark_complex_constrained_attributes_1,
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -2901,6 +2901,39 @@ x24[1] = "b"
 reveal_type(x24)  # revealed: dict[int | str, str | int]
 ```
 
+## Recursive collection-use constraints
+
+Empty collections can be constrained by their later uses. When a conditional expression provides
+peer context at different nesting depths, those constraints can refer back to the collection being
+inferred.
+
+### Return statements
+
+Inference still converges when several empty dictionaries share a return statement:
+
+```py
+def nested_return(flag: bool):
+    x = {}
+    y = {}
+    return {"a": x, "b": {"c": y} if flag else {"d": {"e": y}}}
+```
+
+### Assignments
+
+The same nesting also works in an assignment. With no concrete keys or values added to either empty
+dictionary, their element types remain unknown:
+
+```py
+def nested_assignment(flag: bool):
+    x = {}
+    y = {}
+    result = {"a": x, "b": {"c": y} if flag else {"d": {"e": y}}}
+    reveal_type(x)  # revealed: dict[Unknown, Unknown]
+    reveal_type(y)  # revealed: dict[Unknown, Unknown]
+    # revealed: dict[str, dict[Unknown, Unknown] | dict[str, dict[str, dict[Unknown, Unknown]]]]
+    reveal_type(result)
+```
+
 ## Multi-inference diagnostics
 
 Diagnostics unrelated to the type-context are only reported once:

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -2901,39 +2901,6 @@ x24[1] = "b"
 reveal_type(x24)  # revealed: dict[int | str, str | int]
 ```
 
-## Recursive collection-use constraints
-
-Empty collections can be constrained by their later uses. When a conditional expression provides
-peer context at different nesting depths, those constraints can refer back to the collection being
-inferred.
-
-### Return statements
-
-Inference still converges when several empty dictionaries share a return statement:
-
-```py
-def nested_return(flag: bool):
-    x = {}
-    y = {}
-    return {"a": x, "b": {"c": y} if flag else {"d": {"e": y}}}
-```
-
-### Assignments
-
-The same nesting also works in an assignment. With no concrete keys or values added to either empty
-dictionary, their element types remain unknown:
-
-```py
-def nested_assignment(flag: bool):
-    x = {}
-    y = {}
-    result = {"a": x, "b": {"c": y} if flag else {"d": {"e": y}}}
-    reveal_type(x)  # revealed: dict[Unknown, Unknown]
-    reveal_type(y)  # revealed: dict[Unknown, Unknown]
-    # revealed: dict[str, dict[Unknown, Unknown] | dict[str, dict[str, dict[Unknown, Unknown]]]]
-    reveal_type(result)
-```
-
 ## Multi-inference diagnostics
 
 Diagnostics unrelated to the type-context are only reported once:

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -122,6 +122,28 @@ fn extend_collection_use_constraints<'db>(
     }
 }
 
+/// Normalizes recursive collection constraints so that each cycle iteration cannot add another
+/// layer of nesting. These constraints feed back into the collection's initializer, so they need
+/// the same normalization as expression and binding types before the next iteration uses them.
+fn normalize_collection_use_constraints<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    constraints: &mut CollectionUseConstraints<'db>,
+    cycle: &salsa::Cycle,
+) {
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "constraints for distinct collection definitions are normalized independently"
+    )]
+    for types in constraints.values_mut() {
+        *types = std::mem::take(types)
+            .into_iter()
+            .map(|ty| ty.recursive_type_normalized(db, env, cycle))
+            .collect();
+        types.shrink_to_fit();
+    }
+}
+
 /// Infer all types for a [`Definition`] (including sub-expressions).
 /// Use when resolving a place use or public type of a place.
 #[salsa::tracked(
@@ -962,6 +984,15 @@ impl<'db> ScopeInference<'db> {
             );
         }
 
+        if let Some(extra) = self.extra.as_deref_mut() {
+            normalize_collection_use_constraints(
+                db,
+                env,
+                &mut extra.collection_use_constraints,
+                cycle,
+            );
+        }
+
         self
     }
 
@@ -1545,6 +1576,15 @@ impl<'db> DefinitionInference<'db> {
             self.extra = Some(Box::new(DefinitionInferenceExtra::Other(Box::new(extra))));
         }
 
+        if let Some(DefinitionInferenceExtra::Other(extra)) = self.extra.as_deref_mut() {
+            normalize_collection_use_constraints(
+                db,
+                &env,
+                &mut extra.collection_use_constraints,
+                cycle,
+            );
+        }
+
         self
     }
 
@@ -1835,6 +1875,15 @@ impl<'db> ExpressionInference<'db> {
             );
         }
 
+        if let Some(extra) = self.extra.as_deref_mut() {
+            normalize_collection_use_constraints(
+                db,
+                env,
+                &mut extra.collection_use_constraints,
+                cycle,
+            );
+        }
+
         self
     }
 
@@ -2066,6 +2115,15 @@ impl<'db> StatementInferenceInner<'db> {
             extend_collection_use_constraints(
                 &mut extra.collection_use_constraints,
                 &previous_extra.collection_use_constraints,
+            );
+        }
+
+        if let Some(extra) = self.extra.as_deref_mut() {
+            normalize_collection_use_constraints(
+                db,
+                env,
+                &mut extra.collection_use_constraints,
+                cycle,
             );
         }
 


### PR DESCRIPTION
## Summary

We now finish inferring nested unannotated dictionaries such as this example, which previously exceeded a 30-second timeout:

```python
def f(flag: bool):
    x = {}
    y = {}
    return {"a": x, "b": {"c": y} if flag else {"d": {"e": y}}}
```

The saved collection-use constraints feed back into the empty dictionaries' initializers. Without normalization, each cycle iteration adds another layer of dictionary types. We now apply the same recursive-type normalization used for expression and binding types to these constraints, allowing inference to converge.

Concretely, for this example, we:

- Infer `y = {}`
- Inspect constraints from the `return` statement
- Infer the `return` statement, which reads `y`
- Re-enter inference for `y = {}`

Within that `return`, we see `{"c": y} if flag else {"d": {"e": y}}`. If `Y` is our current estimate of `y`'s type:

- The false branch has type `dict[str, dict[str, Y]]`
- We use that branch as contextual guidance for the true branch
- Therefore, the value `y` in `{"c": y}` gets an expected type of `dict[str, Y]`
- We save that expectation as a constraint on `y`’s initializer

Inferring `y` from that saved constraint feeds the additional dictionary layer back into the next iteration. If we start with `Y₀ = dict[Divergent, Divergent]`, the saved constraints grow like:

- `dict[str, Y₀]`
- `dict[str, dict[str, Y₀]]`
- `dict[str, dict[str, dict[str, Y₀]]]`

And they're stored in `extra.collection_use_constraints`. We already normalize expression and binding types during cycle recovery, but weren’t normalizing this field, even though it also feeds back into inference.

The fix applies that same normalization to the saved constraints, reducing these expanding forms to `dict[str, Divergent]`. The next iteration produces the same normalized constraint, allowing inference to converge.

Closes https://github.com/astral-sh/ty/issues/4466.
