### PR TITLE
[ty] Dogfood more ty rules on our own scripts

### DIFF
--- a/scripts/add_plugin.py
+++ b/scripts/add_plugin.py
@@ -12,6 +12,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/add_rule.py
+++ b/scripts/add_rule.py
@@ -12,6 +12,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/build_ruff_pgo.py
+++ b/scripts/build_ruff_pgo.py
@@ -12,6 +12,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/bump-workspace-crate-versions.py
+++ b/scripts/bump-workspace-crate-versions.py
@@ -17,6 +17,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/check_docs_formatted.py
+++ b/scripts/check_docs_formatted.py
@@ -12,6 +12,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/collect_ty_ecosystem_run_metadata.py
+++ b/scripts/collect_ty_ecosystem_run_metadata.py
@@ -12,6 +12,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true
@@ -632,6 +637,8 @@ def collect_diagnostic_entries(test_cases: list[TestCase]) -> list[DiagnosticEnt
                         title=Change.CHANGED.into_title(), test_case=tc, source=None
                     )
                 )
+            else:
+                assert_never(change)
         else:
             if change == Change.ADDED:
                 new_class = tc.classify(Source.NEW)
@@ -679,6 +686,8 @@ def collect_diagnostic_entries(test_cases: list[TestCase]) -> list[DiagnosticEnt
                             source=Source.NEW,
                         )
                     )
+            else:
+                assert_never(change)
 
     entries.sort(
         key=lambda e: (TITLE_PRIORITY.get(e.title, 99), e.title, e.test_case.key)

--- a/scripts/ecosystem_all_check.py
+++ b/scripts/ecosystem_all_check.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/generate-crate-readmes.py
+++ b/scripts/generate-crate-readmes.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/generate_builtin_modules.py
+++ b/scripts/generate_builtin_modules.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/generate_known_standard_library.py
+++ b/scripts/generate_known_standard_library.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -14,6 +14,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/memory_report.py
+++ b/scripts/memory_report.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/publish-crates.py
+++ b/scripts/publish-crates.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/setup_primer_project.py
+++ b/scripts/setup_primer_project.py
@@ -12,6 +12,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/transform_readme.py
+++ b/scripts/transform_readme.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true

--- a/scripts/update_ambiguous_characters.py
+++ b/scripts/update_ambiguous_characters.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true
@@ -53,8 +58,9 @@ def get_mapping_data() -> dict[str, list[int]]:
         encoding="utf-8",
     )
     # The content is a JSON object literal wrapped in a JSON string, so double decode:
-    mapping_data: dict[str, list[int]] = json.loads(json.loads(content))
-    return mapping_data
+    mapping_data = json.loads(json.loads(content))
+    assert isinstance(mapping_data, dict)
+    return mapping_data  # ty: ignore[unsound-return-statement]
 
 
 def format_number(number: int) -> str:

--- a/scripts/update_schemastore.py
+++ b/scripts/update_schemastore.py
@@ -10,6 +10,11 @@
 # unsound-yield = "warn"
 # unsupported-dynamic-base = "warn"
 # division-by-zero = "warn"
+# dynamic-function-decorator-return = "warn"
+# unsound-assignment = "warn"
+# redundant-condition-strict = "warn"
+# disjoint-cast = "warn"
+# missing-direct-dependency = "warn"
 #
 # [tool.uv]
 # no-build = true


### PR DESCRIPTION
## Summary

Enable five opt-in ty rules in the repository's PEP 723 scripts that already configure ty: `dynamic-function-decorator-return`, `unsound-assignment`, `redundant-condition-strict`, `disjoint-cast`, and `missing-direct-dependency`. The existing script dogfooding check uses `TY_UV=scripts`, so the dependency rule can compare each script's imports with its declared dependencies.

Make the conformance-result classification exhaustive over changed cases and verify that downloaded ambiguous-character data has a dictionary at the top level. The mapping's element types come from the external dataset, so its return statement has a rule-specific suppression at that boundary.
