### PR TITLE
[ty] Box cached MRO error details

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -528,21 +528,21 @@ impl<'db> GenericAlias<'db> {
         cycle_initial=|db, _, alias: GenericAlias<'db>| {
             let origin = alias.origin(db);
             let env = ProgramEnvironment::from_scope(origin.body_scope(db));
-            Err(StaticMroError::cycle(
+            Err(Box::new(StaticMroError::cycle(
                 db,
                 &env,
                 origin.apply_optional_specialization(db, Some(alias.specialization(db))),
-            ))
+            )))
         },
         heap_size=ruff_memory_usage::heap_size
     )]
     pub(in crate::types) fn try_mro(
         self,
         db: &'db dyn Db,
-    ) -> Result<Mro<'db>, StaticMroError<'db>> {
+    ) -> Result<Mro<'db>, Box<StaticMroError<'db>>> {
         let origin = self.origin(db);
         tracing::trace!("GenericAlias::try_mro: {}", origin.name(db));
-        Mro::of_static_class(db, origin, Some(self.specialization(db)))
+        Mro::of_static_class(db, origin, Some(self.specialization(db))).map_err(Box::new)
     }
 
     /// Compose each type argument's variance with its formal parameter's variance. Inferred

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -830,22 +830,23 @@ impl<'db> StaticClassLiteral<'db> {
             None => self.try_mro_unspecialized(db),
             Some(specialization) => GenericAlias::new(db, self, specialization).try_mro(db),
         }
+        .map_err(Box::as_ref)
     }
 
     #[salsa::tracked(
         returns(as_ref),
         cycle_initial=|db, _, self_: StaticClassLiteral<'db>| {
             let env = ProgramEnvironment::from_scope(self_.body_scope(db));
-            Err(StaticMroError::cycle(
+            Err(Box::new(StaticMroError::cycle(
                 db, &env,
                 self_.apply_optional_specialization(db, None),
-            ))
+            )))
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn try_mro_unspecialized(self, db: &'db dyn Db) -> Result<Mro<'db>, StaticMroError<'db>> {
+    fn try_mro_unspecialized(self, db: &'db dyn Db) -> Result<Mro<'db>, Box<StaticMroError<'db>>> {
         tracing::trace!("StaticClassLiteral::try_mro: {}", self.name(db));
-        Mro::of_static_class(db, self, None)
+        Mro::of_static_class(db, self, None).map_err(Box::new)
     }
 
     /// Iterate over the [method resolution order] ("MRO") of the class.

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -719,10 +719,7 @@ impl DoubleEndedIterator for MroIterator<'_> {
 }
 
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-pub(super) struct StaticMroError<'db> {
-    kind: StaticMroErrorKind<'db>,
-    fallback_mro: Mro<'db>,
-}
+pub(super) struct StaticMroError<'db>(Box<StaticMroErrorInner<'db>>);
 
 impl<'db> StaticMroError<'db> {
     /// Construct an MRO error of kind `InheritanceCycle`.
@@ -735,19 +732,26 @@ impl<'db> StaticMroError<'db> {
     }
 
     pub(super) fn is_cycle(&self) -> bool {
-        matches!(self.kind, StaticMroErrorKind::InheritanceCycle)
+        matches!(self.0.kind, StaticMroErrorKind::InheritanceCycle)
     }
 
     /// Return an [`StaticMroErrorKind`] variant describing why we could not resolve the MRO for this class.
     pub(super) fn reason(&self) -> &StaticMroErrorKind<'db> {
-        &self.kind
+        &self.0.kind
     }
 
     /// Return the fallback MRO we should infer for this class during type inference
     /// (since accurate resolution of its "true" MRO was impossible)
     fn fallback_mro(&self) -> &Mro<'db> {
-        &self.fallback_mro
+        &self.0.fallback_mro
     }
+}
+
+/// Failure details are boxed so successful cached MROs do not reserve space for them.
+#[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+struct StaticMroErrorInner<'db> {
+    kind: StaticMroErrorKind<'db>,
+    fallback_mro: Mro<'db>,
 }
 
 /// Possible ways in which attempting to resolve the MRO of a statically-defined class might fail.
@@ -796,10 +800,10 @@ impl<'db> StaticMroErrorKind<'db> {
         env: &ProgramEnvironment<'db>,
         class: ClassType<'db>,
     ) -> StaticMroError<'db> {
-        StaticMroError {
+        StaticMroError(Box::new(StaticMroErrorInner {
             kind: self,
             fallback_mro: Mro::from_error(db, env, class),
-        }
+        }))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -718,8 +718,12 @@ impl DoubleEndedIterator for MroIterator<'_> {
     }
 }
 
+/// Boxed in cached MRO results so successful MROs do not reserve space for failure details.
 #[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-pub(super) struct StaticMroError<'db>(Box<StaticMroErrorInner<'db>>);
+pub(super) struct StaticMroError<'db> {
+    kind: StaticMroErrorKind<'db>,
+    fallback_mro: Mro<'db>,
+}
 
 impl<'db> StaticMroError<'db> {
     /// Construct an MRO error of kind `InheritanceCycle`.
@@ -732,26 +736,19 @@ impl<'db> StaticMroError<'db> {
     }
 
     pub(super) fn is_cycle(&self) -> bool {
-        matches!(self.0.kind, StaticMroErrorKind::InheritanceCycle)
+        matches!(self.kind, StaticMroErrorKind::InheritanceCycle)
     }
 
     /// Return an [`StaticMroErrorKind`] variant describing why we could not resolve the MRO for this class.
     pub(super) fn reason(&self) -> &StaticMroErrorKind<'db> {
-        &self.0.kind
+        &self.kind
     }
 
     /// Return the fallback MRO we should infer for this class during type inference
     /// (since accurate resolution of its "true" MRO was impossible)
     fn fallback_mro(&self) -> &Mro<'db> {
-        &self.0.fallback_mro
+        &self.fallback_mro
     }
-}
-
-/// Failure details are boxed so successful cached MROs do not reserve space for them.
-#[derive(Debug, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-struct StaticMroErrorInner<'db> {
-    kind: StaticMroErrorKind<'db>,
-    fallback_mro: Mro<'db>,
 }
 
 /// Possible ways in which attempting to resolve the MRO of a statically-defined class might fail.
@@ -800,10 +797,10 @@ impl<'db> StaticMroErrorKind<'db> {
         env: &ProgramEnvironment<'db>,
         class: ClassType<'db>,
     ) -> StaticMroError<'db> {
-        StaticMroError(Box::new(StaticMroErrorInner {
+        StaticMroError {
             kind: self,
             fallback_mro: Mro::from_error(db, env, class),
-        }))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Successful MRO queries retain a result layout large enough to hold the full error kind and fallback MRO. We now box `StaticMroError` in the cached `Result`, reducing the retained size of the cached result.
