### PR TITLE
[ty] Reduce retained AST memory by shrinking expressions

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_comprehensions.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_comprehensions.rs
@@ -18,7 +18,7 @@ pub(crate) fn deferred_comprehensions(checker: &mut Checker) {
             .and_then(|expr| match expr {
                 Expr::ListComp(comp) => Some(comp.generators.as_slice()),
                 Expr::SetComp(comp) => Some(comp.generators.as_slice()),
-                Expr::DictComp(comp) => Some(comp.generators.as_slice()),
+                Expr::DictComp(comp) => Some(comp.generators.as_ref()),
                 Expr::Generator(generator) => Some(generator.generators.as_slice()),
                 _ => None,
             })

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1646,13 +1646,15 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
         }
         Expr::Compare(
             compare @ ast::ExprCompare {
-                left,
                 ops,
-                comparators,
+                operands,
                 range: _,
                 node_index: _,
             },
         ) => {
+            let Some((left, comparators)) = operands.split_first() else {
+                return;
+            };
             if checker.any_rule_enabled(&[Rule::NoneComparison, Rule::TrueFalseComparison]) {
                 pycodestyle::rules::literal_comparisons(checker, compare);
             }

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_in_3_1.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_in_3_1.rs
@@ -6,9 +6,9 @@ use crate::rules::airflow::helpers::{
 };
 use crate::{FixAvailability, Violation};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{Expr, ExprAttribute, ExprName};
+use ruff_python_ast::Expr;
 use ruff_python_semantic::Modules;
-use ruff_text_size::TextRange;
+use ruff_text_size::{Ranged, TextRange};
 
 /// ## What it does
 /// Checks for uses of deprecated or moved Airflow functions and values in Airflow 3.1.
@@ -85,8 +85,8 @@ pub(crate) fn airflow_3_1_moved_expr(checker: &Checker, expr: &Expr) {
     }
 
     match expr {
-        Expr::Attribute(ExprAttribute { range, .. }) | Expr::Name(ExprName { range, .. }) => {
-            check_name(checker, expr, *range);
+        Expr::Attribute(_) | Expr::Name(_) => {
+            check_name(checker, expr, expr.range());
         }
         _ => {}
     }

--- a/crates/ruff_linter/src/rules/airflow/rules/moved_in_3_1.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/moved_in_3_1.rs
@@ -6,9 +6,9 @@ use crate::rules::airflow::helpers::{
 };
 use crate::{FixAvailability, Violation};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::Expr;
+use ruff_python_ast::{Expr, ExprAttribute, ExprName};
 use ruff_python_semantic::Modules;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::TextRange;
 
 /// ## What it does
 /// Checks for uses of deprecated or moved Airflow functions and values in Airflow 3.1.
@@ -85,8 +85,8 @@ pub(crate) fn airflow_3_1_moved_expr(checker: &Checker, expr: &Expr) {
     }
 
     match expr {
-        Expr::Attribute(_) | Expr::Name(_) => {
-            check_name(checker, expr, expr.range());
+        Expr::Attribute(ExprAttribute { range, .. }) | Expr::Name(ExprName { range, .. }) => {
+            check_name(checker, expr, *range);
         }
         _ => {}
     }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -108,8 +108,8 @@ pub(crate) fn airflow_3_removal_expr(checker: &Checker, expr: &Expr) {
             check_method(checker, call_expr);
             check_context_key_usage_in_call(checker, call_expr);
         }
-        Expr::Attribute(attribute_expr) => {
-            check_name(checker, expr, expr.range());
+        Expr::Attribute(attribute_expr @ ExprAttribute { range, .. }) => {
+            check_name(checker, expr, *range);
             check_class_attribute(checker, attribute_expr);
             check_removed_attribute_access_on_context_key(checker, attribute_expr);
         }

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -108,8 +108,8 @@ pub(crate) fn airflow_3_removal_expr(checker: &Checker, expr: &Expr) {
             check_method(checker, call_expr);
             check_context_key_usage_in_call(checker, call_expr);
         }
-        Expr::Attribute(attribute_expr @ ExprAttribute { range, .. }) => {
-            check_name(checker, expr, *range);
+        Expr::Attribute(attribute_expr) => {
+            check_name(checker, expr, expr.range());
             check_class_attribute(checker, attribute_expr);
             check_removed_attribute_access_on_context_key(checker, attribute_expr);
         }

--- a/crates/ruff_linter/src/rules/airflow/rules/runtime_value_in_dag_or_task.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/runtime_value_in_dag_or_task.rs
@@ -230,13 +230,9 @@ fn find_runtime_varying_call<'a>(
         Expr::Yield(ast::ExprYield { value, .. }) => value
             .as_ref()
             .and_then(|v| find_runtime_varying_call(v, semantic)),
-        Expr::Compare(ast::ExprCompare {
-            left, comparators, ..
-        }) => find_runtime_varying_call(left, semantic).or_else(|| {
-            comparators
-                .iter()
-                .find_map(|c| find_runtime_varying_call(c, semantic))
-        }),
+        Expr::Compare(ast::ExprCompare { operands, .. }) => operands
+            .iter()
+            .find_map(|operand| find_runtime_varying_call(operand, semantic)),
         Expr::FString(ast::ExprFString { value, .. }) => value
             .elements()
             .find_map(|element| find_runtime_in_interpolated_element(element, semantic)),

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_bind_all_interfaces.rs
@@ -49,12 +49,12 @@ pub(crate) fn hardcoded_bind_all_interfaces(checker: &Checker, string: StringLik
         StringLike::FString(ast::ExprFString { value, .. }) => {
             for part in value {
                 match part {
-                    ast::FStringPart::Literal(literal) => {
+                    ast::FStringPartRef::Literal(literal) => {
                         if &**literal == "0.0.0.0" {
                             checker.report_diagnostic(HardcodedBindAllInterfaces, literal.range());
                         }
                     }
-                    ast::FStringPart::FString(f_string) => {
+                    ast::FStringPartRef::FString(f_string) => {
                         for literal in f_string.elements.literals() {
                             if &**literal == "0.0.0.0" {
                                 checker

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_tmp_directory.rs
@@ -66,10 +66,10 @@ pub(crate) fn hardcoded_tmp_directory(checker: &Checker, string: StringLike) {
         StringLike::FString(ast::ExprFString { value, .. }) => {
             for part in value {
                 match part {
-                    ast::FStringPart::Literal(literal) => {
+                    ast::FStringPartRef::Literal(literal) => {
                         check(checker, literal, literal.range());
                     }
-                    ast::FStringPart::FString(f_string) => {
+                    ast::FStringPartRef::FString(f_string) => {
                         for literal in f_string.elements.literals() {
                             check(checker, literal, literal.range());
                         }

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_bad_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_bad_defaults.rs
@@ -1,5 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, Expr, StmtFunctionDef};
+use ruff_text_size::Ranged;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
@@ -65,14 +66,12 @@ pub(crate) fn ssl_with_bad_defaults(checker: &Checker, function_def: &StmtFuncti
                     *range,
                 );
             }
-            Expr::Attribute(ast::ExprAttribute { attr, range, .. })
-                if is_insecure_protocol(attr.as_str()) =>
-            {
+            Expr::Attribute(attribute) if is_insecure_protocol(attribute.attr.as_str()) => {
                 checker.report_diagnostic(
                     SslWithBadDefaults {
-                        protocol: attr.to_string(),
+                        protocol: attribute.attr.to_string(),
                     },
-                    *range,
+                    attribute.range(),
                 );
             }
             _ => {}

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_bad_defaults.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/ssl_with_bad_defaults.rs
@@ -1,6 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, Expr, StmtFunctionDef};
-use ruff_text_size::Ranged;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
@@ -66,12 +65,14 @@ pub(crate) fn ssl_with_bad_defaults(checker: &Checker, function_def: &StmtFuncti
                     *range,
                 );
             }
-            Expr::Attribute(attribute) if is_insecure_protocol(attribute.attr.as_str()) => {
+            Expr::Attribute(ast::ExprAttribute { attr, range, .. })
+                if is_insecure_protocol(attr.as_str()) =>
+            {
                 checker.report_diagnostic(
                     SslWithBadDefaults {
-                        protocol: attribute.attr.to_string(),
+                        protocol: attr.to_string(),
                     },
-                    attribute.range(),
+                    *range,
                 );
             }
             _ => {}

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -64,9 +64,9 @@ fn assertion_error(msg: Option<&Expr>) -> Stmt {
             })),
             arguments: Arguments {
                 args: if let Some(msg) = msg {
-                    Box::from([msg.clone()])
+                    [msg.clone()].into()
                 } else {
-                    Box::from([])
+                    [].into()
                 },
                 keywords: std::iter::empty().collect(),
                 range: TextRange::default(),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/delattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/delattr_with_constant.rs
@@ -119,6 +119,7 @@ fn generate_del_statement(obj: &Expr, attr_name: &str, generator: Generator) -> 
             value: Box::new(obj.clone()),
             attr: Identifier::new(attr_name.to_string(), TextRange::default()),
             ctx: ExprContext::Del,
+            range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })],
         range: TextRange::default(),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/delattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/delattr_with_constant.rs
@@ -119,7 +119,6 @@ fn generate_del_statement(obj: &Expr, attr_name: &str, generator: Generator) -> 
             value: Box::new(obj.clone()),
             attr: Identifier::new(attr_name.to_string(), TextRange::default()),
             ctx: ExprContext::Del,
-            range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })],
         range: TextRange::default(),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::{
     ExprTuple, Stmt, StmtAssign, StmtAugAssign, StmtDelete, StmtFor, StmtIf, StmtTry, StmtWhile,
     visitor::{self, Visitor},
 };
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::TextRange;
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
@@ -304,6 +304,7 @@ impl<'a> LoopMutationsVisitor<'a> {
     /// Handle, e.g., `items.append(1)`.
     fn handle_call(&mut self, func: &Expr) {
         if let Expr::Attribute(ExprAttribute {
+            range,
             node_index: _,
             value,
             attr,
@@ -313,7 +314,7 @@ impl<'a> LoopMutationsVisitor<'a> {
             if is_mutating_function(attr.as_str()) {
                 // Find, e.g., `items.remove(1)`.
                 if ComparableExpr::from(self.iter) == ComparableExpr::from(value) {
-                    self.add_mutation(func.range());
+                    self.add_mutation(*range);
                 }
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -10,7 +10,7 @@ use ruff_python_ast::{
     ExprTuple, Stmt, StmtAssign, StmtAugAssign, StmtDelete, StmtFor, StmtIf, StmtTry, StmtWhile,
     visitor::{self, Visitor},
 };
-use ruff_text_size::TextRange;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::Violation;
 use crate::checkers::ast::Checker;
@@ -304,7 +304,6 @@ impl<'a> LoopMutationsVisitor<'a> {
     /// Handle, e.g., `items.append(1)`.
     fn handle_call(&mut self, func: &Expr) {
         if let Expr::Attribute(ExprAttribute {
-            range,
             node_index: _,
             value,
             attr,
@@ -314,7 +313,7 @@ impl<'a> LoopMutationsVisitor<'a> {
             if is_mutating_function(attr.as_str()) {
                 // Find, e.g., `items.remove(1)`.
                 if ComparableExpr::from(self.iter) == ComparableExpr::from(value) {
-                    self.add_mutation(*range);
+                    self.add_mutation(func.range());
                 }
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_variable_overrides_iterator.rs
@@ -92,10 +92,14 @@ impl<'a> Visitor<'a> for NameFinder<'a> {
                 self.names.insert(id, expr);
             }
             Expr::ListComp(ast::ExprListComp { generators, .. })
-            | Expr::DictComp(ast::ExprDictComp { generators, .. })
             | Expr::SetComp(ast::ExprSetComp { generators, .. })
             | Expr::Generator(ast::ExprGenerator { generators, .. }) => {
                 for comp in generators {
+                    self.visit_expr(&comp.iter);
+                }
+            }
+            Expr::DictComp(ast::ExprDictComp { generators, .. }) => {
+                for comp in generators.as_ref() {
                     self.visit_expr(&comp.iter);
                 }
             }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -75,6 +75,7 @@ fn assignment(obj: &Expr, name: &str, value: &Expr, generator: Generator) -> Str
             value: Box::new(obj.clone()),
             attr: Identifier::new(name.to_string(), TextRange::default()),
             ctx: ExprContext::Store,
+            range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })],
         value: Box::new(value.clone()),

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/setattr_with_constant.rs
@@ -75,7 +75,6 @@ fn assignment(obj: &Expr, name: &str, value: &Expr, generator: Generator) -> Str
             value: Box::new(obj.clone()),
             attr: Identifier::new(name.to_string(), TextRange::default()),
             ctx: ExprContext::Store,
-            range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })],
         value: Box::new(value.clone()),

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -78,7 +78,7 @@ pub(crate) fn unnecessary_dict_comprehension_for_iterable(
     checker: &Checker,
     dict_comp: &ast::ExprDictComp,
 ) {
-    let [generator] = dict_comp.generators.as_slice() else {
+    let [generator] = dict_comp.generators.as_ref() else {
         return;
     };
 
@@ -209,9 +209,9 @@ fn fix_unnecessary_dict_comprehension(value: &Expr, generator: &Comprehension) -
     let iterable = generator.iter.clone();
     let args = Arguments {
         args: if value.is_none_literal_expr() {
-            Box::from([iterable])
+            [iterable].into()
         } else {
-            Box::from([iterable, value.clone()])
+            [iterable, value.clone()].into()
         },
         keywords: std::iter::empty().collect(),
         range: TextRange::default(),

--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_strptime_without_zone.rs
@@ -120,12 +120,12 @@ pub(crate) fn call_datetime_strptime_without_zone(checker: &Checker, call: &ast:
             Expr::FString(ast::ExprFString { value, .. }) => {
                 for f_string_part in value {
                     match f_string_part {
-                        ast::FStringPart::Literal(string) => {
+                        ast::FStringPartRef::Literal(string) => {
                             if string.contains("%z") {
                                 return;
                             }
                         }
-                        ast::FStringPart::FString(f_string) => {
+                        ast::FStringPartRef::FString(f_string) => {
                             if f_string
                                 .elements
                                 .literals()

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -44,22 +44,22 @@ fn logging_f_string(
         .value
         .iter()
         .map(|part| match part {
-            ast::FStringPart::Literal(literal) => literal.flags.quote_str(),
-            ast::FStringPart::FString(f) => f.flags.quote_str(),
+            ast::FStringPartRef::Literal(literal) => literal.flags.quote_str(),
+            ast::FStringPartRef::FString(f) => f.flags.quote_str(),
         })
         .next()
         .unwrap_or("\"");
 
     for part in &f_string.value {
         match part {
-            ast::FStringPart::Literal(literal) => {
+            ast::FStringPartRef::Literal(literal) => {
                 let literal_text = literal.as_str();
                 if literal_text.contains('%') {
                     return;
                 }
                 format_string.push_str(literal_text);
             }
-            ast::FStringPart::FString(f) => {
+            ast::FStringPartRef::FString(f) => {
                 for element in &f.elements {
                     match element {
                         InterpolatedStringElement::Literal(lit) => {

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
@@ -193,6 +193,7 @@ pub(crate) fn multiple_starts_ends_with(checker: &Checker, expr: &Expr) {
                 value: Box::new(node1),
                 attr: Identifier::new(attr_name.to_string(), TextRange::default()),
                 ctx: ExprContext::Load,
+                range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
             let node3 = Expr::Call(ast::ExprCall {

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
@@ -193,13 +193,12 @@ pub(crate) fn multiple_starts_ends_with(checker: &Checker, expr: &Expr) {
                 value: Box::new(node1),
                 attr: Identifier::new(attr_name.to_string(), TextRange::default()),
                 ctx: ExprContext::Load,
-                range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
             let node3 = Expr::Call(ast::ExprCall {
                 func: Box::new(node2),
                 arguments: Arguments {
-                    args: Box::from([node]),
+                    args: [node].into(),
                     keywords: std::iter::empty().collect(),
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -116,17 +116,11 @@ impl Violation for BadVersionInfoOrder {
 
 /// PYI006, PYI066
 pub(crate) fn bad_version_info_comparison(checker: &Checker, test: &Expr, has_else_clause: bool) {
-    let Expr::Compare(ast::ExprCompare {
-        left,
-        ops,
-        comparators,
-        ..
-    }) = test
-    else {
+    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
         return;
     };
 
-    let ([op], [_right]) = (&**ops, &**comparators) else {
+    let ([op], [left, _right]) = (&**ops, &**operands) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -46,18 +46,15 @@ impl Violation for ComplexIfStatementInStub {
 
 /// PYI002
 pub(crate) fn complex_if_statement_in_stub(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare {
-        left, comparators, ..
-    }) = test
-    else {
+    let Expr::Compare(ast::ExprCompare { operands, .. }) = test else {
         checker.report_diagnostic(ComplexIfStatementInStub, test.range());
         return;
     };
 
-    if comparators.len() != 1 {
+    let [left, _] = &**operands else {
         checker.report_diagnostic(ComplexIfStatementInStub, test.range());
         return;
-    }
+    };
 
     if left.is_subscript_expr() {
         return;

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/string_or_bytes_too_long.rs
@@ -102,8 +102,8 @@ fn count_f_string_chars(f_string: &ast::ExprFString) -> usize {
         .value
         .iter()
         .map(|part| match part {
-            ast::FStringPart::Literal(string) => string.chars().count(),
-            ast::FStringPart::FString(f_string) => f_string
+            ast::FStringPartRef::Literal(string) => string.chars().count(),
+            ast::FStringPartRef::FString(f_string) => f_string
                 .elements
                 .iter()
                 .map(|element| match element {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -101,17 +101,11 @@ impl Violation for UnrecognizedPlatformName {
 
 /// PYI007, PYI008
 pub(crate) fn unrecognized_platform(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare {
-        left,
-        ops,
-        comparators,
-        ..
-    }) = test
-    else {
+    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
         return;
     };
 
-    let ([op], [right]) = (&**ops, &**comparators) else {
+    let ([op], [left, right]) = (&**ops, &**operands) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -126,17 +126,11 @@ impl Violation for WrongTupleLengthVersionComparison {
 
 /// PYI003, PYI004, PYI005
 pub(crate) fn unrecognized_version_info(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare {
-        left,
-        ops,
-        comparators,
-        ..
-    }) = test
-    else {
+    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
         return;
     };
 
-    let ([op], [comparator]) = (&**ops, &**comparators) else {
+    let ([op], [left, comparator]) = (&**ops, &**operands) else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/helpers.rs
@@ -141,8 +141,8 @@ pub(super) fn is_empty_or_null_string(expr: &Expr) -> bool {
         Expr::NoneLiteral(_) => true,
         Expr::FString(ast::ExprFString { value, .. }) => {
             value.iter().all(|f_string_part| match f_string_part {
-                ast::FStringPart::Literal(literal) => literal.is_empty(),
-                ast::FStringPart::FString(f_string) => f_string
+                ast::FStringPartRef::Literal(literal) => literal.is_empty(),
+                ast::FStringPartRef::FString(f_string) => f_string
                     .elements
                     .iter()
                     .all(is_empty_or_null_interpolated_string_element),

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -172,9 +172,8 @@ fn assert(expr: &Expr, msg: Option<&Expr>) -> Stmt {
 
 fn compare(left: &Expr, cmp_op: CmpOp, right: &Expr) -> Expr {
     Expr::Compare(ast::ExprCompare {
-        left: Box::new(left.clone()),
         ops: [cmp_op].into(),
-        comparators: Box::from([right.clone()]),
+        operands: Box::from([left.clone(), right.clone()]),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     })

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -173,7 +173,7 @@ fn assert(expr: &Expr, msg: Option<&Expr>) -> Stmt {
 fn compare(left: &Expr, cmp_op: CmpOp, right: &Expr) -> Expr {
     Expr::Compare(ast::ExprCompare {
         left: Box::new(left.clone()),
-        ops: Box::from([cmp_op]),
+        ops: [cmp_op].into(),
         comparators: Box::from([right.clone()]),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -392,7 +392,7 @@ impl UnittestAssert {
                 let node1 = ast::ExprCall {
                     func: Box::new(node.into()),
                     arguments: Arguments {
-                        args: Box::from([(**obj).clone(), (**cls).clone()]),
+                        args: [(**obj).clone(), (**cls).clone()].into(),
                         keywords: std::iter::empty().collect(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -435,13 +435,12 @@ impl UnittestAssert {
                     value: Box::new(node.into()),
                     attr: Identifier::new("search".to_string(), TextRange::default()),
                     ctx: ExprContext::Load,
-                    range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 };
                 let node2 = ast::ExprCall {
                     func: Box::new(node1.into()),
                     arguments: Arguments {
-                        args: Box::from([(**regex).clone(), (**text).clone()]),
+                        args: [(**regex).clone(), (**text).clone()].into(),
                         keywords: std::iter::empty().collect(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -435,6 +435,7 @@ impl UnittestAssert {
                     value: Box::new(node.into()),
                     attr: Identifier::new("search".to_string(), TextRange::default()),
                     ctx: ExprContext::Load,
+                    range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 };
                 let node2 = ast::ExprCall {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -459,9 +459,8 @@ pub(crate) fn duplicate_isinstance_call(checker: &Checker, expr: &Expr) {
 
 fn match_eq_target(expr: &Expr) -> Option<(&Name, &Expr)> {
     let Expr::Compare(ast::ExprCompare {
-        left,
         ops,
-        comparators,
+        operands,
         range: _,
         node_index: _,
     }) = expr
@@ -471,10 +470,7 @@ fn match_eq_target(expr: &Expr) -> Option<(&Name, &Expr)> {
     if **ops != [CmpOp::Eq] {
         return None;
     }
-    let Expr::Name(ast::ExprName { id, .. }) = &**left else {
-        return None;
-    };
-    let [comparator] = &**comparators else {
+    let [Expr::Name(ast::ExprName { id, .. }), comparator] = &**operands else {
         return None;
     };
     if !comparator.is_name_expr() {
@@ -545,9 +541,8 @@ pub(crate) fn compare_with_tuple(checker: &Checker, expr: &Expr) {
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         };
         let node2 = ast::ExprCompare {
-            left: Box::new(node1.into()),
             ops: [CmpOp::In].into(),
-            comparators: Box::from([node.into()]),
+            operands: Box::from([node1.into(), node.into()]),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -546,7 +546,7 @@ pub(crate) fn compare_with_tuple(checker: &Checker, expr: &Expr) {
         };
         let node2 = ast::ExprCompare {
             left: Box::new(node1.into()),
-            ops: Box::from([CmpOp::In]),
+            ops: [CmpOp::In].into(),
             comparators: Box::from([node.into()]),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -192,7 +192,7 @@ pub(crate) fn if_expr_with_true_false(
                         .into(),
                     ),
                     arguments: Arguments {
-                        args: Box::from([test.clone()]),
+                        args: [test.clone()].into(),
                         keywords: std::iter::empty().collect(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -153,9 +153,8 @@ pub(crate) fn negation_with_equal_op(checker: &Checker, expr: &Expr, op: UnaryOp
         return;
     }
     let Expr::Compare(ast::ExprCompare {
-        left,
         ops,
-        comparators,
+        operands,
         range: _,
         node_index: _,
     }) = operand
@@ -180,15 +179,14 @@ pub(crate) fn negation_with_equal_op(checker: &Checker, expr: &Expr, op: UnaryOp
 
     let mut diagnostic = checker.report_diagnostic(
         NegateEqualOp {
-            left: checker.generator().expr(left),
-            right: checker.generator().expr(&comparators[0]),
+            left: checker.generator().expr(&operands[0]),
+            right: checker.generator().expr(&operands[1]),
         },
         expr.range(),
     );
     let node = ast::ExprCompare {
-        left: left.clone(),
         ops: [CmpOp::NotEq].into(),
-        comparators: comparators.clone(),
+        operands: operands.clone(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
@@ -209,9 +207,8 @@ pub(crate) fn negation_with_not_equal_op(
         return;
     }
     let Expr::Compare(ast::ExprCompare {
-        left,
         ops,
-        comparators,
+        operands,
         range: _,
         node_index: _,
     }) = operand
@@ -236,15 +233,14 @@ pub(crate) fn negation_with_not_equal_op(
 
     let mut diagnostic = checker.report_diagnostic(
         NegateNotEqualOp {
-            left: checker.generator().expr(left),
-            right: checker.generator().expr(&comparators[0]),
+            left: checker.generator().expr(&operands[0]),
+            right: checker.generator().expr(&operands[1]),
         },
         expr.range(),
     );
     let node = ast::ExprCompare {
-        left: left.clone(),
         ops: [CmpOp::Eq].into(),
-        comparators: comparators.clone(),
+        operands: operands.clone(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -187,7 +187,7 @@ pub(crate) fn negation_with_equal_op(checker: &Checker, expr: &Expr, op: UnaryOp
     );
     let node = ast::ExprCompare {
         left: left.clone(),
-        ops: Box::from([CmpOp::NotEq]),
+        ops: [CmpOp::NotEq].into(),
         comparators: comparators.clone(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -243,7 +243,7 @@ pub(crate) fn negation_with_not_equal_op(
     );
     let node = ast::ExprCompare {
         left: left.clone(),
-        ops: Box::from([CmpOp::Eq]),
+        ops: [CmpOp::Eq].into(),
         comparators: comparators.clone(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -293,7 +293,7 @@ pub(crate) fn double_negation(checker: &Checker, expr: &Expr, op: UnaryOp, opera
         let node1 = ast::ExprCall {
             func: Box::new(node.into()),
             arguments: Arguments {
-                args: Box::from([*operand.clone()]),
+                args: [*operand.clone()].into(),
                 keywords: std::iter::empty().collect(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -274,22 +274,16 @@ fn find_last_nested_if(body: &[Stmt]) -> Option<&Expr> {
 
 /// Returns `true` if an expression is an `if __name__ == "__main__":` check.
 fn is_main_check(expr: &Expr) -> bool {
-    if let Expr::Compare(ast::ExprCompare {
-        left, comparators, ..
-    }) = expr
+    if let Expr::Compare(ast::ExprCompare { operands, .. }) = expr
+        && let [
+            Expr::Name(ast::ExprName { id, .. }),
+            Expr::StringLiteral(ast::ExprStringLiteral { value, .. }),
+        ] = &**operands
     {
-        if let Expr::Name(ast::ExprName { id, .. }) = left.as_ref() {
-            if id == "__name__" {
-                if let [Expr::StringLiteral(ast::ExprStringLiteral { value, .. })] = &**comparators
-                {
-                    if value == "__main__" {
-                        return true;
-                    }
-                }
-            }
-        }
+        id == "__name__" && value == "__main__"
+    } else {
+        false
     }
-    false
 }
 
 fn parenthesize_and_operand(expr: libcst_native::Expression) -> libcst_native::Expression {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -131,16 +131,15 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
     };
 
     let Expr::Compare(ast::ExprCompare {
-        left: test_key,
         ops,
-        comparators: test_dict,
+        operands,
         range: _,
         node_index: _,
     }) = &**test
     else {
         return;
     };
-    let [test_dict] = &**test_dict else {
+    let [test_key, test_dict] = &**operands else {
         return;
     };
 
@@ -194,7 +193,7 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
     }
 
     let node = default_value.clone();
-    let node1 = *test_key.clone();
+    let node1 = test_key.clone();
     let node2 = ast::ExprAttribute {
         value: expected_subscript.clone(),
         attr: Identifier::new("get".to_string(), TextRange::default()),
@@ -259,16 +258,15 @@ pub(crate) fn if_exp_instead_of_dict_get(
     orelse: &Expr,
 ) {
     let Expr::Compare(ast::ExprCompare {
-        left: test_key,
         ops,
-        comparators: test_dict,
+        operands,
         range: _,
         node_index: _,
     }) = test
     else {
         return;
     };
-    let [test_dict] = &**test_dict else {
+    let [test_key, test_dict] = &**operands else {
         return;
     };
 
@@ -303,7 +301,7 @@ pub(crate) fn if_exp_instead_of_dict_get(
     }
 
     let default_value_node = default_value.clone();
-    let dict_key_node = *test_key.clone();
+    let dict_key_node = test_key.clone();
     let dict_get_node = ast::ExprAttribute {
         value: expected_subscript.clone(),
         attr: Identifier::new("get".to_string(), TextRange::default()),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -199,13 +199,12 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
         value: expected_subscript.clone(),
         attr: Identifier::new("get".to_string(), TextRange::default()),
         ctx: ExprContext::Load,
-        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     let node3 = ast::ExprCall {
         func: Box::new(node2.into()),
         arguments: Arguments {
-            args: Box::from([node1, node]),
+            args: [node1, node].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -308,13 +307,12 @@ pub(crate) fn if_exp_instead_of_dict_get(
         value: expected_subscript.clone(),
         attr: Identifier::new("get".to_string(), TextRange::default()),
         ctx: ExprContext::Load,
-        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     let fixed_node = ast::ExprCall {
         func: Box::new(dict_get_node.into()),
         arguments: Arguments {
-            args: Box::from([dict_key_node, default_value_node]),
+            args: [dict_key_node, default_value_node].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -199,6 +199,7 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
         value: expected_subscript.clone(),
         attr: Identifier::new("get".to_string(), TextRange::default()),
         ctx: ExprContext::Load,
+        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     let node3 = ast::ExprCall {
@@ -307,6 +308,7 @@ pub(crate) fn if_exp_instead_of_dict_get(
         value: expected_subscript.clone(),
         attr: Identifier::new("get".to_string(), TextRange::default()),
         ctx: ExprContext::Load,
+        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     let fixed_node = ast::ExprCall {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -60,24 +60,20 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &Checker, stmt_if: &
     } = stmt_if;
 
     let Expr::Compare(ast::ExprCompare {
-        left,
         ops,
-        comparators,
+        operands,
         range: _,
         node_index: _,
     }) = test.as_ref()
     else {
         return;
     };
-    let Expr::Name(ast::ExprName { id: target, .. }) = left.as_ref() else {
+    let [Expr::Name(ast::ExprName { id: target, .. }), expr] = &**operands else {
         return;
     };
     if **ops != [CmpOp::Eq] {
         return;
     }
-    let [expr] = &**comparators else {
-        return;
-    };
     let Some(literal_expr) = expr.as_literal_expr() else {
         return;
     };
@@ -147,21 +143,17 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &Checker, stmt_if: &
             }
             // `elif`
             Some(Expr::Compare(ast::ExprCompare {
-                left,
                 ops,
-                comparators,
+                operands,
                 range: _,
                 node_index: _,
             })) => {
-                let Expr::Name(ast::ExprName { id, .. }) = left.as_ref() else {
+                let [Expr::Name(ast::ExprName { id, .. }), expr] = &**operands else {
                     return;
                 };
                 if id != target || **ops != [CmpOp::Eq] {
                     return;
                 }
-                let [expr] = &**comparators else {
-                    return;
-                };
                 let Some(literal_expr) = expr.as_literal_expr() else {
                     return;
                 };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -185,9 +185,9 @@ pub(crate) fn key_in_dict_compare(checker: &Checker, compare: &ast::ExprCompare)
         return;
     }
 
-    let [right] = &*compare.comparators else {
+    let [left, right] = &*compare.operands else {
         return;
     };
 
-    key_in_dict(checker, &compare.left, right, *op, compare.into());
+    key_in_dict(checker, left, right, *op, compare.into());
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -254,7 +254,7 @@ pub(crate) fn needless_bool(checker: &Checker, stmt: &Stmt) {
                     };
 
                     Some(Expr::Compare(ast::ExprCompare {
-                        ops: Box::new([op.negate()]),
+                        ops: [op.negate()].into(),
                         left: left.clone(),
                         comparators: Box::new([right.clone()]),
                         range: TextRange::default(),
@@ -284,7 +284,7 @@ pub(crate) fn needless_bool(checker: &Checker, stmt: &Stmt) {
             let call_node = ast::ExprCall {
                 func: Box::new(func_node.into()),
                 arguments: Arguments {
-                    args: Box::from([if_test.clone()]),
+                    args: [if_test.clone()].into(),
                     keywords: std::iter::empty().collect(),
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -234,29 +234,19 @@ pub(crate) fn needless_bool(checker: &Checker, stmt: &Stmt) {
                     ..
                 }) => Some((**operand).clone()),
 
-                Expr::Compare(ast::ExprCompare {
-                    ops,
-                    left,
-                    comparators,
-                    ..
-                }) if matches!(
-                    ops.as_ref(),
-                    [ast::CmpOp::Eq
+                Expr::Compare(ast::ExprCompare { ops, operands, .. })
+                    if let [
+                        op @ (ast::CmpOp::Eq
                         | ast::CmpOp::NotEq
                         | ast::CmpOp::In
                         | ast::CmpOp::NotIn
                         | ast::CmpOp::Is
-                        | ast::CmpOp::IsNot]
-                ) =>
+                        | ast::CmpOp::IsNot),
+                    ] = ops.as_ref() =>
                 {
-                    let ([op], [right]) = (ops.as_ref(), comparators.as_ref()) else {
-                        unreachable!("Single comparison with multiple comparators");
-                    };
-
                     Some(Expr::Compare(ast::ExprCompare {
                         ops: [op.negate()].into(),
-                        left: left.clone(),
-                        comparators: Box::new([right.clone()]),
+                        operands: operands.clone(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                     }))

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -172,7 +172,7 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &Checker, stmt: &Stmt) {
                         };
                         let node = ast::ExprCompare {
                             left: left.clone(),
-                            ops: Box::from([op]),
+                            ops: [op].into(),
                             comparators: Box::from([comparator.clone()]),
                             range: TextRange::default(),
                             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -431,7 +431,7 @@ fn return_stmt(id: Name, test: &Expr, target: &Expr, iter: &Expr, generator: Gen
     let node2 = ast::ExprCall {
         func: Box::new(node1.into()),
         arguments: Arguments {
-            args: Box::from([node.into()]),
+            args: [node.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -150,14 +150,13 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &Checker, stmt: &Stmt) {
                 {
                     *operand.clone()
                 } else if let Expr::Compare(ast::ExprCompare {
-                    left,
                     ops,
-                    comparators,
+                    operands,
                     range: _,
                     node_index: _,
                 }) = &loop_.test
                 {
-                    if let ([op], [comparator]) = (&**ops, &**comparators) {
+                    if let ([op], [_, _]) = (&**ops, &**operands) {
                         let op = match op {
                             CmpOp::Eq => CmpOp::NotEq,
                             CmpOp::NotEq => CmpOp::Eq,
@@ -171,9 +170,8 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &Checker, stmt: &Stmt) {
                             CmpOp::NotIn => CmpOp::In,
                         };
                         let node = ast::ExprCompare {
-                            left: left.clone(),
                             ops: [op].into(),
-                            comparators: Box::from([comparator.clone()]),
+                            operands: operands.clone(),
                             range: TextRange::default(),
                             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                         };

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -213,11 +213,14 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
     let mut diagnostics = vec![];
 
     // Check `left`.
-    let mut comparator = compare.left.as_ref();
+    let Some((left, comparators)) = compare.operands.split_first() else {
+        return;
+    };
+    let mut comparator = left;
     let [op, ..] = &*compare.ops else {
         return;
     };
-    let [next, ..] = &*compare.comparators else {
+    let [next, ..] = comparators else {
         return;
     };
 
@@ -284,7 +287,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
     }
 
     // Check each comparator in order.
-    for (index, (op, next)) in compare.ops.iter().zip(&compare.comparators).enumerate() {
+    for (index, (op, next)) in compare.ops.iter().zip(comparators).enumerate() {
         if helpers::is_constant_non_singleton(comparator) {
             comparator = next;
             continue;
@@ -381,42 +384,21 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
         let tokens = checker.tokens();
         let source = checker.source();
 
-        let content = match (&*compare.ops, &*compare.comparators) {
+        let content = match (&*compare.ops, comparators) {
             ([op], [comparator]) => {
-                if let Some(kind) = is_redundant_boolean_comparison(*op, &compare.left) {
-                    let needs_wrap = compare.left.range().start() != compare.range().start();
+                if let Some(kind) = is_redundant_boolean_comparison(*op, left) {
+                    let needs_wrap = left.range().start() != compare.range().start();
                     generate_redundant_comparison(
                         compare, tokens, source, comparator, kind, needs_wrap,
                     )
                 } else if let Some(kind) = is_redundant_boolean_comparison(*op, comparator) {
                     let needs_wrap = comparator.range().end() != compare.range().end();
-                    generate_redundant_comparison(
-                        compare,
-                        tokens,
-                        source,
-                        &compare.left,
-                        kind,
-                        needs_wrap,
-                    )
+                    generate_redundant_comparison(compare, tokens, source, left, kind, needs_wrap)
                 } else {
-                    generate_comparison(
-                        &compare.left,
-                        &ops,
-                        &compare.comparators,
-                        compare.into(),
-                        tokens,
-                        source,
-                    )
+                    generate_comparison(left, &ops, comparators, compare.into(), tokens, source)
                 }
             }
-            _ => generate_comparison(
-                &compare.left,
-                &ops,
-                &compare.comparators,
-                compare.into(),
-                tokens,
-                source,
-            ),
+            _ => generate_comparison(left, &ops, comparators, compare.into(), tokens, source),
         };
 
         for diagnostic in &mut diagnostics {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
@@ -87,13 +87,16 @@ pub(crate) fn not_tests(checker: &Checker, unary_op: &ast::ExprUnaryOp) {
     }
 
     let Expr::Compare(ast::ExprCompare {
-        left,
         ops,
-        comparators,
+        operands,
         range: _,
         node_index: _,
     }) = unary_op.operand.as_ref()
     else {
+        return;
+    };
+
+    let Some((left, comparators)) = operands.split_first() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -63,8 +63,9 @@ impl Violation for TypeComparison {
 
 /// E721
 pub(crate) fn type_comparison(checker: &Checker, compare: &ast::ExprCompare) {
-    for (left, right) in std::iter::once(&*compare.left)
-        .chain(&compare.comparators)
+    for (left, right) in compare
+        .operands
+        .iter()
         .tuple_windows()
         .zip(&compare.ops)
         .filter(|(_, op)| matches!(op, CmpOp::Eq | CmpOp::NotEq))

--- a/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/assert_on_string_literal.rs
@@ -76,8 +76,8 @@ pub(crate) fn assert_on_string_literal(checker: &Checker, test: &Expr) {
         }
         Expr::FString(ast::ExprFString { value, .. }) => {
             let kind = if value.iter().all(|f_string_part| match f_string_part {
-                ast::FStringPart::Literal(literal) => literal.is_empty(),
-                ast::FStringPart::FString(f_string) => {
+                ast::FStringPartRef::Literal(literal) => literal.is_empty(),
+                ast::FStringPartRef::FString(f_string) => {
                     f_string.elements.iter().all(|element| match element {
                         ast::InterpolatedStringElement::Literal(
                             ast::InterpolatedStringLiteralElement { value, .. },
@@ -88,8 +88,8 @@ pub(crate) fn assert_on_string_literal(checker: &Checker, test: &Expr) {
             }) {
                 Kind::Empty
             } else if value.iter().any(|f_string_part| match f_string_part {
-                ast::FStringPart::Literal(literal) => !literal.is_empty(),
-                ast::FStringPart::FString(f_string) => {
+                ast::FStringPartRef::Literal(literal) => !literal.is_empty(),
+                ast::FStringPartRef::FString(f_string) => {
                     f_string.elements.iter().any(|element| match element {
                         ast::InterpolatedStringElement::Literal(
                             ast::InterpolatedStringLiteralElement { value, .. },

--- a/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
@@ -78,11 +78,11 @@ pub(crate) fn boolean_chained_comparison(checker: &Checker, expr_bool_op: &ExprB
                 are_compare_expr_simplifiable(left_compare, right_compare)
             })
     {
-        let Some(Expr::Name(left_compare_right)) = left_compare.comparators.last() else {
+        let Some(Expr::Name(left_compare_right)) = left_compare.operands.last() else {
             continue;
         };
 
-        let Expr::Name(right_compare_left) = &*right_compare.left else {
+        let Some(Expr::Name(right_compare_left)) = right_compare.operands.first() else {
             continue;
         };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
@@ -110,13 +110,7 @@ pub(crate) fn if_stmt_min_max(checker: &Checker, stmt_if: &ast::StmtIf) {
         return;
     };
 
-    let Some(ast::ExprCompare {
-        ops,
-        left,
-        comparators,
-        ..
-    }) = test.as_compare_expr()
-    else {
+    let Some(ast::ExprCompare { ops, operands, .. }) = test.as_compare_expr() else {
         return;
     };
 
@@ -124,7 +118,7 @@ pub(crate) fn if_stmt_min_max(checker: &Checker, stmt_if: &ast::StmtIf) {
     let [op] = &**ops else {
         return;
     };
-    let [right] = &**comparators else {
+    let [left, right] = &**operands else {
         return;
     };
 
@@ -159,9 +153,9 @@ pub(crate) fn if_stmt_min_max(checker: &Checker, stmt_if: &ast::StmtIf) {
     };
 
     let (arg1, arg2) = if flip_args {
-        (right, &**left)
+        (right, left)
     } else {
-        (&**left, right)
+        (left, right)
     };
 
     let replacement = format!(

--- a/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
@@ -59,7 +59,7 @@ pub(crate) fn literal_membership(checker: &Checker, compare: &ast::ExprCompare) 
         return;
     }
 
-    let [right] = &*compare.comparators else {
+    let [left, right] = &*compare.operands else {
         return;
     };
 
@@ -75,33 +75,30 @@ pub(crate) fn literal_membership(checker: &Checker, compare: &ast::ExprCompare) 
     }
 
     // If `left`, or any of the elements in `right`, are known to _not_ be hashable, return.
-    if std::iter::once(compare.left.as_ref())
-        .chain(elts)
-        .any(|expr| match expr {
-            // Expressions that are known _not_ to be hashable.
-            Expr::List(_)
-            | Expr::Set(_)
-            | Expr::Dict(_)
-            | Expr::ListComp(_)
-            | Expr::SetComp(_)
-            | Expr::DictComp(_)
-            | Expr::Generator(_)
-            | Expr::Await(_)
-            | Expr::Yield(_)
-            | Expr::YieldFrom(_) => true,
-            // Expressions that can be _inferred_ not to be hashable.
-            Expr::Name(name) => {
-                let Some(id) = checker.semantic().resolve_name(name) else {
-                    return false;
-                };
-                let binding = checker.semantic().binding(id);
-                typing::is_list(binding, checker.semantic())
-                    || typing::is_dict(binding, checker.semantic())
-                    || typing::is_set(binding, checker.semantic())
-            }
-            _ => false,
-        })
-    {
+    if std::iter::once(left).chain(elts).any(|expr| match expr {
+        // Expressions that are known _not_ to be hashable.
+        Expr::List(_)
+        | Expr::Set(_)
+        | Expr::Dict(_)
+        | Expr::ListComp(_)
+        | Expr::SetComp(_)
+        | Expr::DictComp(_)
+        | Expr::Generator(_)
+        | Expr::Await(_)
+        | Expr::Yield(_)
+        | Expr::YieldFrom(_) => true,
+        // Expressions that can be _inferred_ not to be hashable.
+        Expr::Name(name) => {
+            let Some(id) = checker.semantic().resolve_name(name) else {
+                return false;
+            };
+            let binding = checker.semantic().binding(id);
+            typing::is_list(binding, checker.semantic())
+                || typing::is_dict(binding, checker.semantic())
+                || typing::is_set(binding, checker.semantic())
+        }
+        _ => false,
+    }) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
@@ -51,11 +51,7 @@ impl AlwaysFixableViolation for LiteralMembership {
 
 /// PLR6201
 pub(crate) fn literal_membership(checker: &Checker, compare: &ast::ExprCompare) {
-    let [op] = &*compare.ops else {
-        return;
-    };
-
-    if !matches!(op, CmpOp::In | CmpOp::NotIn) {
+    if !matches!(&*compare.ops, [CmpOp::In | CmpOp::NotIn]) {
         return;
     }
 

--- a/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
@@ -203,7 +203,7 @@ pub(crate) fn nested_min_max(
         let flattened_expr = Expr::Call(ast::ExprCall {
             func: Box::new(func.clone()),
             arguments: Arguments {
-                args: collect_nested_args(min_max, args, checker.semantic()).into_boxed_slice(),
+                args: collect_nested_args(min_max, args, checker.semantic()).into(),
                 keywords: keywords.iter().cloned().collect(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -204,8 +204,8 @@ pub(crate) fn repeated_equality_comparison(checker: &Checker, bool_op: &ast::Exp
                         .chain(std::iter::once(Expr::Compare(ast::ExprCompare {
                             left: Box::new(expr.clone()),
                             ops: match bool_op.op {
-                                BoolOp::Or => Box::from([CmpOp::In]),
-                                BoolOp::And => Box::from([CmpOp::NotIn]),
+                                BoolOp::Or => [CmpOp::In].into(),
+                                BoolOp::And => [CmpOp::NotIn].into(),
                             },
                             comparators: Box::from([comparator]),
                             range: bool_op.range(),

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -202,12 +202,11 @@ pub(crate) fn repeated_equality_comparison(checker: &Checker, bool_op: &ast::Exp
                     op: bool_op.op,
                     values: before
                         .chain(std::iter::once(Expr::Compare(ast::ExprCompare {
-                            left: Box::new(expr.clone()),
                             ops: match bool_op.op {
                                 BoolOp::Or => [CmpOp::In].into(),
                                 BoolOp::And => [CmpOp::NotIn].into(),
                             },
-                            comparators: Box::from([comparator]),
+                            operands: Box::from([expr.clone(), comparator]),
                             range: bool_op.range(),
                             node_index: AtomicNodeIndex::NONE,
                         })))
@@ -230,13 +229,7 @@ fn to_allowed_value<'a>(
     value: &'a Expr,
     semantic: &SemanticModel,
 ) -> Option<(&'a Expr, &'a Expr)> {
-    let Expr::Compare(ast::ExprCompare {
-        left,
-        ops,
-        comparators,
-        ..
-    }) = value
-    else {
+    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = value else {
         return None;
     };
 
@@ -253,7 +246,7 @@ fn to_allowed_value<'a>(
     }
 
     // Ignore self-comparisons, e.g., `foo == foo`.
-    let [right] = &**comparators else {
+    let [left, right] = &**operands else {
         return None;
     };
     if ComparableExpr::from(left) == ComparableExpr::from(right) {

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
@@ -70,22 +70,20 @@ pub(crate) fn unnecessary_dict_index_lookup(checker: &Checker, stmt_for: &StmtFo
 
 /// PLR1733
 pub(crate) fn unnecessary_dict_index_lookup_comprehension(checker: &Checker, expr: &Expr) {
-    let (Expr::Generator(ast::ExprGenerator {
-        elt, generators, ..
-    })
-    | Expr::DictComp(ast::ExprDictComp {
-        value: elt,
-        generators,
-        ..
-    })
-    | Expr::SetComp(ast::ExprSetComp {
-        elt, generators, ..
-    })
-    | Expr::ListComp(ast::ExprListComp {
-        elt, generators, ..
-    })) = expr
-    else {
-        return;
+    let (elt, generators) = match expr {
+        Expr::Generator(ast::ExprGenerator {
+            elt, generators, ..
+        })
+        | Expr::SetComp(ast::ExprSetComp {
+            elt, generators, ..
+        })
+        | Expr::ListComp(ast::ExprListComp {
+            elt, generators, ..
+        }) => (elt.as_ref(), generators.as_slice()),
+        Expr::DictComp(ast::ExprDictComp {
+            value, generators, ..
+        }) => (value.as_ref(), generators.as_ref()),
+        _ => return,
     };
 
     for comp in generators {
@@ -96,7 +94,7 @@ pub(crate) fn unnecessary_dict_index_lookup_comprehension(checker: &Checker, exp
         let ranges = {
             let mut visitor =
                 SequenceIndexVisitor::new(&dict_name.id, &index_name.id, &value_name.id);
-            visitor.visit_expr(elt.as_ref());
+            visitor.visit_expr(elt);
             for expr in &comp.ifs {
                 visitor.visit_expr(expr);
             }

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -73,22 +73,20 @@ pub(crate) fn unnecessary_list_index_lookup(checker: &Checker, stmt_for: &StmtFo
 
 /// PLR1736
 pub(crate) fn unnecessary_list_index_lookup_comprehension(checker: &Checker, expr: &Expr) {
-    let (Expr::Generator(ast::ExprGenerator {
-        elt, generators, ..
-    })
-    | Expr::DictComp(ast::ExprDictComp {
-        value: elt,
-        generators,
-        ..
-    })
-    | Expr::SetComp(ast::ExprSetComp {
-        elt, generators, ..
-    })
-    | Expr::ListComp(ast::ExprListComp {
-        elt, generators, ..
-    })) = expr
-    else {
-        return;
+    let (elt, generators) = match expr {
+        Expr::Generator(ast::ExprGenerator {
+            elt, generators, ..
+        })
+        | Expr::SetComp(ast::ExprSetComp {
+            elt, generators, ..
+        })
+        | Expr::ListComp(ast::ExprListComp {
+            elt, generators, ..
+        }) => (elt.as_ref(), generators.as_slice()),
+        Expr::DictComp(ast::ExprDictComp {
+            value, generators, ..
+        }) => (value.as_ref(), generators.as_ref()),
+        _ => return,
     };
 
     for comp in generators {
@@ -101,7 +99,7 @@ pub(crate) fn unnecessary_list_index_lookup_comprehension(checker: &Checker, exp
         let ranges = {
             let mut visitor =
                 SequenceIndexVisitor::new(&sequence.id, &index_name.id, &value_name.id);
-            visitor.visit_expr(elt.as_ref());
+            visitor.visit_expr(elt);
             visitor.into_accesses()
         };
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -237,7 +237,7 @@ fn create_class_def_stmt(typename: &str, body: Suite, base_class: &Expr) -> Stmt
     ast::StmtClassDef {
         name: Identifier::new(typename.to_string(), TextRange::default()),
         arguments: Some(Box::new(Arguments {
-            args: Box::from([base_class.clone()]),
+            args: [base_class.clone()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -177,7 +177,7 @@ fn create_class_def_stmt(
     ast::StmtClassDef {
         name: Identifier::new(class_name.to_string(), TextRange::default()),
         arguments: Some(Box::new(Arguments {
-            args: Box::from([base_class.clone()]),
+            args: [base_class.clone()].into(),
             keywords: match total_keyword {
                 Some(keyword) => std::iter::once(keyword.clone()).collect(),
                 None => std::iter::empty().collect(),

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -92,9 +92,8 @@ enum Reason {
 pub(crate) fn outdated_version_block(checker: &Checker, stmt_if: &StmtIf) {
     for branch in if_elif_branches(stmt_if) {
         let Expr::Compare(ast::ExprCompare {
-            left,
             ops,
-            comparators,
+            operands,
             range: _,
             node_index: _,
         }) = &branch.test
@@ -102,7 +101,7 @@ pub(crate) fn outdated_version_block(checker: &Checker, stmt_if: &StmtIf) {
             continue;
         };
 
-        let ([op], [comparison]) = (&**ops, &**comparators) else {
+        let ([op], [left, comparison]) = (&**ops, &**operands) else {
             continue;
         };
 

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -25,6 +25,7 @@ pub(super) fn generate_method_call(name: Name, method: &str, generator: Generato
         value: Box::new(var.into()),
         attr: ast::Identifier::new(method.to_string(), TextRange::default()),
         ctx: ast::ExprContext::Load,
+        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make it into a call `name.method()`

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -66,9 +66,8 @@ pub(super) fn replace_with_identity_check(
     };
 
     let new_expr = Expr::Compare(ast::ExprCompare {
-        left: left.clone().into(),
         ops: [op].into(),
-        comparators: [ast::ExprNoneLiteral::default().into()].into(),
+        operands: [left.clone(), ast::ExprNoneLiteral::default().into()].into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     });

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -25,14 +25,13 @@ pub(super) fn generate_method_call(name: Name, method: &str, generator: Generato
         value: Box::new(var.into()),
         attr: ast::Identifier::new(method.to_string(), TextRange::default()),
         ctx: ast::ExprContext::Load,
-        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make it into a call `name.method()`
     let call = ast::ExprCall {
         func: Box::new(attr.into()),
         arguments: ast::Arguments {
-            args: Box::from([]),
+            args: [].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -192,14 +192,13 @@ fn make_suggestion(set: &ast::ExprName, element: &Expr, generator: Generator) ->
         value: Box::new(set.clone().into()),
         attr: ast::Identifier::new("discard".to_string(), TextRange::default()),
         ctx: ast::ExprContext::Load,
-        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make the actual call `set.discard(element)`
     let call = ast::ExprCall {
         func: Box::new(attr.into()),
         arguments: ast::Arguments {
-            args: Box::from([element.clone()]),
+            args: [element.clone()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -192,6 +192,7 @@ fn make_suggestion(set: &ast::ExprName, element: &Expr, generator: Generator) ->
         value: Box::new(set.clone().into()),
         attr: ast::Identifier::new("discard".to_string(), TextRange::default()),
         ctx: ast::ExprContext::Load,
+        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make the actual call `set.discard(element)`

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -132,22 +132,17 @@ fn compare(lhs: &ComparableExpr, rhs: &ComparableExpr) -> bool {
 
 /// Match `if` condition to be `expr in name`, returns a tuple of (`expr`, `name`) on success.
 fn match_check(if_stmt: &ast::StmtIf) -> Option<(&Expr, &ast::ExprName)> {
-    let ast::ExprCompare {
-        ops,
-        left,
-        comparators,
-        ..
-    } = if_stmt.test.as_compare_expr()?;
+    let ast::ExprCompare { ops, operands, .. } = if_stmt.test.as_compare_expr()?;
 
     if **ops != [CmpOp::In] {
         return None;
     }
 
-    let [Expr::Name(right @ ast::ExprName { .. })] = &**comparators else {
+    let [left, Expr::Name(right @ ast::ExprName { .. })] = &**operands else {
         return None;
     };
 
-    Some((left.as_ref(), right))
+    Some((left, right))
 }
 
 /// Match `if` body to be `name.remove(expr)`, returns a tuple of (`expr`, `name`) on success.

--- a/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
@@ -87,13 +87,7 @@ impl Violation for IfExprMinMax {
 
 /// FURB136
 pub(crate) fn if_expr_min_max(checker: &Checker, if_exp: &ast::ExprIf) {
-    let Expr::Compare(ast::ExprCompare {
-        left,
-        ops,
-        comparators,
-        ..
-    }) = if_exp.test.as_ref()
-    else {
+    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = if_exp.test.as_ref() else {
         return;
     };
 
@@ -112,7 +106,7 @@ pub(crate) fn if_expr_min_max(checker: &Checker, if_exp: &ast::ExprIf) {
         _ => return,
     };
 
-    let [right] = &**comparators else {
+    let [left, right] = &**operands else {
         return;
     };
 
@@ -129,9 +123,9 @@ pub(crate) fn if_expr_min_max(checker: &Checker, if_exp: &ast::ExprIf) {
     }
 
     let (arg1, arg2) = if flip_args {
-        (right, left.as_ref())
+        (right, left)
     } else {
-        (left.as_ref(), right)
+        (left, right)
     };
 
     let replacement = format!(

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -244,8 +244,7 @@ impl EmptyStringFix {
             .iter()
             .filter(|arg| !is_empty_string(arg))
             .cloned()
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+            .collect();
 
         // Remove the `sep` keyword argument if it exists.
         if separator == Separator::Remove {

--- a/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
@@ -179,7 +179,7 @@ fn make_suggestion(open: &FileOpen<'_>, generator: Generator) -> String {
     let call = ast::ExprCall {
         func: Box::new(name.into()),
         arguments: ast::Arguments {
-            args: Box::from([]),
+            args: [].into(),
             keywords: open.keywords.iter().copied().cloned().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -433,24 +433,24 @@ fn cmp_op(expr: &ast::ExprCompare, params: &Parameters) -> Option<&'static str> 
     let [op] = &*expr.ops else {
         return None;
     };
-    let [right] = &*expr.comparators else {
+    let [left, right] = &*expr.operands else {
         return None;
     };
 
     match op {
-        ast::CmpOp::Eq => match_arguments(arg1, arg2, &expr.left, right).then_some("eq"),
-        ast::CmpOp::NotEq => match_arguments(arg1, arg2, &expr.left, right).then_some("ne"),
-        ast::CmpOp::Lt => match_arguments(arg1, arg2, &expr.left, right).then_some("lt"),
-        ast::CmpOp::LtE => match_arguments(arg1, arg2, &expr.left, right).then_some("le"),
-        ast::CmpOp::Gt => match_arguments(arg1, arg2, &expr.left, right).then_some("gt"),
-        ast::CmpOp::GtE => match_arguments(arg1, arg2, &expr.left, right).then_some("ge"),
-        ast::CmpOp::Is => match_arguments(arg1, arg2, &expr.left, right).then_some("is_"),
-        ast::CmpOp::IsNot => match_arguments(arg1, arg2, &expr.left, right).then_some("is_not"),
+        ast::CmpOp::Eq => match_arguments(arg1, arg2, left, right).then_some("eq"),
+        ast::CmpOp::NotEq => match_arguments(arg1, arg2, left, right).then_some("ne"),
+        ast::CmpOp::Lt => match_arguments(arg1, arg2, left, right).then_some("lt"),
+        ast::CmpOp::LtE => match_arguments(arg1, arg2, left, right).then_some("le"),
+        ast::CmpOp::Gt => match_arguments(arg1, arg2, left, right).then_some("gt"),
+        ast::CmpOp::GtE => match_arguments(arg1, arg2, left, right).then_some("ge"),
+        ast::CmpOp::Is => match_arguments(arg1, arg2, left, right).then_some("is_"),
+        ast::CmpOp::IsNot => match_arguments(arg1, arg2, left, right).then_some("is_not"),
         ast::CmpOp::In => {
             // Note: `operator.contains` reverses the order of arguments. That is:
             // `operator.contains` is equivalent to `lambda x, y: y in x`, rather than
             // `lambda x, y: x in y`.
-            match_arguments(arg1, arg2, right, &expr.left).then_some("contains")
+            match_arguments(arg1, arg2, right, left).then_some("contains")
         }
         ast::CmpOp::NotIn => None,
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -320,7 +320,7 @@ fn construct_starmap_call(starmap_binding: Name, iter: &Expr, func: &Expr) -> as
     ast::ExprCall {
         func: Box::new(starmap.into()),
         arguments: ast::Arguments {
-            args: Box::from([func.clone(), iter.clone()]),
+            args: [func.clone(), iter.clone()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -341,7 +341,7 @@ fn wrap_with_call_to(call: ast::ExprCall, func_name: Name) -> ast::ExprCall {
     ast::ExprCall {
         func: Box::new(name.into()),
         arguments: ast::Arguments {
-            args: Box::from([call.into()]),
+            args: [call.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
@@ -353,14 +353,13 @@ fn make_suggestion(group: &AppendGroup, generator: Generator) -> String {
         value: Box::new(first.receiver.clone().into()),
         attr: ast::Identifier::new("extend".to_string(), TextRange::default()),
         ctx: ast::ExprContext::Load,
-        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make the actual call `var.extend((elt1, elt2, ..., eltN))`
     let call = ast::ExprCall {
         func: Box::new(attr.into()),
         arguments: ast::Arguments {
-            args: Box::from([tuple.into()]),
+            args: [tuple.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
@@ -353,6 +353,7 @@ fn make_suggestion(group: &AppendGroup, generator: Generator) -> String {
         value: Box::new(first.receiver.clone().into()),
         attr: ast::Identifier::new("extend".to_string(), TextRange::default()),
         ctx: ast::ExprContext::Load,
+        range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make the actual call `var.extend((elt1, elt2, ..., eltN))`

--- a/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
@@ -54,7 +54,7 @@ impl AlwaysFixableViolation for TypeNoneComparison {
 
 /// FURB169
 pub(crate) fn type_none_comparison(checker: &Checker, compare: &ast::ExprCompare) {
-    let ([op], [right]) = (&*compare.ops, &*compare.comparators) else {
+    let ([op], [left, right]) = (&*compare.ops, &*compare.operands) else {
         return;
     };
 
@@ -64,7 +64,7 @@ pub(crate) fn type_none_comparison(checker: &Checker, compare: &ast::ExprCompare
         _ => return,
     };
 
-    let Some(left_arg) = type_call_arg(&compare.left, checker.semantic()) else {
+    let Some(left_arg) = type_call_arg(left, checker.semantic()) else {
         return;
     };
     let Some(right_arg) = type_call_arg(right, checker.semantic()) else {

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -248,7 +248,7 @@ fn generate_range_len_call(name: Name, generator: Generator) -> String {
             .into(),
         ),
         arguments: Arguments {
-            args: Box::from([var.into()]),
+            args: [var.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -268,7 +268,7 @@ fn generate_range_len_call(name: Name, generator: Generator) -> String {
             .into(),
         ),
         arguments: Arguments {
-            args: Box::from([len.into()]),
+            args: [len.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -126,8 +126,9 @@ pub(crate) fn float_equality_comparison(checker: &Checker, compare: &ast::ExprCo
     let locator = checker.locator();
     let semantic = checker.semantic();
 
-    for (left, right, operator) in std::iter::once(&*compare.left)
-        .chain(&compare.comparators)
+    for (left, right, operator) in compare
+        .operands
+        .iter()
         .tuple_windows()
         .zip(&compare.ops)
         .filter(|(_, op)| matches!(op, CmpOp::Eq | CmpOp::NotEq))

--- a/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
@@ -84,7 +84,7 @@ fn extract_dict_and_key_from_test(test: &Expr) -> Option<(&Dict, &Key)> {
         return None;
     };
 
-    let [Expr::Name(dict)] = comp.comparators.as_ref() else {
+    let [key, Expr::Name(dict)] = comp.operands.as_ref() else {
         return None;
     };
 
@@ -92,7 +92,7 @@ fn extract_dict_and_key_from_test(test: &Expr) -> Option<(&Dict, &Key)> {
         return None;
     }
 
-    Some((dict, &comp.left))
+    Some((dict, key))
 }
 
 fn extract_dict_and_key_from_del(targets: &[Expr]) -> Option<(&Dict, &Key)> {

--- a/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
@@ -46,7 +46,7 @@ pub(crate) fn in_empty_collection(checker: &Checker, compare: &ast::ExprCompare)
         return;
     }
 
-    let [right] = &*compare.comparators else {
+    let [_, right] = &*compare.operands else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_fromkeys_value.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_fromkeys_value.rs
@@ -124,7 +124,7 @@ fn generate_dict_comprehension(
     let dict_comp = ast::ExprDictComp {
         key: Some(Box::new(key.into())),
         value: Box::new(value.clone()),
-        generators: vec![comp],
+        generators: Box::new([comp]),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -69,13 +69,7 @@ pub(crate) fn unnecessary_key_check(checker: &Checker, expr: &Expr) {
     };
 
     // Left should be, e.g., `key in dct`.
-    let Expr::Compare(ast::ExprCompare {
-        left: key_left,
-        ops,
-        comparators,
-        ..
-    }) = left
-    else {
+    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = left else {
         return;
     };
 
@@ -83,7 +77,7 @@ pub(crate) fn unnecessary_key_check(checker: &Checker, expr: &Expr) {
         return;
     }
 
-    let [obj_left] = &**comparators else {
+    let [key_left, obj_left] = &**operands else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -332,9 +332,8 @@ impl<'a> ReFunc<'a> {
     /// Return a new compare expr of the form `left op right`
     fn compare_expr(left: &Expr, op: CmpOp, right: &Expr) -> Expr {
         Expr::Compare(ExprCompare {
-            left: Box::new(left.clone()),
             ops: [op].into(),
-            comparators: Box::new([right.clone()]),
+            operands: Box::new([left.clone(), right.clone()]),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })
@@ -443,7 +442,7 @@ fn get_comparison_to_none(semantic: &SemanticModel) -> Option<(ComparisonToNone,
 
     let Expr::Compare(ExprCompare {
         ops,
-        comparators,
+        operands,
         range,
         ..
     }) = parent_expr
@@ -451,7 +450,7 @@ fn get_comparison_to_none(semantic: &SemanticModel) -> Option<(ComparisonToNone,
         return None;
     };
 
-    let Some(Expr::NoneLiteral(_)) = comparators.first() else {
+    let Some(Expr::NoneLiteral(_)) = operands.get(1) else {
         return None;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -347,6 +347,7 @@ impl<'a> ReFunc<'a> {
             value: Box::new(self.string.clone()),
             attr: Identifier::new(method, TextRange::default()),
             ctx: ExprContext::Load,
+            range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         });
         Expr::Call(ExprCall {

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -333,7 +333,7 @@ impl<'a> ReFunc<'a> {
     fn compare_expr(left: &Expr, op: CmpOp, right: &Expr) -> Expr {
         Expr::Compare(ExprCompare {
             left: Box::new(left.clone()),
-            ops: Box::new([op]),
+            ops: [op].into(),
             comparators: Box::new([right.clone()]),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
@@ -347,13 +347,12 @@ impl<'a> ReFunc<'a> {
             value: Box::new(self.string.clone()),
             attr: Identifier::new(method, TextRange::default()),
             ctx: ExprContext::Load,
-            range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         });
         Expr::Call(ExprCall {
             func: Box::new(method),
             arguments: Arguments {
-                args: args.into_boxed_slice(),
+                args: args.into(),
                 keywords: std::iter::empty().collect(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -91,12 +91,12 @@ fn contains_message(expr: &Expr) -> bool {
         Expr::FString(ast::ExprFString { value, .. }) => {
             for f_string_part in value {
                 match f_string_part {
-                    ast::FStringPart::Literal(literal) => {
+                    ast::FStringPartRef::Literal(literal) => {
                         if literal.chars().any(char::is_whitespace) {
                             return true;
                         }
                     }
-                    ast::FStringPart::FString(f_string) => {
+                    ast::FStringPartRef::FString(f_string) => {
                         for literal in f_string.elements.literals() {
                             if literal.chars().any(char::is_whitespace) {
                                 return true;

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -490,8 +490,6 @@ derives = ["Default"]
 
 [Expr.nodes.ExprAttribute]
 doc = "See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)"
-custom_debug = true
-custom_range = true
 fields = [
   { name = "value", type = "Expr" },
   { name = "attr", type = "Identifier" },

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -411,11 +411,16 @@ doc = "See also [YieldFrom](https://docs.python.org/3/library/ast.html#ast.Yield
 fields = [{ name = "value", type = "Expr" }]
 
 [Expr.nodes.ExprCompare]
-doc = "See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)"
+doc = """A comparison or chain of comparisons.
+
+`operands` contains all operands in source order, including the leftmost operand.
+For example, `a < b <= c` has operands `[a, b, c]` and operators `[Lt, LtE]`.
+There is at least one operator, and `operands.len() == ops.len() + 1`.
+
+See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)."""
 fields = [
-  { name = "left", type = "Expr" },
-  { name = "ops", type = "ThinVec<CmpOp>" },
-  { name = "comparators", type = "Box<[Expr]>" },
+  { name = "ops", type = "Box<[CmpOp]>" },
+  { name = "operands", type = "Box<[Expr]>" },
 ]
 # The fields must be visited simultaneously
 custom_source_order = true

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -387,7 +387,7 @@ doc = "See also [DictComp](https://docs.python.org/3/library/ast.html#ast.DictCo
 fields = [
   { name = "key", type = "Expr?" },
   { name = "value", type = "Expr" },
-  { name = "generators", type = "Comprehension*" },
+  { name = "generators", type = "Box<[Comprehension]>" },
 ]
 
 [Expr.nodes.ExprGenerator]
@@ -414,7 +414,7 @@ fields = [{ name = "value", type = "Expr" }]
 doc = "See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)"
 fields = [
   { name = "left", type = "Expr" },
-  { name = "ops", type = "Box<[CmpOp]>" },
+  { name = "ops", type = "ThinVec<CmpOp>" },
   { name = "comparators", type = "Box<[Expr]>" },
 ]
 # The fields must be visited simultaneously
@@ -490,6 +490,8 @@ derives = ["Default"]
 
 [Expr.nodes.ExprAttribute]
 doc = "See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)"
+custom_debug = true
+custom_range = true
 fields = [
   { name = "value", type = "Expr" },
   { name = "attr", type = "Identifier" },

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -1291,7 +1291,6 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 value,
                 attr,
                 ctx: _,
-                range: _,
                 node_index: _,
             }) => Self::Attribute(ExprAttribute {
                 value: value.into(),

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -706,10 +706,10 @@ impl<'a> From<&'a ast::FStringValue> for ComparableFString<'a> {
 
         for part in value {
             match part {
-                ast::FStringPart::Literal(string_literal) => {
+                ast::FStringPartRef::Literal(string_literal) => {
                     collector.push_literal(&string_literal.value);
                 }
-                ast::FStringPart::FString(fstring) => {
+                ast::FStringPartRef::FString(fstring) => {
                     for element in &fstring.elements {
                         match element {
                             ast::InterpolatedStringElement::Literal(literal) => {

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -1291,6 +1291,7 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 value,
                 attr,
                 ctx: _,
+                range: _,
                 node_index: _,
             }) => Self::Attribute(ExprAttribute {
                 value: value.into(),

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -941,9 +941,8 @@ pub struct ExprYieldFrom<'a> {
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct ExprCompare<'a> {
-    left: Box<ComparableExpr<'a>>,
     ops: Vec<ComparableCmpOp>,
-    comparators: Vec<ComparableExpr<'a>>,
+    operands: Vec<ComparableExpr<'a>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -1222,15 +1221,13 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 value: value.into(),
             }),
             ast::Expr::Compare(ast::ExprCompare {
-                left,
                 ops,
-                comparators,
+                operands,
                 range: _,
                 node_index: _,
             }) => Self::Compare(ExprCompare {
-                left: left.into(),
                 ops: ops.iter().copied().map(Into::into).collect(),
-                comparators: comparators.iter().map(Into::into).collect(),
+                operands: operands.iter().map(Into::into).collect(),
             }),
             ast::Expr::Call(ast::ExprCall {
                 func,

--- a/crates/ruff_python_ast/src/expression.rs
+++ b/crates/ruff_python_ast/src/expression.rs
@@ -319,7 +319,7 @@ impl Ranged for StringLikePart<'_> {
 pub enum StringLikePartIter<'a> {
     String(std::slice::Iter<'a, ast::StringLiteral>),
     Bytes(std::slice::Iter<'a, ast::BytesLiteral>),
-    FString(std::slice::Iter<'a, ast::FStringPart>),
+    FString(ast::FStringParts<'a>),
     TString(std::slice::Iter<'a, ast::TString>),
 }
 
@@ -333,10 +333,10 @@ impl<'a> Iterator for StringLikePartIter<'a> {
             StringLikePartIter::FString(inner) => {
                 let part = inner.next()?;
                 match part {
-                    ast::FStringPart::Literal(string_literal) => {
+                    ast::FStringPartRef::Literal(string_literal) => {
                         StringLikePart::String(string_literal)
                     }
-                    ast::FStringPart::FString(f_string) => StringLikePart::FString(f_string),
+                    ast::FStringPartRef::FString(f_string) => StringLikePart::FString(f_string),
                 }
             }
             StringLikePartIter::TString(inner) => StringLikePart::TString(inner.next()?),
@@ -363,10 +363,10 @@ impl DoubleEndedIterator for StringLikePartIter<'_> {
             StringLikePartIter::FString(inner) => {
                 let part = inner.next_back()?;
                 match part {
-                    ast::FStringPart::Literal(string_literal) => {
+                    ast::FStringPartRef::Literal(string_literal) => {
                         StringLikePart::String(string_literal)
                     }
-                    ast::FStringPart::FString(f_string) => StringLikePart::FString(f_string),
+                    ast::FStringPartRef::FString(f_string) => StringLikePart::FString(f_string),
                 }
             }
             StringLikePartIter::TString(inner) => StringLikePart::TString(inner.next_back()?),

--- a/crates/ruff_python_ast/src/expression.rs
+++ b/crates/ruff_python_ast/src/expression.rs
@@ -278,6 +278,15 @@ impl<'a> From<&'a ast::FString> for StringLikePart<'a> {
     }
 }
 
+impl<'a> From<ast::FStringPartRef<'a>> for StringLikePart<'a> {
+    fn from(value: ast::FStringPartRef<'a>) -> Self {
+        match value {
+            ast::FStringPartRef::Literal(literal) => Self::String(literal),
+            ast::FStringPartRef::FString(fstring) => Self::FString(fstring),
+        }
+    }
+}
+
 impl<'a> From<&'a ast::TString> for StringLikePart<'a> {
     fn from(value: &'a ast::TString) -> Self {
         StringLikePart::TString(value)
@@ -330,15 +339,7 @@ impl<'a> Iterator for StringLikePartIter<'a> {
         let part = match self {
             StringLikePartIter::String(inner) => StringLikePart::String(inner.next()?),
             StringLikePartIter::Bytes(inner) => StringLikePart::Bytes(inner.next()?),
-            StringLikePartIter::FString(inner) => {
-                let part = inner.next()?;
-                match part {
-                    ast::FStringPartRef::Literal(string_literal) => {
-                        StringLikePart::String(string_literal)
-                    }
-                    ast::FStringPartRef::FString(f_string) => StringLikePart::FString(f_string),
-                }
-            }
+            StringLikePartIter::FString(inner) => inner.next()?.into(),
             StringLikePartIter::TString(inner) => StringLikePart::TString(inner.next()?),
         };
 
@@ -360,15 +361,7 @@ impl DoubleEndedIterator for StringLikePartIter<'_> {
         let part = match self {
             StringLikePartIter::String(inner) => StringLikePart::String(inner.next_back()?),
             StringLikePartIter::Bytes(inner) => StringLikePart::Bytes(inner.next_back()?),
-            StringLikePartIter::FString(inner) => {
-                let part = inner.next_back()?;
-                match part {
-                    ast::FStringPartRef::Literal(string_literal) => {
-                        StringLikePart::String(string_literal)
-                    }
-                    ast::FStringPartRef::FString(f_string) => StringLikePart::FString(f_string),
-                }
-            }
+            StringLikePartIter::FString(inner) => inner.next_back()?.into(),
             StringLikePartIter::TString(inner) => StringLikePart::TString(inner.next_back()?),
         };
 

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -9767,15 +9767,20 @@ pub struct ExprYieldFrom {
     pub value: Box<Expr>,
 }
 
-/// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)
+/// A comparison or chain of comparisons.
+///
+/// `operands` contains all operands in source order, including the leftmost operand.
+/// For example, `a < b <= c` has operands `[a, b, c]` and operators `[Lt, LtE]`.
+/// There is at least one operator, and `operands.len() == ops.len() + 1`.
+///
+/// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare).
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct ExprCompare {
     pub node_index: crate::AtomicNodeIndex,
     pub range: ruff_text_size::TextRange,
-    pub left: Box<Expr>,
-    pub ops: thin_vec::ThinVec<crate::CmpOp>,
-    pub comparators: Box<[Expr]>,
+    pub ops: Box<[crate::CmpOp]>,
+    pub operands: Box<[Expr]>,
 }
 
 /// A call expression whose end offset is derived from its arguments.

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -3870,6 +3870,12 @@ impl ruff_text_size::Ranged for crate::ExprEllipsisLiteral {
     }
 }
 
+impl ruff_text_size::Ranged for crate::ExprAttribute {
+    fn range(&self) -> ruff_text_size::TextRange {
+        self.range
+    }
+}
+
 impl ruff_text_size::Ranged for crate::ExprSubscript {
     fn range(&self) -> ruff_text_size::TextRange {
         self.range
@@ -9870,10 +9876,11 @@ pub struct ExprEllipsisLiteral {
 }
 
 /// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct ExprAttribute {
     pub node_index: crate::AtomicNodeIndex,
+    pub range: ruff_text_size::TextRange,
     pub value: Box<Expr>,
     pub attr: crate::Identifier,
     pub ctx: crate::ExprContext,
@@ -10892,6 +10899,7 @@ impl ExprAttribute {
             value,
             attr,
             ctx: _,
+            range: _,
             node_index: _,
         } = self;
         visitor.visit_expr(value);

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -3870,12 +3870,6 @@ impl ruff_text_size::Ranged for crate::ExprEllipsisLiteral {
     }
 }
 
-impl ruff_text_size::Ranged for crate::ExprAttribute {
-    fn range(&self) -> ruff_text_size::TextRange {
-        self.range
-    }
-}
-
 impl ruff_text_size::Ranged for crate::ExprSubscript {
     fn range(&self) -> ruff_text_size::TextRange {
         self.range
@@ -9726,7 +9720,7 @@ pub struct ExprDictComp {
     pub range: ruff_text_size::TextRange,
     pub key: Option<Box<Expr>>,
     pub value: Box<Expr>,
-    pub generators: Vec<crate::Comprehension>,
+    pub generators: Box<[crate::Comprehension]>,
 }
 
 /// See also [GeneratorExp](https://docs.python.org/3/library/ast.html#ast.GeneratorExp)
@@ -9774,7 +9768,7 @@ pub struct ExprCompare {
     pub node_index: crate::AtomicNodeIndex,
     pub range: ruff_text_size::TextRange,
     pub left: Box<Expr>,
-    pub ops: Box<[crate::CmpOp]>,
+    pub ops: thin_vec::ThinVec<crate::CmpOp>,
     pub comparators: Box<[Expr]>,
 }
 
@@ -9876,11 +9870,10 @@ pub struct ExprEllipsisLiteral {
 }
 
 /// See also [Attribute](https://docs.python.org/3/library/ast.html#ast.Attribute)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct ExprAttribute {
     pub node_index: crate::AtomicNodeIndex,
-    pub range: ruff_text_size::TextRange,
     pub value: Box<Expr>,
     pub attr: crate::Identifier,
     pub ctx: crate::ExprContext,
@@ -10899,7 +10892,6 @@ impl ExprAttribute {
             value,
             attr,
             ctx: _,
-            range: _,
             node_index: _,
         } = self;
         visitor.visit_expr(value);

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -1599,8 +1599,8 @@ fn is_non_empty_f_string(expr: &ast::ExprFString) -> bool {
     }
 
     expr.value.iter().any(|part| match part {
-        ast::FStringPart::Literal(string_literal) => !string_literal.is_empty(),
-        ast::FStringPart::FString(f_string) => {
+        ast::FStringPartRef::Literal(string_literal) => !string_literal.is_empty(),
+        ast::FStringPartRef::FString(f_string) => {
             // The part is a concatenation of elements, so it's guaranteed non-empty if any element is
             f_string.elements.iter().any(|element| match element {
                 InterpolatedStringElement::Literal(string_literal) => !string_literal.is_empty(),
@@ -1648,8 +1648,8 @@ pub fn is_empty_f_string(expr: &ast::ExprFString) -> bool {
     }
 
     expr.value.iter().all(|part| match part {
-        ast::FStringPart::Literal(string_literal) => string_literal.is_empty(),
-        ast::FStringPart::FString(f_string) => {
+        ast::FStringPartRef::Literal(string_literal) => string_literal.is_empty(),
+        ast::FStringPartRef::FString(f_string) => {
             is_empty_interpolated_elements(f_string.elements.iter())
         }
     })

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -389,13 +389,8 @@ where
             }) => value
                 .as_ref()
                 .is_some_and(|value| any_over_expr(value, func)),
-            Expr::Compare(ast::ExprCompare {
-                left, comparators, ..
-            }) => {
-                any_over_expr(left, &mut *func)
-                    || comparators
-                        .iter()
-                        .any(|expr| any_over_expr(expr, &mut *func))
+            Expr::Compare(ast::ExprCompare { operands, .. }) => {
+                operands.iter().any(|expr| any_over_expr(expr, &mut *func))
             }
             Expr::Call(ast::ExprCall {
                 func: call_func,

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -575,6 +575,7 @@ impl ast::Identifier {
             range: _,
             node_index: _,
             id: _,
+            expression_start: _,
         } = self;
     }
 }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -148,10 +148,10 @@ impl ast::ExprFString {
 
         for f_string_part in value {
             match f_string_part {
-                ast::FStringPart::Literal(string_literal) => {
+                ast::FStringPartRef::Literal(string_literal) => {
                     visitor.visit_string_literal(string_literal);
                 }
-                ast::FStringPart::FString(f_string) => {
+                ast::FStringPartRef::FString(f_string) => {
                     visitor.visit_f_string(f_string);
                 }
             }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -75,18 +75,18 @@ impl ast::ExprCompare {
         V: SourceOrderVisitor<'a> + ?Sized,
     {
         let ast::ExprCompare {
-            left,
             ops,
-            comparators,
+            operands,
             range: _,
             node_index: _,
         } = self;
 
-        visitor.visit_expr(left);
-
-        for (op, comparator) in ops.iter().zip(comparators) {
-            visitor.visit_cmp_op(op);
-            visitor.visit_expr(comparator);
+        if let Some((left, comparators)) = operands.split_first() {
+            visitor.visit_expr(left);
+            for (op, comparator) in ops.iter().zip(comparators) {
+                visitor.visit_cmp_op(op);
+                visitor.visit_expr(comparator);
+            }
         }
     }
 }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -575,7 +575,6 @@ impl ast::Identifier {
             range: _,
             node_index: _,
             id: _,
-            expression_start: _,
         } = self;
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -469,10 +469,13 @@ impl DebugText {
 impl ExprFString {
     /// Returns the single [`FString`] if the f-string isn't implicitly concatenated, [`None`]
     /// otherwise.
-    pub const fn as_single_part_fstring(&self) -> Option<&FString> {
+    pub fn as_single_part_fstring(&self) -> Option<&FString> {
         match &self.value.inner {
-            FStringValueInner::Single(FStringPart::FString(fstring)) => Some(fstring),
-            _ => None,
+            FStringValueInner::Single(part) => match part.as_ref() {
+                FStringPart::FString(fstring) => Some(fstring),
+                FStringPart::Literal(_) => None,
+            },
+            FStringValueInner::Concatenated(_) => None,
         }
     }
 }
@@ -488,7 +491,7 @@ impl FStringValue {
     /// Creates a new f-string literal with a single [`FString`] part.
     pub fn single(value: FString) -> Self {
         Self {
-            inner: FStringValueInner::Single(FStringPart::FString(value)),
+            inner: FStringValueInner::Single(Box::new(FStringPart::FString(value))),
         }
     }
 
@@ -517,7 +520,7 @@ impl FStringValue {
     /// Returns a slice of all the [`FStringPart`]s contained in this value.
     pub fn as_slice(&self) -> &[FStringPart] {
         match &self.inner {
-            FStringValueInner::Single(part) => std::slice::from_ref(part),
+            FStringValueInner::Single(part) => std::slice::from_ref(part.as_ref()),
             FStringValueInner::Concatenated(parts) => parts,
         }
     }
@@ -525,7 +528,7 @@ impl FStringValue {
     /// Returns a mutable slice of all the [`FStringPart`]s contained in this value.
     fn as_mut_slice(&mut self) -> &mut [FStringPart] {
         match &mut self.inner {
-            FStringValueInner::Single(part) => std::slice::from_mut(part),
+            FStringValueInner::Single(part) => std::slice::from_mut(part.as_mut()),
             FStringValueInner::Concatenated(parts) => parts,
         }
     }
@@ -622,7 +625,7 @@ enum FStringValueInner {
     ///
     /// This is always going to be `FStringPart::FString` variant which is
     /// maintained by the `FStringValue::single` constructor.
-    Single(FStringPart),
+    Single(Box<FStringPart>),
 
     /// An implicitly concatenated f-string i.e., `"foo" f"bar {x}"`.
     Concatenated(Vec<FStringPart>),
@@ -664,7 +667,7 @@ impl Ranged for FStringPart {
 impl ExprTString {
     /// Returns the single [`TString`] if the t-string isn't implicitly concatenated, [`None`]
     /// otherwise.
-    pub const fn as_single_part_tstring(&self) -> Option<&TString> {
+    pub fn as_single_part_tstring(&self) -> Option<&TString> {
         match &self.value.inner {
             TStringValueInner::Single(tstring) => Some(tstring),
             TStringValueInner::Concatenated(_) => None,
@@ -683,7 +686,7 @@ impl TStringValue {
     /// Creates a new t-string literal with a single [`TString`] part.
     pub fn single(value: TString) -> Self {
         Self {
-            inner: TStringValueInner::Single(value),
+            inner: TStringValueInner::Single(Box::new(value)),
         }
     }
 
@@ -712,7 +715,7 @@ impl TStringValue {
     /// Returns a slice of all the [`TString`]s contained in this value.
     pub fn as_slice(&self) -> &[TString] {
         match &self.inner {
-            TStringValueInner::Single(part) => std::slice::from_ref(part),
+            TStringValueInner::Single(part) => std::slice::from_ref(part.as_ref()),
             TStringValueInner::Concatenated(parts) => parts,
         }
     }
@@ -720,7 +723,7 @@ impl TStringValue {
     /// Returns a mutable slice of all the [`TString`]s contained in this value.
     fn as_mut_slice(&mut self) -> &mut [TString] {
         match &mut self.inner {
-            TStringValueInner::Single(part) => std::slice::from_mut(part),
+            TStringValueInner::Single(part) => std::slice::from_mut(part.as_mut()),
             TStringValueInner::Concatenated(parts) => parts,
         }
     }
@@ -790,7 +793,7 @@ impl<'a> IntoIterator for &'a mut TStringValue {
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 enum TStringValueInner {
     /// A single t-string i.e., `t"foo"`.
-    Single(TString),
+    Single(Box<TString>),
 
     /// An implicitly concatenated t-string i.e., `t"foo" t"bar {x}"`.
     Concatenated(Vec<TString>),
@@ -3501,7 +3504,7 @@ impl ParameterWithDefault {
 pub struct Arguments {
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    pub args: Box<[Expr]>,
+    pub args: ThinVec<Expr>,
     pub keywords: ThinVec<Keyword>,
 }
 
@@ -3836,12 +3839,16 @@ impl IpyEscapeKind {
 /// def 1():
 ///     ...
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct Identifier {
     pub id: Name,
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
+    /// The start of the enclosing attribute expression, when this names an attribute.
+    /// Other identifiers use their own start offset. This fits in the identifier's padding,
+    /// so attribute expressions can retain their start without a separate range field.
+    pub expression_start: TextSize,
 }
 
 impl Identifier {
@@ -3851,6 +3858,7 @@ impl Identifier {
             id: id.into(),
             node_index: AtomicNodeIndex::NONE,
             range,
+            expression_start: range.start(),
         }
     }
 
@@ -3860,6 +3868,43 @@ impl Identifier {
 
     pub fn is_valid(&self) -> bool {
         !self.id.is_empty()
+    }
+}
+
+#[expect(
+    clippy::missing_fields_in_debug,
+    reason = "`expression_start` is represented by the enclosing attribute expression's range"
+)]
+impl fmt::Debug for Identifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Identifier")
+            .field("id", &self.id)
+            .field("range", &self.range)
+            .field("node_index", &self.node_index)
+            .finish()
+    }
+}
+
+impl Ranged for crate::ExprAttribute {
+    fn range(&self) -> TextRange {
+        // Parsed attributes end at their identifier. Relocated string annotations instead
+        // expand the receiver to the annotation range without changing identifier ranges.
+        TextRange::new(
+            self.attr.expression_start,
+            self.value.end().max(self.attr.end()),
+        )
+    }
+}
+
+impl fmt::Debug for crate::ExprAttribute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExprAttribute")
+            .field("node_index", &self.node_index)
+            .field("range", &self.range())
+            .field("value", &self.value)
+            .field("attr", &self.attr)
+            .field("ctx", &self.ctx)
+            .finish()
     }
 }
 
@@ -3933,7 +3978,7 @@ impl From<bool> for Singleton {
 #[cfg(test)]
 mod tests {
     use crate::generated::*;
-    use crate::{Arguments, Mod, Parameters};
+    use crate::{Arguments, Identifier, Mod, Parameters};
 
     #[test]
     #[cfg(target_pointer_width = "64")]
@@ -3945,20 +3990,21 @@ mod tests {
         assert_eq!(std::mem::size_of::<Mod>(), 32);
         assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
-        assert_eq!(std::mem::size_of::<Arguments>(), 40);
-        assert_eq!(std::mem::size_of::<Expr>(), 64);
-        assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
+        assert_eq!(std::mem::size_of::<Arguments>(), 32);
+        assert_eq!(std::mem::size_of::<Identifier>(), 32);
+        assert_eq!(std::mem::size_of::<Expr>(), 56);
+        assert_eq!(std::mem::size_of::<ExprAttribute>(), 48);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);
         assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
         assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);
         assert_eq!(std::mem::size_of::<ExprBooleanLiteral>(), 16);
         assert_eq!(std::mem::size_of::<ExprBytesLiteral>(), 48);
-        assert_eq!(std::mem::size_of::<ExprCall>(), 56);
-        assert_eq!(std::mem::size_of::<ExprCompare>(), 56);
+        assert_eq!(std::mem::size_of::<ExprCall>(), 48);
+        assert_eq!(std::mem::size_of::<ExprCompare>(), 48);
         assert_eq!(std::mem::size_of::<ExprDict>(), 40);
-        assert_eq!(std::mem::size_of::<ExprDictComp>(), 56);
+        assert_eq!(std::mem::size_of::<ExprDictComp>(), 48);
         assert_eq!(std::mem::size_of::<ExprEllipsisLiteral>(), 12);
-        assert_eq!(std::mem::size_of::<ExprFString>(), 56);
+        assert_eq!(std::mem::size_of::<ExprFString>(), 40);
         assert_eq!(std::mem::size_of::<ExprGenerator>(), 48);
         assert_eq!(std::mem::size_of::<ExprIf>(), 40);
         assert_eq!(std::mem::size_of::<ExprIpyEscapeCommand>(), 32);
@@ -3975,6 +4021,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprStarred>(), 24);
         assert_eq!(std::mem::size_of::<ExprStringLiteral>(), 48);
         assert_eq!(std::mem::size_of::<ExprSubscript>(), 32);
+        assert_eq!(std::mem::size_of::<ExprTString>(), 40);
         assert_eq!(std::mem::size_of::<ExprTuple>(), 40);
         assert_eq!(std::mem::size_of::<ExprUnaryOp>(), 24);
         assert_eq!(std::mem::size_of::<ExprYield>(), 24);

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -3839,16 +3839,12 @@ impl IpyEscapeKind {
 /// def 1():
 ///     ...
 /// ```
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct Identifier {
     pub id: Name,
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    /// The start of the enclosing attribute expression, when this names an attribute.
-    /// Other identifiers use their own start offset. This fits in the identifier's padding,
-    /// so attribute expressions can retain their start without a separate range field.
-    pub expression_start: TextSize,
 }
 
 impl Identifier {
@@ -3858,7 +3854,6 @@ impl Identifier {
             id: id.into(),
             node_index: AtomicNodeIndex::NONE,
             range,
-            expression_start: range.start(),
         }
     }
 
@@ -3868,43 +3863,6 @@ impl Identifier {
 
     pub fn is_valid(&self) -> bool {
         !self.id.is_empty()
-    }
-}
-
-#[expect(
-    clippy::missing_fields_in_debug,
-    reason = "`expression_start` is represented by the enclosing attribute expression's range"
-)]
-impl fmt::Debug for Identifier {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Identifier")
-            .field("id", &self.id)
-            .field("range", &self.range)
-            .field("node_index", &self.node_index)
-            .finish()
-    }
-}
-
-impl Ranged for crate::ExprAttribute {
-    fn range(&self) -> TextRange {
-        // Parsed attributes end at their identifier. Relocated string annotations instead
-        // expand the receiver to the annotation range without changing identifier ranges.
-        TextRange::new(
-            self.attr.expression_start,
-            self.value.end().max(self.attr.end()),
-        )
-    }
-}
-
-impl fmt::Debug for crate::ExprAttribute {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ExprAttribute")
-            .field("node_index", &self.node_index)
-            .field("range", &self.range())
-            .field("value", &self.value)
-            .field("attr", &self.attr)
-            .field("ctx", &self.ctx)
-            .finish()
     }
 }
 
@@ -3978,7 +3936,7 @@ impl From<bool> for Singleton {
 #[cfg(test)]
 mod tests {
     use crate::generated::*;
-    use crate::{Arguments, Identifier, Mod, Parameters};
+    use crate::{Arguments, Mod, Parameters};
 
     #[test]
     #[cfg(target_pointer_width = "64")]
@@ -3991,9 +3949,8 @@ mod tests {
         assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
         assert_eq!(std::mem::size_of::<Arguments>(), 32);
-        assert_eq!(std::mem::size_of::<Identifier>(), 32);
         assert_eq!(std::mem::size_of::<Expr>(), 56);
-        assert_eq!(std::mem::size_of::<ExprAttribute>(), 48);
+        assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);
         assert_eq!(std::mem::size_of::<ExprBinOp>(), 32);
         assert_eq!(std::mem::size_of::<ExprBoolOp>(), 40);

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -469,12 +469,9 @@ impl DebugText {
 impl ExprFString {
     /// Returns the single [`FString`] if the f-string isn't implicitly concatenated, [`None`]
     /// otherwise.
-    pub fn as_single_part_fstring(&self) -> Option<&FString> {
+    pub const fn as_single_part_fstring(&self) -> Option<&FString> {
         match &self.value.inner {
-            FStringValueInner::Single(part) => match part.as_ref() {
-                FStringPart::FString(fstring) => Some(fstring),
-                FStringPart::Literal(_) => None,
-            },
+            FStringValueInner::Single(fstring) => Some(fstring),
             FStringValueInner::Concatenated(_) => None,
         }
     }
@@ -491,7 +488,7 @@ impl FStringValue {
     /// Creates a new f-string literal with a single [`FString`] part.
     pub fn single(value: FString) -> Self {
         Self {
-            inner: FStringValueInner::Single(Box::new(FStringPart::FString(value))),
+            inner: FStringValueInner::Single(value),
         }
     }
 
@@ -517,31 +514,32 @@ impl FStringValue {
         matches!(self.inner, FStringValueInner::Concatenated(_))
     }
 
-    /// Returns a slice of all the [`FStringPart`]s contained in this value.
-    pub fn as_slice(&self) -> &[FStringPart] {
+    /// Returns an iterator over the parts of this f-string, in source order.
+    pub fn iter(&self) -> FStringParts<'_> {
         match &self.inner {
-            FStringValueInner::Single(part) => std::slice::from_ref(part.as_ref()),
-            FStringValueInner::Concatenated(parts) => parts,
+            FStringValueInner::Single(fstring) => FStringParts {
+                single: Some(fstring),
+                concatenated: [].iter(),
+            },
+            FStringValueInner::Concatenated(parts) => FStringParts {
+                single: None,
+                concatenated: parts.iter(),
+            },
         }
     }
 
-    /// Returns a mutable slice of all the [`FStringPart`]s contained in this value.
-    fn as_mut_slice(&mut self) -> &mut [FStringPart] {
+    /// Returns a mutable iterator over the parts of this f-string, in source order.
+    pub fn iter_mut(&mut self) -> FStringPartsMut<'_> {
         match &mut self.inner {
-            FStringValueInner::Single(part) => std::slice::from_mut(part.as_mut()),
-            FStringValueInner::Concatenated(parts) => parts,
+            FStringValueInner::Single(fstring) => FStringPartsMut {
+                single: Some(fstring),
+                concatenated: [].iter_mut(),
+            },
+            FStringValueInner::Concatenated(parts) => FStringPartsMut {
+                single: None,
+                concatenated: parts.iter_mut(),
+            },
         }
-    }
-
-    /// Returns an iterator over all the [`FStringPart`]s contained in this value.
-    pub fn iter(&self) -> Iter<'_, FStringPart> {
-        self.as_slice().iter()
-    }
-
-    /// Returns an iterator over all the [`FStringPart`]s contained in this value
-    /// that allows modification.
-    pub fn iter_mut(&mut self) -> IterMut<'_, FStringPart> {
-        self.as_mut_slice().iter_mut()
     }
 
     /// Returns an iterator over the [`StringLiteral`] parts contained in this value.
@@ -554,7 +552,10 @@ impl FStringValue {
     ///
     /// Here, the string literal parts returned would be `"foo"` and `"baz"`.
     pub fn literals(&self) -> impl Iterator<Item = &StringLiteral> {
-        self.iter().filter_map(|part| part.as_literal())
+        self.iter().filter_map(|part| match part {
+            FStringPartRef::Literal(literal) => Some(literal),
+            FStringPartRef::FString(_) => None,
+        })
     }
 
     /// Returns an iterator over the [`FString`] parts contained in this value.
@@ -567,7 +568,10 @@ impl FStringValue {
     ///
     /// Here, the f-string parts returned would be `f"bar {x}"` and `f"qux"`.
     pub fn f_strings(&self) -> impl Iterator<Item = &FString> {
-        self.iter().filter_map(|part| part.as_f_string())
+        self.iter().filter_map(|part| match part {
+            FStringPartRef::FString(fstring) => Some(fstring),
+            FStringPartRef::Literal(_) => None,
+        })
     }
 
     /// Returns an iterator over all the [`InterpolatedStringElement`] contained in this value.
@@ -592,7 +596,7 @@ impl FStringValue {
     /// f-string, not whether the f-string has 0 parts inside it.
     pub fn is_empty_literal(&self) -> bool {
         match &self.inner {
-            FStringValueInner::Single(fstring_part) => fstring_part.is_empty_literal(),
+            FStringValueInner::Single(fstring) => fstring.elements.is_empty(),
             FStringValueInner::Concatenated(fstring_parts) => {
                 fstring_parts.iter().all(FStringPart::is_empty_literal)
             }
@@ -601,8 +605,8 @@ impl FStringValue {
 }
 
 impl<'a> IntoIterator for &'a FStringValue {
-    type Item = &'a FStringPart;
-    type IntoIter = Iter<'a, FStringPart>;
+    type Item = FStringPartRef<'a>;
+    type IntoIter = FStringParts<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -610,8 +614,8 @@ impl<'a> IntoIterator for &'a FStringValue {
 }
 
 impl<'a> IntoIterator for &'a mut FStringValue {
-    type Item = &'a mut FStringPart;
-    type IntoIter = IterMut<'a, FStringPart>;
+    type Item = FStringPartMut<'a>;
+    type IntoIter = FStringPartsMut<'a>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
     }
@@ -622,10 +626,7 @@ impl<'a> IntoIterator for &'a mut FStringValue {
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 enum FStringValueInner {
     /// A single f-string i.e., `f"foo"`.
-    ///
-    /// This is always going to be `FStringPart::FString` variant which is
-    /// maintained by the `FStringValue::single` constructor.
-    Single(Box<FStringPart>),
+    Single(FString),
 
     /// An implicitly concatenated f-string i.e., `"foo" f"bar {x}"`.
     Concatenated(Vec<FStringPart>),
@@ -664,10 +665,128 @@ impl Ranged for FStringPart {
     }
 }
 
+/// A borrowed string literal or f-string part of an [`FStringValue`].
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum FStringPartRef<'a> {
+    Literal(&'a StringLiteral),
+    FString(&'a FString),
+}
+
+impl FStringPartRef<'_> {
+    pub fn quote_style(self) -> Quote {
+        match self {
+            Self::Literal(literal) => literal.flags.quote_style(),
+            Self::FString(fstring) => fstring.flags.quote_style(),
+        }
+    }
+}
+
+impl<'a> From<&'a FStringPart> for FStringPartRef<'a> {
+    fn from(part: &'a FStringPart) -> Self {
+        match part {
+            FStringPart::Literal(literal) => Self::Literal(literal),
+            FStringPart::FString(fstring) => Self::FString(fstring),
+        }
+    }
+}
+
+impl Ranged for FStringPartRef<'_> {
+    fn range(&self) -> TextRange {
+        match self {
+            Self::Literal(literal) => literal.range(),
+            Self::FString(fstring) => fstring.range(),
+        }
+    }
+}
+
+/// A mutably borrowed string literal or f-string part of an [`FStringValue`].
+pub enum FStringPartMut<'a> {
+    Literal(&'a mut StringLiteral),
+    FString(&'a mut FString),
+}
+
+impl<'a> From<&'a mut FStringPart> for FStringPartMut<'a> {
+    fn from(part: &'a mut FStringPart) -> Self {
+        match part {
+            FStringPart::Literal(literal) => Self::Literal(literal),
+            FStringPart::FString(fstring) => Self::FString(fstring),
+        }
+    }
+}
+
+/// The iterator returned by [`FStringValue::iter`].
+#[derive(Clone)]
+pub struct FStringParts<'a> {
+    single: Option<&'a FString>,
+    concatenated: Iter<'a, FStringPart>,
+}
+
+impl<'a> Iterator for FStringParts<'a> {
+    type Item = FStringPartRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.single
+            .take()
+            .map(FStringPartRef::FString)
+            .or_else(|| self.concatenated.next().map(FStringPartRef::from))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = usize::from(self.single.is_some()) + self.concatenated.len();
+        (len, Some(len))
+    }
+}
+
+impl DoubleEndedIterator for FStringParts<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.concatenated
+            .next_back()
+            .map(FStringPartRef::from)
+            .or_else(|| self.single.take().map(FStringPartRef::FString))
+    }
+}
+
+impl ExactSizeIterator for FStringParts<'_> {}
+impl FusedIterator for FStringParts<'_> {}
+
+/// The iterator returned by [`FStringValue::iter_mut`].
+pub struct FStringPartsMut<'a> {
+    single: Option<&'a mut FString>,
+    concatenated: IterMut<'a, FStringPart>,
+}
+
+impl<'a> Iterator for FStringPartsMut<'a> {
+    type Item = FStringPartMut<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.single
+            .take()
+            .map(FStringPartMut::FString)
+            .or_else(|| self.concatenated.next().map(FStringPartMut::from))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = usize::from(self.single.is_some()) + self.concatenated.len();
+        (len, Some(len))
+    }
+}
+
+impl DoubleEndedIterator for FStringPartsMut<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.concatenated
+            .next_back()
+            .map(FStringPartMut::from)
+            .or_else(|| self.single.take().map(FStringPartMut::FString))
+    }
+}
+
+impl ExactSizeIterator for FStringPartsMut<'_> {}
+impl FusedIterator for FStringPartsMut<'_> {}
+
 impl ExprTString {
     /// Returns the single [`TString`] if the t-string isn't implicitly concatenated, [`None`]
     /// otherwise.
-    pub fn as_single_part_tstring(&self) -> Option<&TString> {
+    pub const fn as_single_part_tstring(&self) -> Option<&TString> {
         match &self.value.inner {
             TStringValueInner::Single(tstring) => Some(tstring),
             TStringValueInner::Concatenated(_) => None,
@@ -686,7 +805,7 @@ impl TStringValue {
     /// Creates a new t-string literal with a single [`TString`] part.
     pub fn single(value: TString) -> Self {
         Self {
-            inner: TStringValueInner::Single(Box::new(value)),
+            inner: TStringValueInner::Single(value),
         }
     }
 
@@ -715,7 +834,7 @@ impl TStringValue {
     /// Returns a slice of all the [`TString`]s contained in this value.
     pub fn as_slice(&self) -> &[TString] {
         match &self.inner {
-            TStringValueInner::Single(part) => std::slice::from_ref(part.as_ref()),
+            TStringValueInner::Single(part) => std::slice::from_ref(part),
             TStringValueInner::Concatenated(parts) => parts,
         }
     }
@@ -723,7 +842,7 @@ impl TStringValue {
     /// Returns a mutable slice of all the [`TString`]s contained in this value.
     fn as_mut_slice(&mut self) -> &mut [TString] {
         match &mut self.inner {
-            TStringValueInner::Single(part) => std::slice::from_mut(part.as_mut()),
+            TStringValueInner::Single(part) => std::slice::from_mut(part),
             TStringValueInner::Concatenated(parts) => parts,
         }
     }
@@ -793,7 +912,7 @@ impl<'a> IntoIterator for &'a mut TStringValue {
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 enum TStringValueInner {
     /// A single t-string i.e., `t"foo"`.
-    Single(Box<TString>),
+    Single(TString),
 
     /// An implicitly concatenated t-string i.e., `t"foo" t"bar {x}"`.
     Concatenated(Vec<TString>),
@@ -1231,7 +1350,7 @@ impl From<FString> for Expr {
 /// A newtype wrapper around a list of [`InterpolatedStringElement`].
 #[derive(Clone, Default, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
-pub struct InterpolatedStringElements(Vec<InterpolatedStringElement>);
+pub struct InterpolatedStringElements(Box<[InterpolatedStringElement]>);
 
 impl InterpolatedStringElements {
     /// Returns an iterator over all the [`InterpolatedStringLiteralElement`] nodes contained in this f-string.
@@ -1247,7 +1366,7 @@ impl InterpolatedStringElements {
 
 impl From<Vec<InterpolatedStringElement>> for InterpolatedStringElements {
     fn from(elements: Vec<InterpolatedStringElement>) -> Self {
-        InterpolatedStringElements(elements)
+        InterpolatedStringElements(elements.into_boxed_slice())
     }
 }
 
@@ -3935,8 +4054,73 @@ impl From<bool> for Singleton {
 
 #[cfg(test)]
 mod tests {
+    use ruff_text_size::{Ranged, TextRange, TextSize};
+
     use crate::generated::*;
-    use crate::{Arguments, Mod, Parameters};
+    use crate::{
+        Arguments, AtomicNodeIndex, FString, FStringFlags, FStringPart, FStringPartMut,
+        FStringValue, Mod, Parameters, StringLiteral, StringLiteralFlags,
+    };
+
+    #[test]
+    fn f_string_parts() {
+        let fstring = |start| FString {
+            range: TextRange::at(TextSize::new(start), TextSize::new(3)),
+            node_index: AtomicNodeIndex::NONE,
+            elements: Vec::new().into(),
+            flags: FStringFlags::empty(),
+        };
+        let single = FStringValue::single(fstring(0));
+        let concatenated = FStringValue::concatenated(vec![
+            FStringPart::FString(fstring(0)),
+            FStringPart::Literal(StringLiteral {
+                range: TextRange::at(TextSize::new(3), TextSize::new(3)),
+                node_index: AtomicNodeIndex::NONE,
+                value: "x".into(),
+                flags: StringLiteralFlags::empty(),
+            }),
+            FStringPart::FString(fstring(6)),
+        ]);
+
+        for (mut value, starts) in [(single, vec![0]), (concatenated, vec![0, 3, 6])] {
+            let mut parts = value.iter();
+            let mut expected = starts.iter();
+            while expected.len() > 0 {
+                assert_eq!(parts.len(), expected.len());
+                assert_eq!(
+                    parts.next().map(|part| part.start().to_u32()),
+                    expected.next().copied()
+                );
+                assert_eq!(
+                    parts.next_back().map(|part| part.start().to_u32()),
+                    expected.next_back().copied()
+                );
+            }
+            assert_eq!(parts.len(), 0);
+            assert_eq!(parts.next(), None);
+            assert_eq!(parts.next_back(), None);
+
+            let mut parts = value.iter_mut();
+            for (part, start) in parts.by_ref().rev().zip(starts.iter().rev()) {
+                let range = match part {
+                    FStringPartMut::Literal(literal) => &mut literal.range,
+                    FStringPartMut::FString(fstring) => &mut fstring.range,
+                };
+                assert_eq!(range.start().to_u32(), *start);
+                *range = TextRange::at(TextSize::new(start + 10), TextSize::new(3));
+            }
+            assert_eq!(parts.len(), 0);
+            assert!(parts.next().is_none());
+            assert!(parts.next_back().is_none());
+            assert_eq!(
+                value
+                    .iter()
+                    .map(|part| part.start().to_u32())
+                    .collect::<Vec<_>>(),
+                starts.iter().map(|start| start + 10).collect::<Vec<_>>(),
+            );
+        }
+    }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
@@ -3961,7 +4145,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprDict>(), 40);
         assert_eq!(std::mem::size_of::<ExprDictComp>(), 48);
         assert_eq!(std::mem::size_of::<ExprEllipsisLiteral>(), 12);
-        assert_eq!(std::mem::size_of::<ExprFString>(), 40);
+        assert_eq!(std::mem::size_of::<ExprFString>(), 48);
         assert_eq!(std::mem::size_of::<ExprGenerator>(), 48);
         assert_eq!(std::mem::size_of::<ExprIf>(), 40);
         assert_eq!(std::mem::size_of::<ExprIpyEscapeCommand>(), 32);
@@ -3978,7 +4162,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprStarred>(), 24);
         assert_eq!(std::mem::size_of::<ExprStringLiteral>(), 48);
         assert_eq!(std::mem::size_of::<ExprSubscript>(), 32);
-        assert_eq!(std::mem::size_of::<ExprTString>(), 40);
+        assert_eq!(std::mem::size_of::<ExprTString>(), 48);
         assert_eq!(std::mem::size_of::<ExprTuple>(), 40);
         assert_eq!(std::mem::size_of::<ExprUnaryOp>(), 24);
         assert_eq!(std::mem::size_of::<ExprYield>(), 24);

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -8,7 +8,7 @@ use crate::generated::{
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
-use std::iter::FusedIterator;
+use std::iter::{FusedIterator, Once};
 use std::ops::{Deref, DerefMut};
 use std::slice::{Iter, IterMut};
 use std::sync::OnceLock;
@@ -517,28 +517,18 @@ impl FStringValue {
     /// Returns an iterator over the parts of this f-string, in source order.
     pub fn iter(&self) -> FStringParts<'_> {
         match &self.inner {
-            FStringValueInner::Single(fstring) => FStringParts {
-                single: Some(fstring),
-                concatenated: [].iter(),
-            },
-            FStringValueInner::Concatenated(parts) => FStringParts {
-                single: None,
-                concatenated: parts.iter(),
-            },
+            FStringValueInner::Single(fstring) => FStringParts::Single(std::iter::once(fstring)),
+            FStringValueInner::Concatenated(parts) => FStringParts::Concatenated(parts.iter()),
         }
     }
 
     /// Returns a mutable iterator over the parts of this f-string, in source order.
     pub fn iter_mut(&mut self) -> FStringPartsMut<'_> {
         match &mut self.inner {
-            FStringValueInner::Single(fstring) => FStringPartsMut {
-                single: Some(fstring),
-                concatenated: [].iter_mut(),
-            },
-            FStringValueInner::Concatenated(parts) => FStringPartsMut {
-                single: None,
-                concatenated: parts.iter_mut(),
-            },
+            FStringValueInner::Single(fstring) => FStringPartsMut::Single(std::iter::once(fstring)),
+            FStringValueInner::Concatenated(parts) => {
+                FStringPartsMut::Concatenated(parts.iter_mut())
+            }
         }
     }
 
@@ -642,10 +632,7 @@ pub enum FStringPart {
 
 impl FStringPart {
     pub fn quote_style(&self) -> Quote {
-        match self {
-            Self::Literal(string_literal) => string_literal.flags.quote_style(),
-            Self::FString(f_string) => f_string.flags.quote_style(),
-        }
+        FStringPartRef::from(self).quote_style()
     }
 
     pub fn is_empty_literal(&self) -> bool {
@@ -658,10 +645,7 @@ impl FStringPart {
 
 impl Ranged for FStringPart {
     fn range(&self) -> TextRange {
-        match self {
-            FStringPart::Literal(string_literal) => string_literal.range(),
-            FStringPart::FString(f_string) => f_string.range(),
-        }
+        FStringPartRef::from(self).range()
     }
 }
 
@@ -716,33 +700,35 @@ impl<'a> From<&'a mut FStringPart> for FStringPartMut<'a> {
 
 /// The iterator returned by [`FStringValue::iter`].
 #[derive(Clone)]
-pub struct FStringParts<'a> {
-    single: Option<&'a FString>,
-    concatenated: Iter<'a, FStringPart>,
+pub enum FStringParts<'a> {
+    Single(Once<&'a FString>),
+    Concatenated(Iter<'a, FStringPart>),
 }
 
 impl<'a> Iterator for FStringParts<'a> {
     type Item = FStringPartRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.single
-            .take()
-            .map(FStringPartRef::FString)
-            .or_else(|| self.concatenated.next().map(FStringPartRef::from))
+        match self {
+            Self::Single(single) => single.next().map(FStringPartRef::FString),
+            Self::Concatenated(parts) => parts.next().map(FStringPartRef::from),
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = usize::from(self.single.is_some()) + self.concatenated.len();
-        (len, Some(len))
+        match self {
+            Self::Single(single) => single.size_hint(),
+            Self::Concatenated(parts) => parts.size_hint(),
+        }
     }
 }
 
 impl DoubleEndedIterator for FStringParts<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.concatenated
-            .next_back()
-            .map(FStringPartRef::from)
-            .or_else(|| self.single.take().map(FStringPartRef::FString))
+        match self {
+            Self::Single(single) => single.next_back().map(FStringPartRef::FString),
+            Self::Concatenated(parts) => parts.next_back().map(FStringPartRef::from),
+        }
     }
 }
 
@@ -750,33 +736,35 @@ impl ExactSizeIterator for FStringParts<'_> {}
 impl FusedIterator for FStringParts<'_> {}
 
 /// The iterator returned by [`FStringValue::iter_mut`].
-pub struct FStringPartsMut<'a> {
-    single: Option<&'a mut FString>,
-    concatenated: IterMut<'a, FStringPart>,
+pub enum FStringPartsMut<'a> {
+    Single(Once<&'a mut FString>),
+    Concatenated(IterMut<'a, FStringPart>),
 }
 
 impl<'a> Iterator for FStringPartsMut<'a> {
     type Item = FStringPartMut<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.single
-            .take()
-            .map(FStringPartMut::FString)
-            .or_else(|| self.concatenated.next().map(FStringPartMut::from))
+        match self {
+            Self::Single(single) => single.next().map(FStringPartMut::FString),
+            Self::Concatenated(parts) => parts.next().map(FStringPartMut::from),
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = usize::from(self.single.is_some()) + self.concatenated.len();
-        (len, Some(len))
+        match self {
+            Self::Single(single) => single.size_hint(),
+            Self::Concatenated(parts) => parts.size_hint(),
+        }
     }
 }
 
 impl DoubleEndedIterator for FStringPartsMut<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.concatenated
-            .next_back()
-            .map(FStringPartMut::from)
-            .or_else(|| self.single.take().map(FStringPartMut::FString))
+        match self {
+            Self::Single(single) => single.next_back().map(FStringPartMut::FString),
+            Self::Concatenated(parts) => parts.next_back().map(FStringPartMut::from),
+        }
     }
 }
 

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -1,4 +1,4 @@
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::TextRange;
 
 use crate::visitor::transformer::{Transformer, walk_expr, walk_keyword};
 use crate::{self as ast};
@@ -98,11 +98,8 @@ impl Transformer for Relocator {
             Expr::EllipsisLiteral(ast::ExprEllipsisLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Attribute(ast::ExprAttribute { attr, .. }) => {
-                if attr.end() > self.range.end() {
-                    attr.range = TextRange::empty(self.range.end());
-                }
-                attr.expression_start = self.range.start();
+            Expr::Attribute(ast::ExprAttribute { range, .. }) => {
+                *range = self.range;
             }
             Expr::Subscript(ast::ExprSubscript { range, .. }) => {
                 *range = self.range;

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -1,4 +1,4 @@
-use ruff_text_size::TextRange;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::visitor::transformer::{Transformer, walk_expr, walk_keyword};
 use crate::{self as ast};
@@ -98,8 +98,11 @@ impl Transformer for Relocator {
             Expr::EllipsisLiteral(ast::ExprEllipsisLiteral { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Attribute(ast::ExprAttribute { range, .. }) => {
-                *range = self.range;
+            Expr::Attribute(ast::ExprAttribute { attr, .. }) => {
+                if attr.end() > self.range.end() {
+                    attr.range = TextRange::empty(self.range.end());
+                }
+                attr.expression_start = self.range.start();
             }
             Expr::Subscript(ast::ExprSubscript { range, .. }) => {
                 *range = self.range;

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -5,7 +5,7 @@ pub mod transformer;
 
 use crate::{
     self as ast, Alias, AnyParameterRef, Arguments, BoolOp, BytesLiteral, CmpOp, Comprehension,
-    Decorator, ElifElseClause, ExceptHandler, Expr, ExprContext, FString, FStringPart,
+    Decorator, ElifElseClause, ExceptHandler, Expr, ExprContext, FString, FStringPartRef,
     InterpolatedStringElement, Keyword, MatchCase, Operator, Parameter, Parameters, Pattern,
     PatternArguments, PatternKeyword, Stmt, StringLiteral, TString, TypeParam, TypeParamParamSpec,
     TypeParamTypeVar, TypeParamTypeVarTuple, TypeParams, UnaryOp, WithItem,
@@ -540,10 +540,10 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
         Expr::FString(ast::ExprFString { value, .. }) => {
             for part in value {
                 match part {
-                    FStringPart::Literal(string_literal) => {
+                    FStringPartRef::Literal(string_literal) => {
                         visitor.visit_string_literal(string_literal);
                     }
-                    FStringPart::FString(f_string) => visitor.visit_f_string(f_string),
+                    FStringPartRef::FString(f_string) => visitor.visit_f_string(f_string),
                 }
             }
         }

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -513,18 +513,19 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             node_index: _,
         }) => visitor.visit_expr(value),
         Expr::Compare(ast::ExprCompare {
-            left,
             ops,
-            comparators,
+            operands,
             range: _,
             node_index: _,
         }) => {
-            visitor.visit_expr(left);
-            for cmp_op in ops {
-                visitor.visit_cmp_op(cmp_op);
-            }
-            for expr in comparators {
-                visitor.visit_expr(expr);
+            if let Some((left, comparators)) = operands.split_first() {
+                visitor.visit_expr(left);
+                for cmp_op in ops {
+                    visitor.visit_cmp_op(cmp_op);
+                }
+                for expr in comparators {
+                    visitor.visit_expr(expr);
+                }
             }
         }
         Expr::Call(ast::ExprCall {

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -500,18 +500,19 @@ pub fn walk_expr<V: Transformer + ?Sized>(visitor: &V, expr: &mut Expr) {
             node_index: _,
         }) => visitor.visit_expr(value),
         Expr::Compare(ast::ExprCompare {
-            left,
             ops,
-            comparators,
+            operands,
             range: _,
             node_index: _,
         }) => {
-            visitor.visit_expr(left);
-            for cmp_op in &mut **ops {
-                visitor.visit_cmp_op(cmp_op);
-            }
-            for expr in &mut **comparators {
-                visitor.visit_expr(expr);
+            if let Some((left, comparators)) = operands.split_first_mut() {
+                visitor.visit_expr(left);
+                for cmp_op in &mut **ops {
+                    visitor.visit_cmp_op(cmp_op);
+                }
+                for expr in comparators {
+                    visitor.visit_expr(expr);
+                }
             }
         }
         Expr::Call(ast::ExprCall {

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -527,10 +527,10 @@ pub fn walk_expr<V: Transformer + ?Sized>(visitor: &V, expr: &mut Expr) {
         Expr::FString(ast::ExprFString { value, .. }) => {
             for f_string_part in value.iter_mut() {
                 match f_string_part {
-                    ast::FStringPart::Literal(string_literal) => {
+                    ast::FStringPartMut::Literal(string_literal) => {
                         visitor.visit_string_literal(string_literal);
                     }
-                    ast::FStringPart::FString(f_string) => {
+                    ast::FStringPartMut::FString(f_string) => {
                         visitor.visit_f_string(f_string);
                     }
                 }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1167,16 +1167,15 @@ impl<'a> Generator<'a> {
                 });
             }
             Expr::Compare(ast::ExprCompare {
-                left,
                 ops,
-                comparators,
+                operands,
                 range: _,
                 node_index: _,
             }) => {
                 group_if!(precedence::CMP, {
                     let new_lvl = precedence::CMP + 1;
-                    self.unparse_expr(left, new_lvl);
-                    for (op, cmp) in ops.iter().zip(comparators) {
+                    self.unparse_expr(&operands[0], new_lvl);
+                    for (op, cmp) in ops.iter().zip(&operands[1..]) {
                         let op = match op {
                             CmpOp::Eq => " == ",
                             CmpOp::NotEq => " != ",

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1464,10 +1464,10 @@ impl<'a> Generator<'a> {
         for f_string_part in value {
             self.p_delim(&mut first, " ");
             match f_string_part {
-                ast::FStringPart::Literal(string_literal) => {
+                ast::FStringPartRef::Literal(string_literal) => {
                     self.unparse_string_literal(string_literal);
                 }
-                ast::FStringPart::FString(f_string) => {
+                ast::FStringPartRef::FString(f_string) => {
                     self.unparse_interpolated_string(&f_string.elements, f_string.flags.into());
                 }
             }

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -44,11 +44,11 @@ impl<'a> BinaryLike<'a> {
             trivia: &TriviaRanges,
             parts: &mut SmallVec<[OperandOrOperator<'a>; 8]>,
         ) {
-            parts.reserve(compare.comparators.len() * 2 + 1);
+            parts.reserve(compare.ops.len() * 2 + 1);
 
             rec(
                 Operand::Left {
-                    expression: &compare.left,
+                    expression: &compare.operands[0],
                     leading_comments,
                 },
                 comments,
@@ -57,12 +57,13 @@ impl<'a> BinaryLike<'a> {
             );
 
             assert_eq!(
-                compare.comparators.len(),
-                compare.ops.len(),
+                compare.operands.len(),
+                compare.ops.len() + 1,
                 "Compare expression with an unbalanced number of comparators and operations."
             );
 
-            if let Some((last_expression, middle_expressions)) = compare.comparators.split_last() {
+            if let Some((last_expression, middle_expressions)) = compare.operands[1..].split_last()
+            {
                 let (last_operator, middle_operators) = compare.ops.split_last().unwrap();
 
                 for (operator, expression) in middle_operators.iter().zip(middle_expressions) {

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -28,6 +28,7 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
     fn fmt_fields(&self, item: &ExprAttribute, f: &mut PyFormatter) -> FormatResult<()> {
         let ExprAttribute {
             value,
+            range: _,
             node_index: _,
             attr,
             ctx: _,

--- a/crates/ruff_python_formatter/src/expression/expr_attribute.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_attribute.rs
@@ -28,7 +28,6 @@ impl FormatNodeRule<ExprAttribute> for FormatExprAttribute {
     fn fmt_fields(&self, item: &ExprAttribute, f: &mut PyFormatter) -> FormatResult<()> {
         let ExprAttribute {
             value,
-            range: _,
             node_index: _,
             attr,
             ctx: _,

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -26,12 +26,12 @@ impl NeedsParentheses for ExprCompare {
     ) -> OptionalParentheses {
         if parent.is_expr_await() {
             OptionalParentheses::Always
-        } else if let Ok(string) = StringLike::try_from(&*self.left) {
+        } else if let Ok(string) = StringLike::try_from(&self.operands[0]) {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
             if !string.is_implicit_concatenated()
                 && string.is_multiline(context)
                 && !context.comments().has(string)
-                && self.comparators.first().is_some_and(|right| {
+                && self.operands.get(1).is_some_and(|right| {
                     has_parentheses(right, context).is_some() && !context.comments().has(right)
                 })
             {

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -699,9 +699,8 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
             Expr::Compare(ast::ExprCompare {
                 range: _,
                 node_index: _,
-                left: _,
                 ops,
-                comparators: _,
+                operands: _,
             }) => {
                 self.update_max_precedence_with_count(
                     OperatorPrecedence::Comparator,
@@ -1437,7 +1436,7 @@ pub(crate) fn left_most<'expr>(expression: &'expr Expr, trivia: &TriviaRanges) -
             | Expr::Subscript(ast::ExprSubscript { value: left, .. }) => Some(&**left),
 
             Expr::BoolOp(expr_bool_op) => expr_bool_op.values.first(),
-            Expr::Compare(compare) => Some(&*compare.left),
+            Expr::Compare(compare) => compare.operands.first(),
 
             Expr::Generator(generator) if !generator.parenthesized => Some(&*generator.elt),
 

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -731,7 +731,6 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
 
             // `[a, b].test.test[300].dot`
             Expr::Attribute(ast::ExprAttribute {
-                range: _,
                 node_index: _,
                 value,
                 attr: _,

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -731,6 +731,7 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
 
             // `[a, b].test.test[300].dot`
             Expr::Attribute(ast::ExprAttribute {
+                range: _,
                 node_index: _,
                 value,
                 attr: _,

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use ruff_python_ast::{
-    self as ast, BytesLiteralFlags, Expr, FStringFlags, FStringPart, InterpolatedStringElement,
+    self as ast, BytesLiteralFlags, Expr, FStringFlags, FStringPartRef, InterpolatedStringElement,
     InterpolatedStringLiteralElement, Stmt, StringFlags,
 };
 use ruff_python_ast::{AtomicNodeIndex, visitor::transformer::Transformer};
@@ -91,10 +91,10 @@ impl Transformer for Normalizer {
 
             Expr::FString(fstring) if fstring.value.is_implicit_concatenated() => {
                 let can_join = fstring.value.iter().all(|part| match part {
-                    FStringPart::Literal(literal) => {
+                    FStringPartRef::Literal(literal) => {
                         !literal.flags.is_triple_quoted() && !literal.flags.prefix().is_raw()
                     }
-                    FStringPart::FString(string) => {
+                    FStringPartRef::FString(string) => {
                         !string.flags.is_triple_quoted() && !string.flags.prefix().is_raw()
                     }
                 });
@@ -142,10 +142,10 @@ impl Transformer for Normalizer {
 
                     for part in &fstring.value {
                         match part {
-                            ast::FStringPart::Literal(string_literal) => {
+                            ast::FStringPartRef::Literal(string_literal) => {
                                 collector.push_literal(&string_literal.value, string_literal.range);
                             }
-                            ast::FStringPart::FString(fstring) => {
+                            ast::FStringPartRef::FString(fstring) => {
                                 for element in &fstring.elements {
                                     match element {
                                         ast::InterpolatedStringElement::Literal(literal) => {

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -508,14 +508,22 @@ impl<'src> Parser<'src> {
 
         if self.at(TokenKind::Name) {
             let name = self.bump_name();
-            return ast::Identifier::new(name, range);
+            return ast::Identifier {
+                id: name,
+                range,
+                node_index: AtomicNodeIndex::NONE,
+            };
         }
 
         if self.current_token_kind().is_soft_keyword() {
             let text = self.src_text(range);
             let id = self.intern_name(text);
             self.bump_soft_keyword_as_name();
-            return ast::Identifier::new(id, range);
+            return ast::Identifier {
+                id,
+                range,
+                node_index: AtomicNodeIndex::NONE,
+            };
         }
 
         // test_err incomplete_attribute_before_for_in_delimiter
@@ -546,7 +554,11 @@ impl<'src> Parser<'src> {
             let text = self.src_text(range);
             let id = self.intern_name(text);
             self.bump_any();
-            ast::Identifier::new(id, range)
+            ast::Identifier {
+                id,
+                range,
+                node_index: AtomicNodeIndex::NONE,
+            }
         } else {
             self.parse_missing_identifier()
         }
@@ -558,7 +570,11 @@ impl<'src> Parser<'src> {
             self.current_token_range(),
         );
 
-        ast::Identifier::new(Name::empty(), self.missing_node_range())
+        ast::Identifier {
+            id: Name::empty(),
+            range: self.missing_node_range(),
+            node_index: AtomicNodeIndex::NONE,
+        }
     }
 
     /// Parses an atom.
@@ -802,7 +818,11 @@ impl<'src> Parser<'src> {
                                 );
                             }
 
-                            ast::Identifier::new(ident_expr.id, ident_expr.range)
+                            ast::Identifier {
+                                id: ident_expr.id,
+                                range: ident_expr.range,
+                                node_index: AtomicNodeIndex::NONE,
+                            }
                         } else {
                             // TODO(dhruvmanila): Parser shouldn't drop the `parsed_expr` if it's
                             // not a name expression. We could add the expression into `args` but
@@ -811,7 +831,11 @@ impl<'src> Parser<'src> {
                                 ParseErrorType::OtherError("Expected a parameter name".to_string()),
                                 &parsed_expr,
                             );
-                            ast::Identifier::new(Name::empty(), parsed_expr.range())
+                            ast::Identifier {
+                                id: Name::empty(),
+                                range: parsed_expr.range(),
+                                node_index: AtomicNodeIndex::NONE,
+                            }
                         };
 
                         let value = parser.parse_conditional_expression_or_higher();
@@ -1118,14 +1142,13 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprAttribute {
         self.bump(TokenKind::Dot);
 
-        let mut attr = self.parse_identifier_with_context(context);
-        debug_assert_eq!(attr.end(), self.node_range(start).end());
-        attr.expression_start = start;
+        let attr = self.parse_identifier_with_context(context);
 
         ast::ExprAttribute {
             value: Box::new(value),
             attr,
             ctx: ExprContext::Load,
+            range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }
     }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -508,22 +508,14 @@ impl<'src> Parser<'src> {
 
         if self.at(TokenKind::Name) {
             let name = self.bump_name();
-            return ast::Identifier {
-                id: name,
-                range,
-                node_index: AtomicNodeIndex::NONE,
-            };
+            return ast::Identifier::new(name, range);
         }
 
         if self.current_token_kind().is_soft_keyword() {
             let text = self.src_text(range);
             let id = self.intern_name(text);
             self.bump_soft_keyword_as_name();
-            return ast::Identifier {
-                id,
-                range,
-                node_index: AtomicNodeIndex::NONE,
-            };
+            return ast::Identifier::new(id, range);
         }
 
         // test_err incomplete_attribute_before_for_in_delimiter
@@ -554,11 +546,7 @@ impl<'src> Parser<'src> {
             let text = self.src_text(range);
             let id = self.intern_name(text);
             self.bump_any();
-            ast::Identifier {
-                id,
-                range,
-                node_index: AtomicNodeIndex::NONE,
-            }
+            ast::Identifier::new(id, range)
         } else {
             self.parse_missing_identifier()
         }
@@ -570,11 +558,7 @@ impl<'src> Parser<'src> {
             self.current_token_range(),
         );
 
-        ast::Identifier {
-            id: Name::empty(),
-            range: self.missing_node_range(),
-            node_index: AtomicNodeIndex::NONE,
-        }
+        ast::Identifier::new(Name::empty(), self.missing_node_range())
     }
 
     /// Parses an atom.
@@ -734,7 +718,7 @@ impl<'src> Parser<'src> {
             return ast::Arguments {
                 range: self.node_range(start),
                 node_index: AtomicNodeIndex::NONE,
-                args: Box::default(),
+                args: ThinVec::new(),
                 keywords: ThinVec::default(),
             };
         }
@@ -818,11 +802,7 @@ impl<'src> Parser<'src> {
                                 );
                             }
 
-                            ast::Identifier {
-                                id: ident_expr.id,
-                                range: ident_expr.range,
-                                node_index: AtomicNodeIndex::NONE,
-                            }
+                            ast::Identifier::new(ident_expr.id, ident_expr.range)
                         } else {
                             // TODO(dhruvmanila): Parser shouldn't drop the `parsed_expr` if it's
                             // not a name expression. We could add the expression into `args` but
@@ -831,11 +811,7 @@ impl<'src> Parser<'src> {
                                 ParseErrorType::OtherError("Expected a parameter name".to_string()),
                                 &parsed_expr,
                             );
-                            ast::Identifier {
-                                id: Name::empty(),
-                                range: parsed_expr.range(),
-                                node_index: AtomicNodeIndex::NONE,
-                            }
+                            ast::Identifier::new(Name::empty(), parsed_expr.range())
                         };
 
                         let value = parser.parse_conditional_expression_or_higher();
@@ -871,7 +847,7 @@ impl<'src> Parser<'src> {
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
-            args: self.expr_scratch.take(args_snapshot),
+            args: self.expr_scratch.take_thin_vec(args_snapshot),
             keywords,
         };
 
@@ -1142,13 +1118,14 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprAttribute {
         self.bump(TokenKind::Dot);
 
-        let attr = self.parse_identifier_with_context(context);
+        let mut attr = self.parse_identifier_with_context(context);
+        debug_assert_eq!(attr.end(), self.node_range(start).end());
+        attr.expression_start = start;
 
         ast::ExprAttribute {
             value: Box::new(value),
             attr,
             ctx: ExprContext::Load,
-            range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }
     }
@@ -1273,7 +1250,7 @@ impl<'src> Parser<'src> {
 
         ast::ExprCompare {
             left: Box::new(lhs),
-            ops: operators.into_boxed_slice(),
+            ops: ThinVec::from(operators),
             comparators: self.expr_scratch.take(comparators_snapshot),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
@@ -2666,7 +2643,7 @@ impl<'src> Parser<'src> {
         ast::ExprDictComp {
             key: key.map(Box::new),
             value: Box::new(value),
-            generators,
+            generators: generators.into_boxed_slice(),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1240,7 +1240,8 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprCompare {
         self.bump_cmp_op(op);
 
-        let comparators_snapshot = self.expr_scratch.snapshot();
+        let operands_snapshot = self.expr_scratch.snapshot();
+        self.expr_scratch.push(lhs);
         let mut operators = vec![op];
 
         let mut progress = ParserProgress::default();
@@ -1272,9 +1273,8 @@ impl<'src> Parser<'src> {
         }
 
         ast::ExprCompare {
-            left: Box::new(lhs),
-            ops: ThinVec::from(operators),
-            comparators: self.expr_scratch.take(comparators_snapshot),
+            ops: operators.into_boxed_slice(),
+            operands: self.expr_scratch.take(operands_snapshot),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -751,11 +751,7 @@ impl Parser<'_> {
                             ),
                             &pattern,
                         );
-                        ast::Identifier {
-                            id: Name::empty(),
-                            range: parser.missing_node_range(),
-                            node_index: AtomicNodeIndex::NONE,
-                        }
+                        ast::Identifier::new(Name::empty(), parser.missing_node_range())
                     };
 
                     let value_pattern = parser.parse_match_pattern(AllowStarPattern::No);

--- a/crates/ruff_python_parser/src/parser/pattern.rs
+++ b/crates/ruff_python_parser/src/parser/pattern.rs
@@ -751,7 +751,11 @@ impl Parser<'_> {
                             ),
                             &pattern,
                         );
-                        ast::Identifier::new(Name::empty(), parser.missing_node_range())
+                        ast::Identifier {
+                            id: Name::empty(),
+                            range: parser.missing_node_range(),
+                            node_index: AtomicNodeIndex::NONE,
+                        }
                     };
 
                     let value_pattern = parser.parse_match_pattern(AllowStarPattern::No);

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
@@ -172,18 +172,18 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 598..620,
-                                            left: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 598..599,
-                                                    id: Name("a"),
-                                                    ctx: Load,
-                                                },
-                                            ),
                                             ops: [
                                                 NotEq,
                                             ],
-                                            comparators: [
+                                            operands: [
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 598..599,
+                                                        id: Name("a"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                                 Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -777,11 +777,7 @@ impl<'src> Parser<'src> {
         if self.eat(TokenKind::Star) {
             let range = self.node_range(start);
             return ast::Alias {
-                name: ast::Identifier {
-                    id: Name::new_static("*"),
-                    range,
-                    node_index: AtomicNodeIndex::NONE,
-                },
+                name: ast::Identifier::new(Name::new_static("*"), range),
                 asname: None,
                 range,
                 node_index: AtomicNodeIndex::NONE,
@@ -854,11 +850,7 @@ impl<'src> Parser<'src> {
         // test_ok dotted_name_normalized_spaces
         // import a.b.c
         // import a .  b  . c
-        ast::Identifier {
-            id,
-            range: self.node_range(start),
-            node_index: AtomicNodeIndex::NONE,
-        }
+        ast::Identifier::new(id, self.node_range(start))
     }
 
     /// Parses a `pass` statement.
@@ -3053,11 +3045,7 @@ impl<'src> Parser<'src> {
                     range,
                     is_async: false,
                     decorator_list: decorators,
-                    name: ast::Identifier {
-                        id: Name::empty(),
-                        range: self.missing_node_range(),
-                        node_index: AtomicNodeIndex::NONE,
-                    },
+                    name: ast::Identifier::new(Name::empty(), self.missing_node_range()),
                     type_params: None,
                     parameters: Box::new(ast::Parameters {
                         range: self.missing_node_range(),

--- a/crates/ruff_python_parser/src/parser/statement.rs
+++ b/crates/ruff_python_parser/src/parser/statement.rs
@@ -777,7 +777,11 @@ impl<'src> Parser<'src> {
         if self.eat(TokenKind::Star) {
             let range = self.node_range(start);
             return ast::Alias {
-                name: ast::Identifier::new(Name::new_static("*"), range),
+                name: ast::Identifier {
+                    id: Name::new_static("*"),
+                    range,
+                    node_index: AtomicNodeIndex::NONE,
+                },
                 asname: None,
                 range,
                 node_index: AtomicNodeIndex::NONE,
@@ -850,7 +854,11 @@ impl<'src> Parser<'src> {
         // test_ok dotted_name_normalized_spaces
         // import a.b.c
         // import a .  b  . c
-        ast::Identifier::new(id, self.node_range(start))
+        ast::Identifier {
+            id,
+            range: self.node_range(start),
+            node_index: AtomicNodeIndex::NONE,
+        }
     }
 
     /// Parses a `pass` statement.
@@ -3045,7 +3053,11 @@ impl<'src> Parser<'src> {
                     range,
                     is_async: false,
                     decorator_list: decorators,
-                    name: ast::Identifier::new(Name::empty(), self.missing_node_range()),
+                    name: ast::Identifier {
+                        id: Name::empty(),
+                        range: self.missing_node_range(),
+                        node_index: AtomicNodeIndex::NONE,
+                    },
                     type_params: None,
                     parameters: Box::new(ast::Parameters {
                         range: self.missing_node_range(),

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,6 +1,7 @@
 use std::assert_matches;
 
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{Mode, ParseOptions, parse, parse_expression, parse_module};
 
@@ -74,6 +75,53 @@ fn nfkc_normalizes_names() {
     };
 
     assert_eq!(name.id.as_str(), "C");
+}
+
+#[test]
+fn attribute_expression_ranges() {
+    let source = "(value).attr";
+    let parsed = parse_expression(source).unwrap();
+    let Expr::Attribute(attribute) = parsed.expr() else {
+        panic!("expected attribute expression, got {:?}", parsed.expr());
+    };
+
+    assert_eq!(
+        attribute.range(),
+        TextRange::new(TextSize::new(0), TextSize::new(12))
+    );
+    assert_eq!(
+        attribute.attr.range(),
+        TextRange::new(TextSize::new(8), TextSize::new(12))
+    );
+
+    let mut expr = parsed.into_syntax().body;
+    ruff_python_ast::relocate::relocate_expr(
+        &mut expr,
+        TextRange::new(TextSize::new(20), TextSize::new(30)),
+    );
+    let Expr::Attribute(attribute) = expr.as_ref() else {
+        panic!("expected relocated attribute expression, got {expr:?}");
+    };
+    assert_eq!(
+        attribute.range(),
+        TextRange::new(TextSize::new(20), TextSize::new(30))
+    );
+    assert_eq!(
+        attribute.attr.range(),
+        TextRange::new(TextSize::new(8), TextSize::new(12))
+    );
+
+    ruff_python_ast::relocate::relocate_expr(
+        &mut expr,
+        TextRange::new(TextSize::new(0), TextSize::new(1)),
+    );
+    let Expr::Attribute(attribute) = expr.as_ref() else {
+        panic!("expected relocated attribute expression, got {expr:?}");
+    };
+    assert_eq!(
+        attribute.range(),
+        TextRange::new(TextSize::new(0), TextSize::new(1))
+    );
 }
 
 #[test]

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -1,7 +1,6 @@
 use std::assert_matches;
 
 use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, Stmt};
-use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{Mode, ParseOptions, parse, parse_expression, parse_module};
 
@@ -75,53 +74,6 @@ fn nfkc_normalizes_names() {
     };
 
     assert_eq!(name.id.as_str(), "C");
-}
-
-#[test]
-fn attribute_expression_ranges() {
-    let source = "(value).attr";
-    let parsed = parse_expression(source).unwrap();
-    let Expr::Attribute(attribute) = parsed.expr() else {
-        panic!("expected attribute expression, got {:?}", parsed.expr());
-    };
-
-    assert_eq!(
-        attribute.range(),
-        TextRange::new(TextSize::new(0), TextSize::new(12))
-    );
-    assert_eq!(
-        attribute.attr.range(),
-        TextRange::new(TextSize::new(8), TextSize::new(12))
-    );
-
-    let mut expr = parsed.into_syntax().body;
-    ruff_python_ast::relocate::relocate_expr(
-        &mut expr,
-        TextRange::new(TextSize::new(20), TextSize::new(30)),
-    );
-    let Expr::Attribute(attribute) = expr.as_ref() else {
-        panic!("expected relocated attribute expression, got {expr:?}");
-    };
-    assert_eq!(
-        attribute.range(),
-        TextRange::new(TextSize::new(20), TextSize::new(30))
-    );
-    assert_eq!(
-        attribute.attr.range(),
-        TextRange::new(TextSize::new(8), TextSize::new(12))
-    );
-
-    ruff_python_ast::relocate::relocate_expr(
-        &mut expr,
-        TextRange::new(TextSize::new(0), TextSize::new(1)),
-    );
-    let Expr::Attribute(attribute) = expr.as_ref() else {
-        panic!("expected relocated attribute expression, got {expr:?}");
-    };
-    assert_eq!(
-        attribute.range(),
-        TextRange::new(TextSize::new(0), TextSize::new(1))
-    );
 }
 
 #[test]

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_constant_range.snap
@@ -13,75 +13,73 @@ expression: suite
                     range: 0..22,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..22,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 2..5,
-                                                node_index: NodeIndex(None),
-                                                value: "aaa",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 5..10,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 6..9,
-                                                        id: Name("bbb"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 10..13,
-                                                node_index: NodeIndex(None),
-                                                value: "ccc",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 13..18,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 14..17,
-                                                        id: Name("ddd"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 18..21,
-                                                node_index: NodeIndex(None),
-                                                value: "eee",
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..22,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 2..5,
+                                            node_index: NodeIndex(None),
+                                            value: "aaa",
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 5..10,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 6..9,
+                                                    id: Name("bbb"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 10..13,
+                                            node_index: NodeIndex(None),
+                                            value: "ccc",
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 13..18,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 14..17,
+                                                    id: Name("ddd"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 18..21,
+                                            node_index: NodeIndex(None),
+                                            value: "eee",
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_character.snap
@@ -13,44 +13,42 @@ expression: suite
                     range: 0..8,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..8,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 2..4,
-                                                node_index: NodeIndex(None),
-                                                value: "\\",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 4..7,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 5..6,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..8,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 2..4,
+                                            node_index: NodeIndex(None),
+                                            value: "\\",
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 4..7,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 5..6,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_escaped_newline.snap
@@ -13,44 +13,42 @@ expression: suite
                     range: 0..8,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..8,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 2..4,
-                                                node_index: NodeIndex(None),
-                                                value: "\n",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 4..7,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 5..6,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..8,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 2..4,
+                                            node_index: NodeIndex(None),
+                                            value: "\n",
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 4..7,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 5..6,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_line_continuation.snap
@@ -13,46 +13,44 @@ expression: suite
                     range: 0..9,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..9,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 3..5,
-                                                node_index: NodeIndex(None),
-                                                value: "\\\n",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 5..8,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 6..7,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Raw {
-                                            uppercase_r: false,
+                            FString {
+                                range: 0..9,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 3..5,
+                                            node_index: NodeIndex(None),
+                                            value: "\\\n",
                                         },
-                                        triple_quoted: false,
-                                        unclosed: false,
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 5..8,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 6..7,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Raw {
+                                        uppercase_r: false,
                                     },
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base.snap
@@ -13,43 +13,41 @@ expression: suite
                     range: 0..10,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..10,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..9,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..7,
-                                                        id: Name("user"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: Some(
-                                                    DebugText {
-                                                        leading: "",
-                                                        expression: "user",
-                                                        trailing: "=",
-                                                    },
-                                                ),
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..10,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..9,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..7,
+                                                    id: Name("user"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: Some(
+                                                DebugText {
+                                                    leading: "",
+                                                    expression: "user",
+                                                    trailing: "=",
+                                                },
+                                            ),
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base_more.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_base_more.snap
@@ -13,80 +13,78 @@ expression: suite
                     range: 0..38,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..38,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 2..6,
-                                                node_index: NodeIndex(None),
-                                                value: "mix ",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 6..13,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 7..11,
-                                                        id: Name("user"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: Some(
-                                                    DebugText {
-                                                        leading: "",
-                                                        expression: "user",
-                                                        trailing: "=",
-                                                    },
-                                                ),
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 13..28,
-                                                node_index: NodeIndex(None),
-                                                value: " with text and ",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 28..37,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 29..35,
-                                                        id: Name("second"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: Some(
-                                                    DebugText {
-                                                        leading: "",
-                                                        expression: "second",
-                                                        trailing: "=",
-                                                    },
-                                                ),
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..38,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 2..6,
+                                            node_index: NodeIndex(None),
+                                            value: "mix ",
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 6..13,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 7..11,
+                                                    id: Name("user"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: Some(
+                                                DebugText {
+                                                    leading: "",
+                                                    expression: "user",
+                                                    trailing: "=",
+                                                },
+                                            ),
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 13..28,
+                                            node_index: NodeIndex(None),
+                                            value: " with text and ",
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 28..37,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 29..35,
+                                                    id: Name("second"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: Some(
+                                                DebugText {
+                                                    leading: "",
+                                                    expression: "second",
+                                                    trailing: "=",
+                                                },
+                                            ),
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_parse_self_documenting_format.snap
@@ -13,57 +13,55 @@ expression: suite
                     range: 0..14,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..14,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..13,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..7,
-                                                        id: Name("user"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: Some(
-                                                    DebugText {
-                                                        leading: "",
-                                                        expression: "user",
-                                                        trailing: "=",
-                                                    },
-                                                ),
-                                                conversion: None,
-                                                format_spec: Some(
-                                                    InterpolatedStringFormatSpec {
-                                                        range: 9..12,
-                                                        node_index: NodeIndex(None),
-                                                        elements: [
-                                                            Literal(
-                                                                InterpolatedStringLiteralElement {
-                                                                    range: 9..12,
-                                                                    node_index: NodeIndex(None),
-                                                                    value: ">10",
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..14,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..13,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..7,
+                                                    id: Name("user"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: Some(
+                                                DebugText {
+                                                    leading: "",
+                                                    expression: "user",
+                                                    trailing: "=",
+                                                },
+                                            ),
+                                            conversion: None,
+                                            format_spec: Some(
+                                                InterpolatedStringFormatSpec {
+                                                    range: 9..12,
+                                                    node_index: NodeIndex(None),
+                                                    elements: [
+                                                        Literal(
+                                                            InterpolatedStringLiteralElement {
+                                                                range: 9..12,
+                                                                node_index: NodeIndex(None),
+                                                                value: ">10",
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__fstring_unescaped_newline.snap
@@ -13,44 +13,42 @@ expression: suite
                     range: 0..11,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..11,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 4..5,
-                                                node_index: NodeIndex(None),
-                                                value: "\n",
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 5..8,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 6..7,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: true,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..11,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 4..5,
+                                            node_index: NodeIndex(None),
+                                            value: "\n",
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 5..8,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 6..7,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: true,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_empty_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_empty_fstring.snap
@@ -13,19 +13,17 @@ expression: suite
                     range: 0..3,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..3,
-                                    node_index: NodeIndex(None),
-                                    elements: [],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..3,
+                                node_index: NodeIndex(None),
+                                elements: [],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring.snap
@@ -13,61 +13,59 @@ expression: suite
                     range: 0..18,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..18,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..5,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..4,
-                                                        id: Name("a"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 5..10,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 7..8,
-                                                        id: Name("b"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                        Literal(
-                                            InterpolatedStringLiteralElement {
-                                                range: 10..17,
-                                                node_index: NodeIndex(None),
-                                                value: "{foo}",
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..18,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..5,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..4,
+                                                    id: Name("a"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 5..10,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 7..8,
+                                                    id: Name("b"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                    Literal(
+                                        InterpolatedStringLiteralElement {
+                                            range: 10..17,
+                                            node_index: NodeIndex(None),
+                                            value: "{foo}",
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
@@ -26,19 +26,19 @@ expression: suite
                                                     ExprCompare {
                                                         node_index: NodeIndex(None),
                                                         range: 3..11,
-                                                        left: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..5,
-                                                                value: Int(
-                                                                    42,
-                                                                ),
-                                                            },
-                                                        ),
                                                         ops: [
                                                             Eq,
                                                         ],
-                                                        comparators: [
+                                                        operands: [
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 3..5,
+                                                                    value: Int(
+                                                                        42,
+                                                                    ),
+                                                                },
+                                                            ),
                                                             NumberLiteral(
                                                                 ExprNumberLiteral {
                                                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
@@ -13,58 +13,56 @@ expression: suite
                     range: 0..13,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..13,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..12,
-                                                node_index: NodeIndex(None),
-                                                expression: Compare(
-                                                    ExprCompare {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..11,
-                                                        ops: [
-                                                            Eq,
-                                                        ],
-                                                        operands: [
-                                                            NumberLiteral(
-                                                                ExprNumberLiteral {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 3..5,
-                                                                    value: Int(
-                                                                        42,
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            NumberLiteral(
-                                                                ExprNumberLiteral {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 9..11,
-                                                                    value: Int(
-                                                                        42,
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..13,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..12,
+                                            node_index: NodeIndex(None),
+                                            expression: Compare(
+                                                ExprCompare {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..11,
+                                                    ops: [
+                                                        Eq,
+                                                    ],
+                                                    operands: [
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 3..5,
+                                                                value: Int(
+                                                                    42,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 9..11,
+                                                                value: Int(
+                                                                    42,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_concatenation_string_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_concatenation_string_spec.snap
@@ -13,90 +13,88 @@ expression: suite
                     range: 0..16,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..16,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..15,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..6,
-                                                        id: Name("foo"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: Some(
-                                                    InterpolatedStringFormatSpec {
-                                                        range: 7..14,
-                                                        node_index: NodeIndex(None),
-                                                        elements: [
-                                                            Interpolation(
-                                                                InterpolatedElement {
-                                                                    range: 7..14,
-                                                                    node_index: NodeIndex(None),
-                                                                    expression: StringLiteral(
-                                                                        ExprStringLiteral {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 8..13,
-                                                                            value: StringLiteralValue {
-                                                                                inner: Concatenated(
-                                                                                    ConcatenatedStringLiteral {
-                                                                                        strings: [
-                                                                                            StringLiteral {
-                                                                                                range: 8..10,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "",
-                                                                                                flags: StringLiteralFlags {
-                                                                                                    quote_style: Single,
-                                                                                                    prefix: Empty,
-                                                                                                    triple_quoted: false,
-                                                                                                    unclosed: false,
-                                                                                                },
+                            FString {
+                                range: 0..16,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..15,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..6,
+                                                    id: Name("foo"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: Some(
+                                                InterpolatedStringFormatSpec {
+                                                    range: 7..14,
+                                                    node_index: NodeIndex(None),
+                                                    elements: [
+                                                        Interpolation(
+                                                            InterpolatedElement {
+                                                                range: 7..14,
+                                                                node_index: NodeIndex(None),
+                                                                expression: StringLiteral(
+                                                                    ExprStringLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 8..13,
+                                                                        value: StringLiteralValue {
+                                                                            inner: Concatenated(
+                                                                                ConcatenatedStringLiteral {
+                                                                                    strings: [
+                                                                                        StringLiteral {
+                                                                                            range: 8..10,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Single,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                                unclosed: false,
                                                                                             },
-                                                                                            StringLiteral {
-                                                                                                range: 11..13,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "",
-                                                                                                flags: StringLiteralFlags {
-                                                                                                    quote_style: Single,
-                                                                                                    prefix: Empty,
-                                                                                                    triple_quoted: false,
-                                                                                                    unclosed: false,
-                                                                                                },
+                                                                                        },
+                                                                                        StringLiteral {
+                                                                                            range: 11..13,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Single,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                                unclosed: false,
                                                                                             },
-                                                                                        ],
-                                                                                        value: "",
-                                                                                    },
-                                                                                ),
-                                                                            },
+                                                                                        },
+                                                                                    ],
+                                                                                    value: "",
+                                                                                },
+                                                                            ),
                                                                         },
-                                                                    ),
-                                                                    debug_text: None,
-                                                                    conversion: None,
-                                                                    format_spec: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                                                                    },
+                                                                ),
+                                                                debug_text: None,
+                                                                conversion: None,
+                                                                format_spec: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_spec.snap
@@ -13,61 +13,59 @@ expression: suite
                     range: 0..15,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..15,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..14,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..6,
-                                                        id: Name("foo"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: Some(
-                                                    InterpolatedStringFormatSpec {
-                                                        range: 7..13,
-                                                        node_index: NodeIndex(None),
-                                                        elements: [
-                                                            Interpolation(
-                                                                InterpolatedElement {
-                                                                    range: 7..13,
-                                                                    node_index: NodeIndex(None),
-                                                                    expression: Name(
-                                                                        ExprName {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 8..12,
-                                                                            id: Name("spec"),
-                                                                            ctx: Load,
-                                                                        },
-                                                                    ),
-                                                                    debug_text: None,
-                                                                    conversion: None,
-                                                                    format_spec: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..15,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..14,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..6,
+                                                    id: Name("foo"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: Some(
+                                                InterpolatedStringFormatSpec {
+                                                    range: 7..13,
+                                                    node_index: NodeIndex(None),
+                                                    elements: [
+                                                        Interpolation(
+                                                            InterpolatedElement {
+                                                                range: 7..13,
+                                                                node_index: NodeIndex(None),
+                                                                expression: Name(
+                                                                    ExprName {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 8..12,
+                                                                        id: Name("spec"),
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                debug_text: None,
+                                                                conversion: None,
+                                                                format_spec: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_string_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_nested_string_spec.snap
@@ -13,74 +13,72 @@ expression: suite
                     range: 0..13,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..13,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..12,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..6,
-                                                        id: Name("foo"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: Some(
-                                                    InterpolatedStringFormatSpec {
-                                                        range: 7..11,
-                                                        node_index: NodeIndex(None),
-                                                        elements: [
-                                                            Interpolation(
-                                                                InterpolatedElement {
-                                                                    range: 7..11,
-                                                                    node_index: NodeIndex(None),
-                                                                    expression: StringLiteral(
-                                                                        ExprStringLiteral {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 8..10,
-                                                                            value: StringLiteralValue {
-                                                                                inner: Single(
-                                                                                    StringLiteral {
-                                                                                        range: 8..10,
-                                                                                        node_index: NodeIndex(None),
-                                                                                        value: "",
-                                                                                        flags: StringLiteralFlags {
-                                                                                            quote_style: Single,
-                                                                                            prefix: Empty,
-                                                                                            triple_quoted: false,
-                                                                                            unclosed: false,
-                                                                                        },
+                            FString {
+                                range: 0..13,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..12,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..6,
+                                                    id: Name("foo"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: Some(
+                                                InterpolatedStringFormatSpec {
+                                                    range: 7..11,
+                                                    node_index: NodeIndex(None),
+                                                    elements: [
+                                                        Interpolation(
+                                                            InterpolatedElement {
+                                                                range: 7..11,
+                                                                node_index: NodeIndex(None),
+                                                                expression: StringLiteral(
+                                                                    ExprStringLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 8..10,
+                                                                        value: StringLiteralValue {
+                                                                            inner: Single(
+                                                                                StringLiteral {
+                                                                                    range: 8..10,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    value: "",
+                                                                                    flags: StringLiteralFlags {
+                                                                                        quote_style: Single,
+                                                                                        prefix: Empty,
+                                                                                        triple_quoted: false,
+                                                                                        unclosed: false,
                                                                                     },
-                                                                                ),
-                                                                            },
+                                                                                },
+                                                                            ),
                                                                         },
-                                                                    ),
-                                                                    debug_text: None,
-                                                                    conversion: None,
-                                                                    format_spec: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                                                                    },
+                                                                ),
+                                                                debug_text: None,
+                                                                conversion: None,
+                                                                format_spec: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
@@ -26,19 +26,19 @@ expression: suite
                                                     ExprCompare {
                                                         node_index: NodeIndex(None),
                                                         range: 3..9,
-                                                        left: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..4,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
                                                         ops: [
                                                             NotEq,
                                                         ],
-                                                        comparators: [
+                                                        operands: [
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 3..4,
+                                                                    value: Int(
+                                                                        1,
+                                                                    ),
+                                                                },
+                                                            ),
                                                             NumberLiteral(
                                                                 ExprNumberLiteral {
                                                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
@@ -13,58 +13,56 @@ expression: suite
                     range: 0..11,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..11,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..10,
-                                                node_index: NodeIndex(None),
-                                                expression: Compare(
-                                                    ExprCompare {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..9,
-                                                        ops: [
-                                                            NotEq,
-                                                        ],
-                                                        operands: [
-                                                            NumberLiteral(
-                                                                ExprNumberLiteral {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 3..4,
-                                                                    value: Int(
-                                                                        1,
-                                                                    ),
-                                                                },
-                                                            ),
-                                                            NumberLiteral(
-                                                                ExprNumberLiteral {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 8..9,
-                                                                    value: Int(
-                                                                        2,
-                                                                    ),
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..11,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..10,
+                                            node_index: NodeIndex(None),
+                                            expression: Compare(
+                                                ExprCompare {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..9,
+                                                    ops: [
+                                                        NotEq,
+                                                    ],
+                                                    operands: [
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 3..4,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 8..9,
+                                                                value: Int(
+                                                                    2,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_nested_spec.snap
@@ -13,51 +13,49 @@ expression: suite
                     range: 0..13,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..13,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..12,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..6,
-                                                        id: Name("foo"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: Some(
-                                                    InterpolatedStringFormatSpec {
-                                                        range: 7..11,
-                                                        node_index: NodeIndex(None),
-                                                        elements: [
-                                                            Literal(
-                                                                InterpolatedStringLiteralElement {
-                                                                    range: 7..11,
-                                                                    node_index: NodeIndex(None),
-                                                                    value: "spec",
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..13,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..12,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..6,
+                                                    id: Name("foo"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: Some(
+                                                InterpolatedStringFormatSpec {
+                                                    range: 7..11,
+                                                    node_index: NodeIndex(None),
+                                                    elements: [
+                                                        Literal(
+                                                            InterpolatedStringLiteralElement {
+                                                                range: 7..11,
+                                                                node_index: NodeIndex(None),
+                                                                value: "spec",
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_prec_space.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_prec_space.snap
@@ -13,43 +13,41 @@ expression: suite
                     range: 0..10,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..10,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..9,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..4,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: Some(
-                                                    DebugText {
-                                                        leading: "",
-                                                        expression: "x",
-                                                        trailing: "   =",
-                                                    },
-                                                ),
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..10,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..9,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..4,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: Some(
+                                                DebugText {
+                                                    leading: "",
+                                                    expression: "x",
+                                                    trailing: "   =",
+                                                },
+                                            ),
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_trailing_space.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_self_doc_trailing_space.snap
@@ -13,43 +13,41 @@ expression: suite
                     range: 0..10,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..10,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..9,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..4,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: Some(
-                                                    DebugText {
-                                                        leading: "",
-                                                        expression: "x",
-                                                        trailing: "=   ",
-                                                    },
-                                                ),
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..10,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..9,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..4,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: Some(
+                                                DebugText {
+                                                    leading: "",
+                                                    expression: "x",
+                                                    trailing: "=   ",
+                                                },
+                                            ),
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_yield_expr.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_yield_expr.snap
@@ -13,36 +13,34 @@ expression: suite
                     range: 0..10,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..10,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 2..9,
-                                                node_index: NodeIndex(None),
-                                                expression: Yield(
-                                                    ExprYield {
-                                                        node_index: NodeIndex(None),
-                                                        range: 3..8,
-                                                        value: None,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Regular,
-                                        triple_quoted: false,
-                                        unclosed: false,
-                                    },
+                            FString {
+                                range: 0..10,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 2..9,
+                                            node_index: NodeIndex(None),
+                                            expression: Yield(
+                                                ExprYield {
+                                                    node_index: NodeIndex(None),
+                                                    range: 3..8,
+                                                    value: None,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
+                                        },
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Regular,
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_equals.snap
@@ -25,19 +25,19 @@ expression: suite
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 3..11,
-                                                    left: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 3..5,
-                                                            value: Int(
-                                                                42,
-                                                            ),
-                                                        },
-                                                    ),
                                                     ops: [
                                                         Eq,
                                                     ],
-                                                    comparators: [
+                                                    operands: [
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 3..5,
+                                                                value: Int(
+                                                                    42,
+                                                                ),
+                                                            },
+                                                        ),
                                                         NumberLiteral(
                                                             ExprNumberLiteral {
                                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_not_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_not_equals.snap
@@ -25,19 +25,19 @@ expression: suite
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 3..9,
-                                                    left: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 3..4,
-                                                            value: Int(
-                                                                1,
-                                                            ),
-                                                        },
-                                                    ),
                                                     ops: [
                                                         NotEq,
                                                     ],
-                                                    comparators: [
+                                                    operands: [
+                                                        NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 3..4,
+                                                                value: Int(
+                                                                    1,
+                                                                ),
+                                                            },
+                                                        ),
                                                         NumberLiteral(
                                                             ExprNumberLiteral {
                                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__raw_fstring.snap
@@ -13,39 +13,37 @@ expression: suite
                     range: 0..7,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..7,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 3..6,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 4..5,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Raw {
-                                            uppercase_r: false,
+                            FString {
+                                range: 0..7,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 3..6,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 4..5,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
                                         },
-                                        triple_quoted: false,
-                                        unclosed: false,
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Raw {
+                                        uppercase_r: false,
                                     },
+                                    triple_quoted: false,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__triple_quoted_raw_fstring.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__triple_quoted_raw_fstring.snap
@@ -13,39 +13,37 @@ expression: suite
                     range: 0..11,
                     value: FStringValue {
                         inner: Single(
-                            FString(
-                                FString {
-                                    range: 0..11,
-                                    node_index: NodeIndex(None),
-                                    elements: [
-                                        Interpolation(
-                                            InterpolatedElement {
-                                                range: 5..8,
-                                                node_index: NodeIndex(None),
-                                                expression: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 6..7,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                debug_text: None,
-                                                conversion: None,
-                                                format_spec: None,
-                                            },
-                                        ),
-                                    ],
-                                    flags: FStringFlags {
-                                        quote_style: Double,
-                                        prefix: Raw {
-                                            uppercase_r: false,
+                            FString {
+                                range: 0..11,
+                                node_index: NodeIndex(None),
+                                elements: [
+                                    Interpolation(
+                                        InterpolatedElement {
+                                            range: 5..8,
+                                            node_index: NodeIndex(None),
+                                            expression: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 6..7,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            debug_text: None,
+                                            conversion: None,
+                                            format_spec: None,
                                         },
-                                        triple_quoted: true,
-                                        unclosed: false,
+                                    ),
+                                ],
+                                flags: FStringFlags {
+                                    quote_style: Double,
+                                    prefix: Raw {
+                                        uppercase_r: false,
                                     },
+                                    triple_quoted: true,
+                                    unclosed: false,
                                 },
-                            ),
+                            },
                         ),
                     },
                 },

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -507,6 +507,18 @@ Root: {root:#?}",
 
 impl<'ast> SourceOrderVisitor<'ast> for ValidateAstVisitor<'ast> {
     fn enter_node(&mut self, node: AnyNodeRef<'ast>) -> TraversalSignal {
+        if let AnyNodeRef::ExprCompare(compare) = node {
+            assert!(
+                !compare.ops.is_empty(),
+                "Comparison without an operator: {compare:#?}"
+            );
+            assert_eq!(
+                compare.operands.len(),
+                compare.ops.len() + 1,
+                "Comparison operands and operators are unbalanced: {compare:#?}",
+            );
+        }
+
         assert!(
             node.end() <= self.source_length,
             "The range of the node exceeds the length of the source code. Node: {node:#?}",

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..10,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 0..1,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 In,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 0..1,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 UnaryOp(
                                     ExprUnaryOp {
                                         node_index: NodeIndex(None),
@@ -68,18 +68,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 38..41,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 38..38,
-                                    id: Name(""),
-                                    ctx: Invalid,
-                                },
-                            ),
                             ops: [
                                 Gt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 38..38,
+                                        id: Name(""),
+                                        ctx: Invalid,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_rhs_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_rhs_expression.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..20,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 0..1,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotIn,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 0..1,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Lambda(
                                     ExprLambda {
                                         node_index: NodeIndex(None),
@@ -84,18 +84,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 22..34,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 22..23,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Eq,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 22..23,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Yield(
                                     ExprYield {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_0.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..3,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 0..1,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Gt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 0..1,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_2.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..8,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 0..1,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 IsNot,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 0..1,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__multiple_equals.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__multiple_equals.py.snap
@@ -19,18 +19,18 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 25..29,
-                                left: Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 25..26,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
                                 ops: [
                                     Eq,
                                 ],
-                                comparators: [
+                                operands: [
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 25..26,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                     Name(
                                         ExprName {
                                             node_index: NodeIndex(None),
@@ -62,18 +62,18 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 33..37,
-                                left: Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 33..34,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
                                 ops: [
                                     NotEq,
                                 ],
-                                comparators: [
+                                operands: [
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 33..34,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                     Name(
                                         ExprName {
                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__named_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__named_expression.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..10,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 0..1,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotIn,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 0..1,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -85,18 +85,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 21..26,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 21..22,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Gt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 21..22,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__starred_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__starred_expression.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..7,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 0..1,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 GtE,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 0..1,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Starred(
                                     ExprStarred {
                                         node_index: NodeIndex(None),
@@ -58,18 +58,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 8..19,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 8..9,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotIn,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 8..9,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Starred(
                                     ExprStarred {
                                         node_index: NodeIndex(None),
@@ -102,18 +102,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 22..27,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 22..23,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         Lt,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 22..23,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),
@@ -142,18 +142,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 29..39,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 29..30,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         IsNot,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 29..30,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star.py.snap
@@ -417,18 +417,18 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 245..251,
-                                            left: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 245..246,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
                                             ops: [
                                                 In,
                                             ],
-                                            comparators: [
+                                            operands: [
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 245..246,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                                 Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),
@@ -461,18 +461,18 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 256..266,
-                                            left: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 256..257,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
                                             ops: [
                                                 NotIn,
                                             ],
-                                            comparators: [
+                                            operands: [
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 256..257,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                                 Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),
@@ -505,18 +505,18 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 271..276,
-                                            left: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 271..272,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
                                             ops: [
                                                 Lt,
                                             ],
-                                            comparators: [
+                                            operands: [
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 271..272,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                                 Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
@@ -65,18 +65,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 96..102,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 96..97,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 96..97,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple_starred_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple_starred_expr.py.snap
@@ -27,18 +27,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 159..165,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 159..160,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 159..160,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -69,18 +69,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 171..177,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 171..172,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 171..172,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -663,18 +663,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 364..370,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 364..365,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 364..365,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -705,18 +705,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 376..382,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 376..377,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 376..377,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
@@ -64,18 +64,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 95..101,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 95..96,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 95..96,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_conversion_follows_exclamation.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_conversion_follows_exclamation.py.snap
@@ -20,37 +20,35 @@ Module(
                             range: 0..9,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..9,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 2..8,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..4,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: Str,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..9,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 2..8,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..4,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: Str,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -112,37 +110,35 @@ Module(
                             range: 20..29,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 20..29,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 22..28,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 23..24,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 20..29,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 22..28,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 23..24,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_empty_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_empty_expression.py.snap
@@ -20,37 +20,35 @@ Module(
                             range: 0..5,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..5,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 2..4,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..3,
-                                                                id: Name(""),
-                                                                ctx: Invalid,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..5,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 2..4,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..3,
+                                                            id: Name(""),
+                                                            ctx: Invalid,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -67,37 +65,35 @@ Module(
                             range: 6..13,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 6..13,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 8..12,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 9..9,
-                                                                id: Name(""),
-                                                                ctx: Invalid,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 6..13,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 8..12,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 9..9,
+                                                            id: Name(""),
+                                                            ctx: Invalid,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_invalid_conversion_flag_name_tok.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_invalid_conversion_flag_name_tok.py.snap
@@ -20,37 +20,35 @@ Module(
                             range: 0..8,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..8,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 2..7,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..4,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..8,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 2..7,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..4,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_invalid_conversion_flag_other_tok.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_invalid_conversion_flag_other_tok.py.snap
@@ -20,37 +20,35 @@ Module(
                             range: 0..10,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..10,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 2..9,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..4,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..10,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 2..9,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..4,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -67,37 +65,35 @@ Module(
                             range: 11..21,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 11..21,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 13..20,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 14..15,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 11..21,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 13..20,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 14..15,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_invalid_starred_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_invalid_starred_expr.py.snap
@@ -20,44 +20,42 @@ Module(
                             range: 77..83,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 77..83,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 79..82,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Starred(
-                                                            ExprStarred {
-                                                                node_index: NodeIndex(None),
-                                                                range: 80..81,
-                                                                value: Name(
-                                                                    ExprName {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 81..81,
-                                                                        id: Name(""),
-                                                                        ctx: Invalid,
-                                                                    },
-                                                                ),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 77..83,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 79..82,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Starred(
+                                                        ExprStarred {
+                                                            node_index: NodeIndex(None),
+                                                            range: 80..81,
+                                                            value: Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 81..81,
+                                                                    id: Name(""),
+                                                                    ctx: Invalid,
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -74,61 +72,59 @@ Module(
                             range: 84..97,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 84..97,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 86..96,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Starred(
-                                                            ExprStarred {
-                                                                node_index: NodeIndex(None),
-                                                                range: 87..95,
-                                                                value: BoolOp(
-                                                                    ExprBoolOp {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 88..95,
-                                                                        op: And,
-                                                                        values: [
-                                                                            Name(
-                                                                                ExprName {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 88..89,
-                                                                                    id: Name("x"),
-                                                                                    ctx: Load,
-                                                                                },
-                                                                            ),
-                                                                            Name(
-                                                                                ExprName {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 94..95,
-                                                                                    id: Name("y"),
-                                                                                    ctx: Load,
-                                                                                },
-                                                                            ),
-                                                                        ],
-                                                                    },
-                                                                ),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 84..97,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 86..96,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Starred(
+                                                        ExprStarred {
+                                                            node_index: NodeIndex(None),
+                                                            range: 87..95,
+                                                            value: BoolOp(
+                                                                ExprBoolOp {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 88..95,
+                                                                    op: And,
+                                                                    values: [
+                                                                        Name(
+                                                                            ExprName {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 88..89,
+                                                                                id: Name("x"),
+                                                                                ctx: Load,
+                                                                            },
+                                                                        ),
+                                                                        Name(
+                                                                            ExprName {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 94..95,
+                                                                                id: Name("y"),
+                                                                                ctx: Load,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -145,52 +141,50 @@ Module(
                             range: 98..111,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 98..111,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 100..110,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Starred(
-                                                            ExprStarred {
-                                                                node_index: NodeIndex(None),
-                                                                range: 101..109,
-                                                                value: Yield(
-                                                                    ExprYield {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 102..109,
-                                                                        value: Some(
-                                                                            Name(
-                                                                                ExprName {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 108..109,
-                                                                                    id: Name("x"),
-                                                                                    ctx: Load,
-                                                                                },
-                                                                            ),
+                                    FString {
+                                        range: 98..111,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 100..110,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Starred(
+                                                        ExprStarred {
+                                                            node_index: NodeIndex(None),
+                                                            range: 101..109,
+                                                            value: Yield(
+                                                                ExprYield {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 102..109,
+                                                                    value: Some(
+                                                                        Name(
+                                                                            ExprName {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 108..109,
+                                                                                id: Name("x"),
+                                                                                ctx: Load,
+                                                                            },
                                                                         ),
-                                                                    },
-                                                                ),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_lambda_without_parentheses.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_lambda_without_parentheses.py.snap
@@ -20,77 +20,75 @@ Module(
                             range: 0..16,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..16,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 2..12,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Lambda(
-                                                            ExprLambda {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..12,
-                                                                parameters: Some(
-                                                                    Parameters {
-                                                                        range: 10..11,
-                                                                        node_index: NodeIndex(None),
-                                                                        posonlyargs: [],
-                                                                        args: [
-                                                                            ParameterWithDefault {
+                                    FString {
+                                        range: 0..16,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 2..12,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Lambda(
+                                                        ExprLambda {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..12,
+                                                            parameters: Some(
+                                                                Parameters {
+                                                                    range: 10..11,
+                                                                    node_index: NodeIndex(None),
+                                                                    posonlyargs: [],
+                                                                    args: [
+                                                                        ParameterWithDefault {
+                                                                            range: 10..11,
+                                                                            node_index: NodeIndex(None),
+                                                                            parameter: Parameter {
                                                                                 range: 10..11,
                                                                                 node_index: NodeIndex(None),
-                                                                                parameter: Parameter {
+                                                                                name: Identifier {
+                                                                                    id: Name("x"),
                                                                                     range: 10..11,
                                                                                     node_index: NodeIndex(None),
-                                                                                    name: Identifier {
-                                                                                        id: Name("x"),
-                                                                                        range: 10..11,
-                                                                                        node_index: NodeIndex(None),
-                                                                                    },
-                                                                                    annotation: None,
                                                                                 },
-                                                                                default: None,
+                                                                                annotation: None,
                                                                             },
-                                                                        ],
-                                                                        vararg: None,
-                                                                        kwonlyargs: [],
-                                                                        kwarg: None,
-                                                                    },
-                                                                ),
-                                                                body: Name(
-                                                                    ExprName {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 12..12,
-                                                                        id: Name(""),
-                                                                        ctx: Invalid,
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 12..14,
-                                                        node_index: NodeIndex(None),
-                                                        value: " x",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            default: None,
+                                                                        },
+                                                                    ],
+                                                                    vararg: None,
+                                                                    kwonlyargs: [],
+                                                                    kwarg: None,
+                                                                },
+                                                            ),
+                                                            body: Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 12..12,
+                                                                    id: Name(""),
+                                                                    ctx: Invalid,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 12..14,
+                                                    node_index: NodeIndex(None),
+                                                    value: " x",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/f_string_unclosed_lbrace.py
 ---
 ## AST
 
@@ -19,37 +20,35 @@ Module(
                             range: 0..4,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..4,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 2..3,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..3,
-                                                                id: Name(""),
-                                                                ctx: Invalid,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..4,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 2..3,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..3,
+                                                            id: Name(""),
+                                                            ctx: Invalid,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -66,37 +65,35 @@ Module(
                             range: 5..14,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 5..14,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 7..13,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 8..11,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: Repr,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 5..14,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 7..13,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 8..11,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: Repr,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -113,43 +110,41 @@ Module(
                             range: 15..23,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 15..23,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 17..22,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 18..21,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "",
-                                                                expression: "foo",
-                                                                trailing: "=",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 15..23,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 17..22,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 18..21,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "",
+                                                            expression: "foo",
+                                                            trailing: "=",
+                                                        },
+                                                    ),
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -166,37 +161,35 @@ Module(
                             range: 24..28,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 24..28,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 26..27,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 27..27,
-                                                                id: Name(""),
-                                                                ctx: Invalid,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 24..28,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 26..27,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 27..27,
+                                                            id: Name(""),
+                                                            ctx: Invalid,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -213,37 +206,35 @@ Module(
                             range: 29..37,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 29..37,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 33..34,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 34..34,
-                                                                id: Name(""),
-                                                                ctx: Invalid,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 29..37,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 33..34,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 34..34,
+                                                            id: Name(""),
+                                                            ctx: Invalid,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace_in_format_spec.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@f_string_unclosed_lbrace_in_format_spec.py.snap
@@ -20,50 +20,48 @@ Module(
                             range: 0..12,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..12,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 2..8,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 8..11,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 9..10,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 11..11,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..12,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 2..8,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 8..11,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 9..10,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 11..11,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -80,58 +78,56 @@ Module(
                             range: 13..28,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 13..28,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 15..21,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 21..27,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 22..23,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 24..27,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 24..27,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ".3f",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 13..28,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 15..21,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 21..27,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 22..23,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 24..27,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 24..27,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ".3f",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target.py.snap
@@ -280,18 +280,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 110..116,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 110..111,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             In,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 110..111,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             Name(
                                                 ExprName {
                                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_binary_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_binary_expr.py.snap
@@ -19,18 +19,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 4..14,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 4..5,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotIn,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 4..5,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -76,18 +76,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 29..35,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 29..30,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Eq,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 29..30,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_in_keyword.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_in_keyword.py.snap
@@ -35,18 +35,18 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 6..12,
-                                            left: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 6..7,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
                                             ops: [
                                                 In,
                                             ],
-                                            comparators: [
+                                            operands: [
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 6..7,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                                 Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),
@@ -101,18 +101,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 34..40,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 34..35,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         In,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 34..35,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),
@@ -166,18 +166,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 62..68,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 62..63,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 In,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 62..63,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -228,18 +228,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 88..94,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 88..89,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             In,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 88..89,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             Name(
                                                 ExprName {
                                                     node_index: NodeIndex(None),
@@ -303,18 +303,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 117..123,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 117..118,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             In,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 117..118,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             Name(
                                                 ExprName {
                                                     node_index: NodeIndex(None),
@@ -377,18 +377,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 146..152,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 146..147,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             In,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 146..147,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             Name(
                                                 ExprName {
                                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_fstring_literal_element.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@invalid_fstring_literal_element.py.snap
@@ -20,27 +20,25 @@ Module(
                             range: 0..26,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..26,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 2..25,
-                                                        node_index: NodeIndex(None),
-                                                        value: "",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..26,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 2..25,
+                                                    node_index: NodeIndex(None),
+                                                    value: "",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -57,27 +55,25 @@ Module(
                             range: 27..57,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 27..57,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 31..54,
-                                                        node_index: NodeIndex(None),
-                                                        value: "",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 27..57,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 31..54,
+                                                    node_index: NodeIndex(None),
+                                                    value: "",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_f_string_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_f_string_py311.py.snap
@@ -20,72 +20,70 @@ Module(
                             range: 44..74,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 44..74,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 46..58,
-                                                        node_index: NodeIndex(None),
-                                                        value: "Magic wand: ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 58..73,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Subscript(
-                                                            ExprSubscript {
-                                                                node_index: NodeIndex(None),
-                                                                range: 60..71,
-                                                                value: Name(
-                                                                    ExprName {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 60..63,
-                                                                        id: Name("bag"),
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                slice: StringLiteral(
-                                                                    ExprStringLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 64..70,
-                                                                        value: StringLiteralValue {
-                                                                            inner: Single(
-                                                                                StringLiteral {
-                                                                                    range: 64..70,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    value: "wand",
-                                                                                    flags: StringLiteralFlags {
-                                                                                        quote_style: Single,
-                                                                                        prefix: Empty,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                    FString {
+                                        range: 44..74,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 46..58,
+                                                    node_index: NodeIndex(None),
+                                                    value: "Magic wand: ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 58..73,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Subscript(
+                                                        ExprSubscript {
+                                                            node_index: NodeIndex(None),
+                                                            range: 60..71,
+                                                            value: Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 60..63,
+                                                                    id: Name("bag"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            slice: StringLiteral(
+                                                                ExprStringLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 64..70,
+                                                                    value: StringLiteralValue {
+                                                                        inner: Single(
+                                                                            StringLiteral {
+                                                                                range: 64..70,
+                                                                                node_index: NodeIndex(None),
+                                                                                value: "wand",
+                                                                                flags: StringLiteralFlags {
+                                                                                    quote_style: Single,
+                                                                                    prefix: Empty,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
-                                                                        },
+                                                                            },
+                                                                        ),
                                                                     },
-                                                                ),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -102,83 +100,81 @@ Module(
                             range: 95..112,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 95..112,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 97..111,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Call(
-                                                            ExprCall {
-                                                                node_index: NodeIndex(None),
-                                                                range: 98..110,
-                                                                func: Attribute(
-                                                                    ExprAttribute {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 98..107,
-                                                                        value: StringLiteral(
-                                                                            ExprStringLiteral {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 98..102,
-                                                                                value: StringLiteralValue {
-                                                                                    inner: Single(
-                                                                                        StringLiteral {
-                                                                                            range: 98..102,
-                                                                                            node_index: NodeIndex(None),
-                                                                                            value: "\n",
-                                                                                            flags: StringLiteralFlags {
-                                                                                                quote_style: Single,
-                                                                                                prefix: Empty,
-                                                                                                triple_quoted: false,
-                                                                                                unclosed: false,
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        attr: Identifier {
-                                                                            id: Name("join"),
-                                                                            range: 103..107,
-                                                                            node_index: NodeIndex(None),
-                                                                        },
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                arguments: Arguments {
-                                                                    range: 107..110,
+                                    FString {
+                                        range: 95..112,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 97..111,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Call(
+                                                        ExprCall {
+                                                            node_index: NodeIndex(None),
+                                                            range: 98..110,
+                                                            func: Attribute(
+                                                                ExprAttribute {
                                                                     node_index: NodeIndex(None),
-                                                                    args: [
-                                                                        Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 108..109,
-                                                                                id: Name("a"),
-                                                                                ctx: Load,
+                                                                    range: 98..107,
+                                                                    value: StringLiteral(
+                                                                        ExprStringLiteral {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 98..102,
+                                                                            value: StringLiteralValue {
+                                                                                inner: Single(
+                                                                                    StringLiteral {
+                                                                                        range: 98..102,
+                                                                                        node_index: NodeIndex(None),
+                                                                                        value: "\n",
+                                                                                        flags: StringLiteralFlags {
+                                                                                            quote_style: Single,
+                                                                                            prefix: Empty,
+                                                                                            triple_quoted: false,
+                                                                                            unclosed: false,
+                                                                                        },
+                                                                                    },
+                                                                                ),
                                                                             },
-                                                                        ),
-                                                                    ],
-                                                                    keywords: [],
+                                                                        },
+                                                                    ),
+                                                                    attr: Identifier {
+                                                                        id: Name("join"),
+                                                                        range: 103..107,
+                                                                        node_index: NodeIndex(None),
+                                                                    },
+                                                                    ctx: Load,
                                                                 },
+                                                            ),
+                                                            arguments: Arguments {
+                                                                range: 107..110,
+                                                                node_index: NodeIndex(None),
+                                                                args: [
+                                                                    Name(
+                                                                        ExprName {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 108..109,
+                                                                            id: Name("a"),
+                                                                            ctx: Load,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                keywords: [],
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -195,72 +191,70 @@ Module(
                             range: 148..220,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 148..220,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 152..169,
-                                                        node_index: NodeIndex(None),
-                                                        value: "A complex trick: ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 169..217,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Subscript(
-                                                            ExprSubscript {
-                                                                node_index: NodeIndex(None),
-                                                                range: 175..185,
-                                                                value: Name(
-                                                                    ExprName {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 175..178,
-                                                                        id: Name("bag"),
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                slice: StringLiteral(
-                                                                    ExprStringLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 179..184,
-                                                                        value: StringLiteralValue {
-                                                                            inner: Single(
-                                                                                StringLiteral {
-                                                                                    range: 179..184,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    value: "bag",
-                                                                                    flags: StringLiteralFlags {
-                                                                                        quote_style: Single,
-                                                                                        prefix: Empty,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                    FString {
+                                        range: 148..220,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 152..169,
+                                                    node_index: NodeIndex(None),
+                                                    value: "A complex trick: ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 169..217,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Subscript(
+                                                        ExprSubscript {
+                                                            node_index: NodeIndex(None),
+                                                            range: 175..185,
+                                                            value: Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 175..178,
+                                                                    id: Name("bag"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            slice: StringLiteral(
+                                                                ExprStringLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 179..184,
+                                                                    value: StringLiteralValue {
+                                                                        inner: Single(
+                                                                            StringLiteral {
+                                                                                range: 179..184,
+                                                                                node_index: NodeIndex(None),
+                                                                                value: "bag",
+                                                                                flags: StringLiteralFlags {
+                                                                                    quote_style: Single,
+                                                                                    prefix: Empty,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
-                                                                        },
+                                                                            },
+                                                                        ),
                                                                     },
-                                                                ),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -277,219 +271,207 @@ Module(
                             range: 221..254,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 221..254,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 223..253,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 224..252,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 224..252,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 226..251,
+                                    FString {
+                                        range: 221..254,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 223..253,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 224..252,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 224..252,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 226..251,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: FString(
+                                                                                        ExprFString {
                                                                                             node_index: NodeIndex(None),
-                                                                                            expression: FString(
-                                                                                                ExprFString {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 227..250,
-                                                                                                    value: FStringValue {
-                                                                                                        inner: Single(
-                                                                                                            FString(
-                                                                                                                FString {
-                                                                                                                    range: 227..250,
+                                                                                            range: 227..250,
+                                                                                            value: FStringValue {
+                                                                                                inner: Single(
+                                                                                                    FString {
+                                                                                                        range: 227..250,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        elements: [
+                                                                                                            Interpolation(
+                                                                                                                InterpolatedElement {
+                                                                                                                    range: 229..249,
                                                                                                                     node_index: NodeIndex(None),
-                                                                                                                    elements: [
-                                                                                                                        Interpolation(
-                                                                                                                            InterpolatedElement {
-                                                                                                                                range: 229..249,
-                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                expression: FString(
-                                                                                                                                    ExprFString {
-                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                    expression: FString(
+                                                                                                                        ExprFString {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 230..248,
+                                                                                                                            value: FStringValue {
+                                                                                                                                inner: Single(
+                                                                                                                                    FString {
                                                                                                                                         range: 230..248,
-                                                                                                                                        value: FStringValue {
-                                                                                                                                            inner: Single(
-                                                                                                                                                FString(
-                                                                                                                                                    FString {
-                                                                                                                                                        range: 230..248,
-                                                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                                                        elements: [
-                                                                                                                                                            Interpolation(
-                                                                                                                                                                InterpolatedElement {
-                                                                                                                                                                    range: 232..247,
-                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                    expression: FString(
-                                                                                                                                                                        ExprFString {
-                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                            range: 233..246,
-                                                                                                                                                                            value: FStringValue {
-                                                                                                                                                                                inner: Single(
-                                                                                                                                                                                    FString(
-                                                                                                                                                                                        FString {
-                                                                                                                                                                                            range: 233..246,
+                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                                        elements: [
+                                                                                                                                            Interpolation(
+                                                                                                                                                InterpolatedElement {
+                                                                                                                                                    range: 232..247,
+                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                    expression: FString(
+                                                                                                                                                        ExprFString {
+                                                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                                                            range: 233..246,
+                                                                                                                                                            value: FStringValue {
+                                                                                                                                                                inner: Single(
+                                                                                                                                                                    FString {
+                                                                                                                                                                        range: 233..246,
+                                                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                                                                        elements: [
+                                                                                                                                                                            Interpolation(
+                                                                                                                                                                                InterpolatedElement {
+                                                                                                                                                                                    range: 235..245,
+                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                    expression: FString(
+                                                                                                                                                                                        ExprFString {
                                                                                                                                                                                             node_index: NodeIndex(None),
-                                                                                                                                                                                            elements: [
-                                                                                                                                                                                                Interpolation(
-                                                                                                                                                                                                    InterpolatedElement {
-                                                                                                                                                                                                        range: 235..245,
+                                                                                                                                                                                            range: 236..244,
+                                                                                                                                                                                            value: FStringValue {
+                                                                                                                                                                                                inner: Single(
+                                                                                                                                                                                                    FString {
+                                                                                                                                                                                                        range: 236..244,
                                                                                                                                                                                                         node_index: NodeIndex(None),
-                                                                                                                                                                                                        expression: FString(
-                                                                                                                                                                                                            ExprFString {
-                                                                                                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                                                                                                range: 236..244,
-                                                                                                                                                                                                                value: FStringValue {
-                                                                                                                                                                                                                    inner: Single(
-                                                                                                                                                                                                                        FString(
-                                                                                                                                                                                                                            FString {
-                                                                                                                                                                                                                                range: 236..244,
-                                                                                                                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                                                                                                                elements: [
-                                                                                                                                                                                                                                    Interpolation(
-                                                                                                                                                                                                                                        InterpolatedElement {
-                                                                                                                                                                                                                                            range: 238..243,
-                                                                                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                                                                                            expression: BinOp(
-                                                                                                                                                                                                                                                ExprBinOp {
-                                                                                                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                                                                                                    range: 239..242,
-                                                                                                                                                                                                                                                    left: NumberLiteral(
-                                                                                                                                                                                                                                                        ExprNumberLiteral {
-                                                                                                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                                                                                                            range: 239..240,
-                                                                                                                                                                                                                                                            value: Int(
-                                                                                                                                                                                                                                                                1,
-                                                                                                                                                                                                                                                            ),
-                                                                                                                                                                                                                                                        },
-                                                                                                                                                                                                                                                    ),
-                                                                                                                                                                                                                                                    op: Add,
-                                                                                                                                                                                                                                                    right: NumberLiteral(
-                                                                                                                                                                                                                                                        ExprNumberLiteral {
-                                                                                                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                                                                                                            range: 241..242,
-                                                                                                                                                                                                                                                            value: Int(
-                                                                                                                                                                                                                                                                1,
-                                                                                                                                                                                                                                                            ),
-                                                                                                                                                                                                                                                        },
-                                                                                                                                                                                                                                                    ),
-                                                                                                                                                                                                                                                },
-                                                                                                                                                                                                                                            ),
-                                                                                                                                                                                                                                            debug_text: None,
-                                                                                                                                                                                                                                            conversion: None,
-                                                                                                                                                                                                                                            format_spec: None,
-                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                        elements: [
+                                                                                                                                                                                                            Interpolation(
+                                                                                                                                                                                                                InterpolatedElement {
+                                                                                                                                                                                                                    range: 238..243,
+                                                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                                                    expression: BinOp(
+                                                                                                                                                                                                                        ExprBinOp {
+                                                                                                                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                                                                                                                            range: 239..242,
+                                                                                                                                                                                                                            left: NumberLiteral(
+                                                                                                                                                                                                                                ExprNumberLiteral {
+                                                                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                                                                    range: 239..240,
+                                                                                                                                                                                                                                    value: Int(
+                                                                                                                                                                                                                                        1,
                                                                                                                                                                                                                                     ),
-                                                                                                                                                                                                                                ],
-                                                                                                                                                                                                                                flags: FStringFlags {
-                                                                                                                                                                                                                                    quote_style: Double,
-                                                                                                                                                                                                                                    prefix: Regular,
-                                                                                                                                                                                                                                    triple_quoted: false,
-                                                                                                                                                                                                                                    unclosed: false,
                                                                                                                                                                                                                                 },
-                                                                                                                                                                                                                            },
-                                                                                                                                                                                                                        ),
+                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                            op: Add,
+                                                                                                                                                                                                                            right: NumberLiteral(
+                                                                                                                                                                                                                                ExprNumberLiteral {
+                                                                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                                                                    range: 241..242,
+                                                                                                                                                                                                                                    value: Int(
+                                                                                                                                                                                                                                        1,
+                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                        },
                                                                                                                                                                                                                     ),
+                                                                                                                                                                                                                    debug_text: None,
+                                                                                                                                                                                                                    conversion: None,
+                                                                                                                                                                                                                    format_spec: None,
                                                                                                                                                                                                                 },
-                                                                                                                                                                                                            },
-                                                                                                                                                                                                        ),
-                                                                                                                                                                                                        debug_text: None,
-                                                                                                                                                                                                        conversion: None,
-                                                                                                                                                                                                        format_spec: None,
+                                                                                                                                                                                                            ),
+                                                                                                                                                                                                        ],
+                                                                                                                                                                                                        flags: FStringFlags {
+                                                                                                                                                                                                            quote_style: Double,
+                                                                                                                                                                                                            prefix: Regular,
+                                                                                                                                                                                                            triple_quoted: false,
+                                                                                                                                                                                                            unclosed: false,
+                                                                                                                                                                                                        },
                                                                                                                                                                                                     },
                                                                                                                                                                                                 ),
-                                                                                                                                                                                            ],
-                                                                                                                                                                                            flags: FStringFlags {
-                                                                                                                                                                                                quote_style: Double,
-                                                                                                                                                                                                prefix: Regular,
-                                                                                                                                                                                                triple_quoted: false,
-                                                                                                                                                                                                unclosed: false,
                                                                                                                                                                                             },
                                                                                                                                                                                         },
                                                                                                                                                                                     ),
-                                                                                                                                                                                ),
-                                                                                                                                                                            },
+                                                                                                                                                                                    debug_text: None,
+                                                                                                                                                                                    conversion: None,
+                                                                                                                                                                                    format_spec: None,
+                                                                                                                                                                                },
+                                                                                                                                                                            ),
+                                                                                                                                                                        ],
+                                                                                                                                                                        flags: FStringFlags {
+                                                                                                                                                                            quote_style: Double,
+                                                                                                                                                                            prefix: Regular,
+                                                                                                                                                                            triple_quoted: false,
+                                                                                                                                                                            unclosed: false,
                                                                                                                                                                         },
-                                                                                                                                                                    ),
-                                                                                                                                                                    debug_text: None,
-                                                                                                                                                                    conversion: None,
-                                                                                                                                                                    format_spec: None,
-                                                                                                                                                                },
-                                                                                                                                                            ),
-                                                                                                                                                        ],
-                                                                                                                                                        flags: FStringFlags {
-                                                                                                                                                            quote_style: Double,
-                                                                                                                                                            prefix: Regular,
-                                                                                                                                                            triple_quoted: false,
-                                                                                                                                                            unclosed: false,
+                                                                                                                                                                    },
+                                                                                                                                                                ),
+                                                                                                                                                            },
                                                                                                                                                         },
-                                                                                                                                                    },
-                                                                                                                                                ),
+                                                                                                                                                    ),
+                                                                                                                                                    debug_text: None,
+                                                                                                                                                    conversion: None,
+                                                                                                                                                    format_spec: None,
+                                                                                                                                                },
                                                                                                                                             ),
+                                                                                                                                        ],
+                                                                                                                                        flags: FStringFlags {
+                                                                                                                                            quote_style: Double,
+                                                                                                                                            prefix: Regular,
+                                                                                                                                            triple_quoted: false,
+                                                                                                                                            unclosed: false,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 ),
-                                                                                                                                debug_text: None,
-                                                                                                                                conversion: None,
-                                                                                                                                format_spec: None,
                                                                                                                             },
-                                                                                                                        ),
-                                                                                                                    ],
-                                                                                                                    flags: FStringFlags {
-                                                                                                                        quote_style: Double,
-                                                                                                                        prefix: Regular,
-                                                                                                                        triple_quoted: false,
-                                                                                                                        unclosed: false,
-                                                                                                                    },
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    debug_text: None,
+                                                                                                                    conversion: None,
+                                                                                                                    format_spec: None,
                                                                                                                 },
                                                                                                             ),
-                                                                                                        ),
+                                                                                                        ],
+                                                                                                        flags: FStringFlags {
+                                                                                                            quote_style: Double,
+                                                                                                            prefix: Regular,
+                                                                                                            triple_quoted: false,
+                                                                                                            unclosed: false,
+                                                                                                        },
                                                                                                     },
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: None,
-                                                                                            conversion: None,
-                                                                                            format_spec: None,
+                                                                                                ),
+                                                                                            },
                                                                                         },
                                                                                     ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Double,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: false,
-                                                                                    unclosed: false,
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Double,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
+                                                                        },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -506,97 +488,93 @@ Module(
                             range: 276..310,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 276..310,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 278..303,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 279..302,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 279..302,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 283..293,
+                                    FString {
+                                        range: 276..310,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 278..303,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 279..302,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 279..302,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 283..293,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: StringLiteral(
+                                                                                        ExprStringLiteral {
                                                                                             node_index: NodeIndex(None),
-                                                                                            expression: StringLiteral(
-                                                                                                ExprStringLiteral {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 284..292,
-                                                                                                    value: StringLiteralValue {
-                                                                                                        inner: Single(
-                                                                                                            StringLiteral {
-                                                                                                                range: 284..292,
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                value: "nested",
-                                                                                                                flags: StringLiteralFlags {
-                                                                                                                    quote_style: Double,
-                                                                                                                    prefix: Empty,
-                                                                                                                    triple_quoted: false,
-                                                                                                                    unclosed: false,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        ),
+                                                                                            range: 284..292,
+                                                                                            value: StringLiteralValue {
+                                                                                                inner: Single(
+                                                                                                    StringLiteral {
+                                                                                                        range: 284..292,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        value: "nested",
+                                                                                                        flags: StringLiteralFlags {
+                                                                                                            quote_style: Double,
+                                                                                                            prefix: Empty,
+                                                                                                            triple_quoted: false,
+                                                                                                            unclosed: false,
+                                                                                                        },
                                                                                                     },
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: None,
-                                                                                            conversion: None,
-                                                                                            format_spec: None,
+                                                                                                ),
+                                                                                            },
                                                                                         },
                                                                                     ),
-                                                                                    Literal(
-                                                                                        InterpolatedStringLiteralElement {
-                                                                                            range: 293..299,
-                                                                                            node_index: NodeIndex(None),
-                                                                                            value: " inner",
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Single,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: true,
-                                                                                    unclosed: false,
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
+                                                                            ),
+                                                                            Literal(
+                                                                                InterpolatedStringLiteralElement {
+                                                                                    range: 293..299,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    value: " inner",
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: true,
+                                                                            unclosed: false,
+                                                                        },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 303..309,
-                                                        node_index: NodeIndex(None),
-                                                        value: " outer",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 303..309,
+                                                    node_index: NodeIndex(None),
+                                                    value: " outer",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -613,38 +591,36 @@ Module(
                             range: 336..348,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 336..348,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 338..347,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 344..345,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 336..348,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 338..347,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 344..345,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -661,51 +637,49 @@ Module(
                             range: 349..372,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 349..372,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 351..356,
-                                                        node_index: NodeIndex(None),
-                                                        value: "test ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 356..366,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 357..358,
-                                                                id: Name("a"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 366..371,
-                                                        node_index: NodeIndex(None),
-                                                        value: " more",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 349..372,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 351..356,
+                                                    node_index: NodeIndex(None),
+                                                    value: "test ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 356..366,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 357..358,
+                                                            id: Name("a"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 366..371,
+                                                    node_index: NodeIndex(None),
+                                                    value: " more",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -722,70 +696,66 @@ Module(
                             range: 416..435,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 416..435,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 420..432,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 421..431,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 421..431,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 425..428,
+                                    FString {
+                                        range: 416..435,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 420..432,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 421..431,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 421..431,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 425..428,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: Name(
+                                                                                        ExprName {
                                                                                             node_index: NodeIndex(None),
-                                                                                            expression: Name(
-                                                                                                ExprName {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 426..427,
-                                                                                                    id: Name("x"),
-                                                                                                    ctx: Load,
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: None,
-                                                                                            conversion: None,
-                                                                                            format_spec: None,
+                                                                                            range: 426..427,
+                                                                                            id: Name("x"),
+                                                                                            ctx: Load,
                                                                                         },
                                                                                     ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Double,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: true,
-                                                                                    unclosed: false,
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Double,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: true,
+                                                                            unclosed: false,
+                                                                        },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -802,147 +772,145 @@ Module(
                             range: 481..515,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 481..515,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 483..514,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Call(
-                                                            ExprCall {
-                                                                node_index: NodeIndex(None),
-                                                                range: 484..513,
-                                                                func: Attribute(
-                                                                    ExprAttribute {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 484..493,
-                                                                        value: StringLiteral(
-                                                                            ExprStringLiteral {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 484..488,
-                                                                                value: StringLiteralValue {
-                                                                                    inner: Single(
-                                                                                        StringLiteral {
-                                                                                            range: 484..488,
-                                                                                            node_index: NodeIndex(None),
-                                                                                            value: "\n",
-                                                                                            flags: StringLiteralFlags {
-                                                                                                quote_style: Single,
-                                                                                                prefix: Empty,
-                                                                                                triple_quoted: false,
-                                                                                                unclosed: false,
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        attr: Identifier {
-                                                                            id: Name("join"),
-                                                                            range: 489..493,
-                                                                            node_index: NodeIndex(None),
-                                                                        },
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                arguments: Arguments {
-                                                                    range: 493..513,
+                                    FString {
+                                        range: 481..515,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 483..514,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Call(
+                                                        ExprCall {
+                                                            node_index: NodeIndex(None),
+                                                            range: 484..513,
+                                                            func: Attribute(
+                                                                ExprAttribute {
                                                                     node_index: NodeIndex(None),
-                                                                    args: [
-                                                                        List(
-                                                                            ExprList {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 494..512,
-                                                                                elts: [
-                                                                                    StringLiteral(
-                                                                                        ExprStringLiteral {
-                                                                                            node_index: NodeIndex(None),
-                                                                                            range: 495..499,
-                                                                                            value: StringLiteralValue {
-                                                                                                inner: Single(
-                                                                                                    StringLiteral {
-                                                                                                        range: 495..499,
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        value: "\t",
-                                                                                                        flags: StringLiteralFlags {
-                                                                                                            quote_style: Single,
-                                                                                                            prefix: Empty,
-                                                                                                            triple_quoted: false,
-                                                                                                            unclosed: false,
-                                                                                                        },
-                                                                                                    },
-                                                                                                ),
-                                                                                            },
+                                                                    range: 484..493,
+                                                                    value: StringLiteral(
+                                                                        ExprStringLiteral {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 484..488,
+                                                                            value: StringLiteralValue {
+                                                                                inner: Single(
+                                                                                    StringLiteral {
+                                                                                        range: 484..488,
+                                                                                        node_index: NodeIndex(None),
+                                                                                        value: "\n",
+                                                                                        flags: StringLiteralFlags {
+                                                                                            quote_style: Single,
+                                                                                            prefix: Empty,
+                                                                                            triple_quoted: false,
+                                                                                            unclosed: false,
                                                                                         },
-                                                                                    ),
-                                                                                    StringLiteral(
-                                                                                        ExprStringLiteral {
-                                                                                            node_index: NodeIndex(None),
-                                                                                            range: 501..505,
-                                                                                            value: StringLiteralValue {
-                                                                                                inner: Single(
-                                                                                                    StringLiteral {
-                                                                                                        range: 501..505,
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        value: "\u{b}",
-                                                                                                        flags: StringLiteralFlags {
-                                                                                                            quote_style: Single,
-                                                                                                            prefix: Empty,
-                                                                                                            triple_quoted: false,
-                                                                                                            unclosed: false,
-                                                                                                        },
-                                                                                                    },
-                                                                                                ),
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                    StringLiteral(
-                                                                                        ExprStringLiteral {
-                                                                                            node_index: NodeIndex(None),
-                                                                                            range: 507..511,
-                                                                                            value: StringLiteralValue {
-                                                                                                inner: Single(
-                                                                                                    StringLiteral {
-                                                                                                        range: 507..511,
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        value: "\r",
-                                                                                                        flags: StringLiteralFlags {
-                                                                                                            quote_style: Single,
-                                                                                                            prefix: Empty,
-                                                                                                            triple_quoted: false,
-                                                                                                            unclosed: false,
-                                                                                                        },
-                                                                                                    },
-                                                                                                ),
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                ctx: Load,
+                                                                                    },
+                                                                                ),
                                                                             },
-                                                                        ),
-                                                                    ],
-                                                                    keywords: [],
+                                                                        },
+                                                                    ),
+                                                                    attr: Identifier {
+                                                                        id: Name("join"),
+                                                                        range: 489..493,
+                                                                        node_index: NodeIndex(None),
+                                                                    },
+                                                                    ctx: Load,
                                                                 },
+                                                            ),
+                                                            arguments: Arguments {
+                                                                range: 493..513,
+                                                                node_index: NodeIndex(None),
+                                                                args: [
+                                                                    List(
+                                                                        ExprList {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 494..512,
+                                                                            elts: [
+                                                                                StringLiteral(
+                                                                                    ExprStringLiteral {
+                                                                                        node_index: NodeIndex(None),
+                                                                                        range: 495..499,
+                                                                                        value: StringLiteralValue {
+                                                                                            inner: Single(
+                                                                                                StringLiteral {
+                                                                                                    range: 495..499,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: "\t",
+                                                                                                    flags: StringLiteralFlags {
+                                                                                                        quote_style: Single,
+                                                                                                        prefix: Empty,
+                                                                                                        triple_quoted: false,
+                                                                                                        unclosed: false,
+                                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                StringLiteral(
+                                                                                    ExprStringLiteral {
+                                                                                        node_index: NodeIndex(None),
+                                                                                        range: 501..505,
+                                                                                        value: StringLiteralValue {
+                                                                                            inner: Single(
+                                                                                                StringLiteral {
+                                                                                                    range: 501..505,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: "\u{b}",
+                                                                                                    flags: StringLiteralFlags {
+                                                                                                        quote_style: Single,
+                                                                                                        prefix: Empty,
+                                                                                                        triple_quoted: false,
+                                                                                                        unclosed: false,
+                                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                                StringLiteral(
+                                                                                    ExprStringLiteral {
+                                                                                        node_index: NodeIndex(None),
+                                                                                        range: 507..511,
+                                                                                        value: StringLiteralValue {
+                                                                                            inner: Single(
+                                                                                                StringLiteral {
+                                                                                                    range: 507..511,
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    value: "\r",
+                                                                                                    flags: StringLiteralFlags {
+                                                                                                        quote_style: Single,
+                                                                                                        prefix: Empty,
+                                                                                                        triple_quoted: false,
+                                                                                                        unclosed: false,
+                                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                        },
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                            ctx: Load,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                keywords: [],
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_nested_interpolation_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@pep701_nested_interpolation_py311.py.snap
@@ -20,89 +20,87 @@ Module(
                             range: 92..114,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 92..114,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 94..113,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 95..96,
-                                                                value: Int(
-                                                                    1,
+                                    FString {
+                                        range: 92..114,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 94..113,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 95..96,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 97..112,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 97..104,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: " abcd \"",
+                                                                    },
                                                                 ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 97..112,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 97..104,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: " abcd \"",
-                                                                        },
-                                                                    ),
-                                                                    Interpolation(
-                                                                        InterpolatedElement {
-                                                                            range: 104..110,
-                                                                            node_index: NodeIndex(None),
-                                                                            expression: StringLiteral(
-                                                                                ExprStringLiteral {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 105..109,
-                                                                                    value: StringLiteralValue {
-                                                                                        inner: Single(
-                                                                                            StringLiteral {
-                                                                                                range: 105..109,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "aa",
-                                                                                                flags: StringLiteralFlags {
-                                                                                                    quote_style: Single,
-                                                                                                    prefix: Empty,
-                                                                                                    triple_quoted: false,
-                                                                                                    unclosed: false,
-                                                                                                },
+                                                                Interpolation(
+                                                                    InterpolatedElement {
+                                                                        range: 104..110,
+                                                                        node_index: NodeIndex(None),
+                                                                        expression: StringLiteral(
+                                                                            ExprStringLiteral {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 105..109,
+                                                                                value: StringLiteralValue {
+                                                                                    inner: Single(
+                                                                                        StringLiteral {
+                                                                                            range: 105..109,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "aa",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Single,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                                unclosed: false,
                                                                                             },
-                                                                                        ),
-                                                                                    },
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            ),
-                                                                            debug_text: None,
-                                                                            conversion: None,
-                                                                            format_spec: None,
-                                                                        },
-                                                                    ),
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 110..112,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "\" ",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            },
+                                                                        ),
+                                                                        debug_text: None,
+                                                                        conversion: None,
+                                                                        format_spec: None,
+                                                                    },
+                                                                ),
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 110..112,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "\" ",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -119,89 +117,87 @@ Module(
                             range: 115..137,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 115..137,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 117..136,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 118..119,
-                                                                value: Int(
-                                                                    1,
+                                    FString {
+                                        range: 115..137,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 117..136,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 118..119,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 120..135,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 120..127,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: " abcd \"",
+                                                                    },
                                                                 ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 120..135,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 120..127,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: " abcd \"",
-                                                                        },
-                                                                    ),
-                                                                    Interpolation(
-                                                                        InterpolatedElement {
-                                                                            range: 127..133,
-                                                                            node_index: NodeIndex(None),
-                                                                            expression: StringLiteral(
-                                                                                ExprStringLiteral {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 128..132,
-                                                                                    value: StringLiteralValue {
-                                                                                        inner: Single(
-                                                                                            StringLiteral {
-                                                                                                range: 128..132,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "\n",
-                                                                                                flags: StringLiteralFlags {
-                                                                                                    quote_style: Double,
-                                                                                                    prefix: Empty,
-                                                                                                    triple_quoted: false,
-                                                                                                    unclosed: false,
-                                                                                                },
+                                                                Interpolation(
+                                                                    InterpolatedElement {
+                                                                        range: 127..133,
+                                                                        node_index: NodeIndex(None),
+                                                                        expression: StringLiteral(
+                                                                            ExprStringLiteral {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 128..132,
+                                                                                value: StringLiteralValue {
+                                                                                    inner: Single(
+                                                                                        StringLiteral {
+                                                                                            range: 128..132,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "\n",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Double,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                                unclosed: false,
                                                                                             },
-                                                                                        ),
-                                                                                    },
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            ),
-                                                                            debug_text: None,
-                                                                            conversion: None,
-                                                                            format_spec: None,
-                                                                        },
-                                                                    ),
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 133..135,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "\" ",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            },
+                                                                        ),
+                                                                        debug_text: None,
+                                                                        conversion: None,
+                                                                        format_spec: None,
+                                                                    },
+                                                                ),
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 133..135,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "\" ",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lex_logical_token.py.snap
@@ -600,44 +600,42 @@ Module(
                                             range: 895..905,
                                             value: FStringValue {
                                                 inner: Single(
-                                                    FString(
-                                                        FString {
-                                                            range: 895..905,
-                                                            node_index: NodeIndex(None),
-                                                            elements: [
-                                                                Literal(
-                                                                    InterpolatedStringLiteralElement {
-                                                                        range: 897..903,
-                                                                        node_index: NodeIndex(None),
-                                                                        value: "hello ",
-                                                                    },
-                                                                ),
-                                                                Interpolation(
-                                                                    InterpolatedElement {
-                                                                        range: 903..905,
-                                                                        node_index: NodeIndex(None),
-                                                                        expression: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 904..905,
-                                                                                id: Name("x"),
-                                                                                ctx: Load,
-                                                                            },
-                                                                        ),
-                                                                        debug_text: None,
-                                                                        conversion: None,
-                                                                        format_spec: None,
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            flags: FStringFlags {
-                                                                quote_style: Double,
-                                                                prefix: Regular,
-                                                                triple_quoted: false,
-                                                                unclosed: true,
-                                                            },
+                                                    FString {
+                                                        range: 895..905,
+                                                        node_index: NodeIndex(None),
+                                                        elements: [
+                                                            Literal(
+                                                                InterpolatedStringLiteralElement {
+                                                                    range: 897..903,
+                                                                    node_index: NodeIndex(None),
+                                                                    value: "hello ",
+                                                                },
+                                                            ),
+                                                            Interpolation(
+                                                                InterpolatedElement {
+                                                                    range: 903..905,
+                                                                    node_index: NodeIndex(None),
+                                                                    expression: Name(
+                                                                        ExprName {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 904..905,
+                                                                            id: Name("x"),
+                                                                            ctx: Load,
+                                                                        },
+                                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: None,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        flags: FStringFlags {
+                                                            quote_style: Double,
+                                                            prefix: Regular,
+                                                            triple_quoted: false,
+                                                            unclosed: true,
                                                         },
-                                                    ),
+                                                    },
                                                 ),
                                             },
                                         },
@@ -710,27 +708,25 @@ Module(
                                             range: 944..951,
                                             value: FStringValue {
                                                 inner: Single(
-                                                    FString(
-                                                        FString {
-                                                            range: 944..951,
-                                                            node_index: NodeIndex(None),
-                                                            elements: [
-                                                                Literal(
-                                                                    InterpolatedStringLiteralElement {
-                                                                        range: 946..951,
-                                                                        node_index: NodeIndex(None),
-                                                                        value: "hello",
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            flags: FStringFlags {
-                                                                quote_style: Double,
-                                                                prefix: Regular,
-                                                                triple_quoted: false,
-                                                                unclosed: true,
-                                                            },
+                                                    FString {
+                                                        range: 944..951,
+                                                        node_index: NodeIndex(None),
+                                                        elements: [
+                                                            Literal(
+                                                                InterpolatedStringLiteralElement {
+                                                                    range: 946..951,
+                                                                    node_index: NodeIndex(None),
+                                                                    value: "hello",
+                                                                },
+                                                            ),
+                                                        ],
+                                                        flags: FStringFlags {
+                                                            quote_style: Double,
+                                                            prefix: Regular,
+                                                            triple_quoted: false,
+                                                            unclosed: true,
                                                         },
-                                                    ),
+                                                    },
                                                 ),
                                             },
                                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__fstring_format_spec_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__fstring_format_spec_1.py.snap
@@ -20,71 +20,69 @@ Module(
                             range: 162..192,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 162..192,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 164..171,
-                                                        node_index: NodeIndex(None),
-                                                        value: "middle ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 171..191,
-                                                        node_index: NodeIndex(None),
-                                                        expression: StringLiteral(
-                                                            ExprStringLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 172..180,
-                                                                value: StringLiteralValue {
-                                                                    inner: Single(
-                                                                        StringLiteral {
-                                                                            range: 172..180,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "string",
-                                                                            flags: StringLiteralFlags {
-                                                                                quote_style: Single,
-                                                                                prefix: Empty,
-                                                                                triple_quoted: false,
-                                                                                unclosed: false,
-                                                                            },
+                                    FString {
+                                        range: 162..192,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 164..171,
+                                                    node_index: NodeIndex(None),
+                                                    value: "middle ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 171..191,
+                                                    node_index: NodeIndex(None),
+                                                    expression: StringLiteral(
+                                                        ExprStringLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 172..180,
+                                                            value: StringLiteralValue {
+                                                                inner: Single(
+                                                                    StringLiteral {
+                                                                        range: 172..180,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "string",
+                                                                        flags: StringLiteralFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Empty,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
                                                                         },
-                                                                    ),
-                                                                },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 181..191,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 181..191,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "        ",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 181..191,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 181..191,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "        ",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -156,71 +154,69 @@ Module(
                             range: 207..228,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 207..228,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 209..216,
-                                                        node_index: NodeIndex(None),
-                                                        value: "middle ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 216..228,
-                                                        node_index: NodeIndex(None),
-                                                        expression: StringLiteral(
-                                                            ExprStringLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 217..225,
-                                                                value: StringLiteralValue {
-                                                                    inner: Single(
-                                                                        StringLiteral {
-                                                                            range: 217..225,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "string",
-                                                                            flags: StringLiteralFlags {
-                                                                                quote_style: Single,
-                                                                                prefix: Empty,
-                                                                                triple_quoted: false,
-                                                                                unclosed: false,
-                                                                            },
+                                    FString {
+                                        range: 207..228,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 209..216,
+                                                    node_index: NodeIndex(None),
+                                                    value: "middle ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 216..228,
+                                                    node_index: NodeIndex(None),
+                                                    expression: StringLiteral(
+                                                        ExprStringLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 217..225,
+                                                            value: StringLiteralValue {
+                                                                inner: Single(
+                                                                    StringLiteral {
+                                                                        range: 217..225,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "string",
+                                                                        flags: StringLiteralFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Empty,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
                                                                         },
-                                                                    ),
-                                                                },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 226..228,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 226..228,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "\\",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: true,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 226..228,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 226..228,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "\\",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: true,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -264,71 +260,69 @@ Module(
                             range: 253..285,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 253..285,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 255..262,
-                                                        node_index: NodeIndex(None),
-                                                        value: "middle ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 262..284,
-                                                        node_index: NodeIndex(None),
-                                                        expression: StringLiteral(
-                                                            ExprStringLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 263..271,
-                                                                value: StringLiteralValue {
-                                                                    inner: Single(
-                                                                        StringLiteral {
-                                                                            range: 263..271,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "string",
-                                                                            flags: StringLiteralFlags {
-                                                                                quote_style: Single,
-                                                                                prefix: Empty,
-                                                                                triple_quoted: false,
-                                                                                unclosed: false,
-                                                                            },
+                                    FString {
+                                        range: 253..285,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 255..262,
+                                                    node_index: NodeIndex(None),
+                                                    value: "middle ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 262..284,
+                                                    node_index: NodeIndex(None),
+                                                    expression: StringLiteral(
+                                                        ExprStringLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 263..271,
+                                                            value: StringLiteralValue {
+                                                                inner: Single(
+                                                                    StringLiteral {
+                                                                        range: 263..271,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "string",
+                                                                        flags: StringLiteralFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Empty,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
                                                                         },
-                                                                    ),
-                                                                },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 272..284,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 272..284,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "\\        ",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 272..284,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 272..284,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "\\        ",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_1.py.snap
@@ -20,44 +20,42 @@ Module(
                             range: 166..178,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 166..178,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 170..176,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 176..178,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 177..178,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: true,
-                                            },
+                                    FString {
+                                        range: 166..178,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 170..176,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 176..178,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 177..178,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: true,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_2.py.snap
@@ -20,51 +20,49 @@ Module(
                             range: 167..183,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 167..183,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 171..180,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 172..175,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 176..180,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 176..180,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ".3f\n",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 167..183,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 171..180,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 172..175,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 176..180,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 176..180,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ".3f\n",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_3.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__triple_quoted_fstring_3.py.snap
@@ -36,51 +36,49 @@ Module(
                                             range: 239..253,
                                             value: FStringValue {
                                                 inner: Single(
-                                                    FString(
-                                                        FString {
-                                                            range: 239..253,
-                                                            node_index: NodeIndex(None),
-                                                            elements: [
-                                                                Interpolation(
-                                                                    InterpolatedElement {
-                                                                        range: 243..250,
-                                                                        node_index: NodeIndex(None),
-                                                                        expression: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 244..245,
-                                                                                id: Name("x"),
-                                                                                ctx: Load,
-                                                                            },
-                                                                        ),
-                                                                        debug_text: None,
-                                                                        conversion: None,
-                                                                        format_spec: Some(
-                                                                            InterpolatedStringFormatSpec {
-                                                                                range: 246..250,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Literal(
-                                                                                        InterpolatedStringLiteralElement {
-                                                                                            range: 246..250,
-                                                                                            node_index: NodeIndex(None),
-                                                                                            value: ".3f\n",
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            flags: FStringFlags {
-                                                                quote_style: Single,
-                                                                prefix: Regular,
-                                                                triple_quoted: true,
-                                                                unclosed: false,
-                                                            },
+                                                    FString {
+                                                        range: 239..253,
+                                                        node_index: NodeIndex(None),
+                                                        elements: [
+                                                            Interpolation(
+                                                                InterpolatedElement {
+                                                                    range: 243..250,
+                                                                    node_index: NodeIndex(None),
+                                                                    expression: Name(
+                                                                        ExprName {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 244..245,
+                                                                            id: Name("x"),
+                                                                            ctx: Load,
+                                                                        },
+                                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: Some(
+                                                                        InterpolatedStringFormatSpec {
+                                                                            range: 246..250,
+                                                                            node_index: NodeIndex(None),
+                                                                            elements: [
+                                                                                Literal(
+                                                                                    InterpolatedStringLiteralElement {
+                                                                                        range: 246..250,
+                                                                                        node_index: NodeIndex(None),
+                                                                                        value: ".3f\n",
+                                                                                    },
+                                                                                ),
+                                                                            ],
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                        ],
+                                                        flags: FStringFlags {
+                                                            quote_style: Single,
+                                                            prefix: Regular,
+                                                            triple_quoted: true,
+                                                            unclosed: false,
                                                         },
-                                                    ),
+                                                    },
                                                 ),
                                             },
                                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@re_lexing__ty_1828.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/invalid/re_lexing/ty_1828.py
 ---
 ## AST
 
@@ -54,43 +55,41 @@ Module(
                                                     range: 78..85,
                                                     value: FStringValue {
                                                         inner: Single(
-                                                            FString(
-                                                                FString {
-                                                                    range: 78..85,
-                                                                    node_index: NodeIndex(None),
-                                                                    elements: [
-                                                                        Interpolation(
-                                                                            InterpolatedElement {
-                                                                                range: 82..85,
-                                                                                node_index: NodeIndex(None),
-                                                                                expression: Name(
-                                                                                    ExprName {
-                                                                                        node_index: NodeIndex(None),
-                                                                                        range: 83..84,
-                                                                                        id: Name("d"),
-                                                                                        ctx: Load,
-                                                                                    },
-                                                                                ),
-                                                                                debug_text: Some(
-                                                                                    DebugText {
-                                                                                        leading: "",
-                                                                                        expression: "d",
-                                                                                        trailing: "=",
-                                                                                    },
-                                                                                ),
-                                                                                conversion: None,
-                                                                                format_spec: None,
-                                                                            },
-                                                                        ),
-                                                                    ],
-                                                                    flags: FStringFlags {
-                                                                        quote_style: Double,
-                                                                        prefix: Regular,
-                                                                        triple_quoted: true,
-                                                                        unclosed: true,
-                                                                    },
+                                                            FString {
+                                                                range: 78..85,
+                                                                node_index: NodeIndex(None),
+                                                                elements: [
+                                                                    Interpolation(
+                                                                        InterpolatedElement {
+                                                                            range: 82..85,
+                                                                            node_index: NodeIndex(None),
+                                                                            expression: Name(
+                                                                                ExprName {
+                                                                                    node_index: NodeIndex(None),
+                                                                                    range: 83..84,
+                                                                                    id: Name("d"),
+                                                                                    ctx: Load,
+                                                                                },
+                                                                            ),
+                                                                            debug_text: Some(
+                                                                                DebugText {
+                                                                                    leading: "",
+                                                                                    expression: "d",
+                                                                                    trailing: "=",
+                                                                                },
+                                                                            ),
+                                                                            conversion: None,
+                                                                            format_spec: None,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                flags: FStringFlags {
+                                                                    quote_style: Double,
+                                                                    prefix: Regular,
+                                                                    triple_quoted: true,
+                                                                    unclosed: true,
                                                                 },
-                                                            ),
+                                                            },
                                                         ),
                                                     },
                                                 },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_assignment_targets.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_assignment_targets.py.snap
@@ -891,37 +891,35 @@ Module(
                                 range: 576..585,
                                 value: FStringValue {
                                     inner: Single(
-                                        FString(
-                                            FString {
-                                                range: 576..585,
-                                                node_index: NodeIndex(None),
-                                                elements: [
-                                                    Interpolation(
-                                                        InterpolatedElement {
-                                                            range: 578..584,
-                                                            node_index: NodeIndex(None),
-                                                            expression: Name(
-                                                                ExprName {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 579..583,
-                                                                    id: Name("quux"),
-                                                                    ctx: Load,
-                                                                },
-                                                            ),
-                                                            debug_text: None,
-                                                            conversion: None,
-                                                            format_spec: None,
-                                                        },
-                                                    ),
-                                                ],
-                                                flags: FStringFlags {
-                                                    quote_style: Double,
-                                                    prefix: Regular,
-                                                    triple_quoted: false,
-                                                    unclosed: false,
-                                                },
+                                        FString {
+                                            range: 576..585,
+                                            node_index: NodeIndex(None),
+                                            elements: [
+                                                Interpolation(
+                                                    InterpolatedElement {
+                                                        range: 578..584,
+                                                        node_index: NodeIndex(None),
+                                                        expression: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 579..583,
+                                                                id: Name("quux"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                                unclosed: false,
                                             },
-                                        ),
+                                        },
                                     ),
                                 },
                             },
@@ -949,61 +947,59 @@ Module(
                                 range: 591..609,
                                 value: FStringValue {
                                     inner: Single(
-                                        FString(
-                                            FString {
-                                                range: 591..609,
-                                                node_index: NodeIndex(None),
-                                                elements: [
-                                                    Interpolation(
-                                                        InterpolatedElement {
-                                                            range: 593..598,
-                                                            node_index: NodeIndex(None),
-                                                            expression: Name(
-                                                                ExprName {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 594..597,
-                                                                    id: Name("foo"),
-                                                                    ctx: Load,
-                                                                },
-                                                            ),
-                                                            debug_text: None,
-                                                            conversion: None,
-                                                            format_spec: None,
-                                                        },
-                                                    ),
-                                                    Literal(
-                                                        InterpolatedStringLiteralElement {
-                                                            range: 598..603,
-                                                            node_index: NodeIndex(None),
-                                                            value: " and ",
-                                                        },
-                                                    ),
-                                                    Interpolation(
-                                                        InterpolatedElement {
-                                                            range: 603..608,
-                                                            node_index: NodeIndex(None),
-                                                            expression: Name(
-                                                                ExprName {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 604..607,
-                                                                    id: Name("bar"),
-                                                                    ctx: Load,
-                                                                },
-                                                            ),
-                                                            debug_text: None,
-                                                            conversion: None,
-                                                            format_spec: None,
-                                                        },
-                                                    ),
-                                                ],
-                                                flags: FStringFlags {
-                                                    quote_style: Double,
-                                                    prefix: Regular,
-                                                    triple_quoted: false,
-                                                    unclosed: false,
-                                                },
+                                        FString {
+                                            range: 591..609,
+                                            node_index: NodeIndex(None),
+                                            elements: [
+                                                Interpolation(
+                                                    InterpolatedElement {
+                                                        range: 593..598,
+                                                        node_index: NodeIndex(None),
+                                                        expression: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 594..597,
+                                                                id: Name("foo"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                                Literal(
+                                                    InterpolatedStringLiteralElement {
+                                                        range: 598..603,
+                                                        node_index: NodeIndex(None),
+                                                        value: " and ",
+                                                    },
+                                                ),
+                                                Interpolation(
+                                                    InterpolatedElement {
+                                                        range: 603..608,
+                                                        node_index: NodeIndex(None),
+                                                        expression: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 604..607,
+                                                                id: Name("bar"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        debug_text: None,
+                                                        conversion: None,
+                                                        format_spec: None,
+                                                    },
+                                                ),
+                                            ],
+                                            flags: FStringFlags {
+                                                quote_style: Double,
+                                                prefix: Regular,
+                                                triple_quoted: false,
+                                                unclosed: false,
                                             },
-                                        ),
+                                        },
                                     ),
                                 },
                             },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_assignment_targets.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_assignment_targets.py.snap
@@ -799,19 +799,19 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 549..558,
-                                left: Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 549..550,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
                                 ops: [
                                     Lt,
                                     Lt,
                                 ],
-                                comparators: [
+                                operands: [
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 549..550,
+                                            id: Name("a"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                     Name(
                                         ExprName {
                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_augmented_assignment_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_augmented_assignment_target.py.snap
@@ -787,37 +787,35 @@ Module(
                             range: 387..396,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 387..396,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 389..395,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 390..394,
-                                                                id: Name("quux"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 387..396,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 389..395,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 390..394,
+                                                            id: Name("quux"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -844,61 +842,59 @@ Module(
                             range: 403..421,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 403..421,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 405..410,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 406..409,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 410..415,
-                                                        node_index: NodeIndex(None),
-                                                        value: " and ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 415..420,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 416..419,
-                                                                id: Name("bar"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 403..421,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 405..410,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 406..409,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 410..415,
+                                                    node_index: NodeIndex(None),
+                                                    value: " and ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 415..420,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 416..419,
+                                                            id: Name("bar"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_augmented_assignment_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_augmented_assignment_target.py.snap
@@ -697,19 +697,19 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 358..367,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 358..359,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Lt,
                                 Lt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 358..359,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@unterminated_fstring_newline_recovery.py.snap
@@ -20,27 +20,25 @@ Module(
                             range: 0..7,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..7,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 2..7,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: true,
-                                            },
+                                    FString {
+                                        range: 0..7,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 2..7,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: true,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -88,44 +86,42 @@ Module(
                             range: 14..24,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 14..24,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 16..22,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 22..24,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 23..24,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: true,
-                                            },
+                                    FString {
+                                        range: 14..24,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 16..22,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 22..24,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 23..24,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: true,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -173,50 +169,48 @@ Module(
                             range: 31..42,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 31..42,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 33..39,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 39..42,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 40..41,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 42..42,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: true,
-                                            },
+                                    FString {
+                                        range: 31..42,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 33..39,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 39..42,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 40..41,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 42..42,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: true,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -264,44 +258,42 @@ Module(
                             range: 49..60,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 49..60,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 51..57,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 57..60,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 58..59,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: true,
-                                            },
+                                    FString {
+                                        range: 49..60,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 51..57,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 57..60,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 58..59,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: true,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@while_stmt_missing_colon.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@while_stmt_missing_colon.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 12..18,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 12..13,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Lt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 12..13,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@ambiguous_lpar_with_items_binary_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@ambiguous_lpar_with_items_binary_expr.py.snap
@@ -76,18 +76,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 149..161,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 150..151,
-                                            id: Name("a"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         IsNot,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 150..151,
+                                                id: Name("a"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__await.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__await.py.snap
@@ -341,25 +341,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 108..120,
-                            left: Await(
-                                ExprAwait {
-                                    node_index: NodeIndex(None),
-                                    range: 108..115,
-                                    value: NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 114..115,
-                                            value: Int(
-                                                1,
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ),
                             ops: [
                                 Eq,
                             ],
-                            comparators: [
+                            operands: [
+                                Await(
+                                    ExprAwait {
+                                        node_index: NodeIndex(None),
+                                        range: 108..115,
+                                        value: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 114..115,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
+                                    },
+                                ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__compare.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__compare.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 9..15,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 9..10,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Eq,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 9..10,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -51,18 +51,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 16..21,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 16..17,
-                                    id: Name("b"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Lt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 16..17,
+                                        id: Name("b"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -84,18 +84,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 22..27,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 22..23,
-                                    id: Name("b"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Gt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 22..23,
+                                        id: Name("b"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -117,18 +117,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 28..34,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 28..29,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 GtE,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 28..29,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -150,18 +150,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 35..41,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 35..36,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 LtE,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 35..36,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -183,18 +183,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 42..48,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 42..43,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotEq,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 42..43,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -216,18 +216,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 49..55,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 49..50,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Is,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 49..50,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -249,18 +249,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 56..62,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 56..57,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 In,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 56..57,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -282,18 +282,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 63..73,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 63..64,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotIn,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 63..64,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -315,18 +315,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 74..84,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 74..75,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 IsNot,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 74..75,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -348,14 +348,6 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 110..156,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 110..111,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotIn,
                                 IsNot,
@@ -363,7 +355,15 @@ Module(
                                 NotIn,
                                 IsNot,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 110..111,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -417,34 +417,34 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 177..203,
-                            left: BinOp(
-                                ExprBinOp {
-                                    node_index: NodeIndex(None),
-                                    range: 177..182,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 177..178,
-                                            id: Name("a"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                    op: BitOr,
-                                    right: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 181..182,
-                                            id: Name("b"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                },
-                            ),
                             ops: [
                                 Lt,
                                 NotIn,
                             ],
-                            comparators: [
+                            operands: [
+                                BinOp(
+                                    ExprBinOp {
+                                        node_index: NodeIndex(None),
+                                        range: 177..182,
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 177..178,
+                                                id: Name("a"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        op: BitOr,
+                                        right: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 181..182,
+                                                id: Name("b"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                    },
+                                ),
                                 BinOp(
                                     ExprBinOp {
                                         node_index: NodeIndex(None),
@@ -509,18 +509,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 383..393,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 383..384,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         NotIn,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 383..384,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),
@@ -564,18 +564,18 @@ Module(
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 400..410,
-                                                    left: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 400..401,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
                                                     ops: [
                                                         NotIn,
                                                     ],
-                                                    comparators: [
+                                                    operands: [
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 400..401,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                         Name(
                                                             ExprName {
                                                                 node_index: NodeIndex(None),
@@ -611,18 +611,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 417..429,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 417..418,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Eq,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 417..418,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Await(
                                     ExprAwait {
                                         node_index: NodeIndex(None),
@@ -650,18 +650,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 430..446,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 430..431,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 IsNot,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 430..431,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Await(
                                     ExprAwait {
                                         node_index: NodeIndex(None),
@@ -689,14 +689,6 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 489..541,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 489..490,
-                                    id: Name("a"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Lt,
                                 Eq,
@@ -708,7 +700,15 @@ Module(
                                 GtE,
                                 NotEq,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 489..490,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__dictionary_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__dictionary_comprehension.py.snap
@@ -309,18 +309,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 98..104,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 98..99,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 98..99,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -488,18 +488,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 170..175,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 170..171,
-                                                        id: Name("k"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 170..171,
+                                                            id: Name("k"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -618,18 +618,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 225..230,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 225..226,
-                                                        id: Name("k"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 225..226,
+                                                            id: Name("k"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__f_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__f_string.py.snap
@@ -20,19 +20,17 @@ Module(
                             range: 18..21,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 18..21,
-                                            node_index: NodeIndex(None),
-                                            elements: [],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 18..21,
+                                        node_index: NodeIndex(None),
+                                        elements: [],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -49,19 +47,17 @@ Module(
                             range: 22..25,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 22..25,
-                                            node_index: NodeIndex(None),
-                                            elements: [],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 22..25,
+                                        node_index: NodeIndex(None),
+                                        elements: [],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -78,19 +74,17 @@ Module(
                             range: 26..29,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 26..29,
-                                            node_index: NodeIndex(None),
-                                            elements: [],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 26..29,
+                                        node_index: NodeIndex(None),
+                                        elements: [],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -107,19 +101,17 @@ Module(
                             range: 30..37,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 30..37,
-                                            node_index: NodeIndex(None),
-                                            elements: [],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 30..37,
+                                        node_index: NodeIndex(None),
+                                        elements: [],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -136,19 +128,17 @@ Module(
                             range: 38..45,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 38..45,
-                                            node_index: NodeIndex(None),
-                                            elements: [],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 38..45,
+                                        node_index: NodeIndex(None),
+                                        elements: [],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -165,50 +155,48 @@ Module(
                             range: 47..56,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 47..56,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 49..55,
-                                                        node_index: NodeIndex(None),
-                                                        expression: StringLiteral(
-                                                            ExprStringLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 50..54,
-                                                                value: StringLiteralValue {
-                                                                    inner: Single(
-                                                                        StringLiteral {
-                                                                            range: 50..54,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: " f",
-                                                                            flags: StringLiteralFlags {
-                                                                                quote_style: Double,
-                                                                                prefix: Empty,
-                                                                                triple_quoted: false,
-                                                                                unclosed: false,
-                                                                            },
+                                    FString {
+                                        range: 47..56,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 49..55,
+                                                    node_index: NodeIndex(None),
+                                                    expression: StringLiteral(
+                                                        ExprStringLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 50..54,
+                                                            value: StringLiteralValue {
+                                                                inner: Single(
+                                                                    StringLiteral {
+                                                                        range: 50..54,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: " f",
+                                                                        flags: StringLiteralFlags {
+                                                                            quote_style: Double,
+                                                                            prefix: Empty,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
                                                                         },
-                                                                    ),
-                                                                },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -225,37 +213,35 @@ Module(
                             range: 57..67,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 57..67,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 59..66,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 60..63,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: Str,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 57..67,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 59..66,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 60..63,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: Str,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -272,48 +258,46 @@ Module(
                             range: 68..75,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 68..75,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 70..74,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Tuple(
-                                                            ExprTuple {
-                                                                node_index: NodeIndex(None),
-                                                                range: 71..73,
-                                                                elts: [
-                                                                    NumberLiteral(
-                                                                        ExprNumberLiteral {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 71..72,
-                                                                            value: Int(
-                                                                                3,
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                                ctx: Load,
-                                                                parenthesized: false,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 68..75,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 70..74,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Tuple(
+                                                        ExprTuple {
+                                                            node_index: NodeIndex(None),
+                                                            range: 71..73,
+                                                            elts: [
+                                                                NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 71..72,
+                                                                        value: Int(
+                                                                            3,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            ctx: Load,
+                                                            parenthesized: false,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -330,64 +314,62 @@ Module(
                             range: 76..86,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 76..86,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 78..85,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Compare(
-                                                            ExprCompare {
-                                                                node_index: NodeIndex(None),
-                                                                range: 79..83,
-                                                                ops: [
-                                                                    NotEq,
-                                                                ],
-                                                                operands: [
-                                                                    NumberLiteral(
-                                                                        ExprNumberLiteral {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 79..80,
-                                                                            value: Int(
-                                                                                3,
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    NumberLiteral(
-                                                                        ExprNumberLiteral {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 82..83,
-                                                                            value: Int(
-                                                                                4,
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 84..84,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 76..86,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 78..85,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Compare(
+                                                        ExprCompare {
+                                                            node_index: NodeIndex(None),
+                                                            range: 79..83,
+                                                            ops: [
+                                                                NotEq,
+                                                            ],
+                                                            operands: [
+                                                                NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 79..80,
+                                                                        value: Int(
+                                                                            3,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 82..83,
+                                                                        value: Int(
+                                                                            4,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 84..84,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -404,82 +386,80 @@ Module(
                             range: 87..102,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 87..102,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 89..101,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 90..91,
-                                                                value: Int(
-                                                                    3,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 92..100,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Interpolation(
-                                                                        InterpolatedElement {
-                                                                            range: 92..97,
-                                                                            node_index: NodeIndex(None),
-                                                                            expression: StringLiteral(
-                                                                                ExprStringLiteral {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 93..96,
-                                                                                    value: StringLiteralValue {
-                                                                                        inner: Single(
-                                                                                            StringLiteral {
-                                                                                                range: 93..96,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "}",
-                                                                                                flags: StringLiteralFlags {
-                                                                                                    quote_style: Double,
-                                                                                                    prefix: Empty,
-                                                                                                    triple_quoted: false,
-                                                                                                    unclosed: false,
-                                                                                                },
+                                    FString {
+                                        range: 87..102,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 89..101,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 90..91,
+                                                            value: Int(
+                                                                3,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 92..100,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Interpolation(
+                                                                    InterpolatedElement {
+                                                                        range: 92..97,
+                                                                        node_index: NodeIndex(None),
+                                                                        expression: StringLiteral(
+                                                                            ExprStringLiteral {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 93..96,
+                                                                                value: StringLiteralValue {
+                                                                                    inner: Single(
+                                                                                        StringLiteral {
+                                                                                            range: 93..96,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "}",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Double,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                                unclosed: false,
                                                                                             },
-                                                                                        ),
-                                                                                    },
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            ),
-                                                                            debug_text: None,
-                                                                            conversion: None,
-                                                                            format_spec: None,
-                                                                        },
-                                                                    ),
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 97..100,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ">10",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            },
+                                                                        ),
+                                                                        debug_text: None,
+                                                                        conversion: None,
+                                                                        format_spec: None,
+                                                                    },
+                                                                ),
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 97..100,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ">10",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -496,82 +476,80 @@ Module(
                             range: 103..118,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 103..118,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 105..117,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 106..107,
-                                                                value: Int(
-                                                                    3,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 108..116,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Interpolation(
-                                                                        InterpolatedElement {
-                                                                            range: 108..113,
-                                                                            node_index: NodeIndex(None),
-                                                                            expression: StringLiteral(
-                                                                                ExprStringLiteral {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 109..112,
-                                                                                    value: StringLiteralValue {
-                                                                                        inner: Single(
-                                                                                            StringLiteral {
-                                                                                                range: 109..112,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "{",
-                                                                                                flags: StringLiteralFlags {
-                                                                                                    quote_style: Double,
-                                                                                                    prefix: Empty,
-                                                                                                    triple_quoted: false,
-                                                                                                    unclosed: false,
-                                                                                                },
+                                    FString {
+                                        range: 103..118,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 105..117,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 106..107,
+                                                            value: Int(
+                                                                3,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 108..116,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Interpolation(
+                                                                    InterpolatedElement {
+                                                                        range: 108..113,
+                                                                        node_index: NodeIndex(None),
+                                                                        expression: StringLiteral(
+                                                                            ExprStringLiteral {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 109..112,
+                                                                                value: StringLiteralValue {
+                                                                                    inner: Single(
+                                                                                        StringLiteral {
+                                                                                            range: 109..112,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "{",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Double,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                                unclosed: false,
                                                                                             },
-                                                                                        ),
-                                                                                    },
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            ),
-                                                                            debug_text: None,
-                                                                            conversion: None,
-                                                                            format_spec: None,
-                                                                        },
-                                                                    ),
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 113..116,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ">10",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            },
+                                                                        ),
+                                                                        debug_text: None,
+                                                                        conversion: None,
+                                                                        format_spec: None,
+                                                                    },
+                                                                ),
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 113..116,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ">10",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -588,43 +566,41 @@ Module(
                             range: 119..133,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 119..133,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 121..132,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 124..127,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "  ",
-                                                                expression: "foo",
-                                                                trailing: " =  ",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 119..133,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 121..132,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 124..127,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "  ",
+                                                            expression: "foo",
+                                                            trailing: " =  ",
+                                                        },
+                                                    ),
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -641,57 +617,55 @@ Module(
                             range: 134..154,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 134..154,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 136..153,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 139..142,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "  ",
-                                                                expression: "foo",
-                                                                trailing: " =  ",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 147..152,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 147..152,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ".3f  ",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 134..154,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 136..153,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 139..142,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "  ",
+                                                            expression: "foo",
+                                                            trailing: " =  ",
+                                                        },
+                                                    ),
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 147..152,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 147..152,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ".3f  ",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -708,43 +682,41 @@ Module(
                             range: 155..173,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 155..173,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 157..172,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 160..163,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "  ",
-                                                                expression: "foo",
-                                                                trailing: " =  ",
-                                                            },
-                                                        ),
-                                                        conversion: Str,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 155..173,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 157..172,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 160..163,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "  ",
+                                                            expression: "foo",
+                                                            trailing: " =  ",
+                                                        },
+                                                    ),
+                                                    conversion: Str,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -761,63 +733,61 @@ Module(
                             range: 174..190,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 174..190,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 176..189,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Tuple(
-                                                            ExprTuple {
-                                                                node_index: NodeIndex(None),
-                                                                range: 179..183,
-                                                                elts: [
-                                                                    NumberLiteral(
-                                                                        ExprNumberLiteral {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 179..180,
-                                                                            value: Int(
-                                                                                1,
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                    NumberLiteral(
-                                                                        ExprNumberLiteral {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 182..183,
-                                                                            value: Int(
-                                                                                2,
-                                                                            ),
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                                ctx: Load,
-                                                                parenthesized: false,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "  ",
-                                                                expression: "1, 2",
-                                                                trailing: "  =  ",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 174..190,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 176..189,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Tuple(
+                                                        ExprTuple {
+                                                            node_index: NodeIndex(None),
+                                                            range: 179..183,
+                                                            elts: [
+                                                                NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 179..180,
+                                                                        value: Int(
+                                                                            1,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 182..183,
+                                                                        value: Int(
+                                                                            2,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            ctx: Load,
+                                                            parenthesized: false,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "  ",
+                                                            expression: "1, 2",
+                                                            trailing: "  =  ",
+                                                        },
+                                                    ),
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -834,105 +804,101 @@ Module(
                             range: 191..217,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 191..217,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 193..216,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 194..210,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 194..210,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 196..209,
+                                    FString {
+                                        range: 191..217,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 193..216,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 194..210,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 194..210,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 196..209,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: NumberLiteral(
+                                                                                        ExprNumberLiteral {
                                                                                             node_index: NodeIndex(None),
-                                                                                            expression: NumberLiteral(
-                                                                                                ExprNumberLiteral {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 197..203,
-                                                                                                    value: Float(
-                                                                                                        3.1415,
-                                                                                                    ),
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: Some(
-                                                                                                DebugText {
-                                                                                                    leading: "",
-                                                                                                    expression: "3.1415",
-                                                                                                    trailing: "=",
-                                                                                                },
-                                                                                            ),
-                                                                                            conversion: None,
-                                                                                            format_spec: Some(
-                                                                                                InterpolatedStringFormatSpec {
-                                                                                                    range: 205..208,
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    elements: [
-                                                                                                        Literal(
-                                                                                                            InterpolatedStringLiteralElement {
-                                                                                                                range: 205..208,
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                value: ".1f",
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ],
-                                                                                                },
+                                                                                            range: 197..203,
+                                                                                            value: Float(
+                                                                                                3.1415,
                                                                                             ),
                                                                                         },
                                                                                     ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Double,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: false,
-                                                                                    unclosed: false,
+                                                                                    debug_text: Some(
+                                                                                        DebugText {
+                                                                                            leading: "",
+                                                                                            expression: "3.1415",
+                                                                                            trailing: "=",
+                                                                                        },
+                                                                                    ),
+                                                                                    conversion: None,
+                                                                                    format_spec: Some(
+                                                                                        InterpolatedStringFormatSpec {
+                                                                                            range: 205..208,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            elements: [
+                                                                                                Literal(
+                                                                                                    InterpolatedStringLiteralElement {
+                                                                                                        range: 205..208,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        value: ".1f",
+                                                                                                    },
+                                                                                                ),
+                                                                                            ],
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 211..215,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 211..215,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "*^20",
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Double,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
                                                                         },
-                                                                    ),
-                                                                ],
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 211..215,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 211..215,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "*^20",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1186,82 +1152,80 @@ Module(
                             range: 347..364,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 347..364,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 349..350,
-                                                        node_index: NodeIndex(None),
-                                                        value: "\\",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 350..355,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 351..354,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 355..356,
-                                                        node_index: NodeIndex(None),
-                                                        value: "\\",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 356..363,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 357..360,
-                                                                id: Name("bar"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 361..362,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 361..362,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "\\",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 347..364,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 349..350,
+                                                    node_index: NodeIndex(None),
+                                                    value: "\\",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 350..355,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 351..354,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 355..356,
+                                                    node_index: NodeIndex(None),
+                                                    value: "\\",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 356..363,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 357..360,
+                                                            id: Name("bar"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 361..362,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 361..362,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "\\",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1278,27 +1242,25 @@ Module(
                             range: 365..379,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 365..379,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 367..378,
-                                                        node_index: NodeIndex(None),
-                                                        value: "\\{foo\\}",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 365..379,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 367..378,
+                                                    node_index: NodeIndex(None),
+                                                    value: "\\{foo\\}",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1315,51 +1277,49 @@ Module(
                             range: 380..420,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 380..420,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 384..417,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 390..393,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 394..416,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 394..416,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "x\n        y\n        z\n",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 380..420,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 384..417,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 390..393,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 394..416,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 394..416,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "x\n        y\n        z\n",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1376,43 +1336,41 @@ Module(
                             range: 421..439,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 421..439,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 423..438,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 428..431,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: " (  ",
-                                                                expression: "foo",
-                                                                trailing: " )  = ",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 421..439,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 423..438,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 428..431,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: " (  ",
+                                                            expression: "foo",
+                                                            trailing: " )  = ",
+                                                        },
+                                                    ),
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1429,99 +1387,97 @@ Module(
                             range: 441..486,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 441..486,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 443..450,
-                                                        node_index: NodeIndex(None),
-                                                        value: "normal ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 450..455,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 451..454,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 455..468,
-                                                        node_index: NodeIndex(None),
-                                                        value: " {another} ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 468..473,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 469..472,
-                                                                id: Name("bar"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 473..476,
-                                                        node_index: NodeIndex(None),
-                                                        value: " {",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 476..483,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 477..482,
-                                                                id: Name("three"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 483..485,
-                                                        node_index: NodeIndex(None),
-                                                        value: "}",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 441..486,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 443..450,
+                                                    node_index: NodeIndex(None),
+                                                    value: "normal ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 450..455,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 451..454,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 455..468,
+                                                    node_index: NodeIndex(None),
+                                                    value: " {another} ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 468..473,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 469..472,
+                                                            id: Name("bar"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 473..476,
+                                                    node_index: NodeIndex(None),
+                                                    value: " {",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 476..483,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 477..482,
+                                                            id: Name("three"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 483..485,
+                                                    node_index: NodeIndex(None),
+                                                    value: "}",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1538,116 +1494,114 @@ Module(
                             range: 487..529,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 487..529,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 489..496,
-                                                        node_index: NodeIndex(None),
-                                                        value: "normal ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 496..503,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 497..500,
-                                                                id: Name("foo"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: Ascii,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 503..504,
-                                                        node_index: NodeIndex(None),
-                                                        value: " ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 504..511,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 505..508,
-                                                                id: Name("bar"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: Str,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 511..512,
-                                                        node_index: NodeIndex(None),
-                                                        value: " ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 512..519,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 513..516,
-                                                                id: Name("baz"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: Repr,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 519..520,
-                                                        node_index: NodeIndex(None),
-                                                        value: " ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 520..528,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 521..527,
-                                                                id: Name("foobar"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 487..529,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 489..496,
+                                                    node_index: NodeIndex(None),
+                                                    value: "normal ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 496..503,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 497..500,
+                                                            id: Name("foo"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: Ascii,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 503..504,
+                                                    node_index: NodeIndex(None),
+                                                    value: " ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 504..511,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 505..508,
+                                                            id: Name("bar"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: Str,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 511..512,
+                                                    node_index: NodeIndex(None),
+                                                    value: " ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 512..519,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 513..516,
+                                                            id: Name("baz"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: Repr,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 519..520,
+                                                    node_index: NodeIndex(None),
+                                                    value: " ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 520..528,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 521..527,
+                                                            id: Name("foobar"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1664,58 +1618,56 @@ Module(
                             range: 530..549,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 530..549,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 532..539,
-                                                        node_index: NodeIndex(None),
-                                                        value: "normal ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 539..548,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 540..541,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 542..547,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 542..547,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "y + 2",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 530..549,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 532..539,
+                                                    node_index: NodeIndex(None),
+                                                    value: "normal ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 539..548,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 540..541,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 542..547,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 542..547,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "y + 2",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1732,94 +1684,92 @@ Module(
                             range: 550..568,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 550..568,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 552..567,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 553..554,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 555..566,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Interpolation(
-                                                                        InterpolatedElement {
-                                                                            range: 555..566,
-                                                                            node_index: NodeIndex(None),
-                                                                            expression: Call(
-                                                                                ExprCall {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 556..565,
-                                                                                    func: Attribute(
-                                                                                        ExprAttribute {
-                                                                                            node_index: NodeIndex(None),
-                                                                                            range: 556..563,
-                                                                                            value: Set(
-                                                                                                ExprSet {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 556..559,
-                                                                                                    elts: [
-                                                                                                        NumberLiteral(
-                                                                                                            ExprNumberLiteral {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 557..558,
-                                                                                                                value: Int(
-                                                                                                                    1,
-                                                                                                                ),
-                                                                                                            },
-                                                                                                        ),
-                                                                                                    ],
-                                                                                                },
-                                                                                            ),
-                                                                                            attr: Identifier {
-                                                                                                id: Name("pop"),
-                                                                                                range: 560..563,
-                                                                                                node_index: NodeIndex(None),
-                                                                                            },
-                                                                                            ctx: Load,
-                                                                                        },
-                                                                                    ),
-                                                                                    arguments: Arguments {
-                                                                                        range: 563..565,
+                                    FString {
+                                        range: 550..568,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 552..567,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 553..554,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 555..566,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Interpolation(
+                                                                    InterpolatedElement {
+                                                                        range: 555..566,
+                                                                        node_index: NodeIndex(None),
+                                                                        expression: Call(
+                                                                            ExprCall {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 556..565,
+                                                                                func: Attribute(
+                                                                                    ExprAttribute {
                                                                                         node_index: NodeIndex(None),
-                                                                                        args: [],
-                                                                                        keywords: [],
+                                                                                        range: 556..563,
+                                                                                        value: Set(
+                                                                                            ExprSet {
+                                                                                                node_index: NodeIndex(None),
+                                                                                                range: 556..559,
+                                                                                                elts: [
+                                                                                                    NumberLiteral(
+                                                                                                        ExprNumberLiteral {
+                                                                                                            node_index: NodeIndex(None),
+                                                                                                            range: 557..558,
+                                                                                                            value: Int(
+                                                                                                                1,
+                                                                                                            ),
+                                                                                                        },
+                                                                                                    ),
+                                                                                                ],
+                                                                                            },
+                                                                                        ),
+                                                                                        attr: Identifier {
+                                                                                            id: Name("pop"),
+                                                                                            range: 560..563,
+                                                                                            node_index: NodeIndex(None),
+                                                                                        },
+                                                                                        ctx: Load,
                                                                                     },
+                                                                                ),
+                                                                                arguments: Arguments {
+                                                                                    range: 563..565,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    args: [],
+                                                                                    keywords: [],
                                                                                 },
-                                                                            ),
-                                                                            debug_text: None,
-                                                                            conversion: None,
-                                                                            format_spec: None,
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            },
+                                                                        ),
+                                                                        debug_text: None,
+                                                                        conversion: None,
+                                                                        format_spec: None,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1836,78 +1786,76 @@ Module(
                             range: 569..588,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 569..588,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 571..587,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Lambda(
-                                                            ExprLambda {
-                                                                node_index: NodeIndex(None),
-                                                                range: 573..585,
-                                                                parameters: Some(
-                                                                    Parameters {
-                                                                        range: 580..581,
-                                                                        node_index: NodeIndex(None),
-                                                                        posonlyargs: [],
-                                                                        args: [
-                                                                            ParameterWithDefault {
+                                    FString {
+                                        range: 569..588,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 571..587,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Lambda(
+                                                        ExprLambda {
+                                                            node_index: NodeIndex(None),
+                                                            range: 573..585,
+                                                            parameters: Some(
+                                                                Parameters {
+                                                                    range: 580..581,
+                                                                    node_index: NodeIndex(None),
+                                                                    posonlyargs: [],
+                                                                    args: [
+                                                                        ParameterWithDefault {
+                                                                            range: 580..581,
+                                                                            node_index: NodeIndex(None),
+                                                                            parameter: Parameter {
                                                                                 range: 580..581,
                                                                                 node_index: NodeIndex(None),
-                                                                                parameter: Parameter {
+                                                                                name: Identifier {
+                                                                                    id: Name("x"),
                                                                                     range: 580..581,
                                                                                     node_index: NodeIndex(None),
-                                                                                    name: Identifier {
-                                                                                        id: Name("x"),
-                                                                                        range: 580..581,
-                                                                                        node_index: NodeIndex(None),
-                                                                                    },
-                                                                                    annotation: None,
                                                                                 },
-                                                                                default: None,
+                                                                                annotation: None,
                                                                             },
-                                                                        ],
-                                                                        vararg: None,
-                                                                        kwonlyargs: [],
-                                                                        kwarg: None,
-                                                                    },
-                                                                ),
-                                                                body: Set(
-                                                                    ExprSet {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 582..585,
-                                                                        elts: [
-                                                                            Name(
-                                                                                ExprName {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 583..584,
-                                                                                    id: Name("x"),
-                                                                                    ctx: Load,
-                                                                                },
-                                                                            ),
-                                                                        ],
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            default: None,
+                                                                        },
+                                                                    ],
+                                                                    vararg: None,
+                                                                    kwonlyargs: [],
+                                                                    kwarg: None,
+                                                                },
+                                                            ),
+                                                            body: Set(
+                                                                ExprSet {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 582..585,
+                                                                    elts: [
+                                                                        Name(
+                                                                            ExprName {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 583..584,
+                                                                                id: Name("x"),
+                                                                                ctx: Load,
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1924,43 +1872,41 @@ Module(
                             range: 589..597,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 589..597,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 591..596,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 592..593,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "",
-                                                                expression: "x",
-                                                                trailing: " =",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 589..597,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 591..596,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 592..593,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "",
+                                                            expression: "x",
+                                                            trailing: " =",
+                                                        },
+                                                    ),
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -1977,43 +1923,41 @@ Module(
                             range: 598..611,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 598..611,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 600..610,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 605..606,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "    ",
-                                                                expression: "x",
-                                                                trailing: " = ",
-                                                            },
-                                                        ),
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 598..611,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 600..610,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 605..606,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "    ",
+                                                            expression: "x",
+                                                            trailing: " = ",
+                                                        },
+                                                    ),
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -2030,43 +1974,41 @@ Module(
                             range: 612..621,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 612..621,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 614..620,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 615..616,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "",
-                                                                expression: "x",
-                                                                trailing: "=",
-                                                            },
-                                                        ),
-                                                        conversion: Ascii,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 612..621,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 614..620,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 615..616,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "",
+                                                            expression: "x",
+                                                            trailing: "=",
+                                                        },
+                                                    ),
+                                                    conversion: Ascii,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -2083,51 +2025,49 @@ Module(
                             range: 622..636,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 622..636,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 624..635,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 625..626,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 627..634,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 627..634,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ".3f!r =",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 622..636,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 624..635,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 625..626,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 627..634,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 627..634,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ".3f!r =",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -2144,57 +2084,55 @@ Module(
                             range: 637..653,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 637..653,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 639..652,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 640..641,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: Some(
-                                                            DebugText {
-                                                                leading: "",
-                                                                expression: "x",
-                                                                trailing: " = ",
-                                                            },
-                                                        ),
-                                                        conversion: Repr,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 648..651,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 648..651,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ".3f",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 637..653,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 639..652,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 640..641,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: Some(
+                                                        DebugText {
+                                                            leading: "",
+                                                            expression: "x",
+                                                            trailing: " = ",
+                                                        },
+                                                    ),
+                                                    conversion: Repr,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 648..651,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 648..651,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ".3f",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -2211,51 +2149,49 @@ Module(
                             range: 654..667,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 654..667,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 656..666,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 657..658,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 659..665,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 659..665,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ".3f=!r",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 654..667,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 656..666,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 657..658,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 659..665,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 659..665,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ".3f=!r",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -2476,69 +2412,67 @@ Module(
                             range: 712..756,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 712..756,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 714..739,
-                                                        node_index: NodeIndex(None),
-                                                        value: "Invalid args in command: ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 739..755,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Tuple(
-                                                            ExprTuple {
-                                                                node_index: NodeIndex(None),
-                                                                range: 740..754,
-                                                                elts: [
-                                                                    Name(
-                                                                        ExprName {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 740..747,
-                                                                            id: Name("command"),
-                                                                            ctx: Load,
-                                                                        },
-                                                                    ),
-                                                                    Starred(
-                                                                        ExprStarred {
-                                                                            node_index: NodeIndex(None),
-                                                                            range: 749..754,
-                                                                            value: Name(
-                                                                                ExprName {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 750..754,
-                                                                                    id: Name("args"),
-                                                                                    ctx: Load,
-                                                                                },
-                                                                            ),
-                                                                            ctx: Load,
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                                ctx: Load,
-                                                                parenthesized: false,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 712..756,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 714..739,
+                                                    node_index: NodeIndex(None),
+                                                    value: "Invalid args in command: ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 739..755,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Tuple(
+                                                        ExprTuple {
+                                                            node_index: NodeIndex(None),
+                                                            range: 740..754,
+                                                            elts: [
+                                                                Name(
+                                                                    ExprName {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 740..747,
+                                                                        id: Name("command"),
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                                Starred(
+                                                                    ExprStarred {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 749..754,
+                                                                        value: Name(
+                                                                            ExprName {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 750..754,
+                                                                                id: Name("args"),
+                                                                                ctx: Load,
+                                                                            },
+                                                                        ),
+                                                                        ctx: Load,
+                                                                    },
+                                                                ),
+                                                            ],
+                                                            ctx: Load,
+                                                            parenthesized: false,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__f_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__f_string.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/valid/expressions/f_string.py
 ---
 ## AST
 
@@ -342,19 +343,19 @@ Module(
                                                             ExprCompare {
                                                                 node_index: NodeIndex(None),
                                                                 range: 79..83,
-                                                                left: NumberLiteral(
-                                                                    ExprNumberLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 79..80,
-                                                                        value: Int(
-                                                                            3,
-                                                                        ),
-                                                                    },
-                                                                ),
                                                                 ops: [
                                                                     NotEq,
                                                                 ],
-                                                                comparators: [
+                                                                operands: [
+                                                                    NumberLiteral(
+                                                                        ExprNumberLiteral {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 79..80,
+                                                                            value: Int(
+                                                                                3,
+                                                                            ),
+                                                                        },
+                                                                    ),
                                                                     NumberLiteral(
                                                                         ExprNumberLiteral {
                                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__generator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__generator.py.snap
@@ -141,18 +141,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 77..83,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 77..78,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 77..78,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -295,18 +295,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 160..165,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 160..161,
-                                                        id: Name("a"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 160..161,
+                                                            id: Name("a"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -416,18 +416,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 232..237,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 232..233,
-                                                        id: Name("a"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 232..233,
+                                                            id: Name("a"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__if.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__if.py.snap
@@ -161,19 +161,19 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 71..76,
-                                    left: NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 71..72,
-                                            value: Int(
-                                                1,
-                                            ),
-                                        },
-                                    ),
                                     ops: [
                                         Lt,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        NumberLiteral(
+                                            ExprNumberLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 71..72,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
                                         NumberLiteral(
                                             ExprNumberLiteral {
                                                 node_index: NodeIndex(None),
@@ -302,18 +302,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 109..115,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 109..110,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         LtE,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 109..110,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
@@ -932,18 +932,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 385..395,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 385..389,
-                                                id: Name("item"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             In,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 385..389,
+                                                    id: Name("item"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             Name(
                                                 ExprName {
                                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list_comprehension.py.snap
@@ -200,18 +200,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 67..73,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 67..68,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 67..68,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -353,18 +353,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 131..136,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 131..132,
-                                                        id: Name("k"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 131..132,
+                                                            id: Name("k"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -473,18 +473,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 183..188,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 183..184,
-                                                        id: Name("k"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 183..184,
+                                                            id: Name("k"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -537,18 +537,18 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 202..208,
-                                            left: Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 202..203,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
                                             ops: [
                                                 In,
                                             ],
-                                            comparators: [
+                                            operands: [
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 202..203,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                                 Name(
                                                     ExprName {
                                                         node_index: NodeIndex(None),
@@ -745,18 +745,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 281..299,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 281..287,
-                                                        id: Name("entity"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     IsNot,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 281..287,
+                                                            id: Name("entity"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     NoneLiteral(
                                                         ExprNoneLiteral {
                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__set_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__set_comprehension.py.snap
@@ -95,18 +95,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 33..39,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 33..34,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     In,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 33..34,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -248,18 +248,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 97..102,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 97..98,
-                                                        id: Name("k"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 97..98,
+                                                            id: Name("k"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),
@@ -368,18 +368,18 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 149..154,
-                                                left: Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 149..150,
-                                                        id: Name("k"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
                                                 ops: [
                                                     Gt,
                                                 ],
-                                                comparators: [
+                                                operands: [
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 149..150,
+                                                            id: Name("k"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                     Name(
                                                         ExprName {
                                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__t_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__t_string.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/valid/expressions/t_string.py
 ---
 ## AST
 
@@ -325,19 +326,19 @@ Module(
                                                         ExprCompare {
                                                             node_index: NodeIndex(None),
                                                             range: 79..83,
-                                                            left: NumberLiteral(
-                                                                ExprNumberLiteral {
-                                                                    node_index: NodeIndex(None),
-                                                                    range: 79..80,
-                                                                    value: Int(
-                                                                        3,
-                                                                    ),
-                                                                },
-                                                            ),
                                                             ops: [
                                                                 NotEq,
                                                             ],
-                                                            comparators: [
+                                                            operands: [
+                                                                NumberLiteral(
+                                                                    ExprNumberLiteral {
+                                                                        node_index: NodeIndex(None),
+                                                                        range: 79..80,
+                                                                        value: Int(
+                                                                            3,
+                                                                        ),
+                                                                    },
+                                                                ),
                                                                 NumberLiteral(
                                                                     ExprNumberLiteral {
                                                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__t_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__t_string.py.snap
@@ -2719,68 +2719,66 @@ Module(
                                                             range: 847..861,
                                                             value: FStringValue {
                                                                 inner: Single(
-                                                                    FString(
-                                                                        FString {
-                                                                            range: 847..861,
-                                                                            node_index: NodeIndex(None),
-                                                                            elements: [
-                                                                                Interpolation(
-                                                                                    InterpolatedElement {
-                                                                                        range: 849..860,
-                                                                                        node_index: NodeIndex(None),
-                                                                                        expression: TString(
-                                                                                            ExprTString {
-                                                                                                node_index: NodeIndex(None),
-                                                                                                range: 850..859,
-                                                                                                value: TStringValue {
-                                                                                                    inner: Single(
-                                                                                                        TString {
-                                                                                                            range: 850..859,
-                                                                                                            node_index: NodeIndex(None),
-                                                                                                            elements: [
-                                                                                                                Interpolation(
-                                                                                                                    InterpolatedElement {
-                                                                                                                        range: 852..858,
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        expression: Name(
-                                                                                                                            ExprName {
-                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                range: 853..857,
-                                                                                                                                id: Name("this"),
-                                                                                                                                ctx: Load,
-                                                                                                                            },
-                                                                                                                        ),
-                                                                                                                        debug_text: None,
-                                                                                                                        conversion: None,
-                                                                                                                        format_spec: None,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            flags: TStringFlags {
-                                                                                                                quote_style: Double,
-                                                                                                                prefix: Regular,
-                                                                                                                triple_quoted: false,
-                                                                                                                unclosed: false,
-                                                                                                            },
+                                                                    FString {
+                                                                        range: 847..861,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 849..860,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: TString(
+                                                                                        ExprTString {
+                                                                                            node_index: NodeIndex(None),
+                                                                                            range: 850..859,
+                                                                                            value: TStringValue {
+                                                                                                inner: Single(
+                                                                                                    TString {
+                                                                                                        range: 850..859,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        elements: [
+                                                                                                            Interpolation(
+                                                                                                                InterpolatedElement {
+                                                                                                                    range: 852..858,
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    expression: Name(
+                                                                                                                        ExprName {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 853..857,
+                                                                                                                            id: Name("this"),
+                                                                                                                            ctx: Load,
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    debug_text: None,
+                                                                                                                    conversion: None,
+                                                                                                                    format_spec: None,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ],
+                                                                                                        flags: TStringFlags {
+                                                                                                            quote_style: Double,
+                                                                                                            prefix: Regular,
+                                                                                                            triple_quoted: false,
+                                                                                                            unclosed: false,
                                                                                                         },
-                                                                                                    ),
-                                                                                                },
+                                                                                                    },
+                                                                                                ),
                                                                                             },
-                                                                                        ),
-                                                                                        debug_text: None,
-                                                                                        conversion: None,
-                                                                                        format_spec: None,
-                                                                                    },
-                                                                                ),
-                                                                            ],
-                                                                            flags: FStringFlags {
-                                                                                quote_style: Double,
-                                                                                prefix: Regular,
-                                                                                triple_quoted: false,
-                                                                                unclosed: false,
-                                                                            },
+                                                                                        },
+                                                                                    ),
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Double,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
                                                                         },
-                                                                    ),
+                                                                    },
                                                                 ),
                                                             },
                                                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield.py.snap
@@ -373,18 +373,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 122..128,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 122..123,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             Eq,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 122..123,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             Name(
                                                 ExprName {
                                                     node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield_from.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield_from.py.snap
@@ -303,18 +303,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 150..156,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 150..151,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         Eq,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 150..151,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@for_in_target_valid_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@for_in_target_valid_expr.py.snap
@@ -31,18 +31,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 6..12,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 6..7,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         In,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 6..7,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),
@@ -95,18 +95,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 34..40,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 34..35,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         In,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 34..35,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),
@@ -168,18 +168,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 63..69,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 63..64,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         In,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 63..64,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@fstring_format_spec_terminator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@fstring_format_spec_terminator.py.snap
@@ -20,57 +20,55 @@ Module(
                             range: 0..19,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 0..19,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 2..8,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 8..12,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 9..10,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 11..11,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 12..18,
-                                                        node_index: NodeIndex(None),
-                                                        value: " world",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 0..19,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 2..8,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 8..12,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 9..10,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 11..11,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 12..18,
+                                                    node_index: NodeIndex(None),
+                                                    value: " world",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -87,65 +85,63 @@ Module(
                             range: 20..42,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 20..42,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 22..28,
-                                                        node_index: NodeIndex(None),
-                                                        value: "hello ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 28..35,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 29..30,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 31..34,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 31..34,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: ".3f",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 35..41,
-                                                        node_index: NodeIndex(None),
-                                                        value: " world",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 20..42,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 22..28,
+                                                    node_index: NodeIndex(None),
+                                                    value: "hello ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 28..35,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 29..30,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 31..34,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 31..34,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: ".3f",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 35..41,
+                                                    node_index: NodeIndex(None),
+                                                    value: " world",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_1.py.snap
@@ -18,18 +18,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..17,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 0..5,
-                                    id: Name("match"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotIn,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 0..5,
+                                        id: Name("match"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_2.py.snap
@@ -32,18 +32,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 6..18,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 6..11,
-                                    id: Name("match"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 NotEq,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 6..11,
+                                        id: Name("match"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),
@@ -335,18 +335,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 132..148,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 132..137,
-                                    id: Name("match"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 IsNot,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 132..137,
+                                        id: Name("match"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_keyword_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_keyword_1.py.snap
@@ -252,44 +252,42 @@ Module(
                             range: 140..150,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 140..150,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 142..146,
-                                                        node_index: NodeIndex(None),
-                                                        value: "foo ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 146..149,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 147..148,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 140..150,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 142..146,
+                                                    node_index: NodeIndex(None),
+                                                    value: "foo ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 146..149,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 147..148,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@non_nested_quote_in_format_spec_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@non_nested_quote_in_format_spec_py311.py.snap
@@ -20,52 +20,50 @@ Module(
                             range: 44..53,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 44..53,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 46..52,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 47..48,
-                                                                value: Int(
-                                                                    1,
+                                    FString {
+                                        range: 44..53,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 46..52,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 47..48,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 49..51,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 49..51,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "''",
+                                                                    },
                                                                 ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 49..51,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 49..51,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "''",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@pep701_f_string_py311.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@pep701_f_string_py311.py.snap
@@ -20,57 +20,55 @@ Module(
                             range: 44..72,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 44..72,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 46..52,
-                                                        node_index: NodeIndex(None),
-                                                        value: "outer ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 52..71,
-                                                        node_index: NodeIndex(None),
-                                                        expression: StringLiteral(
-                                                            ExprStringLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 53..70,
-                                                                value: StringLiteralValue {
-                                                                    inner: Single(
-                                                                        StringLiteral {
-                                                                            range: 53..70,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "# not a comment",
-                                                                            flags: StringLiteralFlags {
-                                                                                quote_style: Single,
-                                                                                prefix: Empty,
-                                                                                triple_quoted: false,
-                                                                                unclosed: false,
-                                                                            },
+                                    FString {
+                                        range: 44..72,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 46..52,
+                                                    node_index: NodeIndex(None),
+                                                    value: "outer ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 52..71,
+                                                    node_index: NodeIndex(None),
+                                                    expression: StringLiteral(
+                                                        ExprStringLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 53..70,
+                                                            value: StringLiteralValue {
+                                                                inner: Single(
+                                                                    StringLiteral {
+                                                                        range: 53..70,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "# not a comment",
+                                                                        flags: StringLiteralFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Empty,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
                                                                         },
-                                                                    ),
-                                                                },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -87,88 +85,86 @@ Module(
                             range: 73..106,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 73..106,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 75..81,
-                                                        node_index: NodeIndex(None),
-                                                        value: "outer ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 81..105,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 82..83,
-                                                                id: Name("x"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 84..104,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Interpolation(
-                                                                        InterpolatedElement {
-                                                                            range: 84..103,
-                                                                            node_index: NodeIndex(None),
-                                                                            expression: StringLiteral(
-                                                                                ExprStringLiteral {
-                                                                                    node_index: NodeIndex(None),
-                                                                                    range: 85..102,
-                                                                                    value: StringLiteralValue {
-                                                                                        inner: Single(
-                                                                                            StringLiteral {
-                                                                                                range: 85..102,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "# not a comment",
-                                                                                                flags: StringLiteralFlags {
-                                                                                                    quote_style: Double,
-                                                                                                    prefix: Empty,
-                                                                                                    triple_quoted: false,
-                                                                                                    unclosed: false,
-                                                                                                },
+                                    FString {
+                                        range: 73..106,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 75..81,
+                                                    node_index: NodeIndex(None),
+                                                    value: "outer ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 81..105,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 82..83,
+                                                            id: Name("x"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 84..104,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Interpolation(
+                                                                    InterpolatedElement {
+                                                                        range: 84..103,
+                                                                        node_index: NodeIndex(None),
+                                                                        expression: StringLiteral(
+                                                                            ExprStringLiteral {
+                                                                                node_index: NodeIndex(None),
+                                                                                range: 85..102,
+                                                                                value: StringLiteralValue {
+                                                                                    inner: Single(
+                                                                                        StringLiteral {
+                                                                                            range: 85..102,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "# not a comment",
+                                                                                            flags: StringLiteralFlags {
+                                                                                                quote_style: Double,
+                                                                                                prefix: Empty,
+                                                                                                triple_quoted: false,
+                                                                                                unclosed: false,
                                                                                             },
-                                                                                        ),
-                                                                                    },
+                                                                                        },
+                                                                                    ),
                                                                                 },
-                                                                            ),
-                                                                            debug_text: None,
-                                                                            conversion: None,
-                                                                            format_spec: None,
-                                                                        },
-                                                                    ),
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 103..104,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: " ",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                            },
+                                                                        ),
+                                                                        debug_text: None,
+                                                                        conversion: None,
+                                                                        format_spec: None,
+                                                                    },
+                                                                ),
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 103..104,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: " ",
+                                                                    },
+                                                                ),
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -185,116 +181,110 @@ Module(
                             range: 107..147,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 107..147,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 111..144,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 112..143,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 112..143,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 116..140,
+                                    FString {
+                                        range: 107..147,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 111..144,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 112..143,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 112..143,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 116..140,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: FString(
+                                                                                        ExprFString {
                                                                                             node_index: NodeIndex(None),
-                                                                                            expression: FString(
-                                                                                                ExprFString {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 117..139,
-                                                                                                    value: FStringValue {
-                                                                                                        inner: Single(
-                                                                                                            FString(
-                                                                                                                FString {
-                                                                                                                    range: 117..139,
+                                                                                            range: 117..139,
+                                                                                            value: FStringValue {
+                                                                                                inner: Single(
+                                                                                                    FString {
+                                                                                                        range: 117..139,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        elements: [
+                                                                                                            Interpolation(
+                                                                                                                InterpolatedElement {
+                                                                                                                    range: 119..138,
                                                                                                                     node_index: NodeIndex(None),
-                                                                                                                    elements: [
-                                                                                                                        Interpolation(
-                                                                                                                            InterpolatedElement {
-                                                                                                                                range: 119..138,
-                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                expression: StringLiteral(
-                                                                                                                                    ExprStringLiteral {
-                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                    expression: StringLiteral(
+                                                                                                                        ExprStringLiteral {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 120..137,
+                                                                                                                            value: StringLiteralValue {
+                                                                                                                                inner: Single(
+                                                                                                                                    StringLiteral {
                                                                                                                                         range: 120..137,
-                                                                                                                                        value: StringLiteralValue {
-                                                                                                                                            inner: Single(
-                                                                                                                                                StringLiteral {
-                                                                                                                                                    range: 120..137,
-                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                    value: "# not a comment",
-                                                                                                                                                    flags: StringLiteralFlags {
-                                                                                                                                                        quote_style: Double,
-                                                                                                                                                        prefix: Empty,
-                                                                                                                                                        triple_quoted: false,
-                                                                                                                                                        unclosed: false,
-                                                                                                                                                    },
-                                                                                                                                                },
-                                                                                                                                            ),
+                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                                        value: "# not a comment",
+                                                                                                                                        flags: StringLiteralFlags {
+                                                                                                                                            quote_style: Double,
+                                                                                                                                            prefix: Empty,
+                                                                                                                                            triple_quoted: false,
+                                                                                                                                            unclosed: false,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 ),
-                                                                                                                                debug_text: None,
-                                                                                                                                conversion: None,
-                                                                                                                                format_spec: None,
                                                                                                                             },
-                                                                                                                        ),
-                                                                                                                    ],
-                                                                                                                    flags: FStringFlags {
-                                                                                                                        quote_style: Single,
-                                                                                                                        prefix: Regular,
-                                                                                                                        triple_quoted: false,
-                                                                                                                        unclosed: false,
-                                                                                                                    },
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    debug_text: None,
+                                                                                                                    conversion: None,
+                                                                                                                    format_spec: None,
                                                                                                                 },
                                                                                                             ),
-                                                                                                        ),
+                                                                                                        ],
+                                                                                                        flags: FStringFlags {
+                                                                                                            quote_style: Single,
+                                                                                                            prefix: Regular,
+                                                                                                            triple_quoted: false,
+                                                                                                            unclosed: false,
+                                                                                                        },
                                                                                                     },
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: None,
-                                                                                            conversion: None,
-                                                                                            format_spec: None,
+                                                                                                ),
+                                                                                            },
                                                                                         },
                                                                                     ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Single,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: true,
-                                                                                    unclosed: false,
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: true,
+                                                                            unclosed: false,
+                                                                        },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -311,195 +301,187 @@ Module(
                             range: 148..230,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 148..230,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 152..208,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 153..207,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 153..207,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Literal(
-                                                                                        InterpolatedStringLiteralElement {
-                                                                                            range: 157..177,
+                                    FString {
+                                        range: 148..230,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 152..208,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 153..207,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 153..207,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Literal(
+                                                                                InterpolatedStringLiteralElement {
+                                                                                    range: 157..177,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    value: "# before expression ",
+                                                                                },
+                                                                            ),
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 177..204,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: FString(
+                                                                                        ExprFString {
                                                                                             node_index: NodeIndex(None),
-                                                                                            value: "# before expression ",
-                                                                                        },
-                                                                                    ),
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 177..204,
-                                                                                            node_index: NodeIndex(None),
-                                                                                            expression: FString(
-                                                                                                ExprFString {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 178..203,
-                                                                                                    value: FStringValue {
-                                                                                                        inner: Single(
-                                                                                                            FString(
-                                                                                                                FString {
-                                                                                                                    range: 178..203,
+                                                                                            range: 178..203,
+                                                                                            value: FStringValue {
+                                                                                                inner: Single(
+                                                                                                    FString {
+                                                                                                        range: 178..203,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        elements: [
+                                                                                                            Literal(
+                                                                                                                InterpolatedStringLiteralElement {
+                                                                                                                    range: 180..185,
                                                                                                                     node_index: NodeIndex(None),
-                                                                                                                    elements: [
-                                                                                                                        Literal(
-                                                                                                                            InterpolatedStringLiteralElement {
-                                                                                                                                range: 180..185,
-                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                value: "# aro",
-                                                                                                                            },
-                                                                                                                        ),
-                                                                                                                        Interpolation(
-                                                                                                                            InterpolatedElement {
-                                                                                                                                range: 185..197,
-                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                expression: FString(
-                                                                                                                                    ExprFString {
-                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                    value: "# aro",
+                                                                                                                },
+                                                                                                            ),
+                                                                                                            Interpolation(
+                                                                                                                InterpolatedElement {
+                                                                                                                    range: 185..197,
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    expression: FString(
+                                                                                                                        ExprFString {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 186..196,
+                                                                                                                            value: FStringValue {
+                                                                                                                                inner: Single(
+                                                                                                                                    FString {
                                                                                                                                         range: 186..196,
-                                                                                                                                        value: FStringValue {
-                                                                                                                                            inner: Single(
-                                                                                                                                                FString(
-                                                                                                                                                    FString {
-                                                                                                                                                        range: 186..196,
-                                                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                                                        elements: [
-                                                                                                                                                            Literal(
-                                                                                                                                                                InterpolatedStringLiteralElement {
-                                                                                                                                                                    range: 188..189,
-                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                    value: "#",
-                                                                                                                                                                },
-                                                                                                                                                            ),
-                                                                                                                                                            Interpolation(
-                                                                                                                                                                InterpolatedElement {
-                                                                                                                                                                    range: 189..194,
-                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                    expression: BinOp(
-                                                                                                                                                                        ExprBinOp {
-                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                            range: 190..193,
-                                                                                                                                                                            left: NumberLiteral(
-                                                                                                                                                                                ExprNumberLiteral {
-                                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                                    range: 190..191,
-                                                                                                                                                                                    value: Int(
-                                                                                                                                                                                        1,
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                            op: Add,
-                                                                                                                                                                            right: NumberLiteral(
-                                                                                                                                                                                ExprNumberLiteral {
-                                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                                    range: 192..193,
-                                                                                                                                                                                    value: Int(
-                                                                                                                                                                                        1,
-                                                                                                                                                                                    ),
-                                                                                                                                                                                },
-                                                                                                                                                                            ),
-                                                                                                                                                                        },
-                                                                                                                                                                    ),
-                                                                                                                                                                    debug_text: None,
-                                                                                                                                                                    conversion: None,
-                                                                                                                                                                    format_spec: None,
-                                                                                                                                                                },
-                                                                                                                                                            ),
-                                                                                                                                                            Literal(
-                                                                                                                                                                InterpolatedStringLiteralElement {
-                                                                                                                                                                    range: 194..195,
-                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                    value: "#",
-                                                                                                                                                                },
-                                                                                                                                                            ),
-                                                                                                                                                        ],
-                                                                                                                                                        flags: FStringFlags {
-                                                                                                                                                            quote_style: Double,
-                                                                                                                                                            prefix: Regular,
-                                                                                                                                                            triple_quoted: false,
-                                                                                                                                                            unclosed: false,
-                                                                                                                                                        },
-                                                                                                                                                    },
-                                                                                                                                                ),
+                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                                        elements: [
+                                                                                                                                            Literal(
+                                                                                                                                                InterpolatedStringLiteralElement {
+                                                                                                                                                    range: 188..189,
+                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                    value: "#",
+                                                                                                                                                },
                                                                                                                                             ),
+                                                                                                                                            Interpolation(
+                                                                                                                                                InterpolatedElement {
+                                                                                                                                                    range: 189..194,
+                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                    expression: BinOp(
+                                                                                                                                                        ExprBinOp {
+                                                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                                                            range: 190..193,
+                                                                                                                                                            left: NumberLiteral(
+                                                                                                                                                                ExprNumberLiteral {
+                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                    range: 190..191,
+                                                                                                                                                                    value: Int(
+                                                                                                                                                                        1,
+                                                                                                                                                                    ),
+                                                                                                                                                                },
+                                                                                                                                                            ),
+                                                                                                                                                            op: Add,
+                                                                                                                                                            right: NumberLiteral(
+                                                                                                                                                                ExprNumberLiteral {
+                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                    range: 192..193,
+                                                                                                                                                                    value: Int(
+                                                                                                                                                                        1,
+                                                                                                                                                                    ),
+                                                                                                                                                                },
+                                                                                                                                                            ),
+                                                                                                                                                        },
+                                                                                                                                                    ),
+                                                                                                                                                    debug_text: None,
+                                                                                                                                                    conversion: None,
+                                                                                                                                                    format_spec: None,
+                                                                                                                                                },
+                                                                                                                                            ),
+                                                                                                                                            Literal(
+                                                                                                                                                InterpolatedStringLiteralElement {
+                                                                                                                                                    range: 194..195,
+                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                    value: "#",
+                                                                                                                                                },
+                                                                                                                                            ),
+                                                                                                                                        ],
+                                                                                                                                        flags: FStringFlags {
+                                                                                                                                            quote_style: Double,
+                                                                                                                                            prefix: Regular,
+                                                                                                                                            triple_quoted: false,
+                                                                                                                                            unclosed: false,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 ),
-                                                                                                                                debug_text: None,
-                                                                                                                                conversion: None,
-                                                                                                                                format_spec: None,
                                                                                                                             },
-                                                                                                                        ),
-                                                                                                                        Literal(
-                                                                                                                            InterpolatedStringLiteralElement {
-                                                                                                                                range: 197..202,
-                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                value: "und #",
-                                                                                                                            },
-                                                                                                                        ),
-                                                                                                                    ],
-                                                                                                                    flags: FStringFlags {
-                                                                                                                        quote_style: Single,
-                                                                                                                        prefix: Regular,
-                                                                                                                        triple_quoted: false,
-                                                                                                                        unclosed: false,
-                                                                                                                    },
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    debug_text: None,
+                                                                                                                    conversion: None,
+                                                                                                                    format_spec: None,
                                                                                                                 },
                                                                                                             ),
-                                                                                                        ),
+                                                                                                            Literal(
+                                                                                                                InterpolatedStringLiteralElement {
+                                                                                                                    range: 197..202,
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    value: "und #",
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ],
+                                                                                                        flags: FStringFlags {
+                                                                                                            quote_style: Single,
+                                                                                                            prefix: Regular,
+                                                                                                            triple_quoted: false,
+                                                                                                            unclosed: false,
+                                                                                                        },
                                                                                                     },
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: None,
-                                                                                            conversion: None,
-                                                                                            format_spec: None,
+                                                                                                ),
+                                                                                            },
                                                                                         },
                                                                                     ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Single,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: true,
-                                                                                    unclosed: false,
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: true,
+                                                                            unclosed: false,
+                                                                        },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 208..227,
-                                                        node_index: NodeIndex(None),
-                                                        value: " # after expression",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 208..227,
+                                                    node_index: NodeIndex(None),
+                                                    value: " # after expression",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -516,38 +498,36 @@ Module(
                             range: 231..247,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 231..247,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 235..244,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 241..242,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 231..247,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 235..244,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 241..242,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -564,51 +544,49 @@ Module(
                             range: 248..280,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 248..280,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 250..271,
-                                                        node_index: NodeIndex(None),
-                                                        value: "escape outside of \t ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 271..277,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 272..276,
-                                                                id: Name("expr"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 277..279,
-                                                        node_index: NodeIndex(None),
-                                                        value: "\n",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 248..280,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 250..271,
+                                                    node_index: NodeIndex(None),
+                                                    value: "escape outside of \t ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 271..277,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 272..276,
+                                                            id: Name("expr"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 277..279,
+                                                    node_index: NodeIndex(None),
+                                                    value: "\n",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -625,27 +603,25 @@ Module(
                             range: 281..294,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 281..294,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 283..293,
-                                                        node_index: NodeIndex(None),
-                                                        value: "test\"abcd",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 281..294,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 283..293,
+                                                    node_index: NodeIndex(None),
+                                                    value: "test\"abcd",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -662,52 +638,50 @@ Module(
                             range: 295..306,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 295..306,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 297..305,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 298..299,
-                                                                value: Int(
-                                                                    1,
+                                    FString {
+                                        range: 295..306,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 297..305,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 298..299,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 300..304,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 300..304,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "d",
+                                                                    },
                                                                 ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 300..304,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 300..304,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "d",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -724,52 +698,50 @@ Module(
                             range: 347..359,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 347..359,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 349..358,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 350..351,
-                                                                value: Int(
-                                                                    1,
+                                    FString {
+                                        range: 347..359,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 349..358,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 350..351,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: Some(
+                                                        InterpolatedStringFormatSpec {
+                                                            range: 352..357,
+                                                            node_index: NodeIndex(None),
+                                                            elements: [
+                                                                Literal(
+                                                                    InterpolatedStringLiteralElement {
+                                                                        range: 352..357,
+                                                                        node_index: NodeIndex(None),
+                                                                        value: "\"d\"",
+                                                                    },
                                                                 ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: Some(
-                                                            InterpolatedStringFormatSpec {
-                                                                range: 352..357,
-                                                                node_index: NodeIndex(None),
-                                                                elements: [
-                                                                    Literal(
-                                                                        InterpolatedStringLiteralElement {
-                                                                            range: 352..357,
-                                                                            node_index: NodeIndex(None),
-                                                                            value: "\"d\"",
-                                                                        },
-                                                                    ),
-                                                                ],
-                                                            },
-                                                        ),
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@pep701_f_string_py312.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@pep701_f_string_py312.py.snap
@@ -20,72 +20,70 @@ Module(
                             range: 44..74,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 44..74,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 46..58,
-                                                        node_index: NodeIndex(None),
-                                                        value: "Magic wand: ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 58..73,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Subscript(
-                                                            ExprSubscript {
-                                                                node_index: NodeIndex(None),
-                                                                range: 60..71,
-                                                                value: Name(
-                                                                    ExprName {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 60..63,
-                                                                        id: Name("bag"),
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                slice: StringLiteral(
-                                                                    ExprStringLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 64..70,
-                                                                        value: StringLiteralValue {
-                                                                            inner: Single(
-                                                                                StringLiteral {
-                                                                                    range: 64..70,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    value: "wand",
-                                                                                    flags: StringLiteralFlags {
-                                                                                        quote_style: Single,
-                                                                                        prefix: Empty,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                    FString {
+                                        range: 44..74,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 46..58,
+                                                    node_index: NodeIndex(None),
+                                                    value: "Magic wand: ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 58..73,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Subscript(
+                                                        ExprSubscript {
+                                                            node_index: NodeIndex(None),
+                                                            range: 60..71,
+                                                            value: Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 60..63,
+                                                                    id: Name("bag"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            slice: StringLiteral(
+                                                                ExprStringLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 64..70,
+                                                                    value: StringLiteralValue {
+                                                                        inner: Single(
+                                                                            StringLiteral {
+                                                                                range: 64..70,
+                                                                                node_index: NodeIndex(None),
+                                                                                value: "wand",
+                                                                                flags: StringLiteralFlags {
+                                                                                    quote_style: Single,
+                                                                                    prefix: Empty,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
-                                                                        },
+                                                                            },
+                                                                        ),
                                                                     },
-                                                                ),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -102,83 +100,81 @@ Module(
                             range: 95..112,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 95..112,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 97..111,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Call(
-                                                            ExprCall {
-                                                                node_index: NodeIndex(None),
-                                                                range: 98..110,
-                                                                func: Attribute(
-                                                                    ExprAttribute {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 98..107,
-                                                                        value: StringLiteral(
-                                                                            ExprStringLiteral {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 98..102,
-                                                                                value: StringLiteralValue {
-                                                                                    inner: Single(
-                                                                                        StringLiteral {
-                                                                                            range: 98..102,
-                                                                                            node_index: NodeIndex(None),
-                                                                                            value: "\n",
-                                                                                            flags: StringLiteralFlags {
-                                                                                                quote_style: Single,
-                                                                                                prefix: Empty,
-                                                                                                triple_quoted: false,
-                                                                                                unclosed: false,
-                                                                                            },
-                                                                                        },
-                                                                                    ),
-                                                                                },
-                                                                            },
-                                                                        ),
-                                                                        attr: Identifier {
-                                                                            id: Name("join"),
-                                                                            range: 103..107,
-                                                                            node_index: NodeIndex(None),
-                                                                        },
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                arguments: Arguments {
-                                                                    range: 107..110,
+                                    FString {
+                                        range: 95..112,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 97..111,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Call(
+                                                        ExprCall {
+                                                            node_index: NodeIndex(None),
+                                                            range: 98..110,
+                                                            func: Attribute(
+                                                                ExprAttribute {
                                                                     node_index: NodeIndex(None),
-                                                                    args: [
-                                                                        Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 108..109,
-                                                                                id: Name("a"),
-                                                                                ctx: Load,
+                                                                    range: 98..107,
+                                                                    value: StringLiteral(
+                                                                        ExprStringLiteral {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 98..102,
+                                                                            value: StringLiteralValue {
+                                                                                inner: Single(
+                                                                                    StringLiteral {
+                                                                                        range: 98..102,
+                                                                                        node_index: NodeIndex(None),
+                                                                                        value: "\n",
+                                                                                        flags: StringLiteralFlags {
+                                                                                            quote_style: Single,
+                                                                                            prefix: Empty,
+                                                                                            triple_quoted: false,
+                                                                                            unclosed: false,
+                                                                                        },
+                                                                                    },
+                                                                                ),
                                                                             },
-                                                                        ),
-                                                                    ],
-                                                                    keywords: [],
+                                                                        },
+                                                                    ),
+                                                                    attr: Identifier {
+                                                                        id: Name("join"),
+                                                                        range: 103..107,
+                                                                        node_index: NodeIndex(None),
+                                                                    },
+                                                                    ctx: Load,
                                                                 },
+                                                            ),
+                                                            arguments: Arguments {
+                                                                range: 107..110,
+                                                                node_index: NodeIndex(None),
+                                                                args: [
+                                                                    Name(
+                                                                        ExprName {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 108..109,
+                                                                            id: Name("a"),
+                                                                            ctx: Load,
+                                                                        },
+                                                                    ),
+                                                                ],
+                                                                keywords: [],
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -195,72 +191,70 @@ Module(
                             range: 148..220,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 148..220,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 152..169,
-                                                        node_index: NodeIndex(None),
-                                                        value: "A complex trick: ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 169..217,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Subscript(
-                                                            ExprSubscript {
-                                                                node_index: NodeIndex(None),
-                                                                range: 175..185,
-                                                                value: Name(
-                                                                    ExprName {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 175..178,
-                                                                        id: Name("bag"),
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                slice: StringLiteral(
-                                                                    ExprStringLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 179..184,
-                                                                        value: StringLiteralValue {
-                                                                            inner: Single(
-                                                                                StringLiteral {
-                                                                                    range: 179..184,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    value: "bag",
-                                                                                    flags: StringLiteralFlags {
-                                                                                        quote_style: Single,
-                                                                                        prefix: Empty,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                    FString {
+                                        range: 148..220,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 152..169,
+                                                    node_index: NodeIndex(None),
+                                                    value: "A complex trick: ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 169..217,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Subscript(
+                                                        ExprSubscript {
+                                                            node_index: NodeIndex(None),
+                                                            range: 175..185,
+                                                            value: Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 175..178,
+                                                                    id: Name("bag"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            slice: StringLiteral(
+                                                                ExprStringLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 179..184,
+                                                                    value: StringLiteralValue {
+                                                                        inner: Single(
+                                                                            StringLiteral {
+                                                                                range: 179..184,
+                                                                                node_index: NodeIndex(None),
+                                                                                value: "bag",
+                                                                                flags: StringLiteralFlags {
+                                                                                    quote_style: Single,
+                                                                                    prefix: Empty,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
-                                                                        },
+                                                                            },
+                                                                        ),
                                                                     },
-                                                                ),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Single,
-                                                prefix: Regular,
-                                                triple_quoted: true,
-                                                unclosed: false,
-                                            },
+                                                                },
+                                                            ),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Single,
+                                            prefix: Regular,
+                                            triple_quoted: true,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -277,219 +271,207 @@ Module(
                             range: 221..254,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 221..254,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 223..253,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 224..252,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 224..252,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 226..251,
+                                    FString {
+                                        range: 221..254,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 223..253,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 224..252,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 224..252,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 226..251,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: FString(
+                                                                                        ExprFString {
                                                                                             node_index: NodeIndex(None),
-                                                                                            expression: FString(
-                                                                                                ExprFString {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 227..250,
-                                                                                                    value: FStringValue {
-                                                                                                        inner: Single(
-                                                                                                            FString(
-                                                                                                                FString {
-                                                                                                                    range: 227..250,
+                                                                                            range: 227..250,
+                                                                                            value: FStringValue {
+                                                                                                inner: Single(
+                                                                                                    FString {
+                                                                                                        range: 227..250,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        elements: [
+                                                                                                            Interpolation(
+                                                                                                                InterpolatedElement {
+                                                                                                                    range: 229..249,
                                                                                                                     node_index: NodeIndex(None),
-                                                                                                                    elements: [
-                                                                                                                        Interpolation(
-                                                                                                                            InterpolatedElement {
-                                                                                                                                range: 229..249,
-                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                expression: FString(
-                                                                                                                                    ExprFString {
-                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                    expression: FString(
+                                                                                                                        ExprFString {
+                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                            range: 230..248,
+                                                                                                                            value: FStringValue {
+                                                                                                                                inner: Single(
+                                                                                                                                    FString {
                                                                                                                                         range: 230..248,
-                                                                                                                                        value: FStringValue {
-                                                                                                                                            inner: Single(
-                                                                                                                                                FString(
-                                                                                                                                                    FString {
-                                                                                                                                                        range: 230..248,
-                                                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                                                        elements: [
-                                                                                                                                                            Interpolation(
-                                                                                                                                                                InterpolatedElement {
-                                                                                                                                                                    range: 232..247,
-                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                    expression: FString(
-                                                                                                                                                                        ExprFString {
-                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                            range: 233..246,
-                                                                                                                                                                            value: FStringValue {
-                                                                                                                                                                                inner: Single(
-                                                                                                                                                                                    FString(
-                                                                                                                                                                                        FString {
-                                                                                                                                                                                            range: 233..246,
+                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                                        elements: [
+                                                                                                                                            Interpolation(
+                                                                                                                                                InterpolatedElement {
+                                                                                                                                                    range: 232..247,
+                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                    expression: FString(
+                                                                                                                                                        ExprFString {
+                                                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                                                            range: 233..246,
+                                                                                                                                                            value: FStringValue {
+                                                                                                                                                                inner: Single(
+                                                                                                                                                                    FString {
+                                                                                                                                                                        range: 233..246,
+                                                                                                                                                                        node_index: NodeIndex(None),
+                                                                                                                                                                        elements: [
+                                                                                                                                                                            Interpolation(
+                                                                                                                                                                                InterpolatedElement {
+                                                                                                                                                                                    range: 235..245,
+                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                    expression: FString(
+                                                                                                                                                                                        ExprFString {
                                                                                                                                                                                             node_index: NodeIndex(None),
-                                                                                                                                                                                            elements: [
-                                                                                                                                                                                                Interpolation(
-                                                                                                                                                                                                    InterpolatedElement {
-                                                                                                                                                                                                        range: 235..245,
+                                                                                                                                                                                            range: 236..244,
+                                                                                                                                                                                            value: FStringValue {
+                                                                                                                                                                                                inner: Single(
+                                                                                                                                                                                                    FString {
+                                                                                                                                                                                                        range: 236..244,
                                                                                                                                                                                                         node_index: NodeIndex(None),
-                                                                                                                                                                                                        expression: FString(
-                                                                                                                                                                                                            ExprFString {
-                                                                                                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                                                                                                range: 236..244,
-                                                                                                                                                                                                                value: FStringValue {
-                                                                                                                                                                                                                    inner: Single(
-                                                                                                                                                                                                                        FString(
-                                                                                                                                                                                                                            FString {
-                                                                                                                                                                                                                                range: 236..244,
-                                                                                                                                                                                                                                node_index: NodeIndex(None),
-                                                                                                                                                                                                                                elements: [
-                                                                                                                                                                                                                                    Interpolation(
-                                                                                                                                                                                                                                        InterpolatedElement {
-                                                                                                                                                                                                                                            range: 238..243,
-                                                                                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                                                                                            expression: BinOp(
-                                                                                                                                                                                                                                                ExprBinOp {
-                                                                                                                                                                                                                                                    node_index: NodeIndex(None),
-                                                                                                                                                                                                                                                    range: 239..242,
-                                                                                                                                                                                                                                                    left: NumberLiteral(
-                                                                                                                                                                                                                                                        ExprNumberLiteral {
-                                                                                                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                                                                                                            range: 239..240,
-                                                                                                                                                                                                                                                            value: Int(
-                                                                                                                                                                                                                                                                1,
-                                                                                                                                                                                                                                                            ),
-                                                                                                                                                                                                                                                        },
-                                                                                                                                                                                                                                                    ),
-                                                                                                                                                                                                                                                    op: Add,
-                                                                                                                                                                                                                                                    right: NumberLiteral(
-                                                                                                                                                                                                                                                        ExprNumberLiteral {
-                                                                                                                                                                                                                                                            node_index: NodeIndex(None),
-                                                                                                                                                                                                                                                            range: 241..242,
-                                                                                                                                                                                                                                                            value: Int(
-                                                                                                                                                                                                                                                                1,
-                                                                                                                                                                                                                                                            ),
-                                                                                                                                                                                                                                                        },
-                                                                                                                                                                                                                                                    ),
-                                                                                                                                                                                                                                                },
-                                                                                                                                                                                                                                            ),
-                                                                                                                                                                                                                                            debug_text: None,
-                                                                                                                                                                                                                                            conversion: None,
-                                                                                                                                                                                                                                            format_spec: None,
-                                                                                                                                                                                                                                        },
+                                                                                                                                                                                                        elements: [
+                                                                                                                                                                                                            Interpolation(
+                                                                                                                                                                                                                InterpolatedElement {
+                                                                                                                                                                                                                    range: 238..243,
+                                                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                                                    expression: BinOp(
+                                                                                                                                                                                                                        ExprBinOp {
+                                                                                                                                                                                                                            node_index: NodeIndex(None),
+                                                                                                                                                                                                                            range: 239..242,
+                                                                                                                                                                                                                            left: NumberLiteral(
+                                                                                                                                                                                                                                ExprNumberLiteral {
+                                                                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                                                                    range: 239..240,
+                                                                                                                                                                                                                                    value: Int(
+                                                                                                                                                                                                                                        1,
                                                                                                                                                                                                                                     ),
-                                                                                                                                                                                                                                ],
-                                                                                                                                                                                                                                flags: FStringFlags {
-                                                                                                                                                                                                                                    quote_style: Double,
-                                                                                                                                                                                                                                    prefix: Regular,
-                                                                                                                                                                                                                                    triple_quoted: false,
-                                                                                                                                                                                                                                    unclosed: false,
                                                                                                                                                                                                                                 },
-                                                                                                                                                                                                                            },
-                                                                                                                                                                                                                        ),
+                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                            op: Add,
+                                                                                                                                                                                                                            right: NumberLiteral(
+                                                                                                                                                                                                                                ExprNumberLiteral {
+                                                                                                                                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                                                                                                                                    range: 241..242,
+                                                                                                                                                                                                                                    value: Int(
+                                                                                                                                                                                                                                        1,
+                                                                                                                                                                                                                                    ),
+                                                                                                                                                                                                                                },
+                                                                                                                                                                                                                            ),
+                                                                                                                                                                                                                        },
                                                                                                                                                                                                                     ),
+                                                                                                                                                                                                                    debug_text: None,
+                                                                                                                                                                                                                    conversion: None,
+                                                                                                                                                                                                                    format_spec: None,
                                                                                                                                                                                                                 },
-                                                                                                                                                                                                            },
-                                                                                                                                                                                                        ),
-                                                                                                                                                                                                        debug_text: None,
-                                                                                                                                                                                                        conversion: None,
-                                                                                                                                                                                                        format_spec: None,
+                                                                                                                                                                                                            ),
+                                                                                                                                                                                                        ],
+                                                                                                                                                                                                        flags: FStringFlags {
+                                                                                                                                                                                                            quote_style: Double,
+                                                                                                                                                                                                            prefix: Regular,
+                                                                                                                                                                                                            triple_quoted: false,
+                                                                                                                                                                                                            unclosed: false,
+                                                                                                                                                                                                        },
                                                                                                                                                                                                     },
                                                                                                                                                                                                 ),
-                                                                                                                                                                                            ],
-                                                                                                                                                                                            flags: FStringFlags {
-                                                                                                                                                                                                quote_style: Double,
-                                                                                                                                                                                                prefix: Regular,
-                                                                                                                                                                                                triple_quoted: false,
-                                                                                                                                                                                                unclosed: false,
                                                                                                                                                                                             },
                                                                                                                                                                                         },
                                                                                                                                                                                     ),
-                                                                                                                                                                                ),
-                                                                                                                                                                            },
+                                                                                                                                                                                    debug_text: None,
+                                                                                                                                                                                    conversion: None,
+                                                                                                                                                                                    format_spec: None,
+                                                                                                                                                                                },
+                                                                                                                                                                            ),
+                                                                                                                                                                        ],
+                                                                                                                                                                        flags: FStringFlags {
+                                                                                                                                                                            quote_style: Double,
+                                                                                                                                                                            prefix: Regular,
+                                                                                                                                                                            triple_quoted: false,
+                                                                                                                                                                            unclosed: false,
                                                                                                                                                                         },
-                                                                                                                                                                    ),
-                                                                                                                                                                    debug_text: None,
-                                                                                                                                                                    conversion: None,
-                                                                                                                                                                    format_spec: None,
-                                                                                                                                                                },
-                                                                                                                                                            ),
-                                                                                                                                                        ],
-                                                                                                                                                        flags: FStringFlags {
-                                                                                                                                                            quote_style: Double,
-                                                                                                                                                            prefix: Regular,
-                                                                                                                                                            triple_quoted: false,
-                                                                                                                                                            unclosed: false,
+                                                                                                                                                                    },
+                                                                                                                                                                ),
+                                                                                                                                                            },
                                                                                                                                                         },
-                                                                                                                                                    },
-                                                                                                                                                ),
+                                                                                                                                                    ),
+                                                                                                                                                    debug_text: None,
+                                                                                                                                                    conversion: None,
+                                                                                                                                                    format_spec: None,
+                                                                                                                                                },
                                                                                                                                             ),
+                                                                                                                                        ],
+                                                                                                                                        flags: FStringFlags {
+                                                                                                                                            quote_style: Double,
+                                                                                                                                            prefix: Regular,
+                                                                                                                                            triple_quoted: false,
+                                                                                                                                            unclosed: false,
                                                                                                                                         },
                                                                                                                                     },
                                                                                                                                 ),
-                                                                                                                                debug_text: None,
-                                                                                                                                conversion: None,
-                                                                                                                                format_spec: None,
                                                                                                                             },
-                                                                                                                        ),
-                                                                                                                    ],
-                                                                                                                    flags: FStringFlags {
-                                                                                                                        quote_style: Double,
-                                                                                                                        prefix: Regular,
-                                                                                                                        triple_quoted: false,
-                                                                                                                        unclosed: false,
-                                                                                                                    },
+                                                                                                                        },
+                                                                                                                    ),
+                                                                                                                    debug_text: None,
+                                                                                                                    conversion: None,
+                                                                                                                    format_spec: None,
                                                                                                                 },
                                                                                                             ),
-                                                                                                        ),
+                                                                                                        ],
+                                                                                                        flags: FStringFlags {
+                                                                                                            quote_style: Double,
+                                                                                                            prefix: Regular,
+                                                                                                            triple_quoted: false,
+                                                                                                            unclosed: false,
+                                                                                                        },
                                                                                                     },
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: None,
-                                                                                            conversion: None,
-                                                                                            format_spec: None,
+                                                                                                ),
+                                                                                            },
                                                                                         },
                                                                                     ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Double,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: false,
-                                                                                    unclosed: false,
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Double,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: false,
+                                                                            unclosed: false,
+                                                                        },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -506,97 +488,93 @@ Module(
                             range: 276..310,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 276..310,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 278..303,
-                                                        node_index: NodeIndex(None),
-                                                        expression: FString(
-                                                            ExprFString {
-                                                                node_index: NodeIndex(None),
-                                                                range: 279..302,
-                                                                value: FStringValue {
-                                                                    inner: Single(
-                                                                        FString(
-                                                                            FString {
-                                                                                range: 279..302,
-                                                                                node_index: NodeIndex(None),
-                                                                                elements: [
-                                                                                    Interpolation(
-                                                                                        InterpolatedElement {
-                                                                                            range: 283..293,
+                                    FString {
+                                        range: 276..310,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 278..303,
+                                                    node_index: NodeIndex(None),
+                                                    expression: FString(
+                                                        ExprFString {
+                                                            node_index: NodeIndex(None),
+                                                            range: 279..302,
+                                                            value: FStringValue {
+                                                                inner: Single(
+                                                                    FString {
+                                                                        range: 279..302,
+                                                                        node_index: NodeIndex(None),
+                                                                        elements: [
+                                                                            Interpolation(
+                                                                                InterpolatedElement {
+                                                                                    range: 283..293,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    expression: StringLiteral(
+                                                                                        ExprStringLiteral {
                                                                                             node_index: NodeIndex(None),
-                                                                                            expression: StringLiteral(
-                                                                                                ExprStringLiteral {
-                                                                                                    node_index: NodeIndex(None),
-                                                                                                    range: 284..292,
-                                                                                                    value: StringLiteralValue {
-                                                                                                        inner: Single(
-                                                                                                            StringLiteral {
-                                                                                                                range: 284..292,
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                value: "nested",
-                                                                                                                flags: StringLiteralFlags {
-                                                                                                                    quote_style: Double,
-                                                                                                                    prefix: Empty,
-                                                                                                                    triple_quoted: false,
-                                                                                                                    unclosed: false,
-                                                                                                                },
-                                                                                                            },
-                                                                                                        ),
+                                                                                            range: 284..292,
+                                                                                            value: StringLiteralValue {
+                                                                                                inner: Single(
+                                                                                                    StringLiteral {
+                                                                                                        range: 284..292,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        value: "nested",
+                                                                                                        flags: StringLiteralFlags {
+                                                                                                            quote_style: Double,
+                                                                                                            prefix: Empty,
+                                                                                                            triple_quoted: false,
+                                                                                                            unclosed: false,
+                                                                                                        },
                                                                                                     },
-                                                                                                },
-                                                                                            ),
-                                                                                            debug_text: None,
-                                                                                            conversion: None,
-                                                                                            format_spec: None,
+                                                                                                ),
+                                                                                            },
                                                                                         },
                                                                                     ),
-                                                                                    Literal(
-                                                                                        InterpolatedStringLiteralElement {
-                                                                                            range: 293..299,
-                                                                                            node_index: NodeIndex(None),
-                                                                                            value: " inner",
-                                                                                        },
-                                                                                    ),
-                                                                                ],
-                                                                                flags: FStringFlags {
-                                                                                    quote_style: Single,
-                                                                                    prefix: Regular,
-                                                                                    triple_quoted: true,
-                                                                                    unclosed: false,
+                                                                                    debug_text: None,
+                                                                                    conversion: None,
+                                                                                    format_spec: None,
                                                                                 },
-                                                                            },
-                                                                        ),
-                                                                    ),
-                                                                },
+                                                                            ),
+                                                                            Literal(
+                                                                                InterpolatedStringLiteralElement {
+                                                                                    range: 293..299,
+                                                                                    node_index: NodeIndex(None),
+                                                                                    value: " inner",
+                                                                                },
+                                                                            ),
+                                                                        ],
+                                                                        flags: FStringFlags {
+                                                                            quote_style: Single,
+                                                                            prefix: Regular,
+                                                                            triple_quoted: true,
+                                                                            unclosed: false,
+                                                                        },
+                                                                    },
+                                                                ),
                                                             },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 303..309,
-                                                        node_index: NodeIndex(None),
-                                                        value: " outer",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 303..309,
+                                                    node_index: NodeIndex(None),
+                                                    value: " outer",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -613,38 +591,36 @@ Module(
                             range: 336..348,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 336..348,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 338..347,
-                                                        node_index: NodeIndex(None),
-                                                        expression: NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 344..345,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 336..348,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 338..347,
+                                                    node_index: NodeIndex(None),
+                                                    expression: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 344..345,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },
@@ -661,51 +637,49 @@ Module(
                             range: 349..372,
                             value: FStringValue {
                                 inner: Single(
-                                    FString(
-                                        FString {
-                                            range: 349..372,
-                                            node_index: NodeIndex(None),
-                                            elements: [
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 351..356,
-                                                        node_index: NodeIndex(None),
-                                                        value: "test ",
-                                                    },
-                                                ),
-                                                Interpolation(
-                                                    InterpolatedElement {
-                                                        range: 356..366,
-                                                        node_index: NodeIndex(None),
-                                                        expression: Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 357..358,
-                                                                id: Name("a"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        debug_text: None,
-                                                        conversion: None,
-                                                        format_spec: None,
-                                                    },
-                                                ),
-                                                Literal(
-                                                    InterpolatedStringLiteralElement {
-                                                        range: 366..371,
-                                                        node_index: NodeIndex(None),
-                                                        value: " more",
-                                                    },
-                                                ),
-                                            ],
-                                            flags: FStringFlags {
-                                                quote_style: Double,
-                                                prefix: Regular,
-                                                triple_quoted: false,
-                                                unclosed: false,
-                                            },
+                                    FString {
+                                        range: 349..372,
+                                        node_index: NodeIndex(None),
+                                        elements: [
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 351..356,
+                                                    node_index: NodeIndex(None),
+                                                    value: "test ",
+                                                },
+                                            ),
+                                            Interpolation(
+                                                InterpolatedElement {
+                                                    range: 356..366,
+                                                    node_index: NodeIndex(None),
+                                                    expression: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 357..358,
+                                                            id: Name("a"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    debug_text: None,
+                                                    conversion: None,
+                                                    format_spec: None,
+                                                },
+                                            ),
+                                            Literal(
+                                                InterpolatedStringLiteralElement {
+                                                    range: 366..371,
+                                                    node_index: NodeIndex(None),
+                                                    value: " more",
+                                                },
+                                            ),
+                                        ],
+                                        flags: FStringFlags {
+                                            quote_style: Double,
+                                            prefix: Regular,
+                                            triple_quoted: false,
+                                            unclosed: false,
                                         },
-                                    ),
+                                    },
                                 ),
                             },
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__ambiguous_lpar_with_items.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__ambiguous_lpar_with_items.py.snap
@@ -577,18 +577,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 959..969,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 959..963,
-                                            id: Name("item"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         Eq,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 959..963,
+                                                id: Name("item"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         NumberLiteral(
                                             ExprNumberLiteral {
                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__ambiguous_lpar_with_items.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__ambiguous_lpar_with_items.py.snap
@@ -1090,51 +1090,49 @@ Module(
                                     range: 1186..1201,
                                     value: FStringValue {
                                         inner: Single(
-                                            FString(
-                                                FString {
-                                                    range: 1186..1201,
-                                                    node_index: NodeIndex(None),
-                                                    elements: [
-                                                        Interpolation(
-                                                            InterpolatedElement {
-                                                                range: 1188..1200,
-                                                                node_index: NodeIndex(None),
-                                                                expression: Name(
-                                                                    ExprName {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 1189..1193,
-                                                                        id: Name("item"),
-                                                                        ctx: Load,
-                                                                    },
-                                                                ),
-                                                                debug_text: None,
-                                                                conversion: None,
-                                                                format_spec: Some(
-                                                                    InterpolatedStringFormatSpec {
-                                                                        range: 1195..1199,
-                                                                        node_index: NodeIndex(None),
-                                                                        elements: [
-                                                                            Literal(
-                                                                                InterpolatedStringLiteralElement {
-                                                                                    range: 1195..1199,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    value: "= 42",
-                                                                                },
-                                                                            ),
-                                                                        ],
-                                                                    },
-                                                                ),
-                                                            },
-                                                        ),
-                                                    ],
-                                                    flags: FStringFlags {
-                                                        quote_style: Double,
-                                                        prefix: Regular,
-                                                        triple_quoted: false,
-                                                        unclosed: false,
-                                                    },
+                                            FString {
+                                                range: 1186..1201,
+                                                node_index: NodeIndex(None),
+                                                elements: [
+                                                    Interpolation(
+                                                        InterpolatedElement {
+                                                            range: 1188..1200,
+                                                            node_index: NodeIndex(None),
+                                                            expression: Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 1189..1193,
+                                                                    id: Name("item"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
+                                                            debug_text: None,
+                                                            conversion: None,
+                                                            format_spec: Some(
+                                                                InterpolatedStringFormatSpec {
+                                                                    range: 1195..1199,
+                                                                    node_index: NodeIndex(None),
+                                                                    elements: [
+                                                                        Literal(
+                                                                            InterpolatedStringLiteralElement {
+                                                                                range: 1195..1199,
+                                                                                node_index: NodeIndex(None),
+                                                                                value: "= 42",
+                                                                            },
+                                                                        ),
+                                                                    ],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
+                                                ],
+                                                flags: FStringFlags {
+                                                    quote_style: Double,
+                                                    prefix: Regular,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
                                                 },
-                                            ),
+                                            },
                                         ),
                                     },
                                 },
@@ -1173,52 +1171,50 @@ Module(
                                     range: 1214..1231,
                                     value: FStringValue {
                                         inner: Single(
-                                            FString(
-                                                FString {
-                                                    range: 1214..1231,
-                                                    node_index: NodeIndex(None),
-                                                    elements: [
-                                                        Interpolation(
-                                                            InterpolatedElement {
-                                                                range: 1216..1230,
-                                                                node_index: NodeIndex(None),
-                                                                expression: Named(
-                                                                    ExprNamed {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 1218..1228,
-                                                                        target: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 1218..1222,
-                                                                                id: Name("item"),
-                                                                                ctx: Store,
-                                                                            },
-                                                                        ),
-                                                                        value: NumberLiteral(
-                                                                            ExprNumberLiteral {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 1226..1228,
-                                                                                value: Int(
-                                                                                    42,
-                                                                                ),
-                                                                            },
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                debug_text: None,
-                                                                conversion: None,
-                                                                format_spec: None,
-                                                            },
-                                                        ),
-                                                    ],
-                                                    flags: FStringFlags {
-                                                        quote_style: Double,
-                                                        prefix: Regular,
-                                                        triple_quoted: false,
-                                                        unclosed: false,
-                                                    },
+                                            FString {
+                                                range: 1214..1231,
+                                                node_index: NodeIndex(None),
+                                                elements: [
+                                                    Interpolation(
+                                                        InterpolatedElement {
+                                                            range: 1216..1230,
+                                                            node_index: NodeIndex(None),
+                                                            expression: Named(
+                                                                ExprNamed {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 1218..1228,
+                                                                    target: Name(
+                                                                        ExprName {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 1218..1222,
+                                                                            id: Name("item"),
+                                                                            ctx: Store,
+                                                                        },
+                                                                    ),
+                                                                    value: NumberLiteral(
+                                                                        ExprNumberLiteral {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 1226..1228,
+                                                                            value: Int(
+                                                                                42,
+                                                                            ),
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            debug_text: None,
+                                                            conversion: None,
+                                                            format_spec: None,
+                                                        },
+                                                    ),
+                                                ],
+                                                flags: FStringFlags {
+                                                    quote_style: Double,
+                                                    prefix: Regular,
+                                                    triple_quoted: false,
+                                                    unclosed: false,
                                                 },
-                                            ),
+                                            },
                                         ),
                                     },
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__assert.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__assert.py.snap
@@ -18,19 +18,19 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 7..12,
-                            left: NumberLiteral(
-                                ExprNumberLiteral {
-                                    node_index: NodeIndex(None),
-                                    range: 7..8,
-                                    value: Int(
-                                        1,
-                                    ),
-                                },
-                            ),
                             ops: [
                                 Lt,
                             ],
-                            comparators: [
+                            operands: [
+                                NumberLiteral(
+                                    ExprNumberLiteral {
+                                        node_index: NodeIndex(None),
+                                        range: 7..8,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__for.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__for.py.snap
@@ -236,18 +236,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 151..157,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 151..152,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 LtE,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 151..152,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__if.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__if.py.snap
@@ -149,18 +149,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 56..61,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 56..57,
-                                    id: Name("x"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 Lt,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 56..57,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 NumberLiteral(
                                     ExprNumberLiteral {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__match.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__match.py.snap
@@ -4313,37 +4313,35 @@ Module(
                                             range: 2932..2938,
                                             value: FStringValue {
                                                 inner: Single(
-                                                    FString(
-                                                        FString {
-                                                            range: 2932..2938,
-                                                            node_index: NodeIndex(None),
-                                                            elements: [
-                                                                Interpolation(
-                                                                    InterpolatedElement {
-                                                                        range: 2934..2937,
-                                                                        node_index: NodeIndex(None),
-                                                                        expression: Name(
-                                                                            ExprName {
-                                                                                node_index: NodeIndex(None),
-                                                                                range: 2935..2936,
-                                                                                id: Name("y"),
-                                                                                ctx: Load,
-                                                                            },
-                                                                        ),
-                                                                        debug_text: None,
-                                                                        conversion: None,
-                                                                        format_spec: None,
-                                                                    },
-                                                                ),
-                                                            ],
-                                                            flags: FStringFlags {
-                                                                quote_style: Double,
-                                                                prefix: Regular,
-                                                                triple_quoted: false,
-                                                                unclosed: false,
-                                                            },
+                                                    FString {
+                                                        range: 2932..2938,
+                                                        node_index: NodeIndex(None),
+                                                        elements: [
+                                                            Interpolation(
+                                                                InterpolatedElement {
+                                                                    range: 2934..2937,
+                                                                    node_index: NodeIndex(None),
+                                                                    expression: Name(
+                                                                        ExprName {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 2935..2936,
+                                                                            id: Name("y"),
+                                                                            ctx: Load,
+                                                                        },
+                                                                    ),
+                                                                    debug_text: None,
+                                                                    conversion: None,
+                                                                    format_spec: None,
+                                                                },
+                                                            ),
+                                                        ],
+                                                        flags: FStringFlags {
+                                                            quote_style: Double,
+                                                            prefix: Regular,
+                                                            triple_quoted: false,
+                                                            unclosed: false,
                                                         },
-                                                    ),
+                                                    },
                                                 ),
                                             },
                                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__match.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__match.py.snap
@@ -3278,18 +3278,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 2282..2292,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 2282..2283,
-                                                id: Name("z"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             Eq,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 2282..2283,
+                                                    id: Name("z"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             BinOp(
                                                 ExprBinOp {
                                                     node_index: NodeIndex(None),
@@ -7947,19 +7947,19 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 5096..5101,
-                                        left: NumberLiteral(
-                                            ExprNumberLiteral {
-                                                node_index: NodeIndex(None),
-                                                range: 5096..5097,
-                                                value: Int(
-                                                    1,
-                                                ),
-                                            },
-                                        ),
                                         ops: [
                                             Lt,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    node_index: NodeIndex(None),
+                                                    range: 5096..5097,
+                                                    value: Int(
+                                                        1,
+                                                    ),
+                                                },
+                                            ),
                                             NumberLiteral(
                                                 ExprNumberLiteral {
                                                     node_index: NodeIndex(None),
@@ -8866,18 +8866,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 5738..5752,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 5738..5743,
-                                            id: Name("query"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         Eq,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 5738..5743,
+                                                id: Name("query"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__raise.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__raise.py.snap
@@ -79,19 +79,19 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 41..46,
-                                left: NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 41..42,
-                                        value: Int(
-                                            1,
-                                        ),
-                                    },
-                                ),
                                 ops: [
                                     Lt,
                                 ],
-                                comparators: [
+                                operands: [
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 41..42,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
                                     NumberLiteral(
                                         ExprNumberLiteral {
                                             node_index: NodeIndex(None),
@@ -342,19 +342,19 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 186..191,
-                                left: NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 186..187,
-                                        value: Int(
-                                            1,
-                                        ),
-                                    },
-                                ),
                                 ops: [
                                     Lt,
                                 ],
-                                comparators: [
+                                operands: [
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 186..187,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
                                     NumberLiteral(
                                         ExprNumberLiteral {
                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__return.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__return.py.snap
@@ -168,19 +168,19 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 80..85,
-                                left: NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 80..81,
-                                        value: Int(
-                                            1,
-                                        ),
-                                    },
-                                ),
                                 ops: [
                                     Lt,
                                 ],
-                                comparators: [
+                                operands: [
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 80..81,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
                                     NumberLiteral(
                                         ExprNumberLiteral {
                                             node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__try.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__try.py.snap
@@ -660,65 +660,63 @@ Module(
                                                                     range: 505..524,
                                                                     value: FStringValue {
                                                                         inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 505..524,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 507..514,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 514..523,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 515..522,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 515..519,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 519..522,
+                                                                            FString {
+                                                                                range: 505..524,
+                                                                                node_index: NodeIndex(None),
+                                                                                elements: [
+                                                                                    Literal(
+                                                                                        InterpolatedStringLiteralElement {
+                                                                                            range: 507..514,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "caught ",
+                                                                                        },
+                                                                                    ),
+                                                                                    Interpolation(
+                                                                                        InterpolatedElement {
+                                                                                            range: 514..523,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            expression: Call(
+                                                                                                ExprCall {
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    range: 515..522,
+                                                                                                    func: Name(
+                                                                                                        ExprName {
                                                                                                             node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 520..521,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
+                                                                                                            range: 515..519,
+                                                                                                            id: Name("type"),
+                                                                                                            ctx: Load,
                                                                                                         },
+                                                                                                    ),
+                                                                                                    arguments: Arguments {
+                                                                                                        range: 519..522,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        args: [
+                                                                                                            Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 520..521,
+                                                                                                                    id: Name("e"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ],
+                                                                                                        keywords: [],
                                                                                                     },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                flags: FStringFlags {
+                                                                                    quote_style: Double,
+                                                                                    prefix: Regular,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
+                                                                            },
                                                                         ),
                                                                     },
                                                                 },
@@ -781,65 +779,63 @@ Module(
                                                                     range: 557..576,
                                                                     value: FStringValue {
                                                                         inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 557..576,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 559..566,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 566..575,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 567..574,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 567..571,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 571..574,
+                                                                            FString {
+                                                                                range: 557..576,
+                                                                                node_index: NodeIndex(None),
+                                                                                elements: [
+                                                                                    Literal(
+                                                                                        InterpolatedStringLiteralElement {
+                                                                                            range: 559..566,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "caught ",
+                                                                                        },
+                                                                                    ),
+                                                                                    Interpolation(
+                                                                                        InterpolatedElement {
+                                                                                            range: 566..575,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            expression: Call(
+                                                                                                ExprCall {
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    range: 567..574,
+                                                                                                    func: Name(
+                                                                                                        ExprName {
                                                                                                             node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 572..573,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
+                                                                                                            range: 567..571,
+                                                                                                            id: Name("type"),
+                                                                                                            ctx: Load,
                                                                                                         },
+                                                                                                    ),
+                                                                                                    arguments: Arguments {
+                                                                                                        range: 571..574,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                        args: [
+                                                                                                            Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 572..573,
+                                                                                                                    id: Name("e"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ],
+                                                                                                        keywords: [],
                                                                                                     },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                flags: FStringFlags {
+                                                                                    quote_style: Double,
+                                                                                    prefix: Regular,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
+                                                                            },
                                                                         ),
                                                                     },
                                                                 },
@@ -1095,101 +1091,99 @@ Module(
                                                                     range: 704..750,
                                                                     value: FStringValue {
                                                                         inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 704..750,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 706..713,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 713..722,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 714..721,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 714..718,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 718..721,
+                                                                            FString {
+                                                                                range: 704..750,
+                                                                                node_index: NodeIndex(None),
+                                                                                elements: [
+                                                                                    Literal(
+                                                                                        InterpolatedStringLiteralElement {
+                                                                                            range: 706..713,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "caught ",
+                                                                                        },
+                                                                                    ),
+                                                                                    Interpolation(
+                                                                                        InterpolatedElement {
+                                                                                            range: 713..722,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            expression: Call(
+                                                                                                ExprCall {
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    range: 714..721,
+                                                                                                    func: Name(
+                                                                                                        ExprName {
                                                                                                             node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 719..720,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
+                                                                                                            range: 714..718,
+                                                                                                            id: Name("type"),
+                                                                                                            ctx: Load,
                                                                                                         },
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 722..735,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: " with nested ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 735..749,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Attribute(
-                                                                                                    ExprAttribute {
+                                                                                                    ),
+                                                                                                    arguments: Arguments {
+                                                                                                        range: 718..721,
                                                                                                         node_index: NodeIndex(None),
-                                                                                                        range: 736..748,
-                                                                                                        value: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 736..737,
-                                                                                                                id: Name("e"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        attr: Identifier {
-                                                                                                            id: Name("exceptions"),
-                                                                                                            range: 738..748,
-                                                                                                            node_index: NodeIndex(None),
-                                                                                                        },
-                                                                                                        ctx: Load,
+                                                                                                        args: [
+                                                                                                            Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 719..720,
+                                                                                                                    id: Name("e"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ],
+                                                                                                        keywords: [],
                                                                                                     },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    Literal(
+                                                                                        InterpolatedStringLiteralElement {
+                                                                                            range: 722..735,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: " with nested ",
+                                                                                        },
+                                                                                    ),
+                                                                                    Interpolation(
+                                                                                        InterpolatedElement {
+                                                                                            range: 735..749,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            expression: Attribute(
+                                                                                                ExprAttribute {
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    range: 736..748,
+                                                                                                    value: Name(
+                                                                                                        ExprName {
+                                                                                                            node_index: NodeIndex(None),
+                                                                                                            range: 736..737,
+                                                                                                            id: Name("e"),
+                                                                                                            ctx: Load,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    attr: Identifier {
+                                                                                                        id: Name("exceptions"),
+                                                                                                        range: 738..748,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                    },
+                                                                                                    ctx: Load,
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                flags: FStringFlags {
+                                                                                    quote_style: Double,
+                                                                                    prefix: Regular,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
+                                                                            },
                                                                         ),
                                                                     },
                                                                 },
@@ -1252,101 +1246,99 @@ Module(
                                                                     range: 784..830,
                                                                     value: FStringValue {
                                                                         inner: Single(
-                                                                            FString(
-                                                                                FString {
-                                                                                    range: 784..830,
-                                                                                    node_index: NodeIndex(None),
-                                                                                    elements: [
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 786..793,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: "caught ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 793..802,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Call(
-                                                                                                    ExprCall {
-                                                                                                        node_index: NodeIndex(None),
-                                                                                                        range: 794..801,
-                                                                                                        func: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 794..798,
-                                                                                                                id: Name("type"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        arguments: Arguments {
-                                                                                                            range: 798..801,
+                                                                            FString {
+                                                                                range: 784..830,
+                                                                                node_index: NodeIndex(None),
+                                                                                elements: [
+                                                                                    Literal(
+                                                                                        InterpolatedStringLiteralElement {
+                                                                                            range: 786..793,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: "caught ",
+                                                                                        },
+                                                                                    ),
+                                                                                    Interpolation(
+                                                                                        InterpolatedElement {
+                                                                                            range: 793..802,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            expression: Call(
+                                                                                                ExprCall {
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    range: 794..801,
+                                                                                                    func: Name(
+                                                                                                        ExprName {
                                                                                                             node_index: NodeIndex(None),
-                                                                                                            args: [
-                                                                                                                Name(
-                                                                                                                    ExprName {
-                                                                                                                        node_index: NodeIndex(None),
-                                                                                                                        range: 799..800,
-                                                                                                                        id: Name("e"),
-                                                                                                                        ctx: Load,
-                                                                                                                    },
-                                                                                                                ),
-                                                                                                            ],
-                                                                                                            keywords: [],
+                                                                                                            range: 794..798,
+                                                                                                            id: Name("type"),
+                                                                                                            ctx: Load,
                                                                                                         },
-                                                                                                    },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                        Literal(
-                                                                                            InterpolatedStringLiteralElement {
-                                                                                                range: 802..815,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                value: " with nested ",
-                                                                                            },
-                                                                                        ),
-                                                                                        Interpolation(
-                                                                                            InterpolatedElement {
-                                                                                                range: 815..829,
-                                                                                                node_index: NodeIndex(None),
-                                                                                                expression: Attribute(
-                                                                                                    ExprAttribute {
+                                                                                                    ),
+                                                                                                    arguments: Arguments {
+                                                                                                        range: 798..801,
                                                                                                         node_index: NodeIndex(None),
-                                                                                                        range: 816..828,
-                                                                                                        value: Name(
-                                                                                                            ExprName {
-                                                                                                                node_index: NodeIndex(None),
-                                                                                                                range: 816..817,
-                                                                                                                id: Name("e"),
-                                                                                                                ctx: Load,
-                                                                                                            },
-                                                                                                        ),
-                                                                                                        attr: Identifier {
-                                                                                                            id: Name("exceptions"),
-                                                                                                            range: 818..828,
-                                                                                                            node_index: NodeIndex(None),
-                                                                                                        },
-                                                                                                        ctx: Load,
+                                                                                                        args: [
+                                                                                                            Name(
+                                                                                                                ExprName {
+                                                                                                                    node_index: NodeIndex(None),
+                                                                                                                    range: 799..800,
+                                                                                                                    id: Name("e"),
+                                                                                                                    ctx: Load,
+                                                                                                                },
+                                                                                                            ),
+                                                                                                        ],
+                                                                                                        keywords: [],
                                                                                                     },
-                                                                                                ),
-                                                                                                debug_text: None,
-                                                                                                conversion: None,
-                                                                                                format_spec: None,
-                                                                                            },
-                                                                                        ),
-                                                                                    ],
-                                                                                    flags: FStringFlags {
-                                                                                        quote_style: Double,
-                                                                                        prefix: Regular,
-                                                                                        triple_quoted: false,
-                                                                                        unclosed: false,
-                                                                                    },
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                    Literal(
+                                                                                        InterpolatedStringLiteralElement {
+                                                                                            range: 802..815,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            value: " with nested ",
+                                                                                        },
+                                                                                    ),
+                                                                                    Interpolation(
+                                                                                        InterpolatedElement {
+                                                                                            range: 815..829,
+                                                                                            node_index: NodeIndex(None),
+                                                                                            expression: Attribute(
+                                                                                                ExprAttribute {
+                                                                                                    node_index: NodeIndex(None),
+                                                                                                    range: 816..828,
+                                                                                                    value: Name(
+                                                                                                        ExprName {
+                                                                                                            node_index: NodeIndex(None),
+                                                                                                            range: 816..817,
+                                                                                                            id: Name("e"),
+                                                                                                            ctx: Load,
+                                                                                                        },
+                                                                                                    ),
+                                                                                                    attr: Identifier {
+                                                                                                        id: Name("exceptions"),
+                                                                                                        range: 818..828,
+                                                                                                        node_index: NodeIndex(None),
+                                                                                                    },
+                                                                                                    ctx: Load,
+                                                                                                },
+                                                                                            ),
+                                                                                            debug_text: None,
+                                                                                            conversion: None,
+                                                                                            format_spec: None,
+                                                                                        },
+                                                                                    ),
+                                                                                ],
+                                                                                flags: FStringFlags {
+                                                                                    quote_style: Double,
+                                                                                    prefix: Regular,
+                                                                                    triple_quoted: false,
+                                                                                    unclosed: false,
                                                                                 },
-                                                                            ),
+                                                                            },
                                                                         ),
                                                                     },
                                                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__type.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__type.py.snap
@@ -2780,18 +2780,18 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 1683..1697,
-                                    left: Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 1683..1688,
-                                            id: Name("query"),
-                                            ctx: Load,
-                                        },
-                                    ),
                                     ops: [
                                         Eq,
                                     ],
-                                    comparators: [
+                                    operands: [
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 1683..1688,
+                                                id: Name("query"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                         Name(
                                             ExprName {
                                                 node_index: NodeIndex(None),
@@ -2917,18 +2917,18 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 1732..1741,
-                            left: Name(
-                                ExprName {
-                                    node_index: NodeIndex(None),
-                                    range: 1732..1736,
-                                    id: Name("type"),
-                                    ctx: Load,
-                                },
-                            ),
                             ops: [
                                 In,
                             ],
-                            comparators: [
+                            operands: [
+                                Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 1732..1736,
+                                        id: Name("type"),
+                                        ctx: Load,
+                                    },
+                                ),
                                 Name(
                                     ExprName {
                                         node_index: NodeIndex(None),

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__while.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__while.py.snap
@@ -53,18 +53,18 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 25..30,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 25..26,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
                                         ops: [
                                             Gt,
                                         ],
-                                        comparators: [
+                                        operands: [
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 25..26,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                             NumberLiteral(
                                                 ExprNumberLiteral {
                                                     node_index: NodeIndex(None),

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2536,16 +2536,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 operand,
                 ..
             }) => Self::condition_evaluation_is_known_safe(operand),
-            ast::Expr::Compare(ast::ExprCompare {
-                left,
-                ops,
-                comparators,
-                ..
-            }) => {
+            ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) => {
                 ops.iter()
                     .all(|op| matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot))
-                    && Self::expression_evaluation_is_known_safe(left)
-                    && comparators
+                    && operands
                         .iter()
                         .all(Self::expression_evaluation_is_known_safe)
             }
@@ -3613,19 +3607,16 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         || !Self::condition_evaluation_is_known_safe(&unary.operand),
                 );
             }
-            ast::Expr::Compare(ast::ExprCompare {
-                left,
-                ops,
-                comparators,
-                ..
-            }) => {
-                self.visit_expr(left);
-                for (op, comparator) in ops.iter().zip(comparators) {
-                    self.visit_expr(comparator);
-                    self.record_exception_checkpoint_if(!matches!(
-                        op,
-                        ast::CmpOp::Is | ast::CmpOp::IsNot
-                    ));
+            ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) => {
+                if let Some((left, comparators)) = operands.split_first() {
+                    self.visit_expr(left);
+                    for (op, comparator) in ops.iter().zip(comparators) {
+                        self.visit_expr(comparator);
+                        self.record_exception_checkpoint_if(!matches!(
+                            op,
+                            ast::CmpOp::Is | ast::CmpOp::IsNot
+                        ));
+                    }
                 }
             }
             ast::Expr::BoolOp(node) => self.visit_bool_expression(node, context),

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -5840,9 +5840,15 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
         for scope_info in self.scope_stack.iter().rev() {
             let scope = &self.scopes[scope_info.file_scope_id];
             let generators = match scope.node() {
-                NodeWithScopeKind::ListComprehension(node) => &node.node(self.module).generators,
-                NodeWithScopeKind::SetComprehension(node) => &node.node(self.module).generators,
-                NodeWithScopeKind::DictComprehension(node) => &node.node(self.module).generators,
+                NodeWithScopeKind::ListComprehension(node) => {
+                    node.node(self.module).generators.as_ref()
+                }
+                NodeWithScopeKind::SetComprehension(node) => {
+                    node.node(self.module).generators.as_ref()
+                }
+                NodeWithScopeKind::DictComprehension(node) => {
+                    node.node(self.module).generators.as_ref()
+                }
                 _ => continue,
             };
             if generators

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -647,12 +647,8 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
     fn expr_compare(&self, expr_compare: &ast::ExprCompare) -> PossiblyNarrowedPlaces {
         let mut places = PossiblyNarrowedPlaces::default();
 
-        // The left side can be narrowed
-        self.add_narrowing_target(&expr_compare.left, &mut places);
-
-        // Each comparator can also be narrowed
-        for comparator in &expr_compare.comparators {
-            self.add_narrowing_target(comparator, &mut places);
+        for operand in &expr_compare.operands {
+            self.add_narrowing_target(operand, &mut places);
         }
 
         let can_narrow_tagged_union_base = matches!(
@@ -661,7 +657,7 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
         );
 
         // Tagged-union checks can also narrow the base of a subscript or attribute on either side.
-        for expr in std::iter::once(&*expr_compare.left).chain(&expr_compare.comparators) {
+        for expr in &expr_compare.operands {
             if can_narrow_tagged_union_base
                 && let ast::Expr::Subscript(subscript) = expr.expression_value()
                 && let Some(place_expr) = PlaceExpr::try_from_expr(&subscript.value)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11057,6 +11057,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ast::ExprAttribute {
             value,
             attr,
+            range: _,
             node_index: _,
             ctx,
         } = attribute;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11057,7 +11057,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ast::ExprAttribute {
             value,
             attr,
-            range: _,
             node_index: _,
             ctx,
         } = attribute;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6966,10 +6966,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Make sure we iter through every parts to infer all sub-expressions. The `collector`
             // struct ensures we don't allocate unnecessary strings.
             match part {
-                ast::FStringPart::Literal(literal) => {
+                ast::FStringPartRef::Literal(literal) => {
                     collector.push_str(&literal.value);
                 }
-                ast::FStringPart::FString(fstring) => {
+                ast::FStringPartRef::FString(fstring) => {
                     for element in &fstring.elements {
                         match element {
                             ast::InterpolatedStringElement::Interpolation(expression) => {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11546,12 +11546,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let ast::ExprCompare {
             range: _,
             node_index: _,
-            left,
             ops,
-            comparators,
+            operands,
         } = compare;
 
-        self.infer_expression(left, TypeContext::default());
+        if let Some(left) = operands.first() {
+            self.infer_expression(left, TypeContext::default());
+        }
         let mut last_comparison_ty = Type::unknown();
 
         // https://docs.python.org/3/reference/expressions.html#comparisons
@@ -11567,10 +11568,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = self.infer_chained_boolean_types(
             ast::BoolOp::And,
             false,
-            std::iter::once(&**left)
-                .chain(comparators)
-                .tuple_windows::<(_, _)>()
-                .zip(ops),
+            operands.iter().tuple_windows::<(_, _)>().zip(ops),
             |_| false,
             |builder, ((left, right), op), _peer_ty| {
                 let left_ty = builder.expression_type(left);

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -122,14 +122,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ));
             }
 
-            if let ast::Expr::Compare(ast::ExprCompare {
-                left,
-                ops,
-                comparators,
-                ..
-            }) = test
+            if let ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test
                 && ops.len() == 1
-                && let [single_comparator] = &**comparators
+                && let [left, single_comparator] = &**operands
             {
                 if let (Type::LiteralValue(left_type), Type::LiteralValue(right_type)) = (
                     self.expression_type(left),
@@ -611,16 +606,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         let env = self.program_environment();
 
-        if let ast::Expr::Compare(ast::ExprCompare {
-            left,
-            ops,
-            comparators,
-            ..
-        }) = test
+        if let ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test
             && let [single_op] = &**ops
-            && let [single_comparator] = &**comparators
+            && let [left, single_comparator] = &**operands
             && let (ast::Expr::Call(call), other) | (other, ast::Expr::Call(call)) =
-                (&**left, single_comparator)
+                (left, single_comparator)
             && matches!(single_op, ast::CmpOp::Eq | ast::CmpOp::NotEq)
             && let ast::Arguments { args, keywords, .. } = &call.arguments
             && keywords.is_empty()
@@ -976,7 +966,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let candidates = match operand {
             ast::Expr::Name(_) => [Some(operand), None],
             ast::Expr::Compare(compare) if compare.ops.len() == 1 => {
-                [Some(compare.left.as_ref()), compare.comparators.first()]
+                [compare.operands.first(), compare.operands.get(1)]
             }
             ast::Expr::Call(call) => [call.arguments.args.first(), None],
             _ => return None,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4032,21 +4032,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let ast::ExprCompare {
             range: _,
             node_index: _,
-            left,
             ops,
-            comparators,
+            operands,
         } = expr_compare;
 
         // Performance optimization: early return if there are no potential narrowing targets.
-        if !is_narrowing_target_candidate(left)
-            && comparators
-                .iter()
-                .all(|c| !is_narrowing_target_candidate(c))
+        if operands
+            .iter()
+            .all(|operand| !is_narrowing_target_candidate(operand))
         {
             return None;
         }
 
-        if !is_positive && comparators.len() > 1 {
+        if !is_positive && ops.len() > 1 {
             // We can't negate a constraint made by a multi-comparator expression, since we can't
             // know which comparison part is the one being negated.
             // For example, the negation of  `x is 1 is y is 2`, would be `(x is not 1) or (y is not 1) or (y is not 2)`
@@ -4056,8 +4054,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         let inference = infer_expression_types(db, expression, TypeContext::default());
 
-        let comparator_tuples = std::iter::once(&**left)
-            .chain(comparators)
+        let comparator_tuples = operands
+            .iter()
             .tuple_windows::<(&ruff_python_ast::Expr, &ruff_python_ast::Expr)>();
         let mut constraints = NarrowingConstraints::default();
 
@@ -4068,7 +4066,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //             reveal_type(t)  # tuple[int, int]
         if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
             && let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is)
-            && let ast::Expr::Subscript(subscript) = left.expression_value()
+            && let ast::Expr::Subscript(subscript) = operands[0].expression_value()
             && let Type::Union(union) = inference
                 .expression_type(&*subscript.value)
                 .resolve_type_alias(db)
@@ -4077,7 +4075,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .expression_type(&*subscript.slice)
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
-            && let rhs_ty = inference.expression_type(&comparators[0])
+            && let rhs_ty = inference.expression_type(&operands[1])
         {
             let filtered = union.filter(db, |elem| {
                 elem.tuple_instance_spec(db, &self.env)
@@ -4135,15 +4133,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
 
             // E.g., `len(items) == 2`
-            if let ast::Expr::Call(call) = left.expression_value() {
-                narrow_len_call(call, inference.expression_type(&comparators[0]), comparison);
+            if let ast::Expr::Call(call) = operands[0].expression_value() {
+                narrow_len_call(call, inference.expression_type(&operands[1]), comparison);
             }
 
             // E.g., `2 == len(items)`
-            if let ast::Expr::Call(call) = comparators[0].expression_value() {
+            if let ast::Expr::Call(call) = operands[1].expression_value() {
                 narrow_len_call(
                     call,
-                    inference.expression_type(&**left),
+                    inference.expression_type(&operands[0]),
                     comparison.reflected(),
                 );
             }
@@ -4189,12 +4187,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             };
 
-            if let ast::Expr::Subscript(subscript) = left.expression_value() {
-                narrow_subscript(subscript, inference.expression_type(&comparators[0]));
+            if let ast::Expr::Subscript(subscript) = operands[0].expression_value() {
+                narrow_subscript(subscript, inference.expression_type(&operands[1]));
             }
 
-            if let ast::Expr::Subscript(subscript) = comparators[0].expression_value() {
-                narrow_subscript(subscript, inference.expression_type(&**left));
+            if let ast::Expr::Subscript(subscript) = operands[1].expression_value() {
+                narrow_subscript(subscript, inference.expression_type(&operands[0]));
             }
         }
 
@@ -4225,17 +4223,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             };
 
-            if let ast::Expr::Attribute(attribute) = &**left
-                && comparators[0].as_named_expr().is_none_or(|named| {
+            if let ast::Expr::Attribute(attribute) = &operands[0]
+                && operands[1].as_named_expr().is_none_or(|named| {
                     PlaceExpr::try_from_expr(&named.target)
                         != PlaceExpr::try_from_expr(&attribute.value)
                 })
             {
-                narrow_attribute(attribute, inference.expression_type(&comparators[0]));
+                narrow_attribute(attribute, inference.expression_type(&operands[1]));
             }
 
-            if let ast::Expr::Attribute(attribute) = &comparators[0] {
-                narrow_attribute(attribute, inference.expression_type(&**left));
+            if let ast::Expr::Attribute(attribute) = &operands[1] {
+                narrow_attribute(attribute, inference.expression_type(&operands[0]));
             }
         }
 
@@ -4252,16 +4250,16 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //     if "foo" not in u:
         //         reveal_type(u)  # revealed: Bar
         if matches!(&**ops, [ast::CmpOp::In | ast::CmpOp::NotIn])
-            && let Some(key) = inference.expression_type(&**left).as_string_literal()
-            && let rhs_expr = comparators[0].expression_value()
-            && let rhs_type = inference.expression_type(&comparators[0])
+            && let Some(key) = inference.expression_type(&operands[0]).as_string_literal()
+            && let rhs_expr = operands[1].expression_value()
+            && let rhs_type = inference.expression_type(&operands[1])
             && is_or_contains_typeddict(db, rhs_type)
         {
             let key = key.value(db);
             let apply_constraint =
                 |constraints: &mut NarrowingConstraints<'db>,
                  constraint: NarrowingConstraint<'db>| {
-                    let comparator_place = PlaceExpr::try_from_expr(&comparators[0])
+                    let comparator_place = PlaceExpr::try_from_expr(&operands[1])
                         .and_then(|place_expr| self.places().place_id(&place_expr));
                     if let Some(place) = comparator_place {
                         constraints.insert(place, constraint.clone());


### PR DESCRIPTION
## Summary

We reduce `Expr` from 64 to 56 bytes on 64-bit targets. The largest variants determine the enum's size, so shrinking those variants saves eight bytes in every `Expr` value, including expressions in the parsed modules retained by ty.

The changes are:

- Store positional call arguments in `ThinVec`, reducing `Arguments` and `ExprCall` by eight bytes.
- Store all comparison operands in one boxed slice. This removes the separate left-operand allocation and reduces `ExprCompare` by eight bytes while keeping operators in a boxed slice.
- Store dictionary-comprehension generators in a boxed slice, reducing `ExprDictComp` by eight bytes.
- Store f-string and t-string elements in boxed slices, and represent a single f-string directly as `FString`. This keeps single parts inline and reduces `ExprFString` and `ExprTString` by eight bytes.

The parser, AST visitors, formatter, lint rules, and type inference use the updated layouts. Size assertions cover the 56-byte enum and its affected variants.
