### PR TITLE
[ty] Avoid caching simple type specializations

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8567,6 +8567,22 @@ impl<'db> Type<'db> {
         specialization: Specialization<'db>,
         specialize_self_domain: bool,
     ) -> Type<'db> {
+        if let Type::NominalInstance(instance) = self
+            && !instance.is_definition_generic(db)
+        {
+            return self;
+        }
+
+        if let Type::TypeVar(typevar) = self
+            && !typevar.is_paramspec(db)
+        {
+            match specialization.get(db, typevar) {
+                Some(mapped) if specialization.materialization_kind(db).is_none() => return mapped,
+                None if !specialize_self_domain || !typevar.typevar(db).is_self(db) => return self,
+                _ => {}
+            }
+        }
+
         if matches!(
             self,
             Type::Dynamic(_)


### PR DESCRIPTION
## Summary

Applying a specialization to a non-generic nominal instance or a directly resolvable type variable retains a Salsa query result and its interned arguments, although the result is already known.

Return these results before entering the tracked query. `ParamSpec` attributes, materialized substitutions, and synthetic `Self` bound rewrites continue through the existing path.
