### PR TITLE
Respect fmt: off in match cases

### DIFF
--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py
@@ -26,3 +26,38 @@ match outer:
             # fmt: off
             case None, y   : pass
             # fmt: on
+
+
+match unclosed:
+    # fmt: off
+    case 1: f()  # type: ignore
+    # keep this own-line comment
+
+
+match prefix:
+    # keep me
+    # fmt: off
+    # fmt: on
+    case 1: pass
+    case 2   : pass
+
+
+match suppressed_comments:
+    # fmt: off
+    # keep me
+    case 1   : pass
+    # between cases
+    case 2   : pass
+    # before on
+    # fmt: on
+    case 3   : pass
+
+
+match repeated:
+    # fmt: off
+    case 1   : pass
+    # fmt: on
+    # fmt: off
+    case 2   : pass
+    # fmt: on
+    case 3   : pass

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py
@@ -5,3 +5,24 @@ match left, right:
     case x,    None: pass
     case x,    y   : pass
     # fmt: on
+
+
+match same_case:
+    # fmt: off
+    # fmt: on
+    case value   : pass
+
+
+match next_case:
+    # fmt: off
+    case value   : pass
+    # fmt: on
+    case other   : pass
+
+
+match outer:
+    case value:
+        match left, right:
+            # fmt: off
+            case None, y   : pass
+            # fmt: on

--- a/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py
+++ b/crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py
@@ -1,0 +1,7 @@
+match left, right:
+    # fmt: off
+    case None, None: pass
+    case None, y   : pass
+    case x,    None: pass
+    case x,    y   : pass
+    # fmt: on

--- a/crates/ruff_python_formatter/src/statement/stmt_match.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_match.rs
@@ -53,16 +53,13 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
         while let Some(case) = cases.get(case_index) {
             let leading_case_comments = comments.leading(case);
             let Some(format_off_index) = leading_case_comments.iter().position(|comment| {
-                comment.line_position().is_own_line() && comment.is_suppression_off_comment(source)
+                comment.is_unformatted()
+                    && comment.line_position().is_own_line()
+                    && comment.is_suppression_off_comment(source)
             }) else {
                 let last_suite_in_statement = Some(case) == cases.last();
                 if case_index == 0 {
-                    write!(
-                        f,
-                        [block_indent(
-                            &case.format().with_options(last_suite_in_statement)
-                        )]
-                    )?;
+                    write!(f, [block_indent(&case.format())])?;
                 } else {
                     let last_case = &cases[case_index - 1];
                     write!(
@@ -127,10 +124,15 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
                         comments.leading(&cases[on_case_index])
                     };
                     let format_on_comment = &on_comments[on_index];
-                    let last_suppressed_case = on_case_index - usize::from(!is_trailing);
+                    let last_suppressed_case = is_trailing
+                        .then_some(on_case_index)
+                        .or_else(|| on_case_index.checked_sub(1))
+                        .filter(|index| *index >= case_index);
 
-                    for suppressed_case in &cases[case_index..=last_suppressed_case] {
-                        comments.mark_verbatim_node_comments_formatted(suppressed_case.into());
+                    if let Some(last_suppressed_case) = last_suppressed_case {
+                        for suppressed_case in &cases[case_index..=last_suppressed_case] {
+                            comments.mark_verbatim_node_comments_formatted(suppressed_case.into());
+                        }
                     }
 
                     if is_trailing {

--- a/crates/ruff_python_formatter/src/statement/stmt_match.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_match.rs
@@ -1,12 +1,15 @@
 use ruff_formatter::{format_args, write};
 use ruff_python_ast::StmtMatch;
+use ruff_text_size::{Ranged, TextRange};
 
-use crate::comments::leading_alternate_branch_comments;
+use crate::comments::format::format_comment;
+use crate::comments::{leading_alternate_branch_comments, leading_comments, trailing_comments};
 use crate::context::{NodeLevel, WithNodeLevel};
 use crate::expression::maybe_parenthesize_expression;
 use crate::expression::parentheses::Parenthesize;
 use crate::prelude::*;
 use crate::statement::clause::{ClauseHeader, clause_header};
+use crate::verbatim::{FormatVerbatimStatementRange, Indentation};
 
 #[derive(Default)]
 pub struct FormatStmtMatch;
@@ -37,30 +40,166 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
         )
         .fmt(f)?;
 
-        let mut cases_iter = cases.iter();
-        let Some(first) = cases_iter.next() else {
+        if cases.is_empty() {
             return Ok(());
-        };
+        }
 
         // The new level is for the `case` nodes.
         let mut f = WithNodeLevel::new(NodeLevel::CompoundStatement, f);
 
-        write!(f, [block_indent(&first.format())])?;
-        let mut last_case = first;
+        let source = f.context().source();
+        let mut case_index = 0;
 
-        for case in cases_iter {
-            let last_suite_in_statement = Some(case) == cases.last();
+        while let Some(case) = cases.get(case_index) {
+            let leading_case_comments = comments.leading(case);
+            let Some(format_off_index) = leading_case_comments.iter().position(|comment| {
+                comment.line_position().is_own_line() && comment.is_suppression_off_comment(source)
+            }) else {
+                let last_suite_in_statement = Some(case) == cases.last();
+                if case_index == 0 {
+                    write!(
+                        f,
+                        [block_indent(
+                            &case.format().with_options(last_suite_in_statement)
+                        )]
+                    )?;
+                } else {
+                    let last_case = &cases[case_index - 1];
+                    write!(
+                        f,
+                        [block_indent(&format_args!(
+                            leading_alternate_branch_comments(
+                                leading_case_comments,
+                                last_case.body.last(),
+                            ),
+                            case.format().with_options(last_suite_in_statement)
+                        ))]
+                    )?;
+                }
+                case_index += 1;
+                continue;
+            };
+
+            let format_off_comment = &leading_case_comments[format_off_index];
+            let mut format_on = None;
+
+            for (index, suppressed_case) in cases.iter().enumerate().skip(case_index) {
+                let leading_comments = comments.leading(suppressed_case);
+                let leading_start = if index == case_index {
+                    format_off_index + 1
+                } else {
+                    0
+                };
+
+                if let Some(comment_index) = leading_comments
+                    .iter()
+                    .enumerate()
+                    .skip(leading_start)
+                    .find_map(|(index, comment)| {
+                        (comment.line_position().is_own_line()
+                            && comment.is_suppression_on_comment(source))
+                        .then_some(index)
+                    })
+                {
+                    format_on = Some((index, false, comment_index));
+                    break;
+                }
+
+                if let Some(comment_index) =
+                    comments
+                        .trailing(suppressed_case)
+                        .iter()
+                        .position(|comment| {
+                            comment.line_position().is_own_line()
+                                && comment.is_suppression_on_comment(source)
+                        })
+                {
+                    format_on = Some((index, true, comment_index));
+                    break;
+                }
+            }
+
+            let (verbatim_end, next_case_index) =
+                if let Some((on_case_index, is_trailing, on_index)) = format_on {
+                    let on_comments = if is_trailing {
+                        comments.trailing(&cases[on_case_index])
+                    } else {
+                        comments.leading(&cases[on_case_index])
+                    };
+                    let format_on_comment = &on_comments[on_index];
+                    let last_suppressed_case = on_case_index - usize::from(!is_trailing);
+
+                    for suppressed_case in &cases[case_index..=last_suppressed_case] {
+                        comments.mark_verbatim_node_comments_formatted(suppressed_case.into());
+                    }
+
+                    if is_trailing {
+                        for comment in &on_comments[on_index..] {
+                            comment.mark_unformatted();
+                        }
+                    } else {
+                        for comment in &on_comments[..on_index] {
+                            comment.mark_formatted();
+                        }
+                    }
+
+                    (
+                        format_on_comment.start(),
+                        if is_trailing {
+                            on_case_index + 1
+                        } else {
+                            on_case_index
+                        },
+                    )
+                } else {
+                    for suppressed_case in &cases[case_index..] {
+                        comments.mark_verbatim_node_comments_formatted(suppressed_case.into());
+                    }
+
+                    (item.end(), cases.len())
+                };
+
+            format_off_comment.mark_formatted();
+            let indentation = Indentation::from_range(case, source);
             write!(
                 f,
-                [block_indent(&format_args!(
-                    leading_alternate_branch_comments(
-                        comments.leading(case),
-                        last_case.body.last(),
-                    ),
-                    case.format().with_options(last_suite_in_statement)
-                ))]
+                [block_indent(&format_with(|f| {
+                    if case_index == 0 {
+                        leading_comments(&leading_case_comments[..format_off_index]).fmt(f)?;
+                    } else {
+                        leading_alternate_branch_comments(
+                            &leading_case_comments[..format_off_index],
+                            cases[case_index - 1].body.last(),
+                        )
+                        .fmt(f)?;
+                    }
+
+                    format_comment(format_off_comment).fmt(f)?;
+                    FormatVerbatimStatementRange {
+                        verbatim_range: TextRange::new(format_off_comment.end(), verbatim_end),
+                        indentation,
+                    }
+                    .fmt(f)?;
+
+                    if let Some((on_case_index, is_trailing, on_index)) = format_on {
+                        let on_comments = if is_trailing {
+                            comments.trailing(&cases[on_case_index])
+                        } else {
+                            comments.leading(&cases[on_case_index])
+                        };
+
+                        if is_trailing {
+                            trailing_comments(&on_comments[on_index..]).fmt(f)?;
+                        } else {
+                            leading_comments(&on_comments[on_index..]).fmt(f)?;
+                        }
+                    }
+
+                    Ok(())
+                }))]
             )?;
-            last_case = case;
+
+            case_index = next_case_index;
         }
 
         Ok(())

--- a/crates/ruff_python_formatter/src/statement/stmt_match.rs
+++ b/crates/ruff_python_formatter/src/statement/stmt_match.rs
@@ -1,5 +1,5 @@
 use ruff_formatter::{format_args, write};
-use ruff_python_ast::StmtMatch;
+use ruff_python_ast::{AnyNodeRef, StmtMatch};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::comments::format::format_comment;
@@ -130,8 +130,27 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
                         .filter(|index| *index >= case_index);
 
                     if let Some(last_suppressed_case) = last_suppressed_case {
-                        for suppressed_case in &cases[case_index..=last_suppressed_case] {
+                        for (index, suppressed_case) in
+                            cases[case_index..=last_suppressed_case].iter().enumerate()
+                        {
                             comments.mark_verbatim_node_comments_formatted(suppressed_case.into());
+
+                            let leading_comments = comments.leading(suppressed_case);
+                            let leading_start = if index == 0 { format_off_index + 1 } else { 0 };
+                            for comment in &leading_comments[leading_start..] {
+                                comment.mark_formatted();
+                            }
+
+                            let trailing_comments = comments.trailing(suppressed_case);
+                            let trailing_end = if is_trailing && case_index + index == on_case_index
+                            {
+                                on_index
+                            } else {
+                                trailing_comments.len()
+                            };
+                            for comment in &trailing_comments[..trailing_end] {
+                                comment.mark_formatted();
+                            }
                         }
                     }
 
@@ -140,7 +159,12 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
                             comment.mark_unformatted();
                         }
                     } else {
-                        for comment in &on_comments[..on_index] {
+                        let leading_start = if on_case_index == case_index {
+                            format_off_index + 1
+                        } else {
+                            0
+                        };
+                        for comment in &on_comments[leading_start..on_index] {
                             comment.mark_formatted();
                         }
                     }
@@ -154,11 +178,32 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
                         },
                     )
                 } else {
-                    for suppressed_case in &cases[case_index..] {
+                    for (index, suppressed_case) in cases[case_index..].iter().enumerate() {
                         comments.mark_verbatim_node_comments_formatted(suppressed_case.into());
+
+                        let leading_comments = comments.leading(suppressed_case);
+                        let leading_start = if index == 0 { format_off_index + 1 } else { 0 };
+                        for comment in &leading_comments[leading_start..] {
+                            comment.mark_formatted();
+                        }
+
+                        for comment in comments.trailing(suppressed_case) {
+                            comment.mark_formatted();
+                        }
                     }
 
-                    (item.end(), cases.len())
+                    let mut current = AnyNodeRef::from(cases.last().unwrap());
+                    let end = loop {
+                        if let Some(comment) = comments.trailing(current).last() {
+                            break comment.end();
+                        } else if let Some(child) = current.last_child_in_body() {
+                            current = child;
+                        } else {
+                            break current.end();
+                        }
+                    };
+
+                    (end, cases.len())
                 };
 
             format_off_comment.mark_formatted();
@@ -189,11 +234,20 @@ impl FormatNodeRule<StmtMatch> for FormatStmtMatch {
                         } else {
                             comments.leading(&cases[on_case_index])
                         };
+                        let following_format_off = on_comments[on_index + 1..]
+                            .iter()
+                            .position(|comment| {
+                                comment.line_position().is_own_line()
+                                    && comment.is_suppression_off_comment(source)
+                            })
+                            .map_or(on_comments.len(), |index| on_index + 1 + index);
 
                         if is_trailing {
-                            trailing_comments(&on_comments[on_index..]).fmt(f)?;
+                            trailing_comments(&on_comments[on_index..following_format_off])
+                                .fmt(f)?;
                         } else {
-                            leading_comments(&on_comments[on_index..]).fmt(f)?;
+                            leading_comments(&on_comments[on_index..following_format_off])
+                                .fmt(f)?;
                         }
                     }
 

--- a/crates/ruff_python_formatter/src/verbatim.rs
+++ b/crates/ruff_python_formatter/src/verbatim.rs
@@ -678,14 +678,18 @@ impl Format<PyFormatContext<'_>> for TrailingFormatOffComment<'_> {
 ///   This implementation makes use of this fact and assumes a tab size of 1.
 /// * The source document is correctly indented because it is valid Python code (or the formatter would have failed parsing the code).
 #[derive(Copy, Clone)]
-struct Indentation(u32);
+pub(crate) struct Indentation(u32);
 
 impl Indentation {
     fn from_stmt(stmt: &Stmt, source: &str) -> Indentation {
-        let line_start = source.line_start(stmt.start());
+        Self::from_range(stmt, source)
+    }
+
+    pub(crate) fn from_range(ranged: impl Ranged, source: &str) -> Indentation {
+        let line_start = source.line_start(ranged.start());
 
         let mut indentation = 0u32;
-        for c in source[TextRange::new(line_start, stmt.start())].chars() {
+        for c in source[TextRange::new(line_start, ranged.start())].chars() {
             if is_indent_whitespace(c) {
                 indentation += 1;
             } else {
@@ -752,9 +756,9 @@ const fn is_indent_whitespace(c: char) -> bool {
 /// but the indentation of the expression remains unchanged. It changes the indentation to:
 /// * Prevent syntax errors because of different indentation levels between formatted and suppressed statements.
 /// * Align with the `fmt: skip` where statements are indented as well, but inner expressions are formatted as is.
-struct FormatVerbatimStatementRange {
-    verbatim_range: TextRange,
-    indentation: Indentation,
+pub(crate) struct FormatVerbatimStatementRange {
+    pub(crate) verbatim_range: TextRange,
+    pub(crate) indentation: Indentation,
 }
 
 impl Format<PyFormatContext<'_>> for FormatVerbatimStatementRange {

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__match_cases.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__match_cases.py.snap
@@ -32,6 +32,41 @@ match outer:
             # fmt: off
             case None, y   : pass
             # fmt: on
+
+
+match unclosed:
+    # fmt: off
+    case 1: f()  # type: ignore
+    # keep this own-line comment
+
+
+match prefix:
+    # keep me
+    # fmt: off
+    # fmt: on
+    case 1: pass
+    case 2   : pass
+
+
+match suppressed_comments:
+    # fmt: off
+    # keep me
+    case 1   : pass
+    # between cases
+    case 2   : pass
+    # before on
+    # fmt: on
+    case 3   : pass
+
+
+match repeated:
+    # fmt: off
+    case 1   : pass
+    # fmt: on
+    # fmt: off
+    case 2   : pass
+    # fmt: on
+    case 3   : pass
 ```
 
 ## Output
@@ -66,4 +101,43 @@ match outer:
             # fmt: off
             case None, y   : pass
             # fmt: on
+
+
+match unclosed:
+    # fmt: off
+    case 1: f()  # type: ignore
+    # keep this own-line comment
+
+
+match prefix:
+    # keep me
+    # fmt: off
+    # fmt: on
+    case 1:
+        pass
+    case 2:
+        pass
+
+
+match suppressed_comments:
+    # fmt: off
+    # keep me
+    case 1   : pass
+    # between cases
+    case 2   : pass
+    # before on
+    # fmt: on
+    case 3:
+        pass
+
+
+match repeated:
+    # fmt: off
+    case 1   : pass
+    # fmt: on
+    # fmt: off
+    case 2   : pass
+    # fmt: on
+    case 3:
+        pass
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__match_cases.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__match_cases.py.snap
@@ -11,6 +11,27 @@ match left, right:
     case x,    None: pass
     case x,    y   : pass
     # fmt: on
+
+
+match same_case:
+    # fmt: off
+    # fmt: on
+    case value   : pass
+
+
+match next_case:
+    # fmt: off
+    case value   : pass
+    # fmt: on
+    case other   : pass
+
+
+match outer:
+    case value:
+        match left, right:
+            # fmt: off
+            case None, y   : pass
+            # fmt: on
 ```
 
 ## Output
@@ -22,4 +43,27 @@ match left, right:
     case x,    None: pass
     case x,    y   : pass
     # fmt: on
+
+
+match same_case:
+    # fmt: off
+    # fmt: on
+    case value:
+        pass
+
+
+match next_case:
+    # fmt: off
+    case value   : pass
+    # fmt: on
+    case other:
+        pass
+
+
+match outer:
+    case value:
+        match left, right:
+            # fmt: off
+            case None, y   : pass
+            # fmt: on
 ```

--- a/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__match_cases.py.snap
+++ b/crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__match_cases.py.snap
@@ -1,0 +1,25 @@
+---
+source: crates/ruff_python_formatter/tests/fixtures.rs
+input_file: crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py
+---
+## Input
+```python
+match left, right:
+    # fmt: off
+    case None, None: pass
+    case None, y   : pass
+    case x,    None: pass
+    case x,    y   : pass
+    # fmt: on
+```
+
+## Output
+```python
+match left, right:
+    # fmt: off
+    case None, None: pass
+    case None, y   : pass
+    case x,    None: pass
+    case x,    y   : pass
+    # fmt: on
+```


### PR DESCRIPTION
## Summary

Preserve match-case source text when `# fmt: off` is used. The formatter now resumes normal formatting after `# fmt: on`, including markers in adjacent case comments and repeated suppression ranges. Add regression coverage for comments, nested cases, and unclosed ranges.

Fixes #28340

## Test Plan

- `cargo test`
- `cargo test -p ruff_python_formatter --test fixtures -- match_cases`
- `cargo test -p ruff_python_formatter --test fixtures -- fmt_on_off`
- `cargo test -p ruff_python_formatter --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `uv run --only-group dev --locked prek run --files crates/ruff_python_formatter/src/statement/stmt_match.rs crates/ruff_python_formatter/src/verbatim.rs crates/ruff_python_formatter/resources/test/fixtures/ruff/fmt_on_off/match_cases.py crates/ruff_python_formatter/tests/snapshots/format@fmt_on_off__match_cases.py.snap`