### PR TITLE
[ty] Compact reachable binding and declaration histories

### DIFF
--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1179,7 +1179,8 @@ mod tests {
         ast_ids::{HasScopedUseId, ScopedUseId},
         db::tests::{TestDb, TestDbBuilder},
         definition::{
-            DefinitionKind, LambdaParameterDefinitionNodeKind, ParameterDefinitionNodeKind,
+            DefinitionKind, DefinitionState, LambdaParameterDefinitionNodeKind,
+            ParameterDefinitionNodeKind,
         },
         program::Program,
     };
@@ -1295,6 +1296,89 @@ mod tests {
             declaration.kind(&db),
             DefinitionKind::AnnotatedAssignment(_)
         );
+    }
+
+    #[test]
+    fn reachable_definitions_include_initial_state() {
+        let TestCase { db, file } = test_case("if flag:\n    x: int = 1\n");
+        let scope = global_scope(&db, program_file(&db, file));
+        let table = place_table(&db, scope);
+        let symbol = table.symbol_id("x").unwrap();
+        let use_def = use_def_map(&db, scope);
+
+        let bindings = use_def
+            .reachable_symbol_bindings(symbol)
+            .collect::<Vec<_>>();
+        let declarations = use_def
+            .reachable_symbol_declarations(symbol)
+            .collect::<Vec<_>>();
+        assert_eq!(bindings.len(), 2);
+        assert_eq!(declarations.len(), 2);
+        assert_matches!(bindings[0].binding, DefinitionState::Undefined);
+        assert_matches!(declarations[0].declaration, DefinitionState::Undefined);
+        assert!(bindings[0].binding_order.is_unbound());
+        assert!(declarations[0].declaration_order.is_unbound());
+        assert_eq!(
+            bindings[0].narrowing_constraint.constraint(),
+            ScopedNarrowingConstraint::ALWAYS_TRUE,
+        );
+        let initial_reachability = bindings[0].reachability_constraint;
+        assert!(!initial_reachability.is_terminal());
+        assert_eq!(initial_reachability, bindings[1].reachability_constraint);
+        assert_eq!(
+            initial_reachability,
+            declarations[0].reachability_constraint
+        );
+        assert_eq!(
+            initial_reachability,
+            declarations[1].reachability_constraint
+        );
+
+        let (_, all_declarations, all_bindings) = use_def
+            .all_reachable_symbols()
+            .find(|(id, _, _)| *id == symbol)
+            .unwrap();
+        assert_eq!(
+            all_bindings
+                .map(|binding| binding.binding_order)
+                .collect::<Vec<_>>(),
+            bindings
+                .iter()
+                .map(|binding| binding.binding_order)
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            all_declarations
+                .map(|declaration| declaration.declaration_order)
+                .collect::<Vec<_>>(),
+            declarations
+                .iter()
+                .map(|declaration| declaration.declaration_order)
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn reachable_initial_state_without_definitions() {
+        let TestCase { db, file } = test_case("if flag:\n    missing\n");
+        let scope = global_scope(&db, program_file(&db, file));
+        let table = place_table(&db, scope);
+        let symbol = table.symbol_id("missing").unwrap();
+        let use_def = use_def_map(&db, scope);
+
+        let mut bindings = use_def.reachable_symbol_bindings(symbol);
+        let mut declarations = use_def.reachable_symbol_declarations(symbol);
+        let binding = bindings.next().unwrap();
+        let declaration = declarations.next().unwrap();
+        assert_matches!(binding.binding, DefinitionState::Undefined);
+        assert_matches!(declaration.declaration, DefinitionState::Undefined);
+        assert!(!binding.reachability_constraint.is_terminal());
+        assert_eq!(
+            binding.reachability_constraint,
+            declaration.reachability_constraint
+        );
+        assert!(bindings.next().is_none());
+        assert!(declarations.next().is_none());
     }
 
     #[test]

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1306,12 +1306,12 @@ mod tests {
         let symbol = table.symbol_id("x").unwrap();
         let use_def = use_def_map(&db, scope);
 
-        let bindings = use_def
-            .reachable_symbol_bindings(symbol)
-            .collect::<Vec<_>>();
-        let declarations = use_def
-            .reachable_symbol_declarations(symbol)
-            .collect::<Vec<_>>();
+        let (_, declarations, bindings) = use_def
+            .all_reachable_symbols()
+            .find(|(id, _, _)| *id == symbol)
+            .unwrap();
+        let bindings = bindings.collect::<Vec<_>>();
+        let declarations = declarations.collect::<Vec<_>>();
         assert_eq!(bindings.len(), 2);
         assert_eq!(declarations.len(), 2);
         assert_matches!(bindings[0].binding, DefinitionState::Undefined);
@@ -1332,29 +1332,6 @@ mod tests {
         assert_eq!(
             initial_reachability,
             declarations[1].reachability_constraint
-        );
-
-        let (_, all_declarations, all_bindings) = use_def
-            .all_reachable_symbols()
-            .find(|(id, _, _)| *id == symbol)
-            .unwrap();
-        assert_eq!(
-            all_bindings
-                .map(|binding| binding.binding_order)
-                .collect::<Vec<_>>(),
-            bindings
-                .iter()
-                .map(|binding| binding.binding_order)
-                .collect::<Vec<_>>(),
-        );
-        assert_eq!(
-            all_declarations
-                .map(|declaration| declaration.declaration_order)
-                .collect::<Vec<_>>(),
-            declarations
-                .iter()
-                .map(|declaration| declaration.declaration_order)
-                .collect::<Vec<_>>(),
         );
     }
 

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -1179,8 +1179,7 @@ mod tests {
         ast_ids::{HasScopedUseId, ScopedUseId},
         db::tests::{TestDb, TestDbBuilder},
         definition::{
-            DefinitionKind, DefinitionState, LambdaParameterDefinitionNodeKind,
-            ParameterDefinitionNodeKind,
+            DefinitionKind, LambdaParameterDefinitionNodeKind, ParameterDefinitionNodeKind,
         },
         program::Program,
     };
@@ -1296,66 +1295,6 @@ mod tests {
             declaration.kind(&db),
             DefinitionKind::AnnotatedAssignment(_)
         );
-    }
-
-    #[test]
-    fn reachable_definitions_include_initial_state() {
-        let TestCase { db, file } = test_case("if flag:\n    x: int = 1\n");
-        let scope = global_scope(&db, program_file(&db, file));
-        let table = place_table(&db, scope);
-        let symbol = table.symbol_id("x").unwrap();
-        let use_def = use_def_map(&db, scope);
-
-        let (_, declarations, bindings) = use_def
-            .all_reachable_symbols()
-            .find(|(id, _, _)| *id == symbol)
-            .unwrap();
-        let bindings = bindings.collect::<Vec<_>>();
-        let declarations = declarations.collect::<Vec<_>>();
-        assert_eq!(bindings.len(), 2);
-        assert_eq!(declarations.len(), 2);
-        assert_matches!(bindings[0].binding, DefinitionState::Undefined);
-        assert_matches!(declarations[0].declaration, DefinitionState::Undefined);
-        assert!(bindings[0].binding_order.is_unbound());
-        assert!(declarations[0].declaration_order.is_unbound());
-        assert_eq!(
-            bindings[0].narrowing_constraint.constraint(),
-            ScopedNarrowingConstraint::ALWAYS_TRUE,
-        );
-        let initial_reachability = bindings[0].reachability_constraint;
-        assert!(!initial_reachability.is_terminal());
-        assert_eq!(initial_reachability, bindings[1].reachability_constraint);
-        assert_eq!(
-            initial_reachability,
-            declarations[0].reachability_constraint
-        );
-        assert_eq!(
-            initial_reachability,
-            declarations[1].reachability_constraint
-        );
-    }
-
-    #[test]
-    fn reachable_initial_state_without_definitions() {
-        let TestCase { db, file } = test_case("if flag:\n    missing\n");
-        let scope = global_scope(&db, program_file(&db, file));
-        let table = place_table(&db, scope);
-        let symbol = table.symbol_id("missing").unwrap();
-        let use_def = use_def_map(&db, scope);
-
-        let mut bindings = use_def.reachable_symbol_bindings(symbol);
-        let mut declarations = use_def.reachable_symbol_declarations(symbol);
-        let binding = bindings.next().unwrap();
-        let declaration = declarations.next().unwrap();
-        assert_matches!(binding.binding, DefinitionState::Undefined);
-        assert_matches!(declaration.declaration, DefinitionState::Undefined);
-        assert!(!binding.reachability_constraint.is_terminal());
-        assert_eq!(
-            binding.reachability_constraint,
-            declaration.reachability_constraint
-        );
-        assert!(bindings.next().is_none());
-        assert!(declarations.next().is_none());
     }
 
     #[test]

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -597,10 +597,10 @@ impl Index<InternedDeclarationsId> for RetainedDeclarations {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
-struct RetainedPlaceStates<T> {
-    end_of_scope: T,
+struct RetainedPlaceStates {
+    end_of_scope: InternedPlaceStateId,
     /// The reachable histories exclude their implicit initial unbound/undeclared entries.
-    reachable: T,
+    reachable: InternedPlaceStateId,
     /// Both initial entries have this reachability constraint and are reconstructed by iterators.
     initial_reachability: ScopedReachabilityConstraintId,
 }
@@ -678,7 +678,7 @@ struct UseDefMapExtra {
     multi_bindings_by_use: MultiBindingsByUse,
 
     /// Retained [`PlaceState`] values for each member.
-    member_states: FrozenIndexVec<ScopedMemberId, RetainedPlaceStates<InternedPlaceStateId>>,
+    member_states: FrozenIndexVec<ScopedMemberId, RetainedPlaceStates>,
 
     /// Snapshots of bindings used to resolve references from nested scopes.
     enclosing_snapshots: FrozenIndexVec<ScopedEnclosingSnapshotId, InternedEnclosingSnapshotId>,
@@ -821,7 +821,7 @@ pub struct UseDefMap<'db> {
     >,
 
     /// Retained [`PlaceState`] values for each symbol.
-    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
+    symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates>,
 
     /// Collection fields omitted when they would all be empty.
     extra: Option<Box<UseDefMapExtra>>,
@@ -1129,9 +1129,14 @@ impl<'db> UseDefMap<'db> {
         &self,
         place: ScopedPlaceId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        match place {
-            ScopedPlaceId::Symbol(symbol) => self.reachable_symbol_bindings(symbol),
-            ScopedPlaceId::Member(member) => self.reachable_member_bindings(member),
+        let state = match place {
+            ScopedPlaceId::Symbol(symbol) => &self.symbol_states[symbol],
+            ScopedPlaceId::Member(member) => &self.extra().member_states[member],
+        };
+        let bindings = &self.interned_bindings[state.reachable.bindings_id()];
+        BindingWithConstraintsIterator {
+            initial_unbound: Some(state.initial_reachability),
+            ..self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
         }
     }
 
@@ -1139,24 +1144,14 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let state = &self.symbol_states[symbol];
-        let bindings = &self.interned_bindings[state.reachable.bindings_id()];
-        BindingWithConstraintsIterator {
-            initial_unbound: Some(state.initial_reachability),
-            ..self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
-        }
+        self.reachable_bindings(symbol.into())
     }
 
     pub fn reachable_member_bindings(
         &self,
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let state = &self.extra().member_states[member];
-        let bindings = &self.interned_bindings[state.reachable.bindings_id()];
-        BindingWithConstraintsIterator {
-            initial_unbound: Some(state.initial_reachability),
-            ..self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
-        }
+        self.reachable_bindings(member.into())
     }
 
     pub(crate) fn enclosing_snapshot(
@@ -1249,30 +1244,25 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let state = &self.symbol_states[symbol];
-        let declarations = &self.interned_declarations[state.reachable.declarations_id()];
-        DeclarationsIterator {
-            initial_undeclared: Some(state.initial_reachability),
-            ..self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
-        }
+        self.reachable_declarations(symbol.into())
     }
 
     pub fn reachable_member_declarations(
         &self,
         member: ScopedMemberId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let state = &self.extra().member_states[member];
+        self.reachable_declarations(member.into())
+    }
+
+    pub fn reachable_declarations(&self, place: ScopedPlaceId) -> DeclarationsIterator<'_, 'db> {
+        let state = match place {
+            ScopedPlaceId::Symbol(symbol) => &self.symbol_states[symbol],
+            ScopedPlaceId::Member(member) => &self.extra().member_states[member],
+        };
         let declarations = &self.interned_declarations[state.reachable.declarations_id()];
         DeclarationsIterator {
             initial_undeclared: Some(state.initial_reachability),
             ..self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
-        }
-    }
-
-    pub fn reachable_declarations(&self, place: ScopedPlaceId) -> DeclarationsIterator<'_, 'db> {
-        match place {
-            ScopedPlaceId::Symbol(symbol) => self.reachable_symbol_declarations(symbol),
-            ScopedPlaceId::Member(member) => self.reachable_member_declarations(member),
         }
     }
 
@@ -3167,7 +3157,7 @@ impl<'db> UseDefMapBuilder<'db> {
         reachable: IndexVec<I, ReachableDefinitions>,
         place_state_interner: &mut PlaceStateInterner,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
-    ) -> FrozenIndexVec<I, RetainedPlaceStates<InternedPlaceStateId>> {
+    ) -> FrozenIndexVec<I, RetainedPlaceStates> {
         assert_eq!(end_of_scope.len(), reachable.len());
 
         end_of_scope

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -558,6 +558,16 @@ impl RetainedDeclarationsBuilder {
         self.ends.push(end)
     }
 
+    fn get(&self, index: InternedDeclarationsId) -> &[LiveDeclaration] {
+        let end = self.ends[index];
+        let start = if index.index() == 0 {
+            0
+        } else {
+            self.ends[InternedDeclarationsId::new(index.index() - 1)]
+        };
+        &self.live_declarations[start as usize..end as usize]
+    }
+
     fn finish(
         self,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
@@ -589,7 +599,10 @@ impl Index<InternedDeclarationsId> for RetainedDeclarations {
 #[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
 struct RetainedPlaceStates<T> {
     end_of_scope: T,
+    /// The reachable histories exclude their implicit initial unbound/undeclared entries.
     reachable: T,
+    /// Both initial entries have this reachability constraint and are reconstructed by iterators.
+    initial_reachability: ScopedReachabilityConstraintId,
 }
 
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
@@ -1126,18 +1139,24 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let place_state_id = self.symbol_states[symbol].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
-        self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
+        let state = &self.symbol_states[symbol];
+        let bindings = &self.interned_bindings[state.reachable.bindings_id()];
+        BindingWithConstraintsIterator {
+            initial_unbound: Some(state.initial_reachability),
+            ..self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
+        }
     }
 
     pub fn reachable_member_bindings(
         &self,
         member: ScopedMemberId,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let place_state_id = self.extra().member_states[member].reachable;
-        let bindings = &self.interned_bindings[place_state_id.bindings_id()];
-        self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
+        let state = &self.extra().member_states[member];
+        let bindings = &self.interned_bindings[state.reachable.bindings_id()];
+        BindingWithConstraintsIterator {
+            initial_unbound: Some(state.initial_reachability),
+            ..self.bindings_iterator(bindings, BoundnessAnalysis::AssumeBound)
+        }
     }
 
     pub(crate) fn enclosing_snapshot(
@@ -1230,18 +1249,24 @@ impl<'db> UseDefMap<'db> {
         &self,
         symbol: ScopedSymbolId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let place_state_id = self.symbol_states[symbol].reachable;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
-        self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
+        let state = &self.symbol_states[symbol];
+        let declarations = &self.interned_declarations[state.reachable.declarations_id()];
+        DeclarationsIterator {
+            initial_undeclared: Some(state.initial_reachability),
+            ..self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
+        }
     }
 
     pub fn reachable_member_declarations(
         &self,
         member: ScopedMemberId,
     ) -> DeclarationsIterator<'_, 'db> {
-        let place_state_id = self.extra().member_states[member].reachable;
-        let declarations = &self.interned_declarations[place_state_id.declarations_id()];
-        self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
+        let state = &self.extra().member_states[member];
+        let declarations = &self.interned_declarations[state.reachable.declarations_id()];
+        DeclarationsIterator {
+            initial_undeclared: Some(state.initial_reachability),
+            ..self.declarations_iterator(declarations, BoundnessAnalysis::AssumeBound)
+        }
     }
 
     pub fn reachable_declarations(&self, place: ScopedPlaceId) -> DeclarationsIterator<'_, 'db> {
@@ -1277,19 +1302,13 @@ impl<'db> UseDefMap<'db> {
             BindingWithConstraintsIterator<'map, 'db>,
         ),
     > + 'map {
-        self.symbol_states.iter_enumerated().map(
-            |(symbol_id, RetainedPlaceStates { reachable, .. })| {
-                let declarations = self.declarations_iterator(
-                    &self.interned_declarations[reachable.declarations_id()],
-                    BoundnessAnalysis::AssumeBound,
-                );
-                let bindings = self.bindings_iterator(
-                    &self.interned_bindings[reachable.bindings_id()],
-                    BoundnessAnalysis::AssumeBound,
-                );
-                (symbol_id, declarations, bindings)
-            },
-        )
+        self.symbol_states.indices().map(|symbol_id| {
+            (
+                symbol_id,
+                self.reachable_symbol_declarations(symbol_id),
+                self.reachable_symbol_bindings(symbol_id),
+            )
+        })
     }
 
     fn bindings_iterator<'map>(
@@ -1301,6 +1320,7 @@ impl<'db> UseDefMap<'db> {
             all_definitions: &self.all_definitions,
             constraint_tables: self.constraint_tables(),
             boundness_analysis,
+            initial_unbound: None,
             inner: bindings.iter(),
         }
     }
@@ -1314,6 +1334,7 @@ impl<'db> UseDefMap<'db> {
             all_definitions: &self.all_definitions,
             constraint_tables: self.constraint_tables(),
             boundness_analysis,
+            initial_undeclared: None,
             inner: declarations.iter(),
         }
     }
@@ -1354,6 +1375,7 @@ pub struct BindingWithConstraintsIterator<'map, 'db> {
     all_definitions: &'map RetainedDefinitions<'db>,
     constraint_tables: &'map ConstraintTables<'db>,
     boundness_analysis: BoundnessAnalysis,
+    initial_unbound: Option<ScopedReachabilityConstraintId>,
     inner: LiveBindingsIterator<'map>,
 }
 
@@ -1375,6 +1397,18 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
     type Item = BindingWithConstraints<'map, 'db>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if let Some(reachability_constraint) = self.initial_unbound.take() {
+            return Some(BindingWithConstraints {
+                binding: DefinitionState::Undefined,
+                binding_order: ScopedDefinitionId::UNBOUND,
+                narrowing_constraint: NarrowingEvaluator {
+                    constraint: ScopedNarrowingConstraint::ALWAYS_TRUE,
+                    constraint_tables: self.constraint_tables,
+                },
+                reachability_constraint,
+            });
+        }
+
         self.inner
             .next()
             .map(|live_binding| BindingWithConstraints {
@@ -1427,6 +1461,7 @@ pub struct DeclarationsIterator<'map, 'db> {
     all_definitions: &'map RetainedDefinitions<'db>,
     constraint_tables: &'map ConstraintTables<'db>,
     boundness_analysis: BoundnessAnalysis,
+    initial_undeclared: Option<ScopedReachabilityConstraintId>,
     inner: LiveDeclarationsIterator<'map>,
 }
 
@@ -1456,6 +1491,14 @@ impl<'db> Iterator for DeclarationsIterator<'_, 'db> {
     type Item = DeclarationWithConstraint<'db>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if let Some(reachability_constraint) = self.initial_undeclared.take() {
+            return Some(DeclarationWithConstraint {
+                declaration: DefinitionState::Undefined,
+                declaration_order: ScopedDefinitionId::UNBOUND,
+                reachability_constraint,
+            });
+        }
+
         self.inner.next().map(
             |LiveDeclaration {
                  declaration,
@@ -1475,8 +1518,22 @@ impl std::iter::FusedIterator for DeclarationsIterator<'_, '_> {}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
 struct ReachableDefinitions {
+    /// Reachability when the place was first encountered. Reachable histories always retain this
+    /// initial unbound/undeclared state. End-of-scope histories can discard it when a later
+    /// definition shadows it. Keeping it separate lets the remaining definitions share storage.
+    initial_reachability: ScopedReachabilityConstraintId,
     bindings: Bindings,
     declarations: Declarations,
+}
+
+impl ReachableDefinitions {
+    fn new(initial_reachability: ScopedReachabilityConstraintId) -> Self {
+        Self {
+            initial_reachability,
+            bindings: Bindings::default(),
+            declarations: Declarations::default(),
+        }
+    }
 }
 
 /// A snapshot of the definitions and constraints state at a particular point in control flow.
@@ -2022,10 +2079,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 debug_assert_eq!(symbol, new_place);
                 let new_place = self
                     .reachable_symbol_definitions
-                    .push(ReachableDefinitions {
-                        bindings: Bindings::unbound(self.reachability),
-                        declarations: Declarations::undeclared(self.reachability),
-                    });
+                    .push(ReachableDefinitions::new(self.reachability));
                 debug_assert_eq!(symbol, new_place);
             }
             ScopedPlaceId::Member(member) => {
@@ -2036,10 +2090,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 debug_assert_eq!(member, new_place);
                 let new_place = self
                     .reachable_member_definitions
-                    .push(ReachableDefinitions {
-                        bindings: Bindings::unbound(self.reachability),
-                        declarations: Declarations::undeclared(self.reachability),
-                    });
+                    .push(ReachableDefinitions::new(self.reachability));
                 debug_assert_eq!(member, new_place);
             }
         }
@@ -3009,15 +3060,17 @@ impl<'db> UseDefMapBuilder<'db> {
         );
         let end_of_scope_members =
             Self::intern_end_of_scope_members(member_states, &mut place_state_interner);
-        let reachable_definitions_by_symbol = Self::intern_place_states(
+        let symbol_states = Self::intern_reachable_place_states(
+            end_of_scope_symbols,
             self.reachable_symbol_definitions,
-            |definitions| (definitions.bindings, definitions.declarations),
             &mut place_state_interner,
+            &mut self.reachability_constraints,
         );
-        let reachable_definitions_by_member = Self::intern_place_states(
+        let member_states = Self::intern_reachable_place_states(
+            end_of_scope_members,
             self.reachable_member_definitions,
-            |definitions| (definitions.bindings, definitions.declarations),
             &mut place_state_interner,
+            &mut self.reachability_constraints,
         );
         let enclosing_snapshots =
             Self::intern_enclosing_snapshots(self.enclosing_snapshots, &mut place_state_interner);
@@ -3056,10 +3109,6 @@ impl<'db> UseDefMapBuilder<'db> {
             }
         }
         self.reachability_constraints.mark_used(self.reachability);
-        let symbol_states =
-            Self::zip_place_states(end_of_scope_symbols, reachable_definitions_by_symbol);
-        let member_states =
-            Self::zip_place_states(end_of_scope_members, reachable_definitions_by_member);
         let multi_bindings_by_use = MultiBindingsByUse::from_map(self.multi_bindings_by_use);
         let loop_headers = self.loop_headers;
         let mut boolean_test_roots = self.boolean_test_roots;
@@ -3112,18 +3161,48 @@ impl<'db> UseDefMapBuilder<'db> {
         }
     }
 
-    fn zip_place_states<I: Idx, T>(
-        end_of_scope: IndexVec<I, T>,
-        reachable: IndexVec<I, T>,
-    ) -> FrozenIndexVec<I, RetainedPlaceStates<T>> {
+    /// Retains reachable definitions without duplicating their initial unbound/undeclared entries.
+    fn intern_reachable_place_states<I: Idx>(
+        end_of_scope: IndexVec<I, InternedPlaceStateId>,
+        reachable: IndexVec<I, ReachableDefinitions>,
+        place_state_interner: &mut PlaceStateInterner,
+        reachability_constraints: &mut ReachabilityConstraintsBuilder,
+    ) -> FrozenIndexVec<I, RetainedPlaceStates<InternedPlaceStateId>> {
         assert_eq!(end_of_scope.len(), reachable.len());
 
         end_of_scope
             .into_iter()
             .zip(reachable)
-            .map(|(end_of_scope, reachable)| RetainedPlaceStates {
-                end_of_scope,
-                reachable,
+            .map(|(end_of_scope, definitions)| {
+                let ReachableDefinitions {
+                    initial_reachability,
+                    bindings,
+                    declarations,
+                } = definitions;
+                // The implicit entries are reconstructed by iterators, so their constraint does
+                // not appear in the binding/declaration tables visited during compaction.
+                reachability_constraints.mark_used(initial_reachability);
+
+                // A place with one declaration commonly has identical end-of-scope and reachable
+                // declarations after removing the initial undeclared entry. Compare this pair
+                // directly because end-of-scope declarations are not all interned.
+                let declarations_id = if place_state_interner
+                    .interned_declarations
+                    .get(end_of_scope.declarations_id())
+                    == declarations.as_slice()
+                {
+                    end_of_scope.declarations_id()
+                } else {
+                    place_state_interner.intern_declarations(declarations)
+                };
+                RetainedPlaceStates {
+                    end_of_scope,
+                    reachable: InternedPlaceStateId(
+                        place_state_interner.intern_bindings(&bindings),
+                        declarations_id,
+                    ),
+                    initial_reachability,
+                }
             })
             .collect()
     }

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -62,7 +62,7 @@ impl ScopedDefinitionId {
     /// unbound or undeclared at a given usage site.
     /// When creating a use-def-map builder, we always add an empty `DefinitionState::Undefined` definition
     /// at index 0, so this ID is always present.
-    const UNBOUND: ScopedDefinitionId = ScopedDefinitionId::from_u32(0);
+    pub(super) const UNBOUND: ScopedDefinitionId = ScopedDefinitionId::from_u32(0);
 
     pub(crate) fn is_unbound(self) -> bool {
         self == Self::UNBOUND
@@ -369,8 +369,12 @@ impl Bindings {
     ) {
         // If we are in a class scope, and the unbound name binding was previously visible, but we will
         // now replace it, record the narrowing constraints on it:
-        if is_class_scope && is_place_name && self.live_bindings[0].binding().is_unbound() {
-            self.unbound_narrowing_constraint = Some(self.live_bindings[0].narrowing_constraint);
+        if is_class_scope
+            && is_place_name
+            && let Some(binding) = self.live_bindings.first()
+            && binding.binding().is_unbound()
+        {
+            self.unbound_narrowing_constraint = Some(binding.narrowing_constraint);
         }
         // If the new binding is a shadowing type, it replaces previous live bindings in this path
         // (unless they're marked as not shadowable), and has no constraints.


### PR DESCRIPTION
## Summary

We retain duplicate binding and declaration lists because reachable histories include implicit unbound/undeclared entries that end-of-scope histories can discard. We now store those initial entries as one reachability constraint per place and intern the remaining definitions, reusing the corresponding end-of-scope declaration list when it matches.
