### PR TITLE
[ty] Avoid composite keys for intersection simplification

### DIFF
--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1390,7 +1390,7 @@ impl<'db> IntersectionBuilder<'db> {
 }
 
 /// The signs of a pair of intersection elements. For `Mixed`, the first is positive.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum IntersectionPolarity {
     Positive,
     Negative,
@@ -1421,12 +1421,57 @@ enum IntersectionSimplification {
 ///
 /// Inferring `C.x` needs the guarded type of `self`. The guard cannot use that unfinished
 /// inference to prove that `C` already satisfies the protocol for `x` and erase the branch.
-#[salsa::tracked(
-    returns(copy),
-    cycle_result=|_, _, _, _| IntersectionSimplification::Unchanged,
-    heap_size=ruff_memory_usage::heap_size,
-)]
 fn simplify_intersection_pair<'db>(
+    db: &'db dyn Db,
+    types: TypePair<'db>,
+    polarity: IntersectionPolarity,
+) -> IntersectionSimplification {
+    // Separate queries encode the polarity in the query identity. Each query can use the
+    // existing TypePair as its key, avoiding another interned key for the pair and polarity.
+    #[salsa::tracked(
+        returns(copy),
+        cycle_result=|_, _, _| IntersectionSimplification::Unchanged,
+        heap_size=ruff_memory_usage::heap_size,
+    )]
+    fn simplify_positive_intersection<'db>(
+        db: &'db dyn Db,
+        types: TypePair<'db>,
+    ) -> IntersectionSimplification {
+        simplify_intersection_pair_impl(db, types, IntersectionPolarity::Positive)
+    }
+
+    #[salsa::tracked(
+        returns(copy),
+        cycle_result=|_, _, _| IntersectionSimplification::Unchanged,
+        heap_size=ruff_memory_usage::heap_size,
+    )]
+    fn simplify_negative_intersection<'db>(
+        db: &'db dyn Db,
+        types: TypePair<'db>,
+    ) -> IntersectionSimplification {
+        simplify_intersection_pair_impl(db, types, IntersectionPolarity::Negative)
+    }
+
+    #[salsa::tracked(
+        returns(copy),
+        cycle_result=|_, _, _| IntersectionSimplification::Unchanged,
+        heap_size=ruff_memory_usage::heap_size,
+    )]
+    fn simplify_mixed_intersection<'db>(
+        db: &'db dyn Db,
+        types: TypePair<'db>,
+    ) -> IntersectionSimplification {
+        simplify_intersection_pair_impl(db, types, IntersectionPolarity::Mixed)
+    }
+
+    match polarity {
+        IntersectionPolarity::Positive => simplify_positive_intersection(db, types),
+        IntersectionPolarity::Negative => simplify_negative_intersection(db, types),
+        IntersectionPolarity::Mixed => simplify_mixed_intersection(db, types),
+    }
+}
+
+fn simplify_intersection_pair_impl<'db>(
     db: &'db dyn Db,
     types: TypePair<'db>,
     polarity: IntersectionPolarity,


### PR DESCRIPTION
## Summary

Intersection simplification interns a second cache key combining an existing `TypePair` with its polarity. We now encode the polarity in three separate Salsa queries and key each directly by `TypePair`. Each query preserves the existing `Unchanged` result for inference cycles.

In the retained-memory report, compared with `a2ac770b03`:

| Project | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Flake8 | 39.03 MiB | 39.01 MiB | 0.05% |
| Sphinx | 172.30 MiB | 171.88 MiB | 0.24% |
| Prefect | 470.90 MiB | 470.42 MiB | 0.10% |
| Trio | 95.86 MiB | 95.76 MiB | 0.11% |
