### PR TITLE
[ty] Avoid redundant constraint support calculations

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1412,12 +1412,23 @@ impl<'db> ConstraintSetStorage<'db> {
         env: &ProgramEnvironment<'db>,
         data: Constraint<'db>,
     ) -> ConstraintId {
-        let support = self.intern_constraint_typevars(db, env, data);
+        self.intern_constraint_with_support(data, |storage| {
+            storage.intern_constraint_typevars(db, env, data)
+        })
+    }
 
+    /// Reuses an existing constraint without recomputing its support. Callers that already
+    /// registered the constraint's typevars can provide the support from that traversal.
+    fn intern_constraint_with_support(
+        &mut self,
+        data: Constraint<'db>,
+        support: impl FnOnce(&mut Self) -> Support,
+    ) -> ConstraintId {
         self.ensure_overlay_identity_caches();
         if let Some(id) = self.constraint_cache.get(&data) {
             return *id;
         }
+        let support = support(self);
         let support_id = self.intern_support(support);
         let id = self.constraints.push(data);
         self.constraint_supports.push(support_id);
@@ -2558,7 +2569,7 @@ impl<'db> Constraint<'db> {
         }
 
         let constraint = Constraint::new(typevar, lower, upper);
-        storage.intern_constraint_typevars(db, env, constraint);
+        let support = storage.intern_constraint_typevars(db, env, constraint);
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the constraint cannot
         // be satisfied, since there is no type that is both greater than `lower`, and less than
@@ -2680,8 +2691,7 @@ impl<'db> Constraint<'db> {
             }
 
             _ => {
-                let constraint =
-                    ConstraintId::new_with_bounds(db, env, storage, typevar, lower, upper);
+                let constraint = storage.intern_constraint_with_support(constraint, |_| support);
                 Node::new_constraint(storage, constraint)
             }
         }

--- a/crates/ty_python_semantic/src/types/constraints/paths.rs
+++ b/crates/ty_python_semantic/src/types/constraints/paths.rs
@@ -519,20 +519,22 @@ impl PathAssignments {
                 continue;
             }
 
-            let existing_support = storage.constraint_support(*existing);
-            let constraint_support = storage.constraint_support(constraint);
+            if !self.independent_typevars.is_empty() {
+                let existing_support = storage.constraint_support(*existing);
+                let constraint_support = storage.constraint_support(constraint);
 
-            // Independent typevars must be checked for disjoint or invalid constraints, but are
-            // otherwise already constrained and do not participate in sequent discovery.
-            if !existing_support.overlaps_with(constraint_support)
-                && existing_support
-                    .iter()
-                    .chain(constraint_support.iter())
-                    .any(|typevar| self.independent_typevars.contains(&typevar))
-                && existing_support.is_complete()
-                && constraint_support.is_complete()
-            {
-                continue;
+                // Independent typevars must be checked for disjoint or invalid constraints, but are
+                // otherwise already constrained and do not participate in sequent discovery.
+                if !existing_support.overlaps_with(constraint_support)
+                    && existing_support
+                        .iter()
+                        .chain(constraint_support.iter())
+                        .any(|typevar| self.independent_typevars.contains(&typevar))
+                    && existing_support.is_complete()
+                    && constraint_support.is_complete()
+                {
+                    continue;
+                }
             }
 
             if SequentMap::pair_cannot_produce_sequents(db, env, storage, *existing, constraint) {


### PR DESCRIPTION
## Summary

Interning a constraint currently traverses its type variables to compute support before checking whether the exact constraint is already interned. We now defer that traversal until a cache miss. When constructing a constraint with unchanged bounds, we also reuse the support already collected before satisfiability and orientation checks.

Changed or split bounds continue through their existing constructors. During sequent discovery, we skip the support-based independence check when there are no independent type variables, since its predicate cannot match.
