### PR TITLE
[ty] Cache exception suppression for context managers

### DIFF
--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1824,6 +1824,40 @@ fn analyze_non_empty_iterable(db: &dyn Db, iterable: Expression) -> Truthiness {
     }
 }
 
+/// Cache the whole predicate so repeated reachability walks can reuse one query result
+/// instead of looking up the expression's type and suppression behavior separately.
+/// Separate sync and async queries use the expression directly as their Salsa key.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _| false,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn sync_context_manager_suppresses<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
+    context_manager_suppresses(db, expression, false)
+}
+
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial = |_, _, _| false,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn async_context_manager_suppresses<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
+    context_manager_suppresses(db, expression, true)
+}
+
+fn context_manager_suppresses<'db>(
+    db: &'db dyn Db,
+    expression: Expression<'db>,
+    is_async: bool,
+) -> bool {
+    let env = ProgramEnvironment::from_scope(expression.scope(db));
+    infer_same_file_expression_type(db, expression, TypeContext::default()).can_suppress_exceptions(
+        db,
+        &env,
+        EvaluationMode::from_is_async(is_async),
+    )
+}
+
 /// Evaluate a condition without re-testing intermediate short-circuit results.
 ///
 /// `None` means evaluation cannot produce a result, as for an operand narrowed to `Never`.
@@ -1930,10 +1964,11 @@ fn analyze_single(db: &dyn Db, env: &ProgramEnvironment<'_>, predicate: &Predica
         PredicateNode::ContextManagerSuppresses {
             expression,
             is_async,
-        } => Truthiness::from(
-            infer_same_file_expression_type(db, expression, TypeContext::default())
-                .can_suppress_exceptions(db, env, EvaluationMode::from_is_async(is_async)),
-        )
+        } => Truthiness::from(if is_async {
+            async_context_manager_suppresses(db, expression)
+        } else {
+            sync_context_manager_suppresses(db, expression)
+        })
         .negate_if(!predicate.is_positive),
         PredicateNode::FinallyNormalPathImpossible {
             scope,

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1833,7 +1833,7 @@ fn analyze_non_empty_iterable(db: &dyn Db, iterable: Expression) -> Truthiness {
     heap_size = get_size2::GetSize::get_heap_size
 )]
 fn sync_context_manager_suppresses<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
-    context_manager_suppresses(db, expression, false)
+    context_manager_suppresses(db, expression, EvaluationMode::Sync)
 }
 
 #[salsa::tracked(
@@ -1842,19 +1842,19 @@ fn sync_context_manager_suppresses<'db>(db: &'db dyn Db, expression: Expression<
     heap_size = get_size2::GetSize::get_heap_size
 )]
 fn async_context_manager_suppresses<'db>(db: &'db dyn Db, expression: Expression<'db>) -> bool {
-    context_manager_suppresses(db, expression, true)
+    context_manager_suppresses(db, expression, EvaluationMode::Async)
 }
 
 fn context_manager_suppresses<'db>(
     db: &'db dyn Db,
     expression: Expression<'db>,
-    is_async: bool,
+    evaluation_mode: EvaluationMode,
 ) -> bool {
     let env = ProgramEnvironment::from_scope(expression.scope(db));
     infer_same_file_expression_type(db, expression, TypeContext::default()).can_suppress_exceptions(
         db,
         &env,
-        EvaluationMode::from_is_async(is_async),
+        evaluation_mode,
     )
 }
 


### PR DESCRIPTION
## Summary

Repeated control-flow evaluation performs expression-type and suppression-query lookups for the same context manager. Cache the complete expression-to-suppression decision, using separate synchronous and asynchronous queries so the expression ID can serve directly as the Salsa key. Cycle recovery uses the same conservative `false` result as `Type::can_suppress_exceptions`.

## Performance

Median CPU time across four runs of profiling CLI builds on macOS arm64, using the existing microbenchmark inputs:

| Benchmark | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `repeated_suppressing_context_managers` | 91.6 ms | 52.7 ms | 42.4% |
| `repeated_suppressing_context_managers_interleaved_calls` | 69.6 ms | 54.9 ms | 21.1% |
| `repeated_narrowed_assignments_suppressing_context_managers` | 354.2 ms | 262.9 ms | 25.8% |
