### PR TITLE
[ty] Reduce repeated work in use-def merges

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1782,6 +1782,9 @@ impl PendingReachability {
             self.narrowing_constraint_between(branch_ancestor, branch, narrowing_constraints);
         let merged_narrowing =
             narrowing_constraints.add_or_constraint(current_narrowing, branch_narrowing);
+        // Consecutive places often share their last applied reachability node, so their
+        // merged path constraint can be reused even when they have distinct place states.
+        let mut last_merged_reachability = None;
         let mut branch_states = branch_states.into_iter();
         for current in current_states {
             let Some(mut branch_state) = branch_states.next() else {
@@ -1819,18 +1822,25 @@ impl PendingReachability {
                         .record_narrowing_constraint(narrowing_constraints, merged_narrowing);
                 }
 
-                let current_constraint = self.constraint_between(
-                    current.reachability,
-                    self.current,
-                    reachability_constraints,
-                );
-                let branch_constraint = self.constraint_between(
-                    branch_state.reachability,
-                    branch,
-                    reachability_constraints,
-                );
-                let merged_constraint = reachability_constraints
-                    .add_or_constraint(current_constraint, branch_constraint);
+                let merged_constraint = match last_merged_reachability {
+                    Some((ancestor, constraint)) if ancestor == current.reachability => constraint,
+                    _ => {
+                        let current_constraint = self.constraint_between(
+                            current.reachability,
+                            self.current,
+                            reachability_constraints,
+                        );
+                        let branch_constraint = self.constraint_between(
+                            current.reachability,
+                            branch,
+                            reachability_constraints,
+                        );
+                        let merged_constraint = reachability_constraints
+                            .add_or_constraint(current_constraint, branch_constraint);
+                        last_merged_reachability = Some((current.reachability, merged_constraint));
+                        merged_constraint
+                    }
+                };
                 if merged_constraint != ScopedReachabilityConstraintId::ALWAYS_TRUE {
                     Rc::make_mut(&mut current.state).record_reachability_constraint(
                         reachability_constraints,
@@ -2923,14 +2933,16 @@ impl<'db> UseDefMapBuilder<'db> {
             &mut self.narrowing_constraints,
             &mut self.reachability_constraints,
         );
-        self.pending_reachability.merge_place_states(
-            &mut self.member_states,
-            snapshot.member_states,
-            branch,
-            snapshot.reachability,
-            &mut self.narrowing_constraints,
-            &mut self.reachability_constraints,
-        );
+        if !self.member_states.is_empty() {
+            self.pending_reachability.merge_place_states(
+                &mut self.member_states,
+                snapshot.member_states,
+                branch,
+                snapshot.reachability,
+                &mut self.narrowing_constraints,
+                &mut self.reachability_constraints,
+            );
+        }
 
         self.reachability = self
             .reachability_constraints

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -181,6 +181,17 @@ impl Declarations {
     }
 
     fn merge(&mut self, b: Self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
+        // A branch can change a declaration's reachability without adding another declaration.
+        if let ([a], [b]) = (
+            self.live_declarations.as_mut_slice(),
+            b.live_declarations.as_slice(),
+        ) && a.declaration == b.declaration
+        {
+            a.reachability_constraint = reachability_constraints
+                .add_or_constraint(a.reachability_constraint, b.reachability_constraint);
+            return;
+        }
+
         let a = std::mem::take(self);
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
@@ -425,6 +436,24 @@ impl Bindings {
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
+        // Merge changed constraints directly when both paths retain one definition.
+        if let ([a], [b_binding]) = (
+            self.live_bindings.as_mut_slice(),
+            b.live_bindings.as_slice(),
+        ) && a.binding() == b_binding.binding()
+        {
+            self.unbound_narrowing_constraint = self
+                .unbound_narrowing_constraint
+                .zip(b.unbound_narrowing_constraint)
+                .map(|(a, b)| narrowing_constraints.add_or_constraint(a, b));
+            a.narrowing_constraint = narrowing_constraints
+                .add_or_constraint(a.narrowing_constraint, b_binding.narrowing_constraint);
+            a.reachability_constraint = reachability_constraints
+                .add_or_constraint(a.reachability_constraint, b_binding.reachability_constraint);
+            debug_assert_eq!(a.can_be_shadowed(), b_binding.can_be_shadowed());
+            return;
+        }
+
         let a = std::mem::take(self);
 
         if let Some((a, b)) = a

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -181,17 +181,6 @@ impl Declarations {
     }
 
     fn merge(&mut self, b: Self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
-        // A branch can change a declaration's reachability without adding another declaration.
-        if let ([a], [b]) = (
-            self.live_declarations.as_mut_slice(),
-            b.live_declarations.as_slice(),
-        ) && a.declaration == b.declaration
-        {
-            a.reachability_constraint = reachability_constraints
-                .add_or_constraint(a.reachability_constraint, b.reachability_constraint);
-            return;
-        }
-
         let a = std::mem::take(self);
 
         // Invariant: merge_join_by consumes the two iterators in sorted order, which ensures that
@@ -436,24 +425,6 @@ impl Bindings {
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
         reachability_constraints: &mut ReachabilityConstraintsBuilder,
     ) {
-        // Merge changed constraints directly when both paths retain one definition.
-        if let ([a], [b_binding]) = (
-            self.live_bindings.as_mut_slice(),
-            b.live_bindings.as_slice(),
-        ) && a.binding() == b_binding.binding()
-        {
-            self.unbound_narrowing_constraint = self
-                .unbound_narrowing_constraint
-                .zip(b.unbound_narrowing_constraint)
-                .map(|(a, b)| narrowing_constraints.add_or_constraint(a, b));
-            a.narrowing_constraint = narrowing_constraints
-                .add_or_constraint(a.narrowing_constraint, b_binding.narrowing_constraint);
-            a.reachability_constraint = reachability_constraints
-                .add_or_constraint(a.reachability_constraint, b_binding.reachability_constraint);
-            debug_assert_eq!(a.can_be_shadowed(), b_binding.can_be_shadowed());
-            return;
-        }
-
         let a = std::mem::take(self);
 
         if let Some((a, b)) = a


### PR DESCRIPTION
## Summary

Branch merges repeat reachability work for consecutive places that share the same last-applied reachability node. We now reuse the most recently merged path constraint within each merge, where both branch tips remain fixed. We also skip the member-state merge when there are no member states.
