### PR TITLE
[ty] Reduce repeated indexing and constraint work

### DIFF
--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -413,6 +413,8 @@ mod indexed {
                         entry_count,
                         layout: IndexChunkLayout::Relative,
                     });
+                    let chunk_words = (node_chunk.len() * usize::from(relative_bits)).div_ceil(64);
+                    words.resize(words.len() + chunk_words, 0);
                     for (entry, node) in node_chunk.iter().enumerate() {
                         let (kind, pointer) = node.into_raw_parts();
                         let address = pointer.as_ptr().expose_provenance();
@@ -442,6 +444,8 @@ mod indexed {
                         u64::try_from(pointer.as_ptr().expose_provenance())
                             .expect("AST node addresses should fit in a bitstream word")
                     }));
+                    let kind_words = (node_chunk.len() * usize::from(Self::KIND_BITS)).div_ceil(64);
+                    words.resize(words.len() + kind_words, 0);
                     for (entry, node) in node_chunk.iter().enumerate() {
                         let (kind, _) = node.into_raw_parts();
                         Self::write_bits(
@@ -456,12 +460,11 @@ mod indexed {
             }
         }
 
-        fn write_bits(words: &mut Vec<u64>, bit: usize, value: u64, bits: u8) {
+        fn write_bits(words: &mut [u64], bit: usize, value: u64, bits: u8) {
             debug_assert!((1..=64).contains(&bits));
             let word = bit / 64;
             let shift = bit % 64;
             let end = bit + usize::from(bits);
-            words.resize(words.len().max(end.div_ceil(64)), 0);
             words[word] |= value << shift;
             if end > (word + 1) * 64 {
                 words[word + 1] |= value >> (64 - shift);

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -89,6 +89,13 @@ struct Loop {
     continue_states: Vec<FlowSnapshot>,
 }
 
+/// A symbol snapshot that can gain bindings when an enclosing scope reassigns the symbol.
+struct LazySymbolSnapshot {
+    enclosing_scope: FileScopeId,
+    enclosing_symbol: ScopedSymbolId,
+    snapshot_id: ScopedEnclosingSnapshotId,
+}
+
 /// A narrowing alias: a variable whose RHS is a narrowing expression
 /// (e.g., `is_none = x is None`).
 #[derive(Clone, Debug)]
@@ -304,6 +311,11 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     annotations: Vec<NodeIndex>,
     /// Snapshots of enclosing-scope place states visible from nested scopes.
     enclosing_snapshots: FxHashMap<EnclosingSnapshotKey, ScopedEnclosingSnapshotId>,
+    /// Lazy snapshots grouped by the name whose reassignments can update them.
+    lazy_symbol_snapshots: FxHashMap<Name, SmallVec<[LazySymbolSnapshot; 1]>>,
+    /// Highest scope ID with a bound `nonlocal` declaration for each name. The final snapshot
+    /// sweep only needs to know whether such a scope exists at or after an enclosing scope.
+    last_nonlocal_binding_scopes: FxHashMap<Name, FileScopeId>,
     /// Errors collected by the `semantic_checker`.
     semantic_syntax_errors: RefCell<Vec<SemanticSyntaxError>>,
 
@@ -361,6 +373,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             annotations: Vec::new(),
 
             enclosing_snapshots: FxHashMap::default(),
+            lazy_symbol_snapshots: FxHashMap::default(),
+            last_nonlocal_binding_scopes: FxHashMap::default(),
 
             resolver_environment: file.resolver_environment(db),
             python_version: file.python_version(db),
@@ -788,6 +802,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     false,
                 );
                 self.enclosing_snapshots.insert(key, lazy_snapshot);
+                self.lazy_symbol_snapshots
+                    .entry(nested_symbol.name().clone())
+                    .or_default()
+                    .push(LazySymbolSnapshot {
+                        enclosing_scope: enclosing_scope_id,
+                        enclosing_symbol: enclosed_symbol_id,
+                        snapshot_id: lazy_snapshot,
+                    });
             }
         }
     }
@@ -826,69 +848,47 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         if !symbol.is_reassigned() {
             return;
         }
-        #[expect(
-            clippy::iter_over_hash_type,
-            reason = "each matching snapshot is updated independently"
-        )]
-        for (key, snapshot_id) in &self.enclosing_snapshots {
-            if let Some(enclosing_symbol) = key.enclosing_place.as_symbol() {
-                let name = self.place_tables[key.enclosing_scope]
-                    .symbol(enclosing_symbol)
-                    .name();
-                let is_reassignment_of_snapshotted_symbol = || {
-                    for (ancestor, _) in self.visible_ancestor_scopes(key.enclosing_scope) {
-                        if ancestor == current_scope {
-                            return true;
-                        }
-                        let ancestor_table = &self.place_tables[ancestor];
-                        // If there is a symbol binding in an ancestor scope,
-                        // then a reassignment in the current scope is not relevant to the snapshot.
-                        if ancestor_table
-                            .symbol_id(name)
-                            .is_some_and(|id| ancestor_table.symbol(id).is_bound())
-                        {
-                            return false;
-                        }
+        let Some(snapshots) = self.lazy_symbol_snapshots.get(symbol.name()) else {
+            return;
+        };
+        for snapshot in snapshots {
+            let is_reassignment_of_snapshotted_symbol = || {
+                for (ancestor, _) in self.visible_ancestor_scopes(snapshot.enclosing_scope) {
+                    if ancestor == current_scope {
+                        return true;
                     }
-                    false
-                };
-
-                if key.nested_laziness.is_lazy()
-                    && symbol.name() == name
-                    && is_reassignment_of_snapshotted_symbol()
-                {
-                    self.use_def_maps[key.enclosing_scope]
-                        .update_enclosing_snapshot(*snapshot_id, enclosing_symbol);
+                    let ancestor_table = &self.place_tables[ancestor];
+                    // If there is a symbol binding in an ancestor scope,
+                    // then a reassignment in the current scope is not relevant to the snapshot.
+                    if ancestor_table
+                        .symbol_id(symbol.name())
+                        .is_some_and(|id| ancestor_table.symbol(id).is_bound())
+                    {
+                        return false;
+                    }
                 }
+                false
+            };
+
+            if is_reassignment_of_snapshotted_symbol() {
+                self.use_def_maps[snapshot.enclosing_scope]
+                    .update_enclosing_snapshot(snapshot.snapshot_id, snapshot.enclosing_symbol);
             }
         }
     }
 
     fn sweep_nonlocal_lazy_snapshots(&mut self) {
         self.enclosing_snapshots.retain(|key, _| {
-            let place_table = &self.place_tables[key.enclosing_scope];
-
-            let is_bound_and_non_local = || -> bool {
-                let ScopedPlaceId::Symbol(symbol_id) = key.enclosing_place else {
-                    return false;
-                };
-
-                let symbol = place_table.symbol(symbol_id);
-                self.scopes
-                    .iter_enumerated()
-                    .skip_while(|(scope_id, _)| *scope_id != key.enclosing_scope)
-                    .any(|(scope_id, _)| {
-                        let other_scope_place_table = &self.place_tables[scope_id];
-                        let Some(symbol_id) = other_scope_place_table.symbol_id(symbol.name())
-                        else {
-                            return false;
-                        };
-                        let symbol = other_scope_place_table.symbol(symbol_id);
-                        symbol.is_nonlocal() && symbol.is_bound()
-                    })
+            if key.nested_laziness.is_eager() {
+                return true;
+            }
+            let ScopedPlaceId::Symbol(symbol_id) = key.enclosing_place else {
+                return true;
             };
-
-            key.nested_laziness.is_eager() || !is_bound_and_non_local()
+            let symbol = self.place_tables[key.enclosing_scope].symbol(symbol_id);
+            self.last_nonlocal_binding_scopes
+                .get(symbol.name())
+                .is_none_or(|scope| *scope < key.enclosing_scope)
         });
     }
 
@@ -1019,6 +1019,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             // Add in any `global` and `nonlocal` declarations from this (non-module) scope.
             if symbol.is_global() || symbol.is_nonlocal() {
+                if symbol.is_nonlocal() && symbol.is_bound() {
+                    self.last_nonlocal_binding_scopes
+                        .entry(symbol.name().clone())
+                        .and_modify(|scope| *scope = (*scope).max(popped_scope_id))
+                        .or_insert(popped_scope_id);
+                }
                 let kind = if symbol.is_global() {
                     GlobalOrNonlocal::Global
                 } else {

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1782,6 +1782,9 @@ impl PendingReachability {
             self.narrowing_constraint_between(branch_ancestor, branch, narrowing_constraints);
         let merged_narrowing =
             narrowing_constraints.add_or_constraint(current_narrowing, branch_narrowing);
+        // Consecutive places often share their last applied reachability node, so their
+        // merged path constraint can be reused even when they have distinct place states.
+        let mut last_merged_reachability = None;
         let mut branch_states = branch_states.into_iter();
         for current in current_states {
             let Some(mut branch_state) = branch_states.next() else {
@@ -1819,18 +1822,25 @@ impl PendingReachability {
                         .record_narrowing_constraint(narrowing_constraints, merged_narrowing);
                 }
 
-                let current_constraint = self.constraint_between(
-                    current.reachability,
-                    self.current,
-                    reachability_constraints,
-                );
-                let branch_constraint = self.constraint_between(
-                    branch_state.reachability,
-                    branch,
-                    reachability_constraints,
-                );
-                let merged_constraint = reachability_constraints
-                    .add_or_constraint(current_constraint, branch_constraint);
+                let merged_constraint = match last_merged_reachability {
+                    Some((ancestor, constraint)) if ancestor == current.reachability => constraint,
+                    _ => {
+                        let current_constraint = self.constraint_between(
+                            current.reachability,
+                            self.current,
+                            reachability_constraints,
+                        );
+                        let branch_constraint = self.constraint_between(
+                            current.reachability,
+                            branch,
+                            reachability_constraints,
+                        );
+                        let merged_constraint = reachability_constraints
+                            .add_or_constraint(current_constraint, branch_constraint);
+                        last_merged_reachability = Some((current.reachability, merged_constraint));
+                        merged_constraint
+                    }
+                };
                 if merged_constraint != ScopedReachabilityConstraintId::ALWAYS_TRUE {
                     Rc::make_mut(&mut current.state).record_reachability_constraint(
                         reachability_constraints,
@@ -2923,14 +2933,16 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
-        self.pending_reachability.merge_place_states(
-            &mut self.member_states,
-            snapshot.member_states,
-            branch,
-            snapshot.reachability,
-            &mut self.narrowing_constraints,
-            &mut self.reachability_constraints,
-        );
+        if !self.member_states.is_empty() {
+            self.pending_reachability.merge_place_states(
+                &mut self.member_states,
+                snapshot.member_states,
+                branch,
+                snapshot.reachability,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            );
+        }
 
         self.reachability = self
             .reachability_constraints
@@ -2992,23 +3004,13 @@ impl<'db> UseDefMapBuilder<'db> {
                 .map(|(use_id, bindings)| (use_id, place_state_interner.intern_bindings(&bindings)))
                 .collect(),
         );
-        let symbol_states = self
-            .symbol_states
-            .into_iter()
-            .map(|state| Rc::unwrap_or_clone(state.state))
-            .collect();
-        let member_states = self
-            .member_states
-            .into_iter()
-            .map(|state| Rc::unwrap_or_clone(state.state))
-            .collect();
         let end_of_scope_symbols = Self::intern_place_states(
-            symbol_states,
-            PlaceState::into_parts,
+            self.symbol_states,
+            |state| Rc::unwrap_or_clone(state.state).into_parts(),
             &mut place_state_interner,
         );
         let end_of_scope_members =
-            Self::intern_end_of_scope_members(member_states, &mut place_state_interner);
+            Self::intern_end_of_scope_members(self.member_states, &mut place_state_interner);
         let reachable_definitions_by_symbol = Self::intern_place_states(
             self.reachable_symbol_definitions,
             |definitions| (definitions.bindings, definitions.declarations),
@@ -3210,7 +3212,7 @@ impl<'db> UseDefMapBuilder<'db> {
     }
 
     fn intern_end_of_scope_members(
-        end_of_scope_members: IndexVec<ScopedMemberId, PlaceState>,
+        end_of_scope_members: IndexVec<ScopedMemberId, PendingPlaceState>,
         place_state_interner: &mut PlaceStateInterner,
     ) -> IndexVec<ScopedMemberId, InternedPlaceStateId> {
         let mut interned_ids_by_member = IndexVec::with_capacity(end_of_scope_members.len());
@@ -3218,6 +3220,7 @@ impl<'db> UseDefMapBuilder<'db> {
             FxHashMap::with_capacity_and_hasher(end_of_scope_members.len(), FxBuildHasher);
 
         for place_state in end_of_scope_members {
+            let place_state = Rc::unwrap_or_clone(place_state.state);
             let interned_id = match interned_ids_by_place_state.entry(place_state) {
                 Entry::Occupied(entry) => *entry.get(),
                 Entry::Vacant(entry) => {

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -181,6 +181,17 @@ impl Declarations {
     }
 
     fn merge(&mut self, b: Self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
+        // A branch can change a declaration's reachability without adding another declaration.
+        if let ([a], [b]) = (
+            self.live_declarations.as_mut_slice(),
+            b.live_declarations.as_slice(),
+        ) && a.declaration == b.declaration
+        {
+            a.reachability_constraint = reachability_constraints
+                .add_or_constraint(a.reachability_constraint, b.reachability_constraint);
+            return;
+        }
+
         let a = std::mem::take(self);
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
@@ -425,6 +436,24 @@ impl Bindings {
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
+        // Merge changed constraints directly when both paths retain one definition.
+        if let ([a], [b_binding]) = (
+            self.live_bindings.as_mut_slice(),
+            b.live_bindings.as_slice(),
+        ) && a.binding() == b_binding.binding()
+        {
+            self.unbound_narrowing_constraint = self
+                .unbound_narrowing_constraint
+                .zip(b.unbound_narrowing_constraint)
+                .map(|(a, b)| narrowing_constraints.add_or_constraint(a, b));
+            a.narrowing_constraint = narrowing_constraints
+                .add_or_constraint(a.narrowing_constraint, b_binding.narrowing_constraint);
+            a.reachability_constraint = reachability_constraints
+                .add_or_constraint(a.reachability_constraint, b_binding.reachability_constraint);
+            debug_assert_eq!(a.can_be_shadowed(), b_binding.can_be_shadowed());
+            return;
+        }
+
         let a = std::mem::take(self);
 
         if let Some((a, b)) = a

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/nested.md
@@ -399,6 +399,27 @@ def f():
         [reveal_type(l[0]) for _ in range(1)]  # revealed: str
 ```
 
+### Nonlocal writes in multiple enclosing scopes
+
+A `nonlocal` write invalidates narrowing for nested functions that read the variable. A separate
+`nonlocal` write to the same name in an outer function does not hide the inner write.
+
+```py
+def outer(x: str | None):
+    def middle():
+        nonlocal x
+        x = None
+
+        def inner(x: str | None):
+            def write():
+                nonlocal x
+                x = None
+
+            if x is not None:
+                def read():
+                    reveal_type(x)  # revealed: str | None
+```
+
 ### Narrowing constraints introduced in multiple scopes
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -466,6 +466,10 @@ pub(crate) struct ApplyTypeMappingVisitor<'env, 'db> {
     promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     skip_promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
+    /// Whether the specialization can require union-valued `ParamSpec` expansion.
+    /// The substitution values stay fixed for this visitor, including when materialization
+    /// polarity flips. Each `ParamSpec` expansion starts a new visitor for its bindings.
+    specialization_may_map_to_union: OnceCell<bool>,
 }
 
 impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
@@ -482,6 +486,7 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
             promotion: OnceCell::default(),
             skip_promotion: OnceCell::default(),
             materialization_equivalence: OnceCell::default(),
+            specialization_may_map_to_union: OnceCell::default(),
         }
     }
 
@@ -2491,14 +2496,44 @@ impl<'db> Type<'db> {
     /// most general form of the type that is fully static.
     #[must_use]
     fn top_materialization(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        (*self).cached_materialization(db, env.program(db), MaterializationKind::Top)
+        (*self).materialization(db, env, MaterializationKind::Top)
     }
 
     /// Returns the bottom materialization (or lower bound materialization) of this type, which is
     /// the most specific form of the type that is fully static.
     #[must_use]
     fn bottom_materialization(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Type<'db> {
-        (*self).cached_materialization(db, env.program(db), MaterializationKind::Bottom)
+        (*self).materialization(db, env, MaterializationKind::Bottom)
+    }
+
+    fn materialization(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        materialization_kind: MaterializationKind,
+    ) -> Type<'db> {
+        match self {
+            Type::Dynamic(_) => match materialization_kind {
+                MaterializationKind::Top => Type::object(),
+                MaterializationKind::Bottom => Type::Never,
+            },
+            Type::Divergent(divergent) => {
+                Type::Divergent(divergent.materialized(materialization_kind))
+            }
+            Type::Never
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy
+            | Type::ClassLiteral(_)
+            | Type::LiteralValue(_)
+            | Type::ModuleLiteral(_)
+            | Type::WrapperDescriptor(_)
+            | Type::DataclassDecorator(_)
+            | Type::DataclassTransformer(_)
+            | Type::BoundSuper(_)
+            | Type::SpecialForm(_) => self,
+            Type::NominalInstance(instance) if !instance.is_definition_generic(db) => self,
+            _ => self.cached_materialization(db, env.program(db), materialization_kind),
+        }
     }
 
     #[salsa::tracked(
@@ -8722,6 +8757,13 @@ impl<'db> Type<'db> {
         if let TypeMapping::ApplySpecialization(specialization)
         | TypeMapping::ApplySpecializationWithMaterialization { specialization, .. } =
             type_mapping
+            && matches!(
+                self,
+                Type::FunctionLiteral(_) | Type::BoundMethod(_) | Type::Callable(_)
+            )
+            && *visitor
+                .specialization_may_map_to_union
+                .get_or_init(|| specialization.may_map_to_union(db))
         {
             let function_signatures = |function: FunctionType<'db>| {
                 if specialization.preserves_lazy_signatures() {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1412,12 +1412,23 @@ impl<'db> ConstraintSetStorage<'db> {
         env: &ProgramEnvironment<'db>,
         data: Constraint<'db>,
     ) -> ConstraintId {
-        let support = self.intern_constraint_typevars(db, env, data);
+        self.intern_constraint_with_support(data, |storage| {
+            storage.intern_constraint_typevars(db, env, data)
+        })
+    }
 
+    /// Reuses an existing constraint without recomputing its support. Callers that already
+    /// registered the constraint's typevars can provide the support from that traversal.
+    fn intern_constraint_with_support(
+        &mut self,
+        data: Constraint<'db>,
+        support: impl FnOnce(&mut Self) -> Support,
+    ) -> ConstraintId {
         self.ensure_overlay_identity_caches();
         if let Some(id) = self.constraint_cache.get(&data) {
             return *id;
         }
+        let support = support(self);
         let support_id = self.intern_support(support);
         let id = self.constraints.push(data);
         self.constraint_supports.push(support_id);
@@ -2558,7 +2569,7 @@ impl<'db> Constraint<'db> {
         }
 
         let constraint = Constraint::new(typevar, lower, upper);
-        storage.intern_constraint_typevars(db, env, constraint);
+        let support = storage.intern_constraint_typevars(db, env, constraint);
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the constraint cannot
         // be satisfied, since there is no type that is both greater than `lower`, and less than
@@ -2680,8 +2691,7 @@ impl<'db> Constraint<'db> {
             }
 
             _ => {
-                let constraint =
-                    ConstraintId::new_with_bounds(db, env, storage, typevar, lower, upper);
+                let constraint = storage.intern_constraint_with_support(constraint, |_| support);
                 Node::new_constraint(storage, constraint)
             }
         }

--- a/crates/ty_python_semantic/src/types/constraints/paths.rs
+++ b/crates/ty_python_semantic/src/types/constraints/paths.rs
@@ -46,6 +46,11 @@ use crate::{Db, FxIndexMap, ProgramEnvironment};
 pub(crate) struct PathAssignments {
     /// All of the rules that we know for inferring derived constraints on the current path.
     sequents: Vec<Sequent>,
+    /// Cached consequences of the first `checked_sequents` rules on this path. A rule only
+    /// needs reevaluation when one of its antecedents changes. Consequences are still replayed
+    /// in rule order, including redundant ones, to preserve the order of derived assignments.
+    sequent_fuels: Vec<Option<AssignmentFuel>>,
+    checked_sequents: usize,
     /// Each assignment's source constraint and the first per-path fuel value with which it was
     /// derived.
     pub(super) assignments: FxIndexMap<ConstraintAssignment, (ConstraintId, u16)>,
@@ -199,6 +204,8 @@ impl PathAssignments {
             .collect();
         Self {
             sequents: Vec::default(),
+            sequent_fuels: Vec::default(),
+            checked_sequents: 0,
             assignments: FxIndexMap::default(),
             additional_fuels: Vec::default(),
             discovered,
@@ -454,6 +461,9 @@ impl PathAssignments {
         self.assignments.truncate(start);
         self.additional_fuels.truncate(additional_fuels_start);
         self.remaining_overall_fuel = previous_remaining_overall_fuel;
+        // Child paths can overwrite cached results and discover rules that remain available
+        // to their siblings. Reevaluate all rules against the restored assignments next time.
+        self.checked_sequents = 0;
         result
     }
 
@@ -519,20 +529,22 @@ impl PathAssignments {
                 continue;
             }
 
-            let existing_support = storage.constraint_support(*existing);
-            let constraint_support = storage.constraint_support(constraint);
+            if !self.independent_typevars.is_empty() {
+                let existing_support = storage.constraint_support(*existing);
+                let constraint_support = storage.constraint_support(constraint);
 
-            // Independent typevars must be checked for disjoint or invalid constraints, but are
-            // otherwise already constrained and do not participate in sequent discovery.
-            if !existing_support.overlaps_with(constraint_support)
-                && existing_support
-                    .iter()
-                    .chain(constraint_support.iter())
-                    .any(|typevar| self.independent_typevars.contains(&typevar))
-                && existing_support.is_complete()
-                && constraint_support.is_complete()
-            {
-                continue;
+                // Independent typevars must be checked for disjoint or invalid constraints, but are
+                // otherwise already constrained and do not participate in sequent discovery.
+                if !existing_support.overlaps_with(constraint_support)
+                    && existing_support
+                        .iter()
+                        .chain(constraint_support.iter())
+                        .any(|typevar| self.independent_typevars.contains(&typevar))
+                    && existing_support.is_complete()
+                    && constraint_support.is_complete()
+                {
+                    continue;
+                }
             }
 
             if SequentMap::pair_cannot_produce_sequents(db, env, storage, *existing, constraint) {
@@ -665,23 +677,51 @@ impl PathAssignments {
         }
 
         // Then use our sequents to add additional facts that we know to be true.
-        //
-        // TODO: This is very naive at the moment, partly for expediency, and partly because we
-        // don't anticipate the sequent maps to be very large. We might consider avoiding the
-        // brute-force search.
-
         self.new_assignments.clear();
         self.discover_constraint(db, env, storage, assignment.constraint());
-
-        for i in 0..self.sequents.len() {
-            let sequent = self.sequents[i];
-            self.check_sequent(db, env, storage, sequent)?;
-        }
+        self.check_sequents(db, env, storage, assignment)?;
 
         // If we were able to derive any new assignments from this one, add them to the processing
         // queue.
         self.assignment_queue.extend(self.new_assignments.drain(..));
 
+        Ok(())
+    }
+
+    /// Replays rule consequences in their original order, recomputing only rules whose
+    /// antecedents changed or whose result has not been checked on this path.
+    fn check_sequents<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        storage: &mut ConstraintSetStorage<'db>,
+        assignment: ConstraintAssignment,
+    ) -> Result<(), PathAssignmentConflict> {
+        self.sequent_fuels.resize(self.sequents.len(), None);
+        let previously_checked = self.checked_sequents;
+        // A conflict can interrupt this scan after some results have changed.
+        self.checked_sequents = 0;
+        for i in 0..self.sequents.len() {
+            let sequent = self.sequents[i];
+            let affected = match sequent {
+                Sequent::SingleTautology { ante } => assignment == ante.when_false(),
+                Sequent::SingleImplication { ante, .. } => assignment == ante.when_true(),
+                Sequent::PairImpossibility { ante1, ante2 }
+                | Sequent::PairImplication { ante1, ante2, .. } => {
+                    assignment == ante1.when_true() || assignment == ante2.when_true()
+                }
+            };
+            if i >= previously_checked || affected {
+                self.sequent_fuels[i] = self.check_sequent(db, env, storage, sequent)?;
+            }
+            if let Some(fuel) = self.sequent_fuels[i]
+                && let Sequent::SingleImplication { post, .. }
+                | Sequent::PairImplication { post, .. } = sequent
+            {
+                self.enqueue_assignment(post.when_true(), fuel);
+            }
+        }
+        self.checked_sequents = self.sequents.len();
         Ok(())
     }
 
@@ -700,21 +740,19 @@ impl PathAssignments {
         env: &ProgramEnvironment<'db>,
         storage: &mut ConstraintSetStorage<'db>,
         sequent: Sequent,
-    ) -> Result<(), PathAssignmentConflict> {
+    ) -> Result<Option<AssignmentFuel>, PathAssignmentConflict> {
         match sequent {
-            Sequent::SingleTautology { ante } => {
-                self.check_single_tautology(db, env, storage, ante)
-            }
-            Sequent::PairImpossibility { ante1, ante2 } => {
-                self.check_pair_impossibility(db, env, storage, ante1, ante2)
-            }
+            Sequent::SingleTautology { ante } => self
+                .check_single_tautology(db, env, storage, ante)
+                .map(|()| None),
+            Sequent::PairImpossibility { ante1, ante2 } => self
+                .check_pair_impossibility(db, env, storage, ante1, ante2)
+                .map(|()| None),
             Sequent::PairImplication { ante1, ante2, post } => {
-                self.check_pair_implication(db, env, storage, ante1, ante2, post);
-                Ok(())
+                Ok(self.check_pair_implication(db, env, storage, ante1, ante2, post))
             }
             Sequent::SingleImplication { ante, post } => {
-                self.check_single_implication(db, env, storage, ante, post);
-                Ok(())
+                Ok(self.check_single_implication(db, env, storage, ante, post))
             }
         }
     }
@@ -783,24 +821,16 @@ impl PathAssignments {
         ante1: ConstraintId,
         ante2: ConstraintId,
         post: ConstraintId,
-    ) {
-        let Some(ante1_fuel) = self.max_remaining_fuel_for(ante1.when_true()) else {
-            return;
-        };
-        let Some(ante2_fuel) = self.max_remaining_fuel_for(ante2.when_true()) else {
-            return;
-        };
+    ) -> Option<AssignmentFuel> {
+        let ante1_fuel = self.max_remaining_fuel_for(ante1.when_true())?;
+        let ante2_fuel = self.max_remaining_fuel_for(ante2.when_true())?;
         let available_fuel = ante1_fuel.min(ante2_fuel);
         let (ante1_constructor_depth, _) = storage.cached_constraint_bound_depth(db, env, ante1);
         let (ante2_constructor_depth, _) = storage.cached_constraint_bound_depth(db, env, ante2);
         let antecedent_constructor_depth = ante1_constructor_depth.max(ante2_constructor_depth);
         let fuel_cost = storage.sequent_fuel_cost(db, env, post, antecedent_constructor_depth);
-        if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
-            self.enqueue_assignment(
-                post.when_true(),
-                AssignmentFuel::derived(fuel_cost, post_fuel),
-            );
-        }
+        let post_fuel = available_fuel.checked_sub(fuel_cost)?;
+        Some(AssignmentFuel::derived(fuel_cost, post_fuel))
     }
 
     fn check_single_implication<'db>(
@@ -810,10 +840,8 @@ impl PathAssignments {
         storage: &mut ConstraintSetStorage<'db>,
         ante: ConstraintId,
         post: ConstraintId,
-    ) {
-        let Some(available_fuel) = self.max_remaining_fuel_for(ante.when_true()) else {
-            return;
-        };
+    ) -> Option<AssignmentFuel> {
+        let available_fuel = self.max_remaining_fuel_for(ante.when_true())?;
         let ante_data = storage.constraint_data(ante);
         let (antecedent_constructor_depth, _) =
             storage.cached_constraint_bound_depth(db, env, ante);
@@ -823,12 +851,8 @@ impl PathAssignments {
         } else {
             storage.sequent_fuel_cost(db, env, post, antecedent_constructor_depth)
         };
-        if let Some(post_fuel) = available_fuel.checked_sub(fuel_cost) {
-            self.enqueue_assignment(
-                post.when_true(),
-                AssignmentFuel::derived(fuel_cost, post_fuel),
-            );
-        }
+        let post_fuel = available_fuel.checked_sub(fuel_cost)?;
+        Some(AssignmentFuel::derived(fuel_cost, post_fuel))
     }
 }
 
@@ -839,6 +863,7 @@ struct PathAssignmentConflict;
 mod tests {
     use super::super::solutions::SolutionWalker;
     use super::super::*;
+    use super::{AssignmentFuel, PATH_FUEL_BUDGET, PathAssignments, Sequent};
 
     use crate::db::tests::{TestDb, setup_db};
     use crate::types::{BoundTypeVarInstance, KnownClass, TypeVarVariance};
@@ -862,6 +887,147 @@ mod tests {
         let env = db.program_environment();
         let ty = bound.to_instance(db, &env);
         ConstraintSet::constrain_typevar(db, &env, builder, bound_typevar, ty, ty)
+    }
+
+    fn create_path_constraint<'db>(
+        db: &'db TestDb,
+        storage: &mut ConstraintSetStorage<'db>,
+        name: &'static str,
+    ) -> ConstraintId {
+        let env = db.program_environment();
+        storage.intern_constraint(
+            db,
+            &env,
+            Constraint::from_evidence(
+                create_typevar(db, name),
+                None,
+                Some(KnownClass::Int.to_instance(db, &env)),
+            ),
+        )
+    }
+
+    #[test]
+    fn cached_sequents_preserve_consequent_order_when_fuel_increases() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let builder = ConstraintSetBuilder::new();
+        let mut storage = builder.storage.borrow_mut();
+        let [a, c, p, q] =
+            ["A", "C", "P", "Q"].map(|name| create_path_constraint(db, &mut storage, name));
+        let mut path = PathAssignments::new([], FxHashSet::default());
+        path.sequents.extend([
+            Sequent::SingleImplication { ante: a, post: p },
+            Sequent::SingleImplication { ante: c, post: q },
+            Sequent::SingleImplication { ante: c, post: p },
+        ]);
+        path.assignments.insert(a.when_true(), (a, 6));
+        path.assignments.insert(p.when_true(), (a, 5));
+        assert!(
+            path.check_sequents(db, &env, &mut storage, a.when_true())
+                .is_ok()
+        );
+        path.new_assignments.clear();
+
+        // The cached A -> P derivation is redundant, but it establishes P's queue position.
+        // C then gives Q and P more fuel without changing the first-occurrence order.
+        path.assignments.insert(c.when_true(), (c, 7));
+        assert!(
+            path.check_sequents(db, &env, &mut storage, c.when_true())
+                .is_ok()
+        );
+        assert_eq!(
+            path.new_assignments.keys().copied().collect::<Vec<_>>(),
+            [p.when_true(), q.when_true()],
+        );
+        assert_eq!(
+            path.new_assignments[&p.when_true()],
+            AssignmentFuel::derived(1, 6)
+        );
+        assert_eq!(
+            path.new_assignments[&q.when_true()],
+            AssignmentFuel::derived(1, 6)
+        );
+    }
+
+    #[test]
+    fn cached_sequents_are_rechecked_after_branch_rollback() {
+        let db = setup_db();
+        let db = &db;
+        let env = db.program_environment();
+        let builder = ConstraintSetBuilder::new();
+        let mut storage = builder.storage.borrow_mut();
+        let [
+            antecedent,
+            left_branch,
+            right_branch,
+            first_post,
+            second_post,
+        ] = ["A", "B", "C", "P", "Q"].map(|name| create_path_constraint(db, &mut storage, name));
+        let mut path = PathAssignments::new(
+            [
+                antecedent,
+                left_branch,
+                right_branch,
+                first_post,
+                second_post,
+            ],
+            FxHashSet::default(),
+        );
+        // Supply explicit rules so the test isolates replay from rule discovery.
+        path.discovered
+            .values_mut()
+            .for_each(|processed| *processed = true);
+        path.assignments
+            .insert(antecedent.when_true(), (antecedent, PATH_FUEL_BUDGET));
+
+        path.walk_edge(
+            db,
+            &env,
+            &mut storage,
+            left_branch.when_true(),
+            |storage, path, _, conflict| {
+                assert!(!conflict);
+                path.sequents.extend([
+                    Sequent::SingleImplication {
+                        ante: antecedent,
+                        post: first_post,
+                    },
+                    Sequent::SingleImplication {
+                        ante: left_branch,
+                        post: second_post,
+                    },
+                ]);
+                path.new_assignments.clear();
+                assert!(
+                    path.check_sequents(db, &env, storage, left_branch.when_true())
+                        .is_ok()
+                );
+                path.assignment_queue.extend(path.new_assignments.drain(..));
+                assert!(
+                    path.drain_assignment_queue(db, &env, storage, left_branch)
+                        .is_ok()
+                );
+                assert!(path.assignment_holds(first_post.when_true()));
+                assert!(path.assignment_holds(second_post.when_true()));
+            },
+        );
+        assert!(!path.assignment_holds(first_post.when_true()));
+        assert!(!path.assignment_holds(second_post.when_true()));
+
+        // Rules learned in the left branch remain available. The shared antecedent still
+        // holds in the right branch, so only its consequence can be derived again.
+        path.walk_edge(
+            db,
+            &env,
+            &mut storage,
+            right_branch.when_true(),
+            |_, path, _, conflict| {
+                assert!(!conflict);
+                assert!(path.assignment_holds(first_post.when_true()));
+                assert!(!path.assignment_holds(second_post.when_true()));
+            },
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1068,46 +1068,39 @@ impl<'db> GenericContext<'db> {
         // class C[T, U = T]: ...
         // ```
         //
-        // If there is a mapping for `T`, we want to map `U` to that type, not to `T`. To handle
-        // this, we repeatedly apply the specialization to itself, until we reach a fixed point.
+        // If there is a mapping for `T`, we want to map `U` to that type, not to `T`.
+        // Fill each argument in order so defaults can use the preceding arguments.
         let mut expanded = Vec::with_capacity(types.len());
-        for typevar in variables.clone() {
-            expanded.push(match typevar.kind(db) {
-                TypeVarKind::LegacyTypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
-                    Type::homogeneous_tuple(db, &env, Type::unknown())
+        for (ty, typevar) in types.zip(variables) {
+            let ty = if let Some(ty) = ty {
+                ty
+            } else if let Some(default) = typevar.default_type(db) {
+                // Typevars are only allowed to refer to earlier typevars in their defaults.
+                // This is statically enforced for PEP 695 contexts, and explicitly required
+                // for legacy contexts.
+                let specialization = ApplySpecialization::Partial {
+                    generic_context: self,
+                    types: &expanded,
+                    skip: None,
+                };
+                default.apply_type_mapping(
+                    db,
+                    &env,
+                    &TypeMapping::ApplySpecialization(specialization),
+                    TypeContext::default(),
+                )
+            } else {
+                match typevar.kind(db) {
+                    TypeVarKind::LegacyTypeVarTuple | TypeVarKind::Pep695TypeVarTuple => {
+                        Type::homogeneous_tuple(db, &env, Type::unknown())
+                    }
+                    TypeVarKind::LegacyParamSpec | TypeVarKind::Pep695ParamSpec => {
+                        Type::paramspec_value_callable(db, Parameters::unknown())
+                    }
+                    _ => Type::unknown(),
                 }
-                TypeVarKind::LegacyParamSpec | TypeVarKind::Pep695ParamSpec => {
-                    Type::paramspec_value_callable(db, Parameters::unknown())
-                }
-                _ => Type::unknown(),
-            });
-        }
-
-        for (idx, (ty, typevar)) in types.zip(variables).enumerate() {
-            if let Some(ty) = ty {
-                expanded[idx] = ty;
-                continue;
-            }
-
-            let Some(default) = typevar.default_type(db) else {
-                continue;
             };
-
-            // Typevars are only allowed to refer to _earlier_ typevars in their defaults. (This is
-            // statically enforced for PEP-695 contexts, and is explicitly called out as a
-            // requirement for legacy contexts.)
-            let specialization = ApplySpecialization::Partial {
-                generic_context: self,
-                types: &expanded[0..idx],
-                skip: None,
-            };
-            let default = default.apply_type_mapping(
-                db,
-                &env,
-                &TypeMapping::ApplySpecialization(specialization),
-                TypeContext::default(),
-            );
-            expanded[idx] = default;
+            expanded.push(ty);
         }
 
         expanded.into_boxed_slice()
@@ -2301,6 +2294,29 @@ impl<'db> ApplySpecialization<'_, 'db> {
         }
     }
 
+    /// Returns whether any type variable might map to a union.
+    ///
+    /// If no substitution is a union, callable specialization cannot need `ParamSpec`
+    /// expansion. Checking the substitution values avoids reading function signatures
+    /// merely to rule out that expansion. Overrides conservatively include the underlying
+    /// mapping, even if they replace its last union-valued substitution.
+    pub(super) fn may_map_to_union(self, db: &'db dyn Db) -> bool {
+        match self {
+            Self::Specialization { specialization, .. } | Self::TypeAlias(specialization) => {
+                specialization.types(db).iter().any(|ty| ty.is_union())
+            }
+            Self::Partial { types, .. } => types.iter().any(|ty| ty.is_union()),
+            Self::ReturnCallables(_) => false,
+            Self::Single(_, ty) => ty.is_union(),
+            Self::WithBindings {
+                specialization,
+                bindings,
+            } => {
+                bindings.iter().any(|(_, ty)| ty.is_union()) || specialization.may_map_to_union(db)
+            }
+        }
+    }
+
     /// Returns the type that a typevar is mapped to, or None if the typevar isn't part of this
     /// mapping.
     pub(crate) fn get(
@@ -3101,6 +3117,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         identity: BoundTypeVarIdentity<'db>,
         ty: Type<'db>,
     ) -> bool {
+        // Self references are not followed, so a cycle needs at least two pending mappings.
+        if types.len() <= 1 {
+            return false;
+        }
+
         let db = self.db;
         match ty {
             // A bare `T = U` edge only replaces one typevar with another; it does not wrap the


### PR DESCRIPTION
## Summary

This combined change is split into independent PRs so each optimization can be reviewed and measured separately:

- #28364: Index lazy enclosing snapshots by symbol name.
- #28365: Reduce repeated work in use-def merges.
- #28366: Intern pending place states directly.
- #28367: Bypass materialization queries for simple types.
- #28368: Skip ParamSpec expansion checks without union substitutions.
- #28369: Avoid unnecessary work when building specializations.
- #28370: Cache unchanged sequent consequences.
- #28371: Avoid redundant constraint support calculations.
- #28372: Pre-size packed AST index chunks.

The [combined CodSpeed Simulation comparison](https://github.com/astral-sh/ruff/runs/101520461071) reports +5.90% for attrs with frozen inputs, +5.82% for attrs, and +5.63% for attrs with all rules against `061ca71`. These results apply to the complete change; the individual PRs have their own performance comparisons.
