### PR TITLE
[`flake8-annotations`] Clarify that `ANN401` checks return types in addition to arguments

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -486,8 +486,8 @@ impl Violation for MissingReturnTypeClassMethod {
 }
 
 /// ## What it does
-/// Checks that function arguments are annotated with a more specific type than
-/// `Any`.
+/// Checks that function arguments and return values are annotated with a more
+/// specific type than `Any`.
 ///
 /// ## Why is this bad?
 /// `Any` is a special type indicating an unconstrained type. When an
@@ -503,13 +503,13 @@ impl Violation for MissingReturnTypeClassMethod {
 /// from typing import Any
 ///
 ///
-/// def foo(x: Any): ...
+/// def foo(x: Any) -> Any: ...
 /// ```
 ///
 /// Use instead:
 ///
 /// ```python
-/// def foo(x: int): ...
+/// def foo(x: int) -> int: ...
 /// ```
 ///
 /// ## Known problems


### PR DESCRIPTION
## Summary

The doc comment for the `ANN401` / `any-type` rule (in `crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs`) says:

> Checks that function arguments are annotated with a more specific type than `Any`.

But the rule also flags return annotations typed as `Any` — the checker calls `check_dynamically_typed` on both argument annotations and return annotations. The old wording implied only arguments were checked, which confused users who saw the rule fire on a `-> Any` return annotation (see issue #28298).

This PR changes the description to say "function arguments and return values" and updates the code example in the docstring to show both a bad `-> Any` return annotation and a corrected `-> int` return annotation, so the full scope of the rule is obvious from the documentation.

No logic was changed. The doc comment is the canonical source for the generated rule docs (`cargo dev generate-docs` reads it), so CI doc-generation should reflect the updated wording.

## Test Plan

No behaviour change — this is a documentation-only fix. The generated docs page will update when `cargo dev generate-docs` runs in CI. I manually verified that the `check_dynamically_typed` function is called for both argument annotations and return annotations in the same file, confirming the existing behaviour matches the updated description.

Closes #28298.

---

Note: I used AI tooling to help locate and understand the code, but this description and the wording changes are my own. I have read the [AI policy](https://github.com/astral-sh/.github/blob/main/AI_POLICY.md) and confirm I can explain these changes in my own words.
