### PR TITLE
[ty] Ensure `f is identity(f)` evaluates to `Literal[True]`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -74,6 +74,8 @@ reveal_type(p)  # revealed: partial[() -> bool]
 
 ### No args bound
 
+With no arguments bound, the partial keeps the full signature and refers to the original function.
+
 ```py
 from functools import partial
 
@@ -82,6 +84,7 @@ def f(a: int, b: str) -> bool:
 
 p = partial(f)
 reveal_type(p)  # revealed: partial[(a: int, b: str) -> bool]
+reveal_type(p.func is f)  # revealed: Literal[True]
 ```
 
 ### Positional-only params
@@ -1760,6 +1763,9 @@ if isinstance(p, PartialMarker):
 
 ### `partial.func` keeps the original callable type
 
+The `func` attribute refers to the original function object, including when some arguments are
+bound. The original function remains generic independently of those bound arguments.
+
 ```py
 from functools import partial
 from typing import TypeVar
@@ -1771,6 +1777,9 @@ def combine(a: T, b: U) -> tuple[T, U]:
     return (a, b)
 
 p = partial(combine, 1)
+reveal_type(partial(combine).func is combine)  # revealed: Literal[True]
+reveal_type(p.func is combine)  # revealed: Literal[True]
+reveal_type(p.func is not combine)  # revealed: Literal[False]
 reveal_type(p.func(2, "x"))  # revealed: tuple[Literal[2], Literal["x"]]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -72,19 +72,26 @@ def identity(value: F) -> F:
 def f():
     pass
 
+reveal_type(identity(f) is f)  # revealed: Literal[True]
+reveal_type(f is identity(f))  # revealed: Literal[True]
+
+reveal_type(identity(f) is not f)  # revealed: Literal[False]
+reveal_type(f is not identity(f))  # revealed: Literal[False]
+
 def g():
     pass
 
-reveal_type(identity(f) is f)  # revealed: Literal[True]
-reveal_type(f is identity(f))  # revealed: Literal[True]
-reveal_type(identity(f) is not f)  # revealed: Literal[False]
 reveal_type(identity(f) is g)  # revealed: Literal[False]
+reveal_type(g is identity(f))  # revealed: Literal[False]
+
+reveal_type(identity(f) is not g)  # revealed: Literal[True]
+reveal_type(g is not identity(f))  # revealed: Literal[True]
 ```
 
 ## Identity comparisons between function specializations
 
-Different specializations of a method have disjoint static types but can refer to the same function
-object at runtime if the method is unbound:
+Different specializations of the same unbound method have disjoint static types but refer to the
+same function object at runtime:
 
 ```toml
 [environment]
@@ -100,8 +107,6 @@ int_method = C[int].method
 str_method = C[str].method
 reveal_type(int_method is str_method)  # revealed: Literal[True]
 reveal_type(int_method is not str_method)  # revealed: Literal[False]
-reveal_type(C[int]().method is C[int]().method)  # revealed: bool
-reveal_type(C[int]().method is C[str]().method)  # revealed: Literal[False]
 ```
 
 ## Identity comparisons with NewTypes

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -56,6 +56,54 @@ reveal_type(list[int] is list[int])  # revealed: bool
 reveal_type(list[int] is not list[int])  # revealed: bool
 ```
 
+## Function identity after generic substitution
+
+Passing a function through a generic identity function preserves the function object, so
+`identity(f) is f` is correctly inferred as `Literal[True]` in the examples below:
+
+```py
+from typing import TypeVar
+
+F = TypeVar("F")
+
+def identity(value: F) -> F:
+    return value
+
+def f():
+    pass
+
+def g():
+    pass
+
+reveal_type(identity(f) is f)  # revealed: Literal[True]
+reveal_type(f is identity(f))  # revealed: Literal[True]
+reveal_type(identity(f) is not f)  # revealed: Literal[False]
+reveal_type(identity(f) is g)  # revealed: Literal[False]
+```
+
+## Identity comparisons between function specializations
+
+Different specializations of a method have disjoint static types but can refer to the same function
+object at runtime if the method is unbound:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class C[T]:
+    def method(self, value: T) -> T:
+        return value
+
+int_method = C[int].method
+str_method = C[str].method
+reveal_type(int_method is str_method)  # revealed: Literal[True]
+reveal_type(int_method is not str_method)  # revealed: Literal[False]
+reveal_type(C[int]().method is C[int]().method)  # revealed: bool
+reveal_type(C[int]().method is C[str]().method)  # revealed: Literal[False]
+```
+
 ## Identity comparisons with NewTypes
 
 Two variables cannot share the same memory address if they have disjoint nominal-instance backing

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -56,7 +56,7 @@ reveal_type(list[int] is list[int])  # revealed: bool
 reveal_type(list[int] is not list[int])  # revealed: bool
 ```
 
-## Function identity after generic substitution
+## Function identity after passing through a generic identity function
 
 Passing a function through a generic identity function preserves the function object, so
 `identity(f) is f` is correctly inferred as `Literal[True]` in the examples below:

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -497,6 +497,32 @@ static_assert(not is_disjoint_from(TypeOf[f], FunctionType))
 static_assert(not is_disjoint_from(TypeOf[f], object))
 ```
 
+### Specialized function literals
+
+Different specializations of an unbound method have incompatible signatures and are considered to
+inhabit disjoint types, even if the two different specializations occupy the same memory address at
+runtime:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_disjoint_from
+
+class C[T]:
+    def method(self, value: T) -> T:
+        return value
+
+int_method = C[int].method
+str_method = C[str].method
+static_assert(is_disjoint_from(TypeOf[int_method], TypeOf[str_method]))
+reveal_type(int_method(C[int](), 1))  # revealed: int
+reveal_type(str_method(C[str](), "a"))  # revealed: str
+```
+
 ### Bound methods
 
 Bound methods are disjoint when their names or possible receiver types cannot overlap.

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -13,9 +13,9 @@ use crate::types::equality::{
 };
 use crate::types::tuple::{Tuple, TupleSpec};
 use crate::types::{
-    DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
-    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext, TypeTransformer,
-    TypeVarBoundOrConstraints, UnionBuilder,
+    DynamicType, FunctionType, IntersectionBuilder, IntersectionType, KnownClass,
+    KnownInstanceType, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type,
+    TypeContext, TypeTransformer, TypeVarBoundOrConstraints, UnionBuilder,
 };
 use ty_python_core::Truthiness;
 
@@ -29,10 +29,14 @@ impl<'db> Type<'db> {
     /// commitments such as `list[int]` and `list[str]` without some other code already being
     /// unsound.
     ///
+    /// Function signature substitutions can likewise differ between views of the same function
+    /// object. Use the underlying function literal without substituted signatures for identity.
+    ///
     /// Preserve negations that constrain the object itself, such as `~None`, `~SomeClass`, and
-    /// `~Literal[1]`. A `NewType` tag, type-variable selection, type-guard proof, or literal-string
-    /// origin can differ between views. A negated string literal excludes its runtime value only
-    /// when another constraint already establishes that the string has literal origin.
+    /// `~Literal[1]`. A `NewType` tag, function signature, type-variable selection, type-guard proof,
+    /// or literal-string origin can differ between views. A negated string literal excludes its
+    /// runtime value only when another constraint already establishes that the string has literal
+    /// origin.
     ///
     /// A type variable can also hide a `NewType` tag: even a variable bounded by `int` can be
     /// instantiated as an integer `NewType`. Expand variables to their upcast bounds or constraints
@@ -40,8 +44,8 @@ impl<'db> Type<'db> {
     /// `object`.
     ///
     /// Use this upcast both to decide whether identity is possible and to narrow the other
-    /// operand when it succeeds. Each operand retains its own existing tags and type-variable
-    /// relationships when the resulting constraint is applied.
+    /// operand when it succeeds. Each operand retains its own existing tags, substituted
+    /// signatures, and type-variable relationships when the resulting constraint is applied.
     pub(crate) fn identity_comparison_type(
         self,
         db: &'db dyn Db,
@@ -61,6 +65,9 @@ impl<'db> Type<'db> {
                 }
                 Type::NewTypeInstance(newtype) => {
                     upcast(db, env, newtype.concrete_base_type(db), visitor)
+                }
+                Type::FunctionLiteral(function) => {
+                    Type::FunctionLiteral(FunctionType::new(db, function.literal(db), None))
                 }
                 Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
                     match typevar.typevar(db).bound_or_constraints(db, env) {
@@ -83,11 +90,13 @@ impl<'db> Type<'db> {
                         builder = builder.add_positive(upcast(db, env, *element, visitor));
                     }
                     for element in intersection.negative(db) {
-                        // Static tags, predicate proofs, and literal-string origin can differ
-                        // between views. Once literal origin is known, an excluded string literal
-                        // also excludes its runtime value and must be preserved.
+                        // Static tags, function signatures, predicate proofs, and literal-string
+                        // origin can differ between views. Once literal origin is known, an
+                        // excluded string literal also excludes its runtime value and must be
+                        // preserved.
                         match element.resolve_type_alias(db) {
                             Type::NewTypeInstance(_)
+                            | Type::FunctionLiteral(_)
                             | Type::TypeVar(_)
                             | Type::TypeIs(_)
                             | Type::TypeGuard(_) => continue,
@@ -145,8 +154,8 @@ impl<'db> Type<'db> {
             return Truthiness::AlwaysTrue;
         }
 
-        // `NewType` instances are identity functions at runtime, so distinct static types can still
-        // identify the same object. Compare the types of their possible runtime objects instead.
+        // Distinct static types can still identify the same object, as with `NewType` tags and
+        // function signature substitutions. Compare the types of their possible runtime objects.
         let left_identity = self.identity_comparison_type(db, env);
         let right_identity = other.identity_comparison_type(db, env);
 


### PR DESCRIPTION
## Summary

Passing a function through a generic identity function can cause `is` to be inferred as `Literal[False]`, even though the function object is unchanged:

```python
from typing import TypeVar

F = TypeVar("F")

def identity(value: F) -> F:
    return value

def f():
    pass

reveal_type(identity(f) is f)  # Previously Literal[False]; now Literal[True]
```

Different specializations of the same function can have disjoint static types while referring to the same runtime object. For `is` and `is not`, compare function literals without their substituted signatures. Preserve each operand's specialization when the identity comparison succeeds, and exclude union alternatives that identify the same function when it fails. This also fixes comparisons such as `functools.partial(f).func is f`.

The approach taken here is very similar to the approach we take for `NewType`s: two `NewType` instances can also be mutually disjoint while referring to the same runtime memory address, e.g.

```py
from typing import NewType

N1 = NewType("N1", int)
N2 = NewType("N2", int)

x = 42
reveal_type(N1(42) is N2(42))  # True at runtime, even though `N1` and `N2` are disjoint
```