### PR TITLE
[ty] Skip decorator flags query for undecorated methods

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -89,7 +89,11 @@ impl MethodReceiverKind {
             return None;
         }
 
-        let decorators = function_known_decorator_flags(db, definition);
+        let decorators = if function.decorator_list.is_empty() {
+            FunctionDecorators::empty()
+        } else {
+            function_known_decorator_flags(db, definition)
+        };
         if decorators.contains(FunctionDecorators::STATICMETHOD) && function.name.id != "__new__" {
             return None;
         }


### PR DESCRIPTION
## Summary

An undecorated method can request `function_known_decorator_flags` while determining its receiver kind. For an empty decorator list, the flags are empty, so use that value directly and avoid retaining the decorator inference query.

The existing fast path in [#24839](https://github.com/astral-sh/ruff/pull/24839) covers function definition inference; this handles the separate receiver classification call site.
