### PR TITLE
[ty] Avoid storing constraint nodes twice

### DIFF
--- a/crates/ty_python_core/src/interned_nodes.rs
+++ b/crates/ty_python_core/src/interned_nodes.rs
@@ -1,0 +1,83 @@
+//! Data structures for interning interior nodes.
+//!
+//! Each graph needs stable IDs for its nodes and a way to reuse an existing ID when the same
+//! node is constructed again. The indexed vector owns the nodes; a hash table of IDs provides
+//! lookup without storing another copy of each node.
+
+use std::hash::{BuildHasher, Hash};
+use std::ops::Index;
+
+use hashbrown::{HashTable, hash_table::Entry};
+use ruff_index::{Idx, IndexVec};
+use rustc_hash::FxBuildHasher;
+
+/// An indexed collection of distinct nodes with a reverse table of their IDs.
+///
+/// The vector owns each node at the index given by its stable ID. The hash table stores only
+/// IDs, hashing and comparing them by reading the corresponding nodes from the vector. Both
+/// collections are private, and [`Self::intern`] updates them together: every table entry
+/// refers to a node in the vector, and an equal node reuses that node's ID. Once the graph is
+/// built, [`Self::into_nodes_boxed_slice`] returns a boxed slice of nodes and drops the table.
+#[derive(Debug)]
+pub(crate) struct InternedNodes<I: Idx, N> {
+    nodes: IndexVec<I, N>,
+    ids: HashTable<I>,
+}
+
+impl<I: Idx, N> Default for InternedNodes<I, N> {
+    fn default() -> Self {
+        Self {
+            nodes: IndexVec::default(),
+            ids: HashTable::default(),
+        }
+    }
+}
+
+impl<I: Idx, N> InternedNodes<I, N> {
+    pub(crate) const fn len(&self) -> usize {
+        self.nodes.raw.len()
+    }
+
+    /// Consume `self` and return an iterator over the interned nodes.
+    pub(crate) fn into_node_iterator(self) -> impl Iterator<Item = N> {
+        self.nodes.into_iter()
+    }
+
+    /// Consume `self` and return a boxed slice of the interned nodes.
+    pub(crate) fn into_nodes_boxed_slice(self) -> Box<[N]> {
+        self.nodes.raw.into_boxed_slice()
+    }
+}
+
+impl<I: Idx, N: Eq + Hash> InternedNodes<I, N> {
+    pub(crate) fn find(&self, node: &N) -> Option<I> {
+        self.ids
+            .find(FxBuildHasher.hash_one(node), |id| self.nodes[*id].eq(node))
+            .copied()
+    }
+
+    /// Returns the node ID and whether the node was newly inserted.
+    pub(crate) fn intern(&mut self, node: N) -> (I, bool) {
+        let nodes = &mut self.nodes;
+        match self.ids.entry(
+            FxBuildHasher.hash_one(&node),
+            |id| nodes[*id].eq(&node),
+            |id| FxBuildHasher.hash_one(&nodes[*id]),
+        ) {
+            Entry::Occupied(entry) => (*entry.get(), false),
+            Entry::Vacant(entry) => {
+                let id = nodes.push(node);
+                entry.insert(id);
+                (id, true)
+            }
+        }
+    }
+}
+
+impl<I: Idx, N> Index<I> for InternedNodes<I, N> {
+    type Output = N;
+
+    fn index(&self, id: I) -> &N {
+        &self.nodes[id]
+    }
+}

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -45,6 +45,7 @@ mod db;
 pub mod definition;
 pub mod expression;
 pub mod frozen;
+mod interned_nodes;
 pub(crate) mod member;
 pub mod narrowing_constraints;
 pub mod node_key;

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -33,9 +33,11 @@
 //! `A OR (NOT A AND B)` simplifies to `A OR B`.
 
 use std::cmp::Ordering;
+use std::hash::BuildHasher;
 
+use hashbrown::hash_table::Entry;
 use ruff_index::{Idx, IndexVec};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::ast_ids::ScopedUseId;
 use crate::predicate::ScopedPredicateId;
@@ -128,11 +130,12 @@ impl NarrowingConstraints {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct NarrowingConstraintsBuilder {
     interiors: IndexVec<ScopedNarrowingConstraint, InteriorNode>,
     interior_used: RankBitBoxVec,
-    interior_cache: FxHashMap<InteriorNode, ScopedNarrowingConstraint>,
+    // Nodes are already stored in `interiors`; keep only their IDs in the reverse table.
+    interior_cache: hashbrown::HashTable<ScopedNarrowingConstraint>,
     and_cache: FxHashMap<
         (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
         ScopedNarrowingConstraint,
@@ -228,10 +231,20 @@ impl NarrowingConstraintsBuilder {
             });
         }
 
-        *self.interior_cache.entry(node).or_insert_with(|| {
-            self.interior_used.push(false);
-            self.interiors.push(node)
-        })
+        let interiors = &mut self.interiors;
+        match self.interior_cache.entry(
+            FxBuildHasher.hash_one(node),
+            |id| interiors[*id] == node,
+            |id| FxBuildHasher.hash_one(interiors[*id]),
+        ) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                self.interior_used.push(false);
+                let id = interiors.push(node);
+                entry.insert(id);
+                id
+            }
+        }
     }
 
     pub(crate) fn add_atom(&mut self, predicate: ScopedPredicateId) -> ScopedNarrowingConstraint {
@@ -280,7 +293,12 @@ impl NarrowingConstraintsBuilder {
             if_uncertain: ALWAYS_FALSE,
             if_false,
         };
-        if let Some(cached) = self.interior_cache.get(&node) {
+        if let Some(cached) = self
+            .interior_cache
+            .find(FxBuildHasher.hash_one(node), |id| {
+                self.interiors[*id] == node
+            })
+        {
             return *cached;
         }
         if self.interiors.len() >= MAX_INTERIOR_NODES {

--- a/crates/ty_python_core/src/narrowing_constraints.rs
+++ b/crates/ty_python_core/src/narrowing_constraints.rs
@@ -33,13 +33,12 @@
 //! `A OR (NOT A AND B)` simplifies to `A OR B`.
 
 use std::cmp::Ordering;
-use std::hash::BuildHasher;
 
-use hashbrown::hash_table::Entry;
-use ruff_index::{Idx, IndexVec};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use ruff_index::Idx;
+use rustc_hash::FxHashMap;
 
 use crate::ast_ids::ScopedUseId;
+use crate::interned_nodes::InternedNodes;
 use crate::predicate::ScopedPredicateId;
 use crate::rank::{RankBitBox, RankBitBoxVec};
 use crate::scope::FileScopeId;
@@ -132,10 +131,8 @@ impl NarrowingConstraints {
 
 #[derive(Debug, Default)]
 pub struct NarrowingConstraintsBuilder {
-    interiors: IndexVec<ScopedNarrowingConstraint, InteriorNode>,
+    interiors: InternedNodes<ScopedNarrowingConstraint, InteriorNode>,
     interior_used: RankBitBoxVec,
-    // Nodes are already stored in `interiors`; keep only their IDs in the reverse table.
-    interior_cache: hashbrown::HashTable<ScopedNarrowingConstraint>,
     and_cache: FxHashMap<
         (ScopedNarrowingConstraint, ScopedNarrowingConstraint),
         ScopedNarrowingConstraint,
@@ -150,13 +147,13 @@ impl NarrowingConstraintsBuilder {
     pub(crate) fn build(self) -> NarrowingConstraints {
         if self.interior_used.first_zero().is_none() {
             NarrowingConstraints {
-                used_interiors: self.interiors.raw.into_boxed_slice(),
+                used_interiors: self.interiors.into_nodes_boxed_slice(),
                 used_indices: None,
             }
         } else {
             let used_interiors = self
                 .interiors
-                .into_iter()
+                .into_node_iterator()
                 .zip(&self.interior_used)
                 .filter_map(|(interior, used)| used.then_some(interior))
                 .collect();
@@ -231,20 +228,11 @@ impl NarrowingConstraintsBuilder {
             });
         }
 
-        let interiors = &mut self.interiors;
-        match self.interior_cache.entry(
-            FxBuildHasher.hash_one(node),
-            |id| interiors[*id] == node,
-            |id| FxBuildHasher.hash_one(interiors[*id]),
-        ) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                self.interior_used.push(false);
-                let id = interiors.push(node);
-                entry.insert(id);
-                id
-            }
+        let (id, inserted) = self.interiors.intern(node);
+        if inserted {
+            self.interior_used.push(false);
         }
+        id
     }
 
     pub(crate) fn add_atom(&mut self, predicate: ScopedPredicateId) -> ScopedNarrowingConstraint {
@@ -293,13 +281,8 @@ impl NarrowingConstraintsBuilder {
             if_uncertain: ALWAYS_FALSE,
             if_false,
         };
-        if let Some(cached) = self
-            .interior_cache
-            .find(FxBuildHasher.hash_one(node), |id| {
-                self.interiors[*id] == node
-            })
-        {
-            return *cached;
+        if let Some(cached) = self.interiors.find(&node) {
+            return cached;
         }
         if self.interiors.len() >= MAX_INTERIOR_NODES {
             return ALWAYS_TRUE;

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -3,9 +3,11 @@
 //! See [`crate::reachability_constraints`] for more details.
 
 use std::cmp::Ordering;
+use std::hash::BuildHasher;
 
+use hashbrown::hash_table::Entry;
 use ruff_index::{Idx, IndexVec};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 
 use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
 use crate::predicate::ScopedPredicateId;
@@ -172,11 +174,12 @@ impl ReachabilityConstraints {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, Default)]
 pub struct ReachabilityConstraintsBuilder {
     interiors: IndexVec<ScopedReachabilityConstraintId, InteriorNode>,
     interior_used: RankBitBoxVec,
-    interior_cache: FxHashMap<InteriorNode, ScopedReachabilityConstraintId>,
+    // Nodes are already stored in `interiors`; keep only their IDs in the reverse table.
+    interior_cache: hashbrown::HashTable<ScopedReachabilityConstraintId>,
     not_cache: FxHashMap<ScopedReachabilityConstraintId, ScopedReachabilityConstraintId>,
     and_cache: FxHashMap<
         (
@@ -351,10 +354,20 @@ impl ReachabilityConstraintsBuilder {
             return node.if_true;
         }
 
-        *self.interior_cache.entry(node).or_insert_with(|| {
-            self.interior_used.push(false);
-            self.interiors.push(node)
-        })
+        let interiors = &mut self.interiors;
+        match self.interior_cache.entry(
+            FxBuildHasher.hash_one(node),
+            |id| interiors[*id] == node,
+            |id| FxBuildHasher.hash_one(interiors[*id]),
+        ) {
+            Entry::Occupied(entry) => *entry.get(),
+            Entry::Vacant(entry) => {
+                self.interior_used.push(false);
+                let id = interiors.push(node);
+                entry.insert(id);
+                id
+            }
+        }
     }
 
     /// Adds a new reachability constraint that checks a single [`super::predicate::Predicate`].

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -3,12 +3,11 @@
 //! See [`crate::reachability_constraints`] for more details.
 
 use std::cmp::Ordering;
-use std::hash::BuildHasher;
 
-use hashbrown::hash_table::Entry;
-use ruff_index::{Idx, IndexVec};
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use ruff_index::Idx;
+use rustc_hash::FxHashMap;
 
+use crate::interned_nodes::InternedNodes;
 use crate::narrowing_constraints::{NarrowingConstraintsBuilder, ScopedNarrowingConstraint};
 use crate::predicate::ScopedPredicateId;
 use crate::rank::{RankBitBox, RankBitBoxVec};
@@ -176,10 +175,8 @@ impl ReachabilityConstraints {
 
 #[derive(Debug, Default)]
 pub struct ReachabilityConstraintsBuilder {
-    interiors: IndexVec<ScopedReachabilityConstraintId, InteriorNode>,
+    interiors: InternedNodes<ScopedReachabilityConstraintId, InteriorNode>,
     interior_used: RankBitBoxVec,
-    // Nodes are already stored in `interiors`; keep only their IDs in the reverse table.
-    interior_cache: hashbrown::HashTable<ScopedReachabilityConstraintId>,
     not_cache: FxHashMap<ScopedReachabilityConstraintId, ScopedReachabilityConstraintId>,
     and_cache: FxHashMap<
         (
@@ -206,11 +203,13 @@ impl ReachabilityConstraintsBuilder {
     pub(crate) fn build(self) -> ReachabilityConstraints {
         if self.interior_used.first_zero().is_none() {
             ReachabilityConstraints {
-                used_interiors: self.interiors.raw.into_boxed_slice(),
+                used_interiors: self.interiors.into_nodes_boxed_slice(),
                 used_indices: None,
             }
         } else {
-            let used_interiors = (self.interiors.into_iter())
+            let used_interiors = self
+                .interiors
+                .into_node_iterator()
                 .zip(&self.interior_used)
                 .filter_map(|(interior, used)| used.then_some(interior))
                 .collect();
@@ -354,20 +353,11 @@ impl ReachabilityConstraintsBuilder {
             return node.if_true;
         }
 
-        let interiors = &mut self.interiors;
-        match self.interior_cache.entry(
-            FxBuildHasher.hash_one(node),
-            |id| interiors[*id] == node,
-            |id| FxBuildHasher.hash_one(interiors[*id]),
-        ) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                self.interior_used.push(false);
-                let id = interiors.push(node);
-                entry.insert(id);
-                id
-            }
+        let (id, inserted) = self.interiors.intern(node);
+        if inserted {
+            self.interior_used.push(false);
         }
+        id
     }
 
     /// Adds a new reachability constraint that checks a single [`super::predicate::Predicate`].


### PR DESCRIPTION
## Summary

Building large reachability and narrowing graphs stores each interior node twice: once in `interiors` and again as the key of the interning map. Store only the node ID in a `hashbrown::HashTable`, using `interiors` for hashing and equality. This reduces temporary memory during semantic-index construction while preserving the resulting nodes and their IDs.

## Performance

Median peak RSS across four runs of profiling CLI builds on macOS arm64, using the existing microbenchmark inputs:

| Benchmark | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `repeated_narrowed_assignments` | 71.7 MiB | 59.5 MiB | 17.1% |
| `repeated_narrowed_assignments_suppressing_context_managers` | 117.6 MiB | 97.6 MiB | 17.0% |
| `repeated_statement_calls_in_try` | 111.3 MiB | 85.6 MiB | 23.1% |

CPU time fell by 3–11% in these three cases and was within ±4% in the remaining measured cases. These savings are in peak memory; the retained constraint graphs are unchanged.
