### PR TITLE
Fix `line-length` path in `--config` example

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -45,7 +45,7 @@ pub struct GlobalConfigArgs {
     /// or a TOML `<KEY> = <VALUE>` pair
     /// (such as you might find in a `ruff.toml` configuration file)
     /// overriding a specific configuration option
-    /// (e.g., `--config "lint.line-length = 100"` or `--config "format.quote-style = 'single'"`).
+    /// (e.g., `--config "line-length = 100"` or `--config "format.quote-style = 'single'"`).
     /// Overrides of individual settings using this option always take precedence
     /// over all configuration files, including configuration files that were also
     /// specified using `--config`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -568,7 +568,7 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option (e.g., `--config "lint.line-length = 100"` or
+          configuration option (e.g., `--config "line-length = 100"` or
           `--config "format.quote-style = 'single'"`). Overrides of individual
           settings using this option always take precedence over all
           configuration files, including configuration files that were also
@@ -715,7 +715,7 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option (e.g., `--config "lint.line-length = 100"` or
+          configuration option (e.g., `--config "line-length = 100"` or
           `--config "format.quote-style = 'single'"`). Overrides of individual
           settings using this option always take precedence over all
           configuration files, including configuration files that were also
@@ -814,7 +814,7 @@ Global options:
           Either a path to a TOML configuration file (`pyproject.toml` or
           `ruff.toml`), or a TOML `<KEY> = <VALUE>` pair (such as you might
           find in a `ruff.toml` configuration file) overriding a specific
-          configuration option (e.g., `--config "lint.line-length = 100"` or
+          configuration option (e.g., `--config "line-length = 100"` or
           `--config "format.quote-style = 'single'"`). Overrides of individual
           settings using this option always take precedence over all
           configuration files, including configuration files that were also


### PR DESCRIPTION
line-length is a global option, not under `lint.`

This was introduced in #25013, after which #25389 attempted to fix it. However, that change was made in autogenerated docs only (instead of fixing it at the source), and thus the fix was undone again in #25396.

This instead fixes the issue in the source code, followed by a `cargo dev generate-all`.