### PR TITLE
fix starred constraints in pep 695 conversions (up040, up046, up047, ruf053)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
@@ -143,3 +143,8 @@ StarredAlias = TypeAliasType("StarredAlias", list[T_starred], type_params=(T_sta
 T_mixed = TypeVar("T_mixed", bool, *constraints)
 MixedList: TypeAlias = list[T_mixed]
 MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))
+
+# The original TypeVar consumes the iterator, so unpacking it again is unsafe.
+constraint_iterator = iter((int, str))
+T_iterator = TypeVar("T_iterator", *constraint_iterator)
+IteratorAlias = TypeAliasType("IteratorAlias", list[T_iterator], type_params=(T_iterator,))

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
@@ -132,3 +132,14 @@ T: TypeAlias = ( # comment0
 # Test case for TypeVar with default - should be converted when preview mode is enabled
 T_default = TypeVar("T_default", default=int)
 DefaultList: TypeAlias = list[T_default]
+
+# A sole starred constraint needs a trailing comma in the PEP 695 constraint tuple.
+constraints = (int, str)
+T_starred = TypeVar("T_starred", *constraints)
+StarredList: TypeAlias = list[T_starred]
+StarredAlias = TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+
+# Mixed constraints retain both the explicit and unpacked types.
+T_mixed = TypeVar("T_mixed", bool, *constraints)
+MixedList: TypeAlias = list[T_mixed]
+MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.pyi
@@ -22,3 +22,9 @@ T: TypeAlias = ( # comment0
     str  # comment6
     # comment7
 ) # comment8
+
+# Starred constraints remain safe in stub files, which are not executed.
+constraints = (int, str)
+T_starred = typing.TypeVar("T_starred", *constraints)
+StarredList: TypeAlias = list[T_starred]
+StarredAlias = typing.TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP046_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP046_0.py
@@ -142,3 +142,20 @@ class DefaultOnlyTypeVar(Generic[W]):  # -> [W = int]
 class Outer:
     class Inner(Generic[T]):
         var: T
+
+
+# A sole starred constraint needs a trailing comma in the PEP 695 constraint tuple.
+constraints = (int, str)
+U = TypeVar("U", *constraints)
+
+
+class StarredConstraints(Generic[U]):
+    var: U
+
+
+# Mixed constraints retain both the explicit and unpacked types.
+V = TypeVar("V", bool, *constraints)
+
+
+class MixedConstraints(Generic[V]):
+    var: V

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP047_0.py
@@ -63,3 +63,25 @@ def multi_param(t: list[T], c: Callable[[T], None]) -> T:
 def outer():
     def inner(t: T) -> T:
         return t
+
+
+# A sole starred constraint needs a trailing comma in the PEP 695 constraint tuple.
+constraints = (int, str)
+U = TypeVar("U", *constraints)
+
+
+def starred_constraints(var: U) -> U:
+    return var
+
+
+# Mixed constraints retain both the explicit and unpacked types.
+W = TypeVar("W", bool, *constraints)
+
+
+def mixed_constraints(var: W) -> W:
+    return var
+
+
+# Both type variables are converted when only one has starred constraints.
+def mixed_parameters(starred: U, bounded: T) -> tuple[U, T]:
+    return starred, bounded

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF053.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF053.py
@@ -98,7 +98,21 @@ class C[T: [a]](Generic[_A]): ...
 
 # Existing bounds should not be deparenthesized.
 # class C[T: (_Y := int)](Generic[_A]): ...  # TODO: Uncomment this
-# class C[T: (*a,)](Generic[_A]): ...        # TODO: Uncomment this
+
+
+# A sole starred constraint needs a trailing comma in the PEP 695 constraint tuple.
+constraints = (str, bytes)
+_H = TypeVar('_H', *constraints)
+class C[T](Generic[_H]): ...
+
+
+# Mixed constraints retain both the explicit and unpacked types.
+_I = TypeVar('_I', bool, *constraints)
+class C[T](Generic[_I]): ...
+
+
+# Existing starred constraint tuples retain their trailing comma.
+class C[T: (*constraints,)](Generic[_A]): ...
 
 
 ### No errors

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/mod.rs
@@ -119,6 +119,11 @@ impl Display for DisplayTypeVar<'_> {
                             f.write_str(", ")?;
                         }
                     }
+                    // A single starred expression needs a comma to form a constraint tuple:
+                    // `TypeVar("T", *constraints)` becomes `T: (*constraints,)`.
+                    if len == 1 {
+                        f.write_str(",")?;
+                    }
                     f.write_str(")")?;
                 }
             }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -14,8 +14,8 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 use ruff_python_ast::PythonVersion;
 
 use super::{
-    DisplayTypeVars, TypeParamKind, TypeVar, TypeVarReferenceVisitor, expr_name_to_type_var,
-    non_default_follows_default,
+    DisplayTypeVars, TypeParamKind, TypeVar, TypeVarReferenceVisitor, TypeVarRestriction,
+    expr_name_to_type_var, non_default_follows_default,
 };
 
 /// ## What it does
@@ -65,6 +65,9 @@ use super::{
 /// runtime behavior around `isinstance()` calls noted above. The fix is also unsafe for
 /// `TypeAliasType` assignments if there are any comments in the replacement range that would be
 /// deleted.
+///
+/// Outside stub files, `TypeAliasType` fixes with starred constraints are also unsafe: the
+/// original `TypeVar` may already have consumed the constraint iterator.
 ///
 /// ## See also
 ///
@@ -286,28 +289,36 @@ fn create_diagnostic(
     );
     let edit = Edit::range_replacement(content, stmt.range());
 
-    let applicability =
-        if type_alias_kind == TypeAliasKind::TypeAlias && !checker.source_type.is_stub() {
-            // The fix is always unsafe in non-stubs
-            // because new-style aliases have different runtime behavior.
-            // See https://github.com/astral-sh/ruff/issues/6434
+    let has_starred_constraint = type_vars.iter().any(|type_var| {
+        matches!(
+            &type_var.restriction,
+            Some(TypeVarRestriction::Constraint(constraints))
+                if constraints.iter().any(|constraint| constraint.is_starred_expr())
+        )
+    });
+
+    let applicability = if !checker.source_type.is_stub()
+        && (type_alias_kind == TypeAliasKind::TypeAlias || has_starred_constraint)
+    {
+        // A `TypeAlias` has different runtime behavior from a `type` statement.
+        // See https://github.com/astral-sh/ruff/issues/6434
+        // Starred constraints can also unpack an iterator already consumed by `TypeVar`.
+        Applicability::Unsafe
+    } else {
+        // For the remaining aliases, the fix is only unsafe if it would delete comments.
+        //
+        // it would be easier to check for comments in the whole `stmt.range`, but because
+        // `create_diagnostic` uses the full source text of `value`, comments within `value` are
+        // actually preserved. thus, we have to check for comments in `stmt` but outside of `value`
+        let pre_value = TextRange::new(stmt.start(), range_with_parentheses.start());
+        let post_value = TextRange::new(range_with_parentheses.end(), stmt.end());
+
+        if comment_ranges.intersects(pre_value) || comment_ranges.intersects(post_value) {
             Applicability::Unsafe
         } else {
-            // In stub files, or in non-stub files for `TypeAliasType` assignments,
-            // the fix is only unsafe if it would delete comments.
-            //
-            // it would be easier to check for comments in the whole `stmt.range`, but because
-            // `create_diagnostic` uses the full source text of `value`, comments within `value` are
-            // actually preserved. thus, we have to check for comments in `stmt` but outside of `value`
-            let pre_value = TextRange::new(stmt.start(), range_with_parentheses.start());
-            let post_value = TextRange::new(range_with_parentheses.end(), stmt.end());
-
-            if comment_ranges.intersects(pre_value) || comment_ranges.intersects(post_value) {
-                Applicability::Unsafe
-            } else {
-                Applicability::Safe
-            }
-        };
+            Applicability::Safe
+        }
+    };
 
     checker
         .report_diagnostic(

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
@@ -436,3 +436,71 @@ help: Use the `type` keyword
 123 |     # comment1
     |
 note: This is an unsafe fix and may change runtime behavior
+
+UP040 [*] Type alias `StarredList` uses `TypeAlias` annotation instead of the `type` keyword
+   --> UP040.py:139:1
+    |
+137 | constraints = (int, str)
+138 | T_starred = TypeVar("T_starred", *constraints)
+139 | StarredList: TypeAlias = list[T_starred]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+140 | StarredAlias = TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+    |
+help: Use the `type` keyword
+    |
+138 | T_starred = TypeVar("T_starred", *constraints)
+    - StarredList: TypeAlias = list[T_starred]
+139 + type StarredList[T_starred: (*constraints,)] = list[T_starred]
+140 | StarredAlias = TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP040 [*] Type alias `StarredAlias` uses `TypeAliasType` assignment instead of the `type` keyword
+   --> UP040.py:140:1
+    |
+138 | T_starred = TypeVar("T_starred", *constraints)
+139 | StarredList: TypeAlias = list[T_starred]
+140 | StarredAlias = TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+141 |
+142 | # Mixed constraints retain both the explicit and unpacked types.
+    |
+help: Use the `type` keyword
+    |
+139 | StarredList: TypeAlias = list[T_starred]
+    - StarredAlias = TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+140 + type StarredAlias[T_starred: (*constraints,)] = list[T_starred]
+141 |
+    |
+
+UP040 [*] Type alias `MixedList` uses `TypeAlias` annotation instead of the `type` keyword
+   --> UP040.py:144:1
+    |
+142 | # Mixed constraints retain both the explicit and unpacked types.
+143 | T_mixed = TypeVar("T_mixed", bool, *constraints)
+144 | MixedList: TypeAlias = list[T_mixed]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+145 | MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))
+    |
+help: Use the `type` keyword
+    |
+143 | T_mixed = TypeVar("T_mixed", bool, *constraints)
+    - MixedList: TypeAlias = list[T_mixed]
+144 + type MixedList[T_mixed: (bool, *constraints)] = list[T_mixed]
+145 | MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP040 [*] Type alias `MixedAlias` uses `TypeAliasType` assignment instead of the `type` keyword
+   --> UP040.py:145:1
+    |
+143 | T_mixed = TypeVar("T_mixed", bool, *constraints)
+144 | MixedList: TypeAlias = list[T_mixed]
+145 | MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Use the `type` keyword
+    |
+144 | MixedList: TypeAlias = list[T_mixed]
+    - MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))
+145 + type MixedAlias[T_mixed: (bool, *constraints)] = list[T_mixed]
+    |

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
@@ -472,6 +472,7 @@ help: Use the `type` keyword
 140 + type StarredAlias[T_starred: (*constraints,)] = list[T_starred]
 141 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `MixedList` uses `TypeAlias` annotation instead of the `type` keyword
    --> UP040.py:144:1
@@ -498,9 +499,29 @@ UP040 [*] Type alias `MixedAlias` uses `TypeAliasType` assignment instead of the
 144 | MixedList: TypeAlias = list[T_mixed]
 145 | MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+146 |
+147 | # The original TypeVar consumes the iterator, so unpacking it again is unsafe.
+    |
 help: Use the `type` keyword
     |
 144 | MixedList: TypeAlias = list[T_mixed]
     - MixedAlias = TypeAliasType("MixedAlias", list[T_mixed], type_params=(T_mixed,))
 145 + type MixedAlias[T_mixed: (bool, *constraints)] = list[T_mixed]
+146 |
     |
+note: This is an unsafe fix and may change runtime behavior
+
+UP040 [*] Type alias `IteratorAlias` uses `TypeAliasType` assignment instead of the `type` keyword
+   --> UP040.py:150:1
+    |
+148 | constraint_iterator = iter((int, str))
+149 | T_iterator = TypeVar("T_iterator", *constraint_iterator)
+150 | IteratorAlias = TypeAliasType("IteratorAlias", list[T_iterator], type_params=(T_iterator,))
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Use the `type` keyword
+    |
+149 | T_iterator = TypeVar("T_iterator", *constraint_iterator)
+    - IteratorAlias = TypeAliasType("IteratorAlias", list[T_iterator], type_params=(T_iterator,))
+150 + type IteratorAlias[T_iterator: (*constraint_iterator,)] = list[T_iterator]
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
@@ -56,10 +56,14 @@ UP040 [*] Type alias `DefaultList` uses `TypeAlias` annotation instead of the `t
 133 | T_default = TypeVar("T_default", default=int)
 134 | DefaultList: TypeAlias = list[T_default]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+135 |
+136 | # A sole starred constraint needs a trailing comma in the PEP 695 constraint tuple.
+    |
 help: Use the `type` keyword
     |
 133 | T_default = TypeVar("T_default", default=int)
     - DefaultList: TypeAlias = list[T_default]
 134 + type DefaultList[T_default = int] = list[T_default]
+135 |
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.pyi.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.pyi.snap
@@ -68,10 +68,44 @@ UP040 [*] Type alias `T` uses `TypeAlias` annotation instead of the `type` keywo
 23 | |     # comment7
 24 | | ) # comment8
    | |_^
+25 |
+26 |   # Starred constraints remain safe in stub files, which are not executed.
+   |
 help: Use the `type` keyword
    |
 15 |
    - T: TypeAlias = ( # comment0
 16 + type T = ( # comment0
 17 |     # comment1
+   |
+
+UP040 [*] Type alias `StarredList` uses `TypeAlias` annotation instead of the `type` keyword
+  --> UP040.pyi:29:1
+   |
+27 | constraints = (int, str)
+28 | T_starred = typing.TypeVar("T_starred", *constraints)
+29 | StarredList: TypeAlias = list[T_starred]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+30 | StarredAlias = typing.TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+   |
+help: Use the `type` keyword
+   |
+28 | T_starred = typing.TypeVar("T_starred", *constraints)
+   - StarredList: TypeAlias = list[T_starred]
+29 + type StarredList[T_starred: (*constraints,)] = list[T_starred]
+30 | StarredAlias = typing.TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+   |
+
+UP040 [*] Type alias `StarredAlias` uses `TypeAliasType` assignment instead of the `type` keyword
+  --> UP040.pyi:30:1
+   |
+28 | T_starred = typing.TypeVar("T_starred", *constraints)
+29 | StarredList: TypeAlias = list[T_starred]
+30 | StarredAlias = typing.TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Use the `type` keyword
+   |
+29 | StarredList: TypeAlias = list[T_starred]
+   - StarredAlias = typing.TypeAliasType("StarredAlias", list[T_starred], type_params=(T_starred,))
+30 + type StarredAlias[T_starred: (*constraints,)] = list[T_starred]
    |

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP046_0.py.snap
@@ -253,3 +253,35 @@ UP046 Generic class `TooManyGenerics` uses `Generic` subclass instead of type pa
 100 |     var: S
     |
 help: Use type parameters
+
+UP046 [*] Generic class `StarredConstraints` uses `Generic` subclass instead of type parameters
+   --> UP046_0.py:152:26
+    |
+152 | class StarredConstraints(Generic[U]):
+    |                          ^^^^^^^^^^
+153 |     var: U
+    |
+help: Use type parameters
+    |
+151 |
+    - class StarredConstraints(Generic[U]):
+152 + class StarredConstraints[U: (*constraints,)]:
+153 |     var: U
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP046 [*] Generic class `MixedConstraints` uses `Generic` subclass instead of type parameters
+   --> UP046_0.py:160:24
+    |
+160 | class MixedConstraints(Generic[V]):
+    |                        ^^^^^^^^^^
+161 |     var: V
+    |
+help: Use type parameters
+    |
+159 |
+    - class MixedConstraints(Generic[V]):
+160 + class MixedConstraints[V: (bool, *constraints)]:
+161 |     var: V
+    |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP047_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP047_0.py.snap
@@ -122,3 +122,52 @@ help: Use type parameters
 57 |     c(t[0])
    |
 note: This is an unsafe fix and may change runtime behavior
+
+UP047 [*] Generic function `starred_constraints` should use type parameters
+  --> UP047_0.py:73:5
+   |
+73 | def starred_constraints(var: U) -> U:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+74 |     return var
+   |
+help: Use type parameters
+   |
+72 |
+   - def starred_constraints(var: U) -> U:
+73 + def starred_constraints[U: (*constraints,)](var: U) -> U:
+74 |     return var
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP047 [*] Generic function `mixed_constraints` should use type parameters
+  --> UP047_0.py:81:5
+   |
+81 | def mixed_constraints(var: W) -> W:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+82 |     return var
+   |
+help: Use type parameters
+   |
+80 |
+   - def mixed_constraints(var: W) -> W:
+81 + def mixed_constraints[W: (bool, *constraints)](var: W) -> W:
+82 |     return var
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP047 [*] Generic function `mixed_parameters` should use type parameters
+  --> UP047_0.py:86:5
+   |
+85 | # Both type variables are converted when only one has starred constraints.
+86 | def mixed_parameters(starred: U, bounded: T) -> tuple[U, T]:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+87 |     return starred, bounded
+   |
+help: Use type parameters
+   |
+85 | # Both type variables are converted when only one has starred constraints.
+   - def mixed_parameters(starred: U, bounded: T) -> tuple[U, T]:
+86 + def mixed_parameters[U: (*constraints,), T: float](starred: U, bounded: T) -> tuple[U, T]:
+87 |     return starred, bounded
+   |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__class-with-mixed-type-vars_RUF053.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__class-with-mixed-type-vars_RUF053.py.snap
@@ -429,7 +429,7 @@ help: Remove `Generic` base class
    |
 94 | # Single-element constraints should not be converted to a bound.
    - class C[T: (str,)](Generic[_A]): ...
-95 + class C[T: (str), _A]: ...
+95 + class C[T: (str,), _A]: ...
 96 | class C[T: [a]](Generic[_A]): ...
    |
 note: This is an unsafe fix and may change runtime behavior
@@ -448,4 +448,51 @@ help: Remove `Generic` base class
 96 + class C[T: [a], _A]: ...
 97 |
    |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF053 [*] Class with type parameter list inherits from `Generic`
+   --> RUF053.py:106:12
+    |
+104 | constraints = (str, bytes)
+105 | _H = TypeVar('_H', *constraints)
+106 | class C[T](Generic[_H]): ...
+    |            ^^^^^^^^^^^
+help: Remove `Generic` base class
+    |
+105 | _H = TypeVar('_H', *constraints)
+    - class C[T](Generic[_H]): ...
+106 + class C[T, _H: (*constraints,)]: ...
+107 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF053 [*] Class with type parameter list inherits from `Generic`
+   --> RUF053.py:111:12
+    |
+109 | # Mixed constraints retain both the explicit and unpacked types.
+110 | _I = TypeVar('_I', bool, *constraints)
+111 | class C[T](Generic[_I]): ...
+    |            ^^^^^^^^^^^
+help: Remove `Generic` base class
+    |
+110 | _I = TypeVar('_I', bool, *constraints)
+    - class C[T](Generic[_I]): ...
+111 + class C[T, _I: (bool, *constraints)]: ...
+112 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+RUF053 [*] Class with type parameter list inherits from `Generic`
+   --> RUF053.py:115:29
+    |
+114 | # Existing starred constraint tuples retain their trailing comma.
+115 | class C[T: (*constraints,)](Generic[_A]): ...
+    |                             ^^^^^^^^^^^
+help: Remove `Generic` base class
+    |
+114 | # Existing starred constraint tuples retain their trailing comma.
+    - class C[T: (*constraints,)](Generic[_A]): ...
+115 + class C[T: (*constraints,), _A]: ...
+116 |
+    |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
fixes #26954.

Adds the missing tuple comma so starred contraints produce valid pep 695 fixes. Existing single element constraint tuples also keep their comma.

up040 marks these alias fixes as unsafe outside stub files, since unpacking an iterator again can lose its constraints. Added tests for the iterator case and safe fixes in stubs.

Tests cover aliases, classes and function type paramters across all four rules. All 2828 linter tests, clippy and hooks passed. checked the fixed code on python 3.12 and 3.14.