### PR TITLE
[ty] Recover a subclass instance when constructor overload resolution fails

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -1384,6 +1384,102 @@ class OnlyNonInstance:
 reveal_type(OnlyNonInstance(1.2))  # revealed: Unknown
 ```
 
+### Failed overload resolution recovers a subclass instance the same way it recovers the base
+
+If no overload matches, but every overload's return type is an instance of the class that declares
+`__new__`, we already fall back to a plain instance of that class rather than `Unknown`, since we
+know the call constructs *something* related to it, even without knowing precisely what. The same
+reasoning applies when constructing a subclass through an inherited `__new__`: an overload's return
+type naming an ancestor class still describes what that inherited constructor produces, so the
+subclass should recover to a plain instance of itself, not `Unknown`.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import overload
+
+class DisagreeingGeneric[T]:
+    @overload
+    def __new__(cls, code: int) -> "DisagreeingGeneric[int]": ...
+    @overload
+    def __new__(cls, code: str) -> "DisagreeingGeneric[str]": ...
+    def __new__(cls, code): ...
+
+class SubOfDisagreeing(DisagreeingGeneric[int]): ...
+
+# error: [no-matching-overload]
+reveal_type(DisagreeingGeneric(1.2))  # revealed: DisagreeingGeneric[T@DisagreeingGeneric]
+
+# error: [no-matching-overload]
+reveal_type(SubOfDisagreeing(1.2))  # revealed: SubOfDisagreeing
+```
+
+If every failing overload's return type instead agrees on the exact same instance, that shared
+return type is precise enough to keep, rather than widening it to a plain, unspecialized instance.
+This applies equally whether the constructed class declares the overloads or inherits them:
+
+```py
+class AgreeingGeneric[T]:
+    @overload
+    def __new__(cls, code: int) -> "AgreeingGeneric[int]": ...
+    @overload
+    def __new__(cls, code: str) -> "AgreeingGeneric[int]": ...
+    def __new__(cls, code): ...
+
+class SubOfAgreeing(AgreeingGeneric[int]): ...
+
+# error: [no-matching-overload]
+reveal_type(AgreeingGeneric(1.2))  # revealed: AgreeingGeneric[int]
+
+# error: [no-matching-overload]
+reveal_type(SubOfAgreeing(1.2))  # revealed: AgreeingGeneric[int]
+```
+
+The same holds for a non-generic class whose overloads agree on a literal return type: inheriting
+the constructor does not change what it returns, so the subclass call still reveals that same type
+rather than an instance of the subclass:
+
+```py
+class Concrete:
+    @overload
+    def __new__(cls, code: int) -> "Concrete": ...
+    @overload
+    def __new__(cls, code: str) -> "Concrete": ...
+    def __new__(cls, code): ...
+
+class SubOfConcrete(Concrete): ...
+
+# error: [no-matching-overload]
+reveal_type(Concrete(1.2))  # revealed: Concrete
+
+# error: [no-matching-overload]
+reveal_type(SubOfConcrete(1.2))  # revealed: Concrete
+```
+
+None of this applies when the overloads' return types are unrelated to the class hierarchy being
+constructed at all: that case still reveals `Unknown`, for a subclass just as for the declaring
+class itself:
+
+```py
+class A: ...
+class B: ...
+
+class Unrelated:
+    @overload
+    def __new__(cls, code: int) -> "A": ...
+    @overload
+    def __new__(cls, code: str) -> "B": ...
+    def __new__(cls, code): ...
+
+class SubOfUnrelated(Unrelated): ...
+
+# error: [no-matching-overload]
+reveal_type(SubOfUnrelated(1.2))  # revealed: Unknown
+```
+
 ### Mixed generic `__new__` overloads should still validate `__init__`
 
 For generic classes, if an instance-returning `__new__` overload matches, we still need to validate

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -9,8 +9,8 @@ use crate::types::generics::{GenericContext, Specialization};
 use crate::types::signatures::Parameter;
 use crate::types::typevar::TypeVarNonceGenerator;
 use crate::types::{
-    ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext,
-    TypeMapping,
+    ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassLiteral, ClassType, DynamicType, Type,
+    TypeContext, TypeMapping,
 };
 
 /// Bindings for a constructor call.
@@ -514,8 +514,10 @@ impl<'db> ConstructorBinding<'db> {
     {
         // If we see both instance and non-instance returns, we return Unknown.
         // If we see multiple different non-instance returns, we also return Unknown.
-        // If we see multiple instance returns, we return `None` (we know we are constructing an
-        // instance of the constructed class, but we don't have more precise information.)
+        // If we see multiple instance returns that agree, we return that shared return type, the
+        // same as if it were the sole instance return; if they disagree, we return `None` (we
+        // know we are constructing an instance of the constructed class, but we don't have more
+        // precise information.)
         // Otherwise, we return the single non-instance return if present, or the single
         // instance return we saw (this is different from simply returning `None` since it
         // could be a specific subclass of the constructed class.)
@@ -525,12 +527,12 @@ impl<'db> ConstructorBinding<'db> {
         for overload in overloads {
             let (return_ty, is_instance_return) = self.single_overload_return(db, env, overload);
             if is_instance_return {
-                if saw_instance_return {
-                    sole_instance_return = None;
-                } else {
-                    sole_instance_return = Some(return_ty);
-                    saw_instance_return = true;
-                }
+                sole_instance_return = match sole_instance_return {
+                    None if !saw_instance_return => Some(return_ty),
+                    Some(previous) if previous == return_ty => Some(previous),
+                    _ => None,
+                };
+                saw_instance_return = true;
             } else {
                 non_instance_return = Some(match non_instance_return {
                     None => return_ty,
@@ -570,9 +572,9 @@ impl<'db> ConstructorBinding<'db> {
                 }),
             );
         if self
-            .constructed_class_literal(db, env)
-            .is_some_and(|class_literal| {
-                constructor_returns_instance(db, env, class_literal, return_ty)
+            .constructed_class_type(db, env)
+            .is_some_and(|constructed_class| {
+                constructor_returns_related_instance(db, env, constructed_class, return_ty)
             })
         {
             return (
@@ -645,6 +647,18 @@ impl<'db> ConstructorBinding<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
     ) -> Option<ClassLiteral<'db>> {
+        self.constructed_class_type(db, env)
+            .map(|class| class.class_literal(db))
+    }
+
+    /// Like [`Self::constructed_class_literal`], but keeps the class's specialization instead of
+    /// discarding it. Needed wherever a caller has to check the constructed class's ancestry, not
+    /// just its identity.
+    fn constructed_class_type(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+    ) -> Option<ClassType<'db>> {
         let instance_type = self.constructed_instance_type();
         let lookup_instance = match instance_type {
             Type::Intersection(_) => instance_type.flatten_typevars(db, env),
@@ -653,7 +667,7 @@ impl<'db> ConstructorBinding<'db> {
         lookup_instance
             .as_nominal_instance()
             // TODO may need to handle `Type::KnownInstance` here as well?
-            .map(|instance| instance.class(db, env).class_literal(db))
+            .map(|instance| instance.class(db, env))
     }
 
     fn constructor_kind(&self) -> ConstructorCallableKind {
@@ -704,6 +718,68 @@ pub(crate) enum ConstructorCallableKind {
 impl ConstructorCallableKind {
     fn is_init(self) -> bool {
         matches!(self, ConstructorCallableKind::Init)
+    }
+}
+
+/// Whether `return_ty` describes an instance of `constructed_class`, or of an ancestor class that
+/// `constructed_class` inherits this constructor overload from.
+///
+/// This is deliberately broader than [`constructor_returns_instance`], which only recognizes
+/// `return_ty` as an instance return when its class is `constructed_class` itself (or a further
+/// subclass). That narrower check is exactly right when a single overload matched the call: its
+/// return annotation describes what *that* call produces. But when overload resolution instead
+/// falls back to considering every overload together -- because none of them matched, or several
+/// matched ambiguously -- an overload declared on an ancestor class, with a concrete (non-`Self`)
+/// return annotation naming that ancestor, still describes what the *inherited* constructor
+/// produces when called through a subclass. Recognizing this lets that fallback construct a plain
+/// instance of the receiver, the same way it already does when the receiver is the class that
+/// declares the overloads, instead of degrading to `Unknown`:
+///
+/// ```python
+/// from typing import overload
+///
+/// class Box[T]:
+///     @overload
+///     def __new__(cls, code: int) -> "Box[int]": ...
+///     @overload
+///     def __new__(cls, code: str) -> "Box[str]": ...
+///     def __new__(cls, code): ...
+///
+/// class Sub(Box): ...
+///
+/// Sub(None)  # no overload matches; `Sub` is still recognized as the resulting instance
+/// ```
+fn constructor_returns_related_instance<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    constructed_class: ClassType<'db>,
+    return_ty: Type<'db>,
+) -> bool {
+    constructor_returns_instance(db, env, constructed_class.class_literal(db), return_ty)
+        || returns_instance_of_ancestor(db, env, constructed_class, return_ty)
+}
+
+/// Whether `return_ty` describes an instance of some ancestor of `constructed_class`.
+///
+/// Mirrors the union/intersection recursion in [`constructor_returns_instance`], so a return type
+/// combining several ancestor classes is recognized the same way a single one would be.
+fn returns_instance_of_ancestor<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    constructed_class: ClassType<'db>,
+    return_ty: Type<'db>,
+) -> bool {
+    match return_ty.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| returns_instance_of_ancestor(db, env, constructed_class, *element)),
+        Type::Intersection(intersection) => intersection
+            .iter_positive(db)
+            .any(|element| returns_instance_of_ancestor(db, env, constructed_class, element)),
+        Type::NominalInstance(instance) => constructed_class
+            .is_subtype_of_class_literal(db, instance.class(db, env).class_literal(db)),
+        _ => false,
     }
 }
 


### PR DESCRIPTION
## Summary

A constructor call that matches no overload falls back to a plain instance of the constructed class when every overload's return type is an instance of that class, rather than degrading to `Unknown`. That fallback only recognized overloads declared directly on the constructed class, so it never applied when the class being constructed inherits `__new__` from an ancestor:

```python
from typing import overload

class Box[T]:
    @overload
    def __new__(cls, code: int) -> "Box[int]": ...
    @overload
    def __new__(cls, code: str) -> "Box[str]": ...
    def __new__(cls, code): ...

class Sub(Box): ...

reveal_type(Box())  # Box[T@Box], recognized as a Box instance
reveal_type(Sub())  # Unknown, even though it's calling the same __new__
```

An overload's return type naming an ancestor class still describes what the inherited constructor produces when called through a subclass, the same way it describes what the constructor produces when called through the ancestor itself, so `Sub()` now also recovers to a plain instance (`Sub`) instead of `Unknown`. `array.array` and `slice` hit this in practice: their `__new__` overloads return concrete `array[...]` / `slice[...]` types rather than `Self`, so any user subclass previously lost its own type, and every attribute access on it, the moment a constructor call failed to match.

Fixing this also exposed a related gap: when overload resolution combines multiple failing overloads and several of them return the same instance type, that shared return type was discarded in favor of the plain fallback, even though the disagreement that makes the fallback necessary in other cases doesn't apply when every candidate agrees. It's now kept, mirroring the equivalent handling already in place for non-instance returns.

Closes astral-sh/ty#4467

## Test Plan

New coverage in `call/constructor.md` alongside the existing "no matching overload" tests: disagreeing ancestor-typed overloads recover to a plain instance for both the declaring class and a subclass; agreeing overloads (generic and non-generic) keep their shared, more precise return type instead of widening it, again for both the declaring class and a subclass; and overloads returning genuinely unrelated types still fall back to `Unknown` for a subclass, unchanged.

Also verified manually against the real-world case from the issue: `class S(array.array): pass` now reveals `S` instead of `Unknown` for `S()`, while a call that does match an overload (`S('i')`) is unaffected.

Checks run:

- `cargo test -p ty_python_semantic`: 433 + 14 unit tests and 494 mdtests pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `uv run --only-dev --locked prek run --files ...`: passes
- `cargo dev generate-all`: no changes (this reuses the existing `no-matching-overload` diagnostic)
