### PR TITLE
docs(flake8-annotations): mention return annotations in any-type (ANN401)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -486,8 +486,8 @@ impl Violation for MissingReturnTypeClassMethod {
 }
 
 /// ## What it does
-/// Checks that function arguments are annotated with a more specific type than
-/// `Any`.
+/// Checks that function arguments and return values are annotated with a more
+/// specific type than `Any`.
 ///
 /// ## Why is this bad?
 /// `Any` is a special type indicating an unconstrained type. When an


### PR DESCRIPTION
## Summary

Fixes #28298.

The `any-type` (`ANN401`) rule also flags return annotations (and `*args`/`**kwargs`), but its documentation only mentioned function arguments. This updates the "What it does" description to reflect that the rule applies to both function arguments and return values.

The rule implementation already checks return annotations in `definition.rs` (the `returns` branch of the ANN401 checker), so this is a documentation-only fix.