### PR TITLE
[ty] Compare signature parameters before return types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/callable.md
@@ -366,6 +366,97 @@ def expects_str_return(c: Callable[[int | str], str]) -> None:
 expects_str_return(wide_return_converter)
 ```
 
+## Literal parameter domains
+
+A callable must accept every literal value allowed by the target parameter. `LiteralString` accepts
+specific string literals, while boolean and integer literals remain distinct:
+
+```py
+from typing import Callable, Literal, Protocol, TypeVar, overload
+from typing_extensions import LiteralString
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
+
+static_assert(not is_assignable_to(Callable[[Literal["a"]], int], Callable[[Literal["b"]], int]))
+static_assert(is_assignable_to(Callable[[LiteralString], int], Callable[[Literal["a"]], int]))
+static_assert(not is_assignable_to(Callable[[Literal["a"]], int], Callable[[LiteralString], int]))
+static_assert(not is_assignable_to(Callable[[Literal[1]], int], Callable[[Literal[True]], int]))
+```
+
+Generic overloads are compared using the matching literal parameter domain. Their remaining
+parameters and return types still determine whether the callable is compatible:
+
+```py
+T = TypeVar("T")
+
+class Lookup(Protocol):
+    @overload
+    def __call__(self, key: Literal["integer"], default: T, /) -> int | T: ...
+    @overload
+    def __call__(self, key: Literal["text"], default: T, /) -> str | T: ...
+
+static_assert(is_assignable_to(Lookup, Callable[[Literal["text"], bytes], str | bytes]))
+static_assert(not is_assignable_to(Lookup, Callable[[Literal["missing"], bytes], object]))
+static_assert(not is_assignable_to(Lookup, Callable[[Literal["text"], bytes], int]))
+```
+
+## Generic parameter and return constraints
+
+A generic callable must have a specialization that satisfies both the parameter and return types.
+Matching its parameter does not make an incompatible return type valid:
+
+```py
+from typing import Callable, Protocol, TypeVar
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
+
+T = TypeVar("T")
+
+class Wrap(Protocol):
+    def __call__(self, value: T, /) -> tuple[T, str]: ...
+
+static_assert(is_assignable_to(Wrap, Callable[[str], tuple[str, str]]))
+static_assert(not is_assignable_to(Wrap, Callable[[str], tuple[str, int]]))
+```
+
+The parameter type also contributes to inference when a callback's return type is generic:
+
+```py
+def identity(value: T) -> T:
+    return value
+
+def result(callback: Callable[[int], T]) -> T:
+    return callback(1)
+
+reveal_type(result(identity))  # revealed: int
+```
+
+## Recursive callable returns
+
+Recursive return types must satisfy the callable relation together with the finite parameter
+requirements. Accepting every object allows the next step to accept an integer as well:
+
+```py
+from __future__ import annotations
+
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_assignable_to
+
+class IntegerStep(Protocol):
+    def __call__(self, value: int, /) -> IntegerStep: ...
+
+class ObjectStep(Protocol):
+    def __call__(self, value: object, /) -> ObjectStep: ...
+
+class StringStep(Protocol):
+    def __call__(self, value: str, /) -> StringStep: ...
+
+static_assert(is_assignable_to(ObjectStep, IntegerStep))
+static_assert(not is_assignable_to(IntegerStep, ObjectStep))
+static_assert(not is_assignable_to(StringStep, IntegerStep))
+```
+
 ## Union
 
 ```py

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -2059,6 +2059,13 @@ impl<'db> VarianceInferable<'db> for &Signature<'db> {
     }
 }
 
+/// Selects when to compare return types while relating two signatures.
+#[derive(Clone, Copy)]
+enum SignatureReturnCheck {
+    Eager,
+    Deferred,
+}
+
 impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     /// Fast path for unary callable assignability: compare overload sets by aggregating
     /// overlapping parameter domains and return types.
@@ -2495,6 +2502,36 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        if self.is_context_collection_enabled()
+            || !source.parameters.is_standard()
+            || !target.parameters.is_standard()
+        {
+            return self.check_signature_pair_impl(db, source, target, SignatureReturnCheck::Eager);
+        }
+
+        // Overload return types can contain large recursive structures. An incompatible parameter
+        // list already rejects the signature, so compare it before exploring those return types.
+        // Keep the original order for diagnostics and ParamSpec binding, which can depend on the
+        // return-type constraints even when the signatures are incompatible.
+        let parameter_constraints =
+            self.check_signature_pair_impl(db, source, target, SignatureReturnCheck::Deferred);
+        if parameter_constraints.is_never_satisfied(db, self.env) {
+            return parameter_constraints;
+        }
+
+        // Preserve the original source order of constraints even though they were evaluated in
+        // the opposite order. This keeps return-type evidence first when selecting a solution.
+        self.check_type_pair(db, source.return_ty, target.return_ty)
+            .and(db, self.constraints, || parameter_constraints)
+    }
+
+    fn check_signature_pair_impl(
+        &self,
+        db: &'db dyn Db,
+        source: &Signature<'db>,
+        target: &Signature<'db>,
+        return_check: SignatureReturnCheck,
+    ) -> ConstraintSet<'db, 'c> {
         /// A helper struct to zip two slices of parameters together that provides control over the
         /// two iterators individually. It also keeps track of the current parameter in each
         /// iterator.
@@ -2724,10 +2761,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Avoid returning early after checking the return types in case there is a `ParamSpec` type
         // variable in either signature to ensure that the `ParamSpec` binding is still applied even
         // if the return types are incompatible.
-        let return_type_constraints = if target_parameters.as_paramspec_with_prefix().is_some() {
-            self.check_paramspec_return_pair(db, source, target.return_ty)
-        } else {
-            self.check_type_pair(db, source.return_ty, target.return_ty)
+        let return_type_constraints = match return_check {
+            SignatureReturnCheck::Deferred => self.always(),
+            SignatureReturnCheck::Eager
+                if target_parameters.as_paramspec_with_prefix().is_some() =>
+            {
+                self.check_paramspec_return_pair(db, source, target.return_ty)
+            }
+            SignatureReturnCheck::Eager => {
+                self.check_type_pair(db, source.return_ty, target.return_ty)
+            }
         };
         let return_type_checks = !result
             .intersect(db, self.constraints, return_type_constraints)


### PR DESCRIPTION
## Summary

Signature comparisons currently explore return types even when incompatible parameters already rule out a match. For standard parameter lists, we now compare parameters first and skip the return comparison when their constraints cannot be satisfied. This avoids expanding large recursive return types for overloads that cannot match.

We still combine return-type evidence before parameter evidence when selecting constraint solutions. Diagnostic collection and `ParamSpec` signatures retain the original evaluation order, including binding behavior for incompatible returns.

Against `e579b84aba`, the existing Pydantic CodSpeed walltime benchmark measured 2.722 s before and 2.628 s after this change alone. This is a 3.5% reduction in elapsed time in this sample. These local measurements use one process pair with six samples per process and two iterations per sample.
