### PR TITLE
[ty] Promote literals in nested (non-covariant) positions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -312,7 +312,7 @@ We promote in non-covariant position in the return type of a generic function, o
 generic class:
 
 ```py
-from typing import Callable, Literal
+from typing import Callable, Literal, Any
 
 class Bivariant[T]:
     def __init__(self, value: T): ...
@@ -367,6 +367,61 @@ reveal_type(f11(1, 1))  # revealed: tuple[Invariant[Covariant[int] | None], Cova
 
 reveal_type(f12(1))  # revealed: ((int, /) -> bool) | None
 reveal_type(f13(1))  # revealed: ((bool, /) -> Invariant[int]) | None
+```
+
+This also works if the type variable is nested inside a union:
+
+```py
+def f14[T](x: T) -> Covariant[T | None]:
+    raise NotImplementedError
+
+def f15[T](x: T) -> Contravariant[T | None]:
+    raise NotImplementedError
+
+def f16[T](x: T) -> Invariant[T | None]:
+    raise NotImplementedError
+
+reveal_type(f14(1))  # revealed: Covariant[Literal[1] | None]
+reveal_type(f15(1))  # revealed: Contravariant[int | None]
+reveal_type(f16(1))  # revealed: Invariant[int | None]
+```
+
+And similarly if the type variable is nested in an intersection (note that negation flips variance):
+
+```py
+from ty_extensions import Intersection, Not
+
+def f17[T](x: T) -> Covariant[Intersection[Any, T]]:
+    raise NotImplementedError
+
+def f18[T](x: T) -> Covariant[Intersection[Any, Not[T]]]:
+    raise NotImplementedError
+
+def f19[T](x: T) -> Invariant[Intersection[Any, T]]:
+    raise NotImplementedError
+
+reveal_type(f17(1))  # revealed: Covariant[Any & Literal[1]]
+reveal_type(f18(1))  # revealed: Covariant[Any & ~int]
+reveal_type(f19(1))  # revealed: Invariant[Any & int]
+```
+
+We also promote a callable's return type, if the whole callable is in invariant position:
+
+```py
+def f20[T](x: T) -> Invariant[Callable[[], T]]:
+    raise NotImplementedError
+
+reveal_type(f20(1))  # revealed: Invariant[() -> int]
+```
+
+When the same nested type occurs in both covariant and contravariant positions, both occurrences
+contribute to promotion:
+
+```py
+def f21[T](x: T) -> tuple[Covariant[T | None], Contravariant[T | None]]:
+    raise NotImplementedError
+
+reveal_type(f21(1))  # revealed: tuple[Covariant[int | None], Contravariant[int | None]]
 ```
 
 ## Promotion is recursive

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -28,7 +28,7 @@ pub(crate) use self::callable::UpcastPolicy;
 use self::class::ClassInstanceFlags;
 pub use self::cyclic::CycleDetector;
 pub(crate) use self::cyclic::TypeTransformer;
-use self::cyclic::{ActiveRecursionDetector, TypeIdentity};
+use self::cyclic::{ActiveRecursionDetector, HasIdentity, TypeIdentity};
 pub use self::dedicated::pytest::{
     FixtureBinding, FixtureExposure, FixtureNameSource, fixture_bindings_for_parameter,
     fixture_exposures_for_definition, pytest_global_plugin_files,
@@ -564,8 +564,21 @@ pub(crate) type FindLegacyTypeVarsVisitor<'db> =
 pub(crate) struct FindLegacyTypeVars;
 
 /// A [`CycleDetector`] that is used in `visit_specialization` methods.
-type SpecializationVisitor<'db> = CycleDetector<'db, VisitSpecialization, Type<'db>, (), 3>;
+type SpecializationVisitor<'db> =
+    CycleDetector<'db, VisitSpecialization, (Type<'db>, TypeVarVariance), (), 3>;
 struct VisitSpecialization;
+
+impl<'db> HasIdentity<'db> for (Type<'db>, TypeVarVariance) {
+    type Id = (TypeIdentity<'db>, TypeVarVariance);
+
+    fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
+        self.1 == other.1 && self.0.may_share_type_identity(db, other.0)
+    }
+
+    fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
+        (self.0.to_type_identity(db), self.1)
+    }
+}
 
 /// The standard-library `typing` module or its `typing_extensions` backport.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
@@ -3448,10 +3461,11 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Recursively visit the specialization of a generic class instance.
+    /// Recursively visit a type and its specializations.
     ///
-    /// The provided closure will be called on any nested types, along with their variance with
-    /// respect to the outermost type.
+    /// The provided closure will be called on the type itself and its nested types, along with
+    /// their variance with respect to the outermost type. Repeated types with the same variance
+    /// may be skipped.
     fn visit_specialization<F>(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>, mut f: F)
     where
         F: FnMut(Type<'db>, TypeVarVariance),
@@ -3473,62 +3487,58 @@ impl<'db> Type<'db> {
         f: &mut dyn FnMut(Type<'db>, TypeVarVariance),
         visitor: &SpecializationVisitor<'db>,
     ) {
-        let Some((_, specialization)) = self.class_specialization(db, env) else {
-            match self {
-                Type::Union(union) => {
-                    for element in union.elements(db) {
-                        element.visit_specialization_impl(db, env, polarity, f, visitor);
-                    }
-                }
-                Type::Intersection(intersection) => {
-                    for element in intersection.positive(db) {
-                        element.visit_specialization_impl(db, env, polarity, f, visitor);
-                    }
-                }
-                Type::TypeAlias(alias) => visitor.visit(db, self, || {
-                    alias
-                        .value_type(db)
-                        .visit_specialization_impl(db, env, polarity, f, visitor);
-                }),
-                Type::Callable(callable) => {
-                    for signature in callable.signatures(db) {
-                        for parameter in signature.parameters() {
-                            let variance = TypeVarVariance::Contravariant.compose(polarity);
+        f(self, polarity);
 
-                            f(parameter.annotated_type(), variance);
-
-                            visitor.visit(db, parameter.annotated_type(), || {
-                                parameter
-                                    .annotated_type()
-                                    .visit_specialization_impl(db, env, variance, f, visitor);
-                            });
+        visitor.visit(db, (self, polarity), || {
+            let Some((_, specialization)) = self.class_specialization(db, env) else {
+                match self {
+                    Type::Union(union) => {
+                        for element in union.elements(db) {
+                            element.visit_specialization_impl(db, env, polarity, f, visitor);
                         }
+                    }
+                    Type::Intersection(intersection) => {
+                        for element in intersection.positive(db) {
+                            element.visit_specialization_impl(db, env, polarity, f, visitor);
+                        }
+                        for element in intersection.negative(db) {
+                            element.visit_specialization_impl(db, env, polarity.flip(), f, visitor);
+                        }
+                    }
+                    Type::TypeAlias(alias) => alias
+                        .value_type(db)
+                        .visit_specialization_impl(db, env, polarity, f, visitor),
+                    Type::Callable(callable) => {
+                        for signature in callable.signatures(db) {
+                            for parameter in signature.parameters() {
+                                parameter.annotated_type().visit_specialization_impl(
+                                    db,
+                                    env,
+                                    polarity.flip(),
+                                    f,
+                                    visitor,
+                                );
+                            }
 
-                        visitor.visit(db, signature.return_ty, || {
                             signature
                                 .return_ty
                                 .visit_specialization_impl(db, env, polarity, f, visitor);
-                        });
+                        }
                     }
+                    _ => {}
                 }
-                _ => {}
-            }
 
-            return;
-        };
+                return;
+            };
 
-        for (typevar, ty) in iter::zip(
-            specialization.generic_context(db).variables(db),
-            specialization.types(db),
-        ) {
-            let variance = typevar.variance_with_polarity(db, polarity);
-
-            f(*ty, variance);
-
-            visitor.visit(db, *ty, || {
+            for (typevar, ty) in iter::zip(
+                specialization.generic_context(db).variables(db),
+                specialization.types(db),
+            ) {
+                let variance = typevar.variance_with_polarity(db, polarity);
                 ty.visit_specialization_impl(db, env, variance, f, visitor);
-            });
-        }
+            }
+        });
     }
 
     /// Return true if there is just a single inhabitant for this type.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -572,11 +572,14 @@ impl<'db> HasIdentity<'db> for (Type<'db>, TypeVarVariance) {
     type Id = (TypeIdentity<'db>, TypeVarVariance);
 
     fn may_share_identity(&self, db: &'db dyn Db, other: &Self) -> bool {
-        self.1 == other.1 && self.0.may_share_type_identity(db, other.0)
+        let (self_ty, self_variance) = self;
+        let (other_ty, other_variance) = other;
+        self_variance == other_variance && self_ty.may_share_type_identity(db, *other_ty)
     }
 
     fn to_identity(&self, db: &'db dyn Db) -> Self::Id {
-        (self.0.to_type_identity(db), self.1)
+        let (ty, variance) = self;
+        (ty.to_type_identity(db), *variance)
     }
 }
 


### PR DESCRIPTION
## Summary

Promote inferred literals when a type variable occurs inside a union/intersection/callable in an invariant or contravariant return position:

```py
def f[T](x: T) -> list[T | None]: ...

reveal_type(f(1))  # now: list[int | None], previously: list[Literal[1] | None]
```

Fixes astral-sh/ty#4468.

## Test Plan

Regression tests