### PR TITLE
[ty] Prevent LSP hangs during inlay hint bursts

### DIFF
--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -248,33 +248,33 @@ impl std::fmt::Debug for SendRequest {
 struct UvSyncWakeups(Vec<(SystemPathBuf, crossbeam::channel::Receiver<()>)>);
 
 impl UvSyncWakeups {
-    /// Waits for a project wakeup, main-loop action, or client message, in that order.
-    /// If incoming requests keep winning, the main loop can block submitting jobs while
-    /// workers block sending responses to its bounded action channel.
+    /// Waits for a main-loop action, project wakeup, or client message, in that order.
+    /// Polling uv can wait for worker database snapshots, so drain the bounded action
+    /// channel before applying uv results. Handle both before accepting new requests.
     fn select(
         &self,
         connection: &crossbeam::channel::Receiver<Message>,
         main_loop: &MainLoopReceiver,
     ) -> Result<Option<Event>, crossbeam::channel::RecvError> {
         let mut select = crossbeam::channel::Select::new_biased();
+        let main_loop_index = select.recv(main_loop);
         for (_, receiver) in &self.0 {
             select.recv(receiver);
         }
-        let main_loop_index = select.recv(main_loop);
         let connection_index = select.recv(connection);
         let operation = select.select();
         let index = operation.index();
 
-        if let Some((project_root, receiver)) = self.0.get(index) {
+        if index == main_loop_index {
+            return operation.recv(main_loop).map(Some);
+        }
+
+        if let Some((project_root, receiver)) = index.checked_sub(1).and_then(|i| self.0.get(i)) {
             return operation.recv(receiver).map(|()| {
                 Some(Event::PollUvEnvironments {
                     project_root: project_root.clone(),
                 })
             });
-        }
-
-        if index == main_loop_index {
-            return operation.recv(main_loop).map(Some);
         }
 
         debug_assert_eq!(index, connection_index);

--- a/crates/ty_server/src/server/main_loop.rs
+++ b/crates/ty_server/src/server/main_loop.rs
@@ -248,7 +248,9 @@ impl std::fmt::Debug for SendRequest {
 struct UvSyncWakeups(Vec<(SystemPathBuf, crossbeam::channel::Receiver<()>)>);
 
 impl UvSyncWakeups {
-    /// Waits for a project wakeup, client message, or main-loop action.
+    /// Waits for a project wakeup, main-loop action, or client message, in that order.
+    /// If incoming requests keep winning, the main loop can block submitting jobs while
+    /// workers block sending responses to its bounded action channel.
     fn select(
         &self,
         connection: &crossbeam::channel::Receiver<Message>,
@@ -258,8 +260,8 @@ impl UvSyncWakeups {
         for (_, receiver) in &self.0 {
             select.recv(receiver);
         }
-        let connection_index = select.recv(connection);
         let main_loop_index = select.recv(main_loop);
+        let connection_index = select.recv(connection);
         let operation = select.select();
         let index = operation.index();
 
@@ -271,12 +273,12 @@ impl UvSyncWakeups {
             });
         }
 
-        if index == connection_index {
-            // Ignore disconnect errors, they're handled by the main loop (it will exit).
-            return Ok(operation.recv(connection).ok().map(Event::Message));
+        if index == main_loop_index {
+            return operation.recv(main_loop).map(Some);
         }
 
-        debug_assert_eq!(index, main_loop_index);
-        operation.recv(main_loop).map(Some)
+        debug_assert_eq!(index, connection_index);
+        // Ignore disconnect errors, they're handled by the main loop (it will exit).
+        Ok(operation.recv(connection).ok().map(Event::Message))
     }
 }

--- a/crates/ty_server/tests/e2e/inlay_hints.rs
+++ b/crates/ty_server/tests/e2e/inlay_hints.rs
@@ -1,10 +1,14 @@
+use std::fmt::Write;
+
 use anyhow::Result;
 use lsp_types::DidOpenTextDocumentNotification;
+use lsp_types::HoverRequest;
 use lsp_types::InlayHintRequest;
 use lsp_types::LanguageKind;
 use lsp_types::{
-    DidOpenTextDocumentParams, InlayHintParams, Position, Range, TextDocumentIdentifier,
-    TextDocumentItem, Uri, WorkDoneProgressParams,
+    DidOpenTextDocumentParams, HoverParams, InlayHintParams, Position, Range,
+    TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Uri,
+    WorkDoneProgressParams,
 };
 use ruff_db::system::SystemPath;
 use ty_server::ClientOptions;
@@ -303,6 +307,74 @@ def get_a() -> A:
       }
     ]
     "#);
+
+    Ok(())
+}
+
+/// A burst of inlay-hint requests must not prevent completed requests or a later hover
+/// from receiving responses.
+#[test]
+fn inlay_hint_burst_does_not_block_responses() -> Result<()> {
+    const REQUEST_COUNT: u32 = 103;
+    const LINES_PER_REQUEST: u32 = 30;
+    const FIRST_ASSIGNMENT_LINE: u32 = 3;
+
+    let workspace_root = SystemPath::new("src");
+    let file = SystemPath::new("src/values.py");
+    let mut content = String::from("def identity(value: int) -> int:\n    return value\n\n");
+    for line in 0..REQUEST_COUNT * LINES_PER_REQUEST {
+        writeln!(content, "value_{line} = identity({line})")?;
+    }
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(file, &content)?
+        .enable_inlay_hints(true)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(file, &content, 1);
+    let first_range = Range::new(
+        Position::new(FIRST_ASSIGNMENT_LINE, 0),
+        Position::new(FIRST_ASSIGNMENT_LINE + LINES_PER_REQUEST, 0),
+    );
+    assert!(
+        server
+            .inlay_hints_request(file, first_range)
+            .is_some_and(|hints| !hints.is_empty())
+    );
+
+    // Queue the full burst before reading any responses so incoming messages and
+    // completed worker actions compete in the main loop.
+    let uri = server.file_uri(file);
+    let mut request_ids = Vec::with_capacity(REQUEST_COUNT as usize);
+    for index in 0..REQUEST_COUNT {
+        let start = FIRST_ASSIGNMENT_LINE + index * LINES_PER_REQUEST;
+        request_ids.push(server.send_request::<InlayHintRequest>(InlayHintParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            range: Range::new(
+                Position::new(start, 0),
+                Position::new(start + LINES_PER_REQUEST, 0),
+            ),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        }));
+    }
+    let hover_id = server.send_request::<HoverRequest>(HoverParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position::new(FIRST_ASSIGNMENT_LINE, 2),
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    });
+
+    for id in request_ids {
+        assert!(
+            server
+                .await_response::<InlayHintRequest>(&id)
+                .is_some_and(|hints| !hints.is_empty())
+        );
+    }
+    assert!(server.await_response::<HoverRequest>(&hover_id).is_some());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

This fixes a dead lock in the server. My script's PR changed the main loop to use a biased select over a randomized `select`. The priority was:

* Completed uv syncs
* incoming requests
* completed actions

The dead lock was caused by new incoming requests trying to send a response. Sending a response writes to the "completed actions" queue, which is bounded at 32 messages. That means, the request handlers block on submitting the response, but the main loop keeps preferring incoming requests over the completed actions (which would make room for new responses, unblocking the request handlers). This ends in a dead lock once all request threads are used, because the main loop blocks on submitting the next request handler work (and the request handlers block on the main loop sending a response).


This PR changes the priority to:

* completed actions (send results as fast as we can)
* completed uv syncs (because they change the result of incoming requests)
* incoming requests (applies some form of back pressure)

Fixes astral-sh/ty#4471.

## Test Plan

Added an E2E test
