### PR TITLE
[ty] Detect multiple unpacked variadic tuples specializing a `TypeVarTuple`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/invalid.md
@@ -345,6 +345,71 @@ def func3(t: tuple[*Ts]):
     t6: tuple[*tuple[str, ...], *Ts]  # error: [invalid-type-form]
 ```
 
+## Multiple starred expressions when specializing a `TypeVarTuple`
+
+The same restriction applies when a generic class or type alias has a `TypeVarTuple` type parameter,
+and it is specialized with more than one unpacked variadic tuple: each one could contribute any
+number of elements, so there is no way to know where one ends and the next begins.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Box[*Ts]: ...
+
+def f[*Ts1, *Ts2](
+    # error: [invalid-type-form] "Multiple unpacked variadic tuples are not allowed when specializing a `TypeVarTuple`"
+    x: Box[*tuple[int, ...], *tuple[str, ...]],
+):
+    reveal_type(x)  # revealed: Box[*tuple[int | str, ...]]
+```
+
+A fixed-length unpacked tuple does not create this ambiguity, since its element count is known
+statically. It may be combined with another unpack, even a variadic one, without error:
+
+```py
+def g(
+    x: Box[*tuple[int, str], *tuple[bool, ...]],
+    y: Box[*tuple[bool, ...], *tuple[int, str]],
+    z: Box[*tuple[int], *tuple[str]],
+):
+    reveal_type(x)  # revealed: Box[*tuple[int, str, *tuple[bool, ...]]]
+    reveal_type(y)  # revealed: Box[*tuple[*tuple[bool, ...], int, str]]
+    reveal_type(z)  # revealed: Box[int, str]
+```
+
+A fixed-length unpacked tuple that itself has a variadic element is still fixed-length, and does not
+get miscounted as a second variadic unpack:
+
+```py
+def i(
+    x: Box[*tuple[tuple[int, ...], str], *tuple[bool, ...]],
+    y: Box[*tuple[tuple[int, ...], str]],
+):
+    reveal_type(x)  # revealed: Box[*tuple[tuple[int, ...], str, *tuple[bool, ...]]]
+    reveal_type(y)  # revealed: Box[tuple[int, ...], str]
+```
+
+The same check applies to a generic type alias, and to a `TypeVarTuple` positioned between two fixed
+type parameters:
+
+```py
+type Pair[*Ts] = tuple[*Ts]
+
+class Wrapped[T1, *Ts, T2]: ...
+
+def h(
+    # error: [invalid-type-form]
+    a: Pair[*tuple[int, ...], *tuple[str, ...]],
+    # error: [invalid-type-form]
+    b: Wrapped[int, *tuple[bool, ...], *tuple[bytes, ...], str],
+):
+    reveal_type(a)  # revealed: tuple[int | str, ...]
+    reveal_type(b)  # revealed: Wrapped[int, *tuple[bool | bytes, ...], str]
+```
+
 ## Ellipses in the wrong place in a `tuple` specialization
 
 ```toml

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -745,10 +745,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         typevars_len,
                     )]
                     .iter()
-                    .all(|typevar| !typevar.is_paramspec(db))
+                    .all(|typevar| !typevar.is_paramspec(db) && !typevar.is_typevartuple(db))
             {
                 // Expand `Foo[Unpack[tuple[int, str]]]` to `Foo[int, str]`. ParamSpec arguments
-                // must still use their dedicated inference path.
+                // must still use their dedicated inference path. A `TypeVarTuple` destination is
+                // also excluded: it has its own dedicated logic below for absorbing a fixed-length
+                // unpacked tuple's elements directly into its captured shape, and exploding the
+                // tuple into one `TypeArgument` per element here (all pointing back at the same
+                // unpack expression) would confuse that logic about which arguments are distinct
+                // top-level unpacks.
                 expanded_type_arguments.extend(tuple.iter_all_elements().map(|ty| TypeArgument {
                     node: expr,
                     ty: Some(ty),
@@ -834,6 +839,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             let typevartuple_start = expanded_type_arguments.len().min(typevartuple_index);
+            // At most one of the arguments assigned to this `TypeVarTuple` may itself be
+            // unbounded (an unpacked `TypeVarTuple`, or an unpacked tuple of unknown length):
+            // with two such arguments, there is no way to know how many elements each one
+            // contributes, so the underlying tuple shape is ambiguous. A fixed-length unpacked
+            // tuple never causes this ambiguity, since its element count is known statically.
+            let mut first_unpacked_variadic_argument: Option<&ast::Expr> = None;
             for type_argument in &expanded_type_arguments
                 [typevartuple_start..expanded_type_arguments.len().min(typevartuple_end)]
             {
@@ -853,12 +864,39 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let is_unpack = self
                     .type_expression_flags(type_argument.node)
                     .contains(TypeExpressionFlags::UNPACK);
+                let mut report_multiple_unpacked_variadic_tuples = || {
+                    if let Some(first) = first_unpacked_variadic_argument {
+                        if let Some(builder) =
+                            self.context.report_lint(&INVALID_TYPE_FORM, subscript)
+                        {
+                            let mut diagnostic = builder.into_diagnostic(
+                                "Multiple unpacked variadic tuples are not allowed when specializing a `TypeVarTuple`",
+                            );
+                            diagnostic.annotate(
+                                self.context
+                                    .secondary(first)
+                                    .message("First unpacked variadic tuple"),
+                            );
+                            diagnostic.annotate(
+                                self.context
+                                    .secondary(type_argument.node)
+                                    .message("Later unpacked variadic tuple"),
+                            );
+                        }
+                    } else {
+                        first_unpacked_variadic_argument = Some(type_argument.node);
+                    }
+                };
                 if is_unpack && let Some(tuple) = provided_type.exact_tuple_instance_spec(db) {
                     tuple_builder = tuple_builder.concat(db, env, &tuple);
+                    if tuple.is_variadic() {
+                        report_multiple_unpacked_variadic_tuples();
+                    }
                 } else if is_unpack
                     && let Type::TypeVar(typevar) = provided_type
                     && typevar.is_typevartuple(db)
                 {
+                    report_multiple_unpacked_variadic_tuples();
                     tuple_builder = tuple_builder.concat_variadic_typevar(db, env, typevar);
                 } else {
                     tuple_builder.push(provided_type);


### PR DESCRIPTION
## Summary

`tuple[*TS1, *TS2]` is correctly rejected: two unpacked variadic tuples contributing to the same specialization make it impossible to know how many elements each one supplies. The same ambiguity was not detected when the `TypeVarTuple` belonged to a user-defined generic class or a generic type alias instead of the builtin `tuple`:

```python
class A[*TS]: ...
type B[*TS] = tuple[*TS]

def f[*TS1, *TS2](a: A[*TS1, *TS2], b: B[*TS1, *TS2]):
    reveal_type(a)  # A[*tuple[object, ...]], no error
    reveal_type(b)  # tuple[object, ...], no error
```

Both specializations silently fell back to `tuple[object, ...]` instead of being flagged. This applies the same check used for `tuple[...]` to the shared code path that resolves arguments against a class or type alias's `TypeVarTuple` parameter, including when that parameter sits between two fixed type parameters (`class C[T1, *TS, T2]`).

A fixed-length unpacked tuple does not introduce this ambiguity, since its element count is known statically, so it may still be combined with another unpack without error.

Closes astral-sh/ty#4054

## Test Plan

New coverage in `annotations/invalid.md` alongside the existing `tuple[...]` check: two variadic unpacks specializing a generic class's `TypeVarTuple` (error, with the same "first"/"later" secondary annotations as the `tuple[...]` diagnostic), the same for a generic type alias and for a `TypeVarTuple` positioned between two fixed type parameters, and three cases confirming a fixed-length unpack does not trigger the check when combined with another unpack in either order.

Also verified manually, unchanged by this PR: a single unpacked `TypeVarTuple` (the common case), two fixed-length unpacks, and three variadic unpacks (which produces two diagnostics, matching the existing `tuple[...]` check's behavior for the same shape).

Checks run:

- `cargo test -p ty_python_semantic`: 431 + 14 unit tests and 494 mdtests pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `uv run --only-dev --locked prek run --files ...`: passes
- `cargo dev generate-all`: no changes (this reuses the existing `invalid-type-form` rule)
