### PR TITLE
[`flake8-annotations`] Mention return annotations in `any-type` (`ANN401`) docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -486,8 +486,8 @@ impl Violation for MissingReturnTypeClassMethod {
 }
 
 /// ## What it does
-/// Checks that function arguments are annotated with a more specific type than
-/// `Any`.
+/// Checks that function arguments and return values are annotated with a more
+/// specific type than `Any`.
 ///
 /// ## Why is this bad?
 /// `Any` is a special type indicating an unconstrained type. When an
@@ -503,13 +503,13 @@ impl Violation for MissingReturnTypeClassMethod {
 /// from typing import Any
 ///
 ///
-/// def foo(x: Any): ...
+/// def foo(x: Any) -> Any: ...
 /// ```
 ///
 /// Use instead:
 ///
 /// ```python
-/// def foo(x: int): ...
+/// def foo(x: int) -> int: ...
 /// ```
 ///
 /// ## Known problems


### PR DESCRIPTION
## Summary

The docs for `any-type` (ANN401) only mention function arguments, but the rule also reports `-> Any` return annotations. Updated the "What it does" sentence and the example so both cases are shown.

See #28298 (the docs part of it; the broader question about nested `Any` is separate).

## Test Plan

Docs-only change, no code touched.
