### PR TITLE
[ty] Reuse generic aliases as MRO query keys

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -36,6 +36,7 @@ use crate::types::generics::{GenericContext, Specialization, walk_specialization
 use crate::types::infer::infer_definition_types;
 use crate::types::known_instance::DeprecatedInstance;
 use crate::types::member::Member;
+use crate::types::mro::{Mro, StaticMroError};
 use crate::types::relation::{
     DisjointnessChecker, HasRelationToVisitor, IsDisjointVisitor, TypeRelation, TypeRelationChecker,
 };
@@ -521,6 +522,29 @@ impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
 
 #[salsa::tracked]
 impl<'db> GenericAlias<'db> {
+    /// Resolve the MRO with this alias's type arguments applied to its base classes.
+    #[salsa::tracked(
+        returns(as_ref),
+        cycle_initial=|db, _, alias: GenericAlias<'db>| {
+            let origin = alias.origin(db);
+            let env = ProgramEnvironment::from_scope(origin.body_scope(db));
+            Err(StaticMroError::cycle(
+                db,
+                &env,
+                origin.apply_optional_specialization(db, Some(alias.specialization(db))),
+            ))
+        },
+        heap_size=ruff_memory_usage::heap_size
+    )]
+    pub(in crate::types) fn try_mro(
+        self,
+        db: &'db dyn Db,
+    ) -> Result<Mro<'db>, StaticMroError<'db>> {
+        let origin = self.origin(db);
+        tracing::trace!("GenericAlias::try_mro: {}", origin.name(db));
+        Mro::of_static_class(db, origin, Some(self.specialization(db)))
+    }
+
     /// Compose each type argument's variance with its formal parameter's variance. Inferred
     /// parameters refer to the unspecialized class equation, keeping references such as
     /// `P[list[T]]` finite without expanding specialized class bodies.

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -828,7 +828,7 @@ impl<'db> StaticClassLiteral<'db> {
     ) -> Result<&'db Mro<'db>, &'db StaticMroError<'db>> {
         match specialization {
             None => self.try_mro_unspecialized(db),
-            Some(specialization) => self.try_mro_specialized(db, specialization),
+            Some(specialization) => GenericAlias::new(db, self, specialization).try_mro(db),
         }
     }
 
@@ -846,26 +846,6 @@ impl<'db> StaticClassLiteral<'db> {
     fn try_mro_unspecialized(self, db: &'db dyn Db) -> Result<Mro<'db>, StaticMroError<'db>> {
         tracing::trace!("StaticClassLiteral::try_mro: {}", self.name(db));
         Mro::of_static_class(db, self, None)
-    }
-
-    #[salsa::tracked(
-        returns(as_ref),
-        cycle_initial=|db, _, self_: StaticClassLiteral<'db>, specialization| {
-            let env = ProgramEnvironment::from_scope(self_.body_scope(db));
-            Err(StaticMroError::cycle(
-                db, &env,
-                self_.apply_optional_specialization(db, Some(specialization)),
-            ))
-        },
-        heap_size=ruff_memory_usage::heap_size
-    )]
-    fn try_mro_specialized(
-        self,
-        db: &'db dyn Db,
-        specialization: Specialization<'db>,
-    ) -> Result<Mro<'db>, StaticMroError<'db>> {
-        tracing::trace!("StaticClassLiteral::try_mro: {}", self.name(db));
-        Mro::of_static_class(db, self, Some(specialization))
     }
 
     /// Iterate over the [method resolution order] ("MRO") of the class.


### PR DESCRIPTION
## Summary

Resolving a specialized MRO retains an extra Salsa key containing the class and its specialization. We now key the query directly by the existing `GenericAlias`, removing the duplicate key storage.

In the retained-memory report, compared with `a2ac770b03`:

| Project | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Flake8 | 39.03 MiB | 38.94 MiB | 0.21% |
| Sphinx | 172.30 MiB | 171.78 MiB | 0.30% |
| Prefect | 470.90 MiB | 469.40 MiB | 0.32% |
| Trio | 95.86 MiB | 95.51 MiB | 0.36% |
