### PR TITLE
[ty] Fix disjointness of type guards and boolean literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -106,6 +106,27 @@ def f(x: N, y: int, z: O):
     reveal_type(x is not z)  # revealed: Literal[True]
 ```
 
+## Identity comparisons with type guard results
+
+`TypeIs` and `TypeGuard` functions return booleans, so comparing their results with `True` or
+`False` can succeed or fail.
+
+```py
+from typing_extensions import TypeGuard, TypeIs
+
+def is_int(x: object) -> TypeIs[int]:
+    return isinstance(x, int)
+
+def is_int_guard(x: object) -> TypeGuard[int]:
+    return isinstance(x, int)
+
+def f(x: object):
+    reveal_type(is_int(x) is True)  # revealed: bool
+    reveal_type(is_int(x) is False)  # revealed: bool
+    reveal_type(is_int_guard(x) is True)  # revealed: bool
+    reveal_type(is_int_guard(x) is False)  # revealed: bool
+```
+
 ## Identity comparisons see through type aliases
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -728,6 +728,32 @@ static_assert(is_disjoint_from(str, TypeGuard[str]))
 static_assert(is_disjoint_from(str, TypeIs[str]))
 ```
 
+Either kind of type guard can return `True` or `False`, so both overlap with each boolean literal.
+
+```py
+from typing import Literal
+
+static_assert(not is_disjoint_from(TypeGuard[str], Literal[True]))
+static_assert(not is_disjoint_from(TypeGuard[str], Literal[False]))
+static_assert(not is_disjoint_from(TypeIs[str], Literal[True]))
+static_assert(not is_disjoint_from(TypeIs[str], Literal[False]))
+
+static_assert(not is_disjoint_from(Literal[True], TypeGuard[str]))
+static_assert(not is_disjoint_from(Literal[False], TypeGuard[str]))
+static_assert(not is_disjoint_from(Literal[True], TypeIs[str]))
+static_assert(not is_disjoint_from(Literal[False], TypeIs[str]))
+```
+
+The integer literals `0` and `1` are distinct from boolean literals, so they remain disjoint from
+type guard return types.
+
+```py
+static_assert(is_disjoint_from(TypeGuard[str], Literal[0]))
+static_assert(is_disjoint_from(TypeIs[str], Literal[1]))
+static_assert(is_disjoint_from(Literal[1], TypeGuard[str]))
+static_assert(is_disjoint_from(Literal[0], TypeIs[str]))
+```
+
 ### `Protocol`
 
 A protocol is disjoint from another type if any of the protocol's members are available as an

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -3767,6 +3767,11 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 })
             }
 
+            (Type::TypeIs(_) | Type::TypeGuard(_), Type::LiteralValue(literal))
+            | (Type::LiteralValue(literal), Type::TypeIs(_) | Type::TypeGuard(_)) => {
+                ConstraintSet::from_bool(self.constraints, !literal.is_bool())
+            }
+
             (Type::TypeIs(_) | Type::TypeGuard(_), Type::NominalInstance(instance))
             | (Type::NominalInstance(instance), Type::TypeIs(_) | Type::TypeGuard(_)) => {
                 // A boolean literal must be an instance of exactly `bool`


### PR DESCRIPTION
## Summary

`TypeIs` and `TypeGuard` return boolean values, but ty currently considers them disjoint from both `Literal[True]` and `Literal[False]`. Handle their literal comparisons explicitly so both boolean literals overlap in either operand order, while non-boolean literals, including `Literal[0]` and `Literal[1]`, remain disjoint.

This is a similar approach that we take elsewhere to `NewType`s of `bool`, which are also considered non-disjoint from `Literal[True]` and `Literal[False]`:

```py
from ty_extensions._internal import is_disjoint_from
from typing import NewType, Literal

X = NewType("X", bool)

reveal_type(is_disjoint_from(X, Literal[True]))  # ConstraintSet[Literal[False]]
```