### PR TITLE
[ty] Skip ParamSpec expansion checks without union substitutions

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -466,6 +466,10 @@ pub(crate) struct ApplyTypeMappingVisitor<'env, 'db> {
     promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     skip_promotion: OnceCell<Box<TypeTransformer<'db, ApplyTypeMappingTag>>>,
     materialization_equivalence: OnceCell<MaterializationEquivalenceVisitor<'db>>,
+    /// Whether the specialization can require union-valued `ParamSpec` expansion.
+    /// The substitution values stay fixed for this visitor, including when materialization
+    /// polarity flips. Each `ParamSpec` expansion starts a new visitor for its bindings.
+    specialization_may_map_to_union: OnceCell<bool>,
 }
 
 impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
@@ -482,6 +486,7 @@ impl<'env, 'db> ApplyTypeMappingVisitor<'env, 'db> {
             promotion: OnceCell::default(),
             skip_promotion: OnceCell::default(),
             materialization_equivalence: OnceCell::default(),
+            specialization_may_map_to_union: OnceCell::default(),
         }
     }
 
@@ -8722,6 +8727,13 @@ impl<'db> Type<'db> {
         if let TypeMapping::ApplySpecialization(specialization)
         | TypeMapping::ApplySpecializationWithMaterialization { specialization, .. } =
             type_mapping
+            && matches!(
+                self,
+                Type::FunctionLiteral(_) | Type::BoundMethod(_) | Type::Callable(_)
+            )
+            && *visitor
+                .specialization_may_map_to_union
+                .get_or_init(|| specialization.may_map_to_union(db))
         {
             let function_signatures = |function: FunctionType<'db>| {
                 if specialization.preserves_lazy_signatures() {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2301,6 +2301,29 @@ impl<'db> ApplySpecialization<'_, 'db> {
         }
     }
 
+    /// Returns whether any type variable might map to a union.
+    ///
+    /// If no substitution is a union, callable specialization cannot need `ParamSpec`
+    /// expansion. Checking the substitution values avoids reading function signatures
+    /// merely to rule out that expansion. Overrides conservatively include the underlying
+    /// mapping, even if they replace its last union-valued substitution.
+    pub(super) fn may_map_to_union(self, db: &'db dyn Db) -> bool {
+        match self {
+            Self::Specialization { specialization, .. } | Self::TypeAlias(specialization) => {
+                specialization.types(db).iter().any(|ty| ty.is_union())
+            }
+            Self::Partial { types, .. } => types.iter().any(|ty| ty.is_union()),
+            Self::ReturnCallables(_) => false,
+            Self::Single(_, ty) => ty.is_union(),
+            Self::WithBindings {
+                specialization,
+                bindings,
+            } => {
+                bindings.iter().any(|(_, ty)| ty.is_union()) || specialization.may_map_to_union(db)
+            }
+        }
+    }
+
     /// Returns the type that a typevar is mapped to, or None if the typevar isn't part of this
     /// mapping.
     pub(crate) fn get(


### PR DESCRIPTION
## Summary

Specializing a callable reads its signatures to check for union-valued `ParamSpec` expansion even when none of the substitution values is a union. We now check the substitution values first and cache that result for the type-mapping visitor, avoiding signature reads when expansion is impossible.

The check is conservative for partial mappings and binding overrides. Mappings that may contain a union still use the existing matching and expansion logic, and each expansion gets a fresh visitor.
