### PR TITLE
[ty] Apply Liskov assignability check to `@override`d `__init__`/`__new__`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -2154,6 +2154,81 @@ class DataSub(DataSuper):
         super().__post_init__(x)
 ```
 
+## `@override` on `__init__` or `__new__`
+
+An explicit `@override` on `__init__` or `__new__` asserts that the override is compatible with the
+overridden method, so the exclusion above does not apply to those two methods. This matches
+[the typing spec](https://typing.python.org/en/latest/spec/class-compat.html#override), which does
+not exempt constructors from the assignability check that `@override` otherwise requires:
+
+```pyi
+from typing_extensions import Self, override
+
+class Base:
+    def __init__(self, x: int) -> None: ...
+    def __new__(cls, x: int) -> Self: ...
+
+class IncompatibleInit(Base):
+    @override
+    def __init__(self, x: str) -> None: ...  # error: [invalid-method-override]
+
+class IncompatibleNew(Base):
+    @override
+    def __new__(cls, x: str) -> Self: ...  # error: [invalid-method-override]
+
+class CompatibleOverride(Base):
+    @override
+    def __init__(self, x: int, y: int = 0) -> None: ...
+    @override
+    def __new__(cls, x: int, y: int = 0) -> Self: ...
+```
+
+Without `@override`, `__init__` and `__new__` keep the exclusion from above, since it is normal for
+a subclass to take different constructor arguments than its parent:
+
+```pyi
+class Unmarked(Base):
+    def __init__(self, x: str) -> None: ...
+    def __new__(cls, x: str) -> Self: ...
+```
+
+`__post_init__` and `__init_subclass__` are not covered by the typing spec's constructor exception
+for `@override`; they keep the exclusion even when explicitly marked:
+
+```pyi
+from typing_extensions import override
+
+class HooksBase:
+    def __post_init__(self) -> None: ...
+    def __init_subclass__(cls, **kwargs: object) -> None: ...
+
+class HooksSub(HooksBase):
+    @override
+    def __post_init__(self, extra: int) -> None: ...
+    @override
+    def __init_subclass__(cls, extra: int, **kwargs: object) -> None: ...
+```
+
+## An `@override`d constructor is checked against every ancestor
+
+An `@override`d constructor is checked against the whole class hierarchy, the same as any other
+overridden method: only one diagnostic is reported, against the closest ancestor that defines the
+method, even when a more distant ancestor also defines an incompatible `__init__`:
+
+```pyi
+from typing_extensions import override
+
+class Grandparent:
+    def __init__(self, x: int) -> None: ...
+
+class Parent(Grandparent):
+    def __init__(self, x: int) -> None: ...
+
+class Child(Parent):
+    @override
+    def __init__(self, x: str) -> None: ...  # error: [invalid-method-override]
+```
+
 ## Functions assigned in a class body
 
 A function assigned in a class body is bound as a method. It can conflict with a method definition

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -2192,6 +2192,22 @@ class Unmarked(Base):
     def __new__(cls, x: str) -> Self: ...
 ```
 
+`__new__`'s implicit `cls` parameter is not part of its override contract: it always takes the type
+it is actually called on, so an `@override`d `__new__` with a covariant, concrete return type is
+accepted even though `cls` is declared as `type[NewBase]` on the base method and `type[NewChild]` on
+the override:
+
+```pyi
+from typing_extensions import override
+
+class NewBase:
+    def __new__(cls, x: int) -> NewBase: ...
+
+class NewChild(NewBase):
+    @override
+    def __new__(cls, x: int) -> NewChild: ...
+```
+
 `__post_init__` and `__init_subclass__` are not covered by the typing spec's constructor exception
 for `@override`; they keep the exclusion even when explicitly marked:
 
@@ -2213,20 +2229,38 @@ class HooksSub(HooksBase):
 
 An `@override`d constructor is checked against the whole class hierarchy, the same as any other
 overridden method: only one diagnostic is reported, against the closest ancestor that defines the
-method, even when a more distant ancestor also defines an incompatible `__init__`:
+method, even when a more distant ancestor also defines an incompatible `__init__`. Here,
+`Parent.__init__` accepts anything, so `Child.__init__` is compatible with it; the diagnostic
+instead names `Grandparent`, which `Child.__init__` is not compatible with:
 
 ```pyi
+from typing import Any
 from typing_extensions import override
 
 class Grandparent:
     def __init__(self, x: int) -> None: ...
 
 class Parent(Grandparent):
-    def __init__(self, x: int) -> None: ...
+    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
 class Child(Parent):
     @override
-    def __init__(self, x: str) -> None: ...  # error: [invalid-method-override]
+    def __init__(self, x: str) -> None: ...  # snapshot: invalid-method-override
+```
+
+```snapshot
+error[invalid-method-override]: Invalid override of method `__init__`
+  --> src/mdtest_snippet.pyi:12:9
+   |
+12 |     def __init__(self, x: str) -> None: ...  # snapshot: invalid-method-override
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Definition is incompatible with `Grandparent.__init__`
+   |
+  ::: src/mdtest_snippet.pyi:5:9
+   |
+ 5 |     def __init__(self, x: int) -> None: ...
+   |         ------------------------------ `Grandparent.__init__` defined here
+info: parameter `x` has an incompatible type: `int` is not assignable to `str`
+info: This violates the Liskov Substitution Principle
 ```
 
 ## Functions assigned in a class body

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -254,7 +254,7 @@ fn check_inherited_method_conflicts<'db>(
                     continue;
                 };
                 let Some((selected_ty, contract_ty)) =
-                    method_override_types(db, env, selected_ty, contract_ty)
+                    method_override_types(db, env, selected_ty, contract_ty, receiver)
                 else {
                     continue;
                 };
@@ -312,7 +312,13 @@ fn check_inherited_method_conflicts<'db>(
                         continue;
                     };
                     if parent_decorator != ancestor_decorator
-                        || !is_assignable_method_override(db, env, parent_ty, ancestor_ty)
+                        || !is_assignable_method_override(
+                            db,
+                            env,
+                            parent_ty,
+                            ancestor_ty,
+                            parent_receiver,
+                        )
                     {
                         continue;
                     }
@@ -902,9 +908,13 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let Some((subclass_override_type, superclass_override_type)) =
-                method_override_types(db, env, type_on_subclass_instance, superclass_type)
-            else {
+            let Some((subclass_override_type, superclass_override_type)) = method_override_types(
+                db,
+                env,
+                type_on_subclass_instance,
+                superclass_type,
+                instance_of_class,
+            ) else {
                 continue;
             };
 
@@ -921,9 +931,9 @@ fn check_class_declaration<'db>(
                     env,
                     bases,
                     method_owner,
-                    superclass,
-                    superclass_type,
+                    (superclass, superclass_type),
                     &member.name,
+                    instance_of_class,
                 )
             {
                 continue;
@@ -1023,9 +1033,11 @@ fn is_inherited_method_violation<'db>(
     env: &ProgramEnvironment<'db>,
     bases: &[ClassBase<'db>],
     method_owner: ClassType<'db>,
-    superclass: ClassType<'db>,
-    superclass_type: Type<'db>,
+    // The ancestor whose contract for this method was just found incompatible, together with the
+    // type of that contract. Bundled into a pair to keep this function's argument count in check.
+    (superclass, superclass_type): (ClassType<'db>, Type<'db>),
     name: &Name,
+    subclass_receiver: Type<'db>,
 ) -> bool {
     // An earlier MRO entry can select a different method in its own hierarchy. Check each
     // ancestor that inherits the method actually selected by the child's MRO.
@@ -1044,7 +1056,13 @@ fn is_inherited_method_violation<'db>(
             else {
                 return false;
             };
-            if is_assignable_method_override(db, env, parent_type, superclass_type) {
+            if is_assignable_method_override(
+                db,
+                env,
+                parent_type,
+                superclass_type,
+                subclass_receiver,
+            ) {
                 return false;
             }
 
@@ -1066,7 +1084,13 @@ fn is_inherited_method_violation<'db>(
                     else {
                         return false;
                     };
-                    !is_assignable_method_override(db, env, parent_type, ancestor_type)
+                    !is_assignable_method_override(
+                        db,
+                        env,
+                        parent_type,
+                        ancestor_type,
+                        subclass_receiver,
+                    )
                 })
         })
 }
@@ -1093,17 +1117,25 @@ fn is_assignable_method_override<'db>(
     env: &ProgramEnvironment<'db>,
     subclass_type: Type<'db>,
     superclass_type: Type<'db>,
+    subclass_receiver: Type<'db>,
 ) -> bool {
-    method_override_types(db, env, subclass_type, superclass_type).is_some_and(
+    method_override_types(db, env, subclass_type, superclass_type, subclass_receiver).is_some_and(
         |(subclass_type, superclass_type)| subclass_type.is_assignable_to(db, env, superclass_type),
     )
 }
 
+/// Returns the callable types to compare for a method override, or `None` if `superclass_type`
+/// cannot be compared as a callable.
+///
+/// `subclass_receiver` is an instance of the subclass whose declaration is being checked. It is
+/// used to normalize the implicit receiver of an `@override`d `__new__`, the same way the
+/// `BoundMethod` case below normalizes the receiver of an ordinary overridden method.
 fn method_override_types<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     subclass_type: Type<'db>,
     superclass_type: Type<'db>,
+    subclass_receiver: Type<'db>,
 ) -> Option<(Type<'db>, Type<'db>)> {
     let (subclass_type, superclass_type) = match (subclass_type, superclass_type) {
         (Type::BoundMethod(subclass_method), Type::BoundMethod(superclass_method))
@@ -1148,6 +1180,32 @@ fn method_override_types<'db>(
                     env,
                     receiver,
                     typing_self_type,
+                )),
+            )
+        }
+        // `__new__` is implicitly static, so member lookup never binds it into a `BoundMethod`
+        // the way it does for the ordinary instance methods handled above: its instance member
+        // type stays a bare `FunctionLiteral`, implicit `cls` parameter and all. Bind both
+        // signatures to the subclass receiver here too, so that implicit `cls` parameter is
+        // dropped from the comparison instead of being compared between two unrelated classes.
+        // Without this, an `@override`d `__new__` with a covariant, concrete return type is
+        // rejected: `cls: type[Child]` is not assignable to `cls: type[Base]`, even though the
+        // parameter is never meant to vary independently of the receiver it is called on.
+        (Type::FunctionLiteral(subclass_function), Type::FunctionLiteral(superclass_function))
+            if subclass_function.name(db) == "__new__" =>
+        {
+            (
+                Type::Callable(subclass_function.into_bound_callable_with_receiver(
+                    db,
+                    env,
+                    subclass_receiver,
+                    subclass_receiver,
+                )),
+                Type::Callable(superclass_function.into_bound_callable_with_receiver(
+                    db,
+                    env,
+                    subclass_receiver,
+                    subclass_receiver,
                 )),
             )
         }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -649,6 +649,10 @@ fn check_class_declaration<'db>(
     let mut overridden_final_variable: Option<(ClassType<'db>, Option<Definition<'db>>)> = None;
     let is_private_member = is_mangled_private(member.name.as_str());
     let mut subclass_variable_kind: Option<Option<VariableKind>> = None;
+    // Whether this member is `__init__` or `__new__` decorated with `@override`. This is
+    // memoized like `subclass_variable_kind` above: it depends only on `member`, which is fixed
+    // for the whole call, so it would otherwise be recomputed on every MRO ancestor below.
+    let mut overridden_constructor_asserts_compatibility: Option<bool> = None;
 
     // Track the first superclass that defines this method so we can distinguish inherited
     // conflicts from violations introduced by the child.
@@ -870,8 +874,24 @@ fn check_class_declaration<'db>(
                 continue;
             };
 
-            // Constructor methods are not checked for Liskov compliance
-            if is_constructor_like_method(&member.name) {
+            // Constructor methods are not checked for Liskov compliance, since `__init__` and
+            // `__new__` routinely take different parameters in each subclass on purpose. An
+            // explicit `@override` on one of them is an exception: it asserts that the override
+            // is signature-compatible with the overridden method, so the typing spec requires the
+            // same assignability check as for any other overridden method.
+            // https://typing.python.org/en/latest/spec/class-compat.html#override
+            let overridden_constructor_asserts_compatibility =
+                *overridden_constructor_asserts_compatibility.get_or_insert_with(|| {
+                    matches!(member.name.as_str(), "__init__" | "__new__")
+                        && matches!(
+                            member.ty,
+                            Type::FunctionLiteral(function)
+                                if function.has_known_decorator(db, FunctionDecorators::OVERRIDE)
+                        )
+                });
+            if is_constructor_like_method(&member.name)
+                && !overridden_constructor_asserts_compatibility
+            {
                 continue;
             }
 


### PR DESCRIPTION
## Summary

`invalid-method-override` unconditionally exempts `__init__` and `__new__` from Liskov
assignability checks, since a subclass constructor routinely takes different parameters than its
parent's:

```python
class Base:
    def __init__(self, x: int) -> None: ...

class Sub(Base):
    def __init__(self, x: int, y: str) -> None: ...  # fine, no error
```

The [typing spec](https://typing.python.org/en/latest/spec/class-compat.html#override) does not
carry this exemption over to an explicit `@override` on `__init__` or `__new__`: writing
`@override` on one of these methods asserts that the override is assignable to the overridden
method, the same as for any other overridden method. ty did not enforce this:

```python
from typing import override

class Sub(Base):
    @override
    def __init__(self, x: str) -> None: ...  # not flagged before this change
```

`__post_init__` and `__init_subclass__` are constructor-like but fall outside the spec's
exception for `__init__`/`__new__`, so they keep the exemption even when marked `@override`.

Closes astral-sh/ty#3595

## Test Plan

Added mdtest coverage in `liskov.md` alongside the existing "Excluded methods" section: an
incompatible `@override`d `__init__` and `__new__` are both flagged; a compatible `@override`
(widening with a default parameter) is not; an unmarked incompatible override keeps the existing
exemption; and `__post_init__`/`__init_subclass__` remain exempt even when marked `@override`.

Also verified manually, unchanged by this PR: overloaded `__init__` with `@override` on the
implementation is checked against the overloads (as any other overridden method would be), and a
dataclass-synthesized `__init__` is unaffected since it is not an explicit class-body member.

Checks run:

- `cargo test -p ty_python_semantic`: 431 + 14 unit tests and 494 mdtests pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `uv run --only-dev --locked prek run --files ...`: passes
- `cargo dev generate-all`: no changes (this reuses the existing `invalid-method-override` rule)

