### PR TITLE
[ty] Reject incompatible TypedDict fields before recursive comparisons

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2360,6 +2360,46 @@ static_assert(is_assignable_to(Person1, Person2))
 static_assert(is_equivalent_to(Person1, Person2))
 ```
 
+## Literal tags on recursive `TypedDict`s
+
+Different required literal tags make recursive `TypedDict`s incompatible and disjoint, including
+when the recursive fields appear before the tags. Matching tags still allow structurally equivalent
+recursive types.
+
+```py
+from typing_extensions import Literal, LiteralString, ReadOnly, TypedDict
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to, is_disjoint_from, is_equivalent_to
+
+class Left(TypedDict):
+    children: list["Left"]
+    tag: Literal["left"]
+
+class Right(TypedDict):
+    children: list["Right"]
+    tag: Literal["right"]
+
+class SameTag(TypedDict):
+    children: list["SameTag"]
+    tag: Literal["left"]
+
+static_assert(not is_assignable_to(Left, Right))
+static_assert(is_disjoint_from(Left, Right))
+static_assert(is_equivalent_to(Left, SameTag))
+```
+
+A read-only `LiteralString` tag accepts a concrete string literal. A broad literal string type does
+not distinguish the alternatives.
+
+```py
+class BroadTag(TypedDict):
+    children: list[Left]
+    tag: ReadOnly[LiteralString]
+
+static_assert(is_assignable_to(Left, BroadTag))
+static_assert(not is_disjoint_from(Left, BroadTag))
+```
+
 ## Recursively-specialized generic `TypedDict`s
 
 ```toml

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -774,6 +774,38 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let target_items = target.items(db);
         let source_openness = source.openness(db);
         let target_openness = target.openness(db);
+
+        // Missing fields, incompatible mutability, and distinct literal tags rule out a match.
+        // Check these before comparing potentially recursive field types. When collecting
+        // diagnostics, preserve the ordinary order so the first incompatible field is reported.
+        if !self.is_context_collection_enabled()
+            && target_items.iter().any(|(name, target_field)| {
+                if let Some(source_field) = source_items.get(name) {
+                    (target_field.is_required() && !source_field.is_required())
+                        || (!target_field.is_read_only()
+                            && (source_field.is_read_only()
+                                || source_field.is_required() != target_field.is_required()))
+                        || (matches!(source_field.declared_ty, Type::LiteralValue(_))
+                            && matches!(target_field.declared_ty, Type::LiteralValue(_))
+                            && self
+                                .check_type_pair(
+                                    db,
+                                    source_field.declared_ty,
+                                    target_field.declared_ty,
+                                )
+                                .is_trivially_never_satisfied())
+                } else {
+                    target_field.is_required()
+                        || (!target_field.is_read_only()
+                            && source_openness
+                                .explicit_extra_items()
+                                .is_none_or(TypedDictExtraItems::is_read_only))
+                }
+            })
+        {
+            return self.never();
+        }
+
         // Many rules violations short-circuit with "never", but asking whether one field is
         // [relation] to/of another can produce more complicated constraints, and we collect those.
         let mut result = self.always();
@@ -1110,6 +1142,28 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         let left_items = left.items(db);
         let right_items = right.items(db);
+        // Required literal tags can establish disjointness before recursive fields are
+        // compared. Keep the field order when collecting diagnostic context.
+        if self.report_context().is_none()
+            && left_items.iter().any(|(name, left_field)| {
+                left_field.is_required()
+                    && matches!(left_field.declared_ty, Type::LiteralValue(_))
+                    && right_items.get(name).is_some_and(|right_field| {
+                        right_field.is_required()
+                            && matches!(right_field.declared_ty, Type::LiteralValue(_))
+                            && self
+                                .check_type_pair(
+                                    db,
+                                    left_field.declared_ty,
+                                    right_field.declared_ty,
+                                )
+                                .is_trivially_always_satisfied()
+                    })
+            })
+        {
+            return self.always();
+        }
+
         let fields_in_common = btreemap_items_with_same_key(left_items, right_items);
         let common_fields_disjoint =
             fields_in_common.when_any(db, self.constraints, |(name, left_field, right_field)| {


### PR DESCRIPTION
## Summary

Comparing recursive `TypedDict` fields can do substantial work before reaching a missing required key, incompatible requiredness or mutability, or conflicting literal tag. We now check these conditions before comparing the remaining field types. Required literal tags can also establish disjointness before recursive fields are explored.

Diagnostic collection retains the original field order so the same mismatch supplies the error context. Optional tags do not establish disjointness, and missing mutable fields still follow the existing explicit `extra_items` rules.

Against `e579b84aba`, the existing Pydantic CodSpeed walltime benchmark measured 2.678 s before and 2.599 s after this change alone. This is a 2.9% reduction in elapsed time in this sample. These local measurements use one process pair with six samples per process and two iterations per sample.
