### PR TITLE
[pyupgrade] Mark runtime-sensitive UP035 fixes as unsafe

### DIFF
--- a/crates/ruff/tests/integration_test.rs
+++ b/crates/ruff/tests/integration_test.rs
@@ -1225,7 +1225,7 @@ fn show_statistics_json_partial_fix() {
         "name": "deprecated-import",
         "count": 2,
         "fixable": false,
-        "fixable_count": 1
+        "fixable_count": 0
       }
     ]
 
@@ -1243,9 +1243,9 @@ fn show_statistics_partial_fix() {
     success: false
     exit_code: 1
     ----- stdout -----
-    2	UP035	[-] deprecated-import
+    2	UP035	deprecated-import
     Found 2 errors.
-    [*] 1 fixable with the `--fix` option.
+    No fixes available (1 hidden fix can be enabled with the `--unsafe-fixes` option).
 
     ----- stderr -----
     ");

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -163,19 +163,19 @@ class RuntimeClass:
 
 
 def typing_only_local():
-    from typing import Sequence as LocalTypingOnlySequence
-
     if TYPE_CHECKING:
+        from typing import Sequence as LocalTypingOnlySequence
+
         local_typing_only_value: LocalTypingOnlySequence
 
 
-def typing_only_local_with_locals():
-    from typing import Sequence as LocalWithLocalsSequence
+def typing_only_local_with_vars():
+    from typing import Sequence as LocalWithVarsSequence
 
     if TYPE_CHECKING:
-        local_with_locals_value: LocalWithLocalsSequence
+        local_with_vars_value: LocalWithVarsSequence
 
-    locals()
+    vars()
 
 
 from typing import Sequence as ShadowedSequence

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -132,3 +132,31 @@ from typing.re import Match
 
 # UP035 on py37+ only
 from typing.re import Pattern
+
+
+# Runtime-sensitive UP035 applicability
+
+from typing import TYPE_CHECKING
+
+from typing import Sequence as TypingOnlySequence
+
+if TYPE_CHECKING:
+    typing_only_value: TypingOnlySequence
+
+from typing import Sequence as RuntimeSequence
+
+runtime_value = RuntimeSequence
+
+from typing import Sequence as RuntimeAnnotationSequence
+
+def runtime_annotation(value: RuntimeAnnotationSequence) -> None:
+    pass
+
+from typing import Sequence as ReexportSequence
+
+__all__ = ["ReexportSequence"]
+
+class RuntimeClass:
+    from typing import Sequence as ClassSequence
+
+    value = ClassSequence

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -160,3 +160,34 @@ class RuntimeClass:
     from typing import Sequence as ClassSequence
 
     value = ClassSequence
+
+
+def typing_only_local():
+    from typing import Sequence as LocalTypingOnlySequence
+
+    if TYPE_CHECKING:
+        local_typing_only_value: LocalTypingOnlySequence
+
+
+def typing_only_local_with_locals():
+    from typing import Sequence as LocalWithLocalsSequence
+
+    if TYPE_CHECKING:
+        local_with_locals_value: LocalWithLocalsSequence
+
+    locals()
+
+
+from typing import Sequence as ShadowedSequence
+
+shadowed_runtime_value = ShadowedSequence
+ShadowedSequence = list
+
+
+from typing import Callable as ShadowedCallable, Sequence as MultiTypingOnlySequence
+
+shadowed_callable_runtime = ShadowedCallable
+ShadowedCallable = object
+
+if TYPE_CHECKING:
+    multi_typing_only_value: MultiTypingOnlySequence

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -14,6 +14,7 @@ pub(crate) fn deferred_scopes(checker: &Checker) {
         Rule::AsyncioDanglingTask,
         Rule::BadStaticmethodArgument,
         Rule::BuiltinAttributeShadowing,
+        Rule::DeprecatedImport,
         Rule::FunctionCallInDataclassDefaultArgument,
         Rule::GlobalVariableNotAssigned,
         Rule::ImportPrivateName,
@@ -86,6 +87,10 @@ pub(crate) fn deferred_scopes(checker: &Checker) {
 
     for scope_id in checker.analyze.scopes.iter().rev().copied() {
         let scope = &checker.semantic.scopes[scope_id];
+
+        if checker.is_rule_enabled(Rule::DeprecatedImport) {
+            pyupgrade::rules::deprecated_import_runtime_sensitive(checker, scope);
+        }
 
         if checker.is_rule_enabled(Rule::UndefinedLocal) {
             pyflakes::rules::undefined_local(checker, scope_id, scope);

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -3,8 +3,9 @@ use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::whitespace::indentation;
-use ruff_python_ast::{Alias, StmtImportFrom, StmtRef};
+use ruff_python_ast::{self as ast, Alias, StmtImportFrom, StmtRef};
 use ruff_python_codegen::Stylist;
+use ruff_python_semantic::{AnyImport, Imported, NodeId, Scope};
 use ruff_text_size::Ranged;
 
 use crate::Locator;
@@ -12,7 +13,7 @@ use crate::checkers::ast::Checker;
 use crate::codes::Category;
 use crate::rules::pyupgrade::fixes;
 use crate::rules::pyupgrade::rules::unnecessary_future_import::is_import_required_by_isort;
-use crate::{Edit, Fix, FixAvailability, Violation};
+use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 use ruff_python_ast::PythonVersion;
 
 use super::RequiredImports;
@@ -48,6 +49,13 @@ enum Deprecation {
 /// ## Why is this bad?
 /// Deprecated imports may be removed in future versions of Python, and
 /// should be replaced with their new equivalents.
+///
+/// ## Fix safety
+/// Fixes that replace deprecated aliases from `typing` or `typing.re` with
+/// runtime implementations can change the value of the imported object.
+/// Ruff marks these fixes as safe only when the affected import has at least
+/// one reference, every reference is in a typing-only context, and the import
+/// is not re-exported. Otherwise, the fix is marked unsafe.
 ///
 /// Note that, in some cases, it may be preferable to continue importing
 /// members from `typing_extensions` even after they're added to the Python
@@ -113,6 +121,13 @@ fn is_relevant_module(module: &str) -> bool {
             | "typing.io"
             | "typing.re"
             | "backports.strenum"
+    )
+}
+
+fn is_runtime_sensitive_migration(module: &str, target: &str) -> bool {
+    matches!(
+        (module, target),
+        ("typing", "collections.abc" | "collections" | "re") | ("typing.re", "re")
     )
 }
 
@@ -739,12 +754,123 @@ impl<'a> ImportReplacer<'a> {
     }
 }
 
+fn runtime_sensitive_applicability(
+    checker: &Checker,
+    scope: &Scope,
+    node_id: NodeId,
+    operation: &WithoutRename,
+) -> Applicability {
+    let mut matched_binding = false;
+
+    for binding_id in scope.binding_ids() {
+        let binding = checker.semantic().binding(binding_id);
+
+        if binding.source != Some(node_id) {
+            continue;
+        }
+
+        let Some(AnyImport::FromImport(import)) = binding.as_any_import() else {
+            continue;
+        };
+
+        if !operation
+            .members
+            .iter()
+            .any(|member| member == import.member_name().as_ref())
+        {
+            continue;
+        }
+
+        matched_binding = true;
+
+        if binding.is_explicit_export() {
+            return Applicability::Unsafe;
+        }
+
+        let mut references = binding.references().peekable();
+
+        if references.peek().is_none() {
+            return Applicability::Unsafe;
+        }
+
+        if references.any(|reference_id| {
+            let reference = checker.semantic().reference(reference_id);
+
+            reference.in_dunder_all_definition() || !reference.in_typing_context()
+        }) {
+            return Applicability::Unsafe;
+        }
+    }
+
+    if matched_binding {
+        Applicability::Safe
+    } else {
+        Applicability::Unsafe
+    }
+}
+
 /// UP035
 pub(crate) fn deprecated_import(checker: &Checker, import_from_stmt: &StmtImportFrom) {
+    report_deprecated_import(
+        checker,
+        import_from_stmt,
+        |module, operation| !is_runtime_sensitive_migration(module, &operation.target),
+        |_| Applicability::Safe,
+        true,
+    );
+}
+
+/// Report runtime-sensitive UP035 fixes after semantic traversal.
+pub(crate) fn deprecated_import_runtime_sensitive(checker: &Checker, scope: &Scope) {
+    let mut statements = scope
+        .binding_ids()
+        .filter_map(|binding_id| {
+            let binding = checker.semantic().binding(binding_id);
+
+            let AnyImport::FromImport(import) = binding.as_any_import()? else {
+                return None;
+            };
+
+            let module = import.source_name().join(".");
+
+            if !matches!(module.as_str(), "typing" | "typing.re") {
+                return None;
+            }
+
+            binding.source
+        })
+        .unique()
+        .collect_vec();
+
+    statements.sort_unstable_by_key(|node_id| checker.semantic().statement(*node_id).start());
+
+    for node_id in statements {
+        let ast::Stmt::ImportFrom(import_from_stmt) = checker.semantic().statement(node_id) else {
+            continue;
+        };
+
+        report_deprecated_import(
+            checker,
+            import_from_stmt,
+            |module, operation| is_runtime_sensitive_migration(module, &operation.target),
+            |operation| runtime_sensitive_applicability(checker, scope, node_id, operation),
+            false,
+        );
+    }
+}
+
+fn report_deprecated_import(
+    checker: &Checker,
+    import_from_stmt: &StmtImportFrom,
+    operation_filter: impl Fn(&str, &WithoutRename) -> bool,
+    applicability: impl Fn(&WithoutRename) -> Applicability,
+    report_renames: bool,
+) {
     // Avoid relative and star imports.
     if import_from_stmt.level > 0 {
         return;
     }
+
     if import_from_stmt
         .names
         .first()
@@ -752,6 +878,7 @@ pub(crate) fn deprecated_import(checker: &Checker, import_from_stmt: &StmtImport
     {
         return;
     }
+
     let Some(module) = import_from_stmt.module.as_deref() else {
         return;
     };
@@ -771,28 +898,39 @@ pub(crate) fn deprecated_import(checker: &Checker, import_from_stmt: &StmtImport
     );
 
     for (operation, fix) in fixer.without_renames() {
+        if !operation_filter(module, &operation) {
+            continue;
+        }
+
+        let fix_applicability = applicability(&operation);
+
         let mut diagnostic = checker.report_diagnostic(
             DeprecatedImport {
                 deprecation: Deprecation::WithoutRename(operation),
             },
             import_from_stmt.range(),
         );
+
         diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+
         if let Some(content) = fix {
-            diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-                content,
-                import_from_stmt.range(),
-            )));
+            diagnostic.set_fix(Fix::applicable_edit(
+                Edit::range_replacement(content, import_from_stmt.range()),
+                fix_applicability,
+            ));
         }
     }
 
-    for operation in fixer.with_renames() {
-        let mut diagnostic = checker.report_diagnostic(
-            DeprecatedImport {
-                deprecation: Deprecation::WithRename(operation),
-            },
-            import_from_stmt.range(),
-        );
-        diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+    if report_renames {
+        for operation in fixer.with_renames() {
+            let mut diagnostic = checker.report_diagnostic(
+                DeprecatedImport {
+                    deprecation: Deprecation::WithRename(operation),
+                },
+                import_from_stmt.range(),
+            );
+
+            diagnostic.add_primary_tag(ruff_db::diagnostic::DiagnosticTag::Deprecated);
+        }
     }
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -53,7 +53,8 @@ enum Deprecation {
 /// ## Fix safety
 /// Fixes that replace deprecated aliases from `typing` or `typing.re` with
 /// runtime implementations can change the value of the imported object.
-/// Ruff marks these fixes as safe only when the affected import has at least
+/// Ruff marks these fixes as safe only for function-local imports when the
+/// function does not inspect its locals, every affected binding has at least
 /// one reference, every reference is in a typing-only context, and the import
 /// is not re-exported. Otherwise, the fix is marked unsafe.
 ///
@@ -760,9 +761,13 @@ fn runtime_sensitive_applicability(
     node_id: NodeId,
     operation: &WithoutRename,
 ) -> Applicability {
+    if !scope.kind.is_function() || scope.uses_locals() {
+        return Applicability::Unsafe;
+    }
+
     let mut matched_binding = false;
 
-    for binding_id in scope.binding_ids() {
+    for (_, binding_id) in scope.all_bindings() {
         let binding = checker.semantic().binding(binding_id);
 
         if binding.source != Some(node_id) {
@@ -823,8 +828,8 @@ pub(crate) fn deprecated_import(checker: &Checker, import_from_stmt: &StmtImport
 /// Report runtime-sensitive UP035 fixes after semantic traversal.
 pub(crate) fn deprecated_import_runtime_sensitive(checker: &Checker, scope: &Scope) {
     let mut statements = scope
-        .binding_ids()
-        .filter_map(|binding_id| {
+        .all_bindings()
+        .filter_map(|(_, binding_id)| {
             let binding = checker.semantic().binding(binding_id);
 
             let AnyImport::FromImport(import) = binding.as_any_import()? else {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -1,11 +1,12 @@
 use itertools::Itertools;
+use rustc_hash::FxHashMap;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::whitespace::indentation;
 use ruff_python_ast::{self as ast, Alias, StmtImportFrom, StmtRef};
 use ruff_python_codegen::Stylist;
-use ruff_python_semantic::{AnyImport, Imported, NodeId, Scope};
+use ruff_python_semantic::{AnyImport, BindingId, Imported, NodeId, Scope};
 use ruff_text_size::Ranged;
 
 use crate::Locator;
@@ -53,10 +54,10 @@ enum Deprecation {
 /// ## Fix safety
 /// Fixes that replace deprecated aliases from `typing` or `typing.re` with
 /// runtime implementations can change the value of the imported object.
-/// Ruff marks these fixes as safe only for function-local imports when the
-/// function does not inspect its locals, every affected binding has at least
-/// one reference, every reference is in a typing-only context, and the import
-/// is not re-exported. Otherwise, the fix is marked unsafe.
+/// Ruff marks these fixes as safe only when every affected import binding is
+/// itself in a typing-only context, has at least one reference, every reference
+/// is in a typing-only context, and the import is not re-exported. Otherwise,
+/// the fix is marked unsafe.
 ///
 /// Note that, in some cases, it may be preferable to continue importing
 /// members from `typing_extensions` even after they're added to the Python
@@ -757,22 +758,13 @@ impl<'a> ImportReplacer<'a> {
 
 fn runtime_sensitive_applicability(
     checker: &Checker,
-    scope: &Scope,
-    node_id: NodeId,
+    binding_ids: &[BindingId],
     operation: &WithoutRename,
 ) -> Applicability {
-    if !scope.kind.is_function() || scope.uses_locals() {
-        return Applicability::Unsafe;
-    }
-
     let mut matched_binding = false;
 
-    for (_, binding_id) in scope.all_bindings() {
+    for &binding_id in binding_ids {
         let binding = checker.semantic().binding(binding_id);
-
-        if binding.source != Some(node_id) {
-            continue;
-        }
 
         let Some(AnyImport::FromImport(import)) = binding.as_any_import() else {
             continue;
@@ -788,7 +780,9 @@ fn runtime_sensitive_applicability(
 
         matched_binding = true;
 
-        if binding.is_explicit_export() {
+        // A runtime import remains observable through namespace inspection,
+        // even when all ordinary references are typing-only.
+        if !binding.context.is_typing() || binding.is_explicit_export() {
             return Applicability::Unsafe;
         }
 
@@ -827,25 +821,32 @@ pub(crate) fn deprecated_import(checker: &Checker, import_from_stmt: &StmtImport
 
 /// Report runtime-sensitive UP035 fixes after semantic traversal.
 pub(crate) fn deprecated_import_runtime_sensitive(checker: &Checker, scope: &Scope) {
-    let mut statements = scope
-        .all_bindings()
-        .filter_map(|(_, binding_id)| {
-            let binding = checker.semantic().binding(binding_id);
+    let mut bindings_by_statement: FxHashMap<NodeId, Vec<BindingId>> = FxHashMap::default();
 
-            let AnyImport::FromImport(import) = binding.as_any_import()? else {
-                return None;
-            };
+    for (_, binding_id) in scope.all_bindings() {
+        let binding = checker.semantic().binding(binding_id);
 
-            let module = import.source_name().join(".");
+        let Some(AnyImport::FromImport(import)) = binding.as_any_import() else {
+            continue;
+        };
 
-            if !matches!(module.as_str(), "typing" | "typing.re") {
-                return None;
-            }
+        let module = import.source_name().join(".");
 
-            binding.source
-        })
-        .unique()
-        .collect_vec();
+        if !matches!(module.as_str(), "typing" | "typing.re") {
+            continue;
+        }
+
+        let Some(node_id) = binding.source else {
+            continue;
+        };
+
+        bindings_by_statement
+            .entry(node_id)
+            .or_default()
+            .push(binding_id);
+    }
+
+    let mut statements = bindings_by_statement.keys().copied().collect_vec();
 
     statements.sort_unstable_by_key(|node_id| checker.semantic().statement(*node_id).start());
 
@@ -854,11 +855,15 @@ pub(crate) fn deprecated_import_runtime_sensitive(checker: &Checker, scope: &Sco
             continue;
         };
 
+        let binding_ids = bindings_by_statement
+            .get(&node_id)
+            .expect("statement was collected from this map");
+
         report_deprecated_import(
             checker,
             import_from_stmt,
             |module, operation| is_runtime_sensitive_migration(module, &operation.target),
-            |operation| runtime_sensitive_applicability(checker, scope, node_id, operation),
+            |operation| runtime_sensitive_applicability(checker, binding_ids, operation),
             false,
         );
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -1264,36 +1264,37 @@ help: Import from `collections.abc`
 note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Sequence`
-   --> UP035.py:166:5
+   --> UP035.py:167:9
     |
 165 | def typing_only_local():
-166 |     from typing import Sequence as LocalTypingOnlySequence
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-167 |
-168 |     if TYPE_CHECKING:
+166 |     if TYPE_CHECKING:
+167 |         from typing import Sequence as LocalTypingOnlySequence
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+168 |
+169 |         local_typing_only_value: LocalTypingOnlySequence
     |
 help: Import from `collections.abc`
     |
-165 | def typing_only_local():
-    -     from typing import Sequence as LocalTypingOnlySequence
-166 +     from collections.abc import Sequence as LocalTypingOnlySequence
-167 |
+166 |     if TYPE_CHECKING:
+    -         from typing import Sequence as LocalTypingOnlySequence
+167 +         from collections.abc import Sequence as LocalTypingOnlySequence
+168 |
     |
 
 UP035 [*] Import from `collections.abc` instead: `Sequence`
    --> UP035.py:173:5
     |
-172 | def typing_only_local_with_locals():
-173 |     from typing import Sequence as LocalWithLocalsSequence
-    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+172 | def typing_only_local_with_vars():
+173 |     from typing import Sequence as LocalWithVarsSequence
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 174 |
 175 |     if TYPE_CHECKING:
     |
 help: Import from `collections.abc`
     |
-172 | def typing_only_local_with_locals():
-    -     from typing import Sequence as LocalWithLocalsSequence
-173 +     from collections.abc import Sequence as LocalWithLocalsSequence
+172 | def typing_only_local_with_vars():
+    -     from typing import Sequence as LocalWithVarsSequence
+173 +     from collections.abc import Sequence as LocalWithVarsSequence
 174 |
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -387,6 +387,25 @@ UP035 `typing.ContextManager` is deprecated, use `contextlib.AbstractContextMana
 52 | from typing_extensions import OrderedDict
    |
 
+UP035 [*] Import from `collections` instead: `OrderedDict`
+  --> UP035.py:51:1
+   |
+49 | # Bad imports from PYI027 that are now handled by PYI022 (UP035)
+50 | from typing import ContextManager
+51 | from typing import OrderedDict
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+52 | from typing_extensions import OrderedDict
+53 | from typing import Callable
+   |
+help: Import from `collections`
+   |
+50 | from typing import ContextManager
+   - from typing import OrderedDict
+51 + from collections import OrderedDict
+52 | from typing_extensions import OrderedDict
+   |
+note: This is an unsafe fix and may change runtime behavior
+
 UP035 [*] Import from `typing` instead: `OrderedDict`
   --> UP035.py:52:1
    |
@@ -404,6 +423,25 @@ help: Import from `typing`
 52 + from typing import OrderedDict
 53 | from typing import Callable
    |
+
+UP035 [*] Import from `collections.abc` instead: `Callable`
+  --> UP035.py:53:1
+   |
+51 | from typing import OrderedDict
+52 | from typing_extensions import OrderedDict
+53 | from typing import Callable
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+54 | from typing import ByteString
+55 | from typing import Container
+   |
+help: Import from `collections.abc`
+   |
+52 | from typing_extensions import OrderedDict
+   - from typing import Callable
+53 + from collections.abc import Callable
+54 | from typing import ByteString
+   |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `ByteString`
   --> UP035.py:54:1
@@ -1148,6 +1186,7 @@ help: Import from `collections.abc`
 141 + from collections.abc import Sequence as TypingOnlySequence
 142 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Sequence`
    --> UP035.py:146:1
@@ -1185,6 +1224,7 @@ help: Import from `collections.abc`
 150 + from collections.abc import Sequence as RuntimeAnnotationSequence
 151 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Sequence`
    --> UP035.py:155:1
@@ -1220,5 +1260,74 @@ help: Import from `collections.abc`
     -     from typing import Sequence as ClassSequence
 160 +     from collections.abc import Sequence as ClassSequence
 161 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:166:5
+    |
+165 | def typing_only_local():
+166 |     from typing import Sequence as LocalTypingOnlySequence
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+167 |
+168 |     if TYPE_CHECKING:
+    |
+help: Import from `collections.abc`
+    |
+165 | def typing_only_local():
+    -     from typing import Sequence as LocalTypingOnlySequence
+166 +     from collections.abc import Sequence as LocalTypingOnlySequence
+167 |
+    |
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:173:5
+    |
+172 | def typing_only_local_with_locals():
+173 |     from typing import Sequence as LocalWithLocalsSequence
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+174 |
+175 |     if TYPE_CHECKING:
+    |
+help: Import from `collections.abc`
+    |
+172 | def typing_only_local_with_locals():
+    -     from typing import Sequence as LocalWithLocalsSequence
+173 +     from collections.abc import Sequence as LocalWithLocalsSequence
+174 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:181:1
+    |
+181 | from typing import Sequence as ShadowedSequence
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+182 |
+183 | shadowed_runtime_value = ShadowedSequence
+    |
+help: Import from `collections.abc`
+    |
+180 |
+    - from typing import Sequence as ShadowedSequence
+181 + from collections.abc import Sequence as ShadowedSequence
+182 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `collections.abc` instead: `Callable`, `Sequence`
+   --> UP035.py:187:1
+    |
+187 | from typing import Callable as ShadowedCallable, Sequence as MultiTypingOnlySequence
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+188 |
+189 | shadowed_callable_runtime = ShadowedCallable
+    |
+help: Import from `collections.abc`
+    |
+186 |
+    - from typing import Callable as ShadowedCallable, Sequence as MultiTypingOnlySequence
+187 + from collections.abc import Callable as ShadowedCallable, Sequence as MultiTypingOnlySequence
+188 |
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -270,63 +270,6 @@ help: Import from `collections.abc`
 42 |
    |
 
-UP035 [*] Import from `collections.abc` instead: `Callable`
-  --> UP035.py:44:1
-   |
-42 |     )
-43 |
-44 | from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-45 |
-46 | if True: from collections import (
-   |
-help: Import from `collections.abc`
-   |
-43 |
-   - from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
-44 + from typing import Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
-45 + from collections.abc import Callable
-46 |
-   |
-
-UP035 [*] Import from `collections` instead: `OrderedDict`
-  --> UP035.py:44:1
-   |
-42 |     )
-43 |
-44 | from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-45 |
-46 | if True: from collections import (
-   |
-help: Import from `collections`
-   |
-43 |
-   - from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
-44 + from typing import Callable, Match, Pattern, List, AbstractSet, ContextManager
-45 + from collections import OrderedDict
-46 |
-   |
-
-UP035 [*] Import from `re` instead: `Match`, `Pattern`
-  --> UP035.py:44:1
-   |
-42 |     )
-43 |
-44 | from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-45 |
-46 | if True: from collections import (
-   |
-help: Import from `re`
-   |
-43 |
-   - from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
-44 + from typing import Callable, List, OrderedDict, AbstractSet, ContextManager
-45 + from re import Match, Pattern
-46 |
-   |
-
 UP035 `typing.List` is deprecated, use `list` instead
   --> UP035.py:44:1
    |
@@ -360,6 +303,66 @@ UP035 `typing.ContextManager` is deprecated, use `contextlib.AbstractContextMana
 46 | if True: from collections import (
    |
 
+UP035 [*] Import from `collections.abc` instead: `Callable`
+  --> UP035.py:44:1
+   |
+42 |     )
+43 |
+44 | from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+45 |
+46 | if True: from collections import (
+   |
+help: Import from `collections.abc`
+   |
+43 |
+   - from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
+44 + from typing import Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
+45 + from collections.abc import Callable
+46 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `collections` instead: `OrderedDict`
+  --> UP035.py:44:1
+   |
+42 |     )
+43 |
+44 | from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+45 |
+46 | if True: from collections import (
+   |
+help: Import from `collections`
+   |
+43 |
+   - from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
+44 + from typing import Callable, Match, Pattern, List, AbstractSet, ContextManager
+45 + from collections import OrderedDict
+46 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `re` instead: `Match`, `Pattern`
+  --> UP035.py:44:1
+   |
+42 |     )
+43 |
+44 | from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+45 |
+46 | if True: from collections import (
+   |
+help: Import from `re`
+   |
+43 |
+   - from typing import Callable, Match, Pattern, List, OrderedDict, AbstractSet, ContextManager
+44 + from typing import Callable, List, OrderedDict, AbstractSet, ContextManager
+45 + from re import Match, Pattern
+46 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
 UP035 Import from `collections.abc` instead: `Mapping`
   --> UP035.py:46:10
    |
@@ -384,24 +387,6 @@ UP035 `typing.ContextManager` is deprecated, use `contextlib.AbstractContextMana
 52 | from typing_extensions import OrderedDict
    |
 
-UP035 [*] Import from `collections` instead: `OrderedDict`
-  --> UP035.py:51:1
-   |
-49 | # Bad imports from PYI027 that are now handled by PYI022 (UP035)
-50 | from typing import ContextManager
-51 | from typing import OrderedDict
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-52 | from typing_extensions import OrderedDict
-53 | from typing import Callable
-   |
-help: Import from `collections`
-   |
-50 | from typing import ContextManager
-   - from typing import OrderedDict
-51 + from collections import OrderedDict
-52 | from typing_extensions import OrderedDict
-   |
-
 UP035 [*] Import from `typing` instead: `OrderedDict`
   --> UP035.py:52:1
    |
@@ -418,24 +403,6 @@ help: Import from `typing`
    - from typing_extensions import OrderedDict
 52 + from typing import OrderedDict
 53 | from typing import Callable
-   |
-
-UP035 [*] Import from `collections.abc` instead: `Callable`
-  --> UP035.py:53:1
-   |
-51 | from typing import OrderedDict
-52 | from typing_extensions import OrderedDict
-53 | from typing import Callable
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-54 | from typing import ByteString
-55 | from typing import Container
-   |
-help: Import from `collections.abc`
-   |
-52 | from typing_extensions import OrderedDict
-   - from typing import Callable
-53 + from collections.abc import Callable
-54 | from typing import ByteString
    |
 
 UP035 [*] Import from `collections.abc` instead: `ByteString`
@@ -455,6 +422,7 @@ help: Import from `collections.abc`
 54 + from collections.abc import ByteString
 55 | from typing import Container
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Container`
   --> UP035.py:55:1
@@ -473,6 +441,7 @@ help: Import from `collections.abc`
 55 + from collections.abc import Container
 56 | from typing import Hashable
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Hashable`
   --> UP035.py:56:1
@@ -491,6 +460,7 @@ help: Import from `collections.abc`
 56 + from collections.abc import Hashable
 57 | from typing import ItemsView
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `ItemsView`
   --> UP035.py:57:1
@@ -509,6 +479,7 @@ help: Import from `collections.abc`
 57 + from collections.abc import ItemsView
 58 | from typing import Iterable
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Iterable`
   --> UP035.py:58:1
@@ -527,6 +498,7 @@ help: Import from `collections.abc`
 58 + from collections.abc import Iterable
 59 | from typing import Iterator
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Iterator`
   --> UP035.py:59:1
@@ -545,6 +517,7 @@ help: Import from `collections.abc`
 59 + from collections.abc import Iterator
 60 | from typing import KeysView
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `KeysView`
   --> UP035.py:60:1
@@ -563,6 +536,7 @@ help: Import from `collections.abc`
 60 + from collections.abc import KeysView
 61 | from typing import Mapping
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Mapping`
   --> UP035.py:61:1
@@ -581,6 +555,7 @@ help: Import from `collections.abc`
 61 + from collections.abc import Mapping
 62 | from typing import MappingView
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `MappingView`
   --> UP035.py:62:1
@@ -599,6 +574,7 @@ help: Import from `collections.abc`
 62 + from collections.abc import MappingView
 63 | from typing import MutableMapping
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `MutableMapping`
   --> UP035.py:63:1
@@ -617,6 +593,7 @@ help: Import from `collections.abc`
 63 + from collections.abc import MutableMapping
 64 | from typing import MutableSequence
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `MutableSequence`
   --> UP035.py:64:1
@@ -635,6 +612,7 @@ help: Import from `collections.abc`
 64 + from collections.abc import MutableSequence
 65 | from typing import MutableSet
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `MutableSet`
   --> UP035.py:65:1
@@ -653,6 +631,7 @@ help: Import from `collections.abc`
 65 + from collections.abc import MutableSet
 66 | from typing import Sequence
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Sequence`
   --> UP035.py:66:1
@@ -671,6 +650,7 @@ help: Import from `collections.abc`
 66 + from collections.abc import Sequence
 67 | from typing import Sized
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Sized`
   --> UP035.py:67:1
@@ -689,6 +669,7 @@ help: Import from `collections.abc`
 67 + from collections.abc import Sized
 68 | from typing import ValuesView
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `ValuesView`
   --> UP035.py:68:1
@@ -707,6 +688,7 @@ help: Import from `collections.abc`
 68 + from collections.abc import ValuesView
 69 | from typing import Awaitable
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Awaitable`
   --> UP035.py:69:1
@@ -725,6 +707,7 @@ help: Import from `collections.abc`
 69 + from collections.abc import Awaitable
 70 | from typing import AsyncIterator
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `AsyncIterator`
   --> UP035.py:70:1
@@ -743,6 +726,7 @@ help: Import from `collections.abc`
 70 + from collections.abc import AsyncIterator
 71 | from typing import AsyncIterable
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `AsyncIterable`
   --> UP035.py:71:1
@@ -761,6 +745,7 @@ help: Import from `collections.abc`
 71 + from collections.abc import AsyncIterable
 72 | from typing import Coroutine
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Coroutine`
   --> UP035.py:72:1
@@ -779,6 +764,7 @@ help: Import from `collections.abc`
 72 + from collections.abc import Coroutine
 73 | from typing import Collection
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Collection`
   --> UP035.py:73:1
@@ -797,6 +783,7 @@ help: Import from `collections.abc`
 73 + from collections.abc import Collection
 74 | from typing import AsyncGenerator
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `AsyncGenerator`
   --> UP035.py:74:1
@@ -815,6 +802,7 @@ help: Import from `collections.abc`
 74 + from collections.abc import AsyncGenerator
 75 | from typing import Reversible
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Reversible`
   --> UP035.py:75:1
@@ -833,6 +821,7 @@ help: Import from `collections.abc`
 75 + from collections.abc import Reversible
 76 | from typing import Generator
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Generator`
   --> UP035.py:76:1
@@ -851,6 +840,7 @@ help: Import from `collections.abc`
 76 + from collections.abc import Generator
 77 | from typing import Callable
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `collections.abc` instead: `Callable`
   --> UP035.py:77:1
@@ -868,6 +858,7 @@ help: Import from `collections.abc`
 77 + from collections.abc import Callable
 78 | from typing import cast
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `typing` instead: `SupportsIndex`
   --> UP035.py:84:1
@@ -1123,6 +1114,7 @@ help: Import from `re`
 131 + from re import Match
 132 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 UP035 [*] Import from `re` instead: `Pattern`
    --> UP035.py:134:1
@@ -1135,4 +1127,98 @@ help: Import from `re`
 133 | # UP035 on py37+ only
     - from typing.re import Pattern
 134 + from re import Pattern
+135 |
     |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:141:1
+    |
+139 | from typing import TYPE_CHECKING
+140 |
+141 | from typing import Sequence as TypingOnlySequence
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+142 |
+143 | if TYPE_CHECKING:
+    |
+help: Import from `collections.abc`
+    |
+140 |
+    - from typing import Sequence as TypingOnlySequence
+141 + from collections.abc import Sequence as TypingOnlySequence
+142 |
+    |
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:146:1
+    |
+144 |     typing_only_value: TypingOnlySequence
+145 |
+146 | from typing import Sequence as RuntimeSequence
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+147 |
+148 | runtime_value = RuntimeSequence
+    |
+help: Import from `collections.abc`
+    |
+145 |
+    - from typing import Sequence as RuntimeSequence
+146 + from collections.abc import Sequence as RuntimeSequence
+147 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:150:1
+    |
+148 | runtime_value = RuntimeSequence
+149 |
+150 | from typing import Sequence as RuntimeAnnotationSequence
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+151 |
+152 | def runtime_annotation(value: RuntimeAnnotationSequence) -> None:
+    |
+help: Import from `collections.abc`
+    |
+149 |
+    - from typing import Sequence as RuntimeAnnotationSequence
+150 + from collections.abc import Sequence as RuntimeAnnotationSequence
+151 |
+    |
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:155:1
+    |
+153 |     pass
+154 |
+155 | from typing import Sequence as ReexportSequence
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+156 |
+157 | __all__ = ["ReexportSequence"]
+    |
+help: Import from `collections.abc`
+    |
+154 |
+    - from typing import Sequence as ReexportSequence
+155 + from collections.abc import Sequence as ReexportSequence
+156 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+UP035 [*] Import from `collections.abc` instead: `Sequence`
+   --> UP035.py:160:5
+    |
+159 | class RuntimeClass:
+160 |     from typing import Sequence as ClassSequence
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+161 |
+162 |     value = ClassSequence
+    |
+help: Import from `collections.abc`
+    |
+159 | class RuntimeClass:
+    -     from typing import Sequence as ClassSequence
+160 +     from collections.abc import Sequence as ClassSequence
+161 |
+    |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Changed UP035 so Ruff still suggests the deprecated-import fix, but marks it unsafe when changing the import could change runtime behavior, and safe when the import is only used for typing.