### PR TITLE
[`pyupgrade`] Retain comments in `UP013`, `UP014` class conversion

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP013.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP013.py
@@ -44,8 +44,13 @@ MyType = TypedDict("MyType", dict())
 
 # Unsafe fix if comments are present
 X = TypedDict("X", {
+    # important
     "some_config": int,  # important
+    # important
+    "other_config": int, # important
+    # important
 })
+
 
 # Private names should not be reported (OK)
 WithPrivate = TypedDict("WithPrivate", {"__x": int})

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP014.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP014.py
@@ -34,6 +34,10 @@ S3File = NamedTuple(
 
 # Unsafe fix if comments are present
 X = NamedTuple("X", [
+    # important
     ("some_config", int),  # important
+    # important
+    ("other_config", int), # important
+    # important
 ])
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -11,7 +11,7 @@ use ruff_python_semantic::SemanticModel;
 use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_python_trivia::CommentRanges;
 use ruff_source_file::LineRanges;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
 use crate::codes::Category;
@@ -286,97 +286,15 @@ fn convert_to_class(params: FixParams<'_>) -> Fix {
         params.base_class,
     ));
 
-    // Extract and append comments if we have list items
-    if let Some(list_expr) = params.list_items {
-        let items = &list_expr.elts;
-        if !items.is_empty() {
-            let all_comments = params.comment_ranges.comments_in_range(list_expr.range());
-            if !all_comments.is_empty() {
-                // Build per-field comments
-                let mut trailing: Vec<Option<&str>> = items.iter().map(|_| None).collect();
-                let mut leading: Vec<Vec<&str>> = items.iter().map(|_| Vec::new()).collect();
-                let mut trailing_own_line: Vec<Vec<&str>> =
-                    items.iter().map(|_| Vec::new()).collect();
-
-                for comment_range in all_comments {
-                    let start = comment_range.start();
-                    let line_start = params.source.line_start(start);
-                    let text = &params.source[*comment_range];
-
-                    // Trailing: same line as a field's end
-                    let mut found = false;
-                    for (i, item) in items.iter().enumerate() {
-                        if line_start <= item.end() && start >= item.end() {
-                            if trailing[i].is_none() {
-                                trailing[i] = Some(text);
-                            }
-                            found = true;
-                            break;
-                        }
-                    }
-
-                    if !found {
-                        // Leading: before some field's start
-                        let mut assigned = false;
-                        for (i, item) in items.iter().enumerate() {
-                            if start < item.start() {
-                                leading[i].push(text);
-                                assigned = true;
-                                break;
-                            }
-                        }
-                        // Trailing own-line: after last field
-                        if !assigned {
-                            let last = items.len() - 1;
-                            if start > items[last].end() {
-                                trailing_own_line[last].push(text);
-                            }
-                        }
-                    }
-                }
-
-                // Apply comments to output
-                let lines: Vec<String> = output.lines().map(String::from).collect();
-                let mut new_lines = Vec::with_capacity(lines.len());
-                let mut field_idx = 0;
-
-                for line in &lines {
-                    let trimmed = line.trim();
-                    if trimmed.contains(": ")
-                        && !trimmed.starts_with("class ")
-                        && !trimmed.starts_with("pass")
-                    {
-                        if field_idx < items.len() {
-                            let indent = line.len() - line.trim_start().len();
-                            let indent_str = " ".repeat(indent);
-
-                            for c in &leading[field_idx] {
-                                new_lines.push(format!("{indent_str}{c}"));
-                            }
-
-                            new_lines.push(line.clone());
-
-                            if let Some(c) = trailing[field_idx] {
-                                let last = new_lines.last_mut().unwrap();
-                                if !last.ends_with(' ') {
-                                    last.push(' ');
-                                }
-                                last.push_str(c);
-                            }
-
-                            for c in &trailing_own_line[field_idx] {
-                                new_lines.push(format!("{indent_str}{c}"));
-                            }
-
-                            field_idx += 1;
-                        }
-                    } else {
-                        new_lines.push(line.clone());
-                    }
-                }
-
-                output = new_lines.join("\n");
-            }
+    if let Some(list_expr) = params.list_items.filter(|l| !l.elts.is_empty()) {
+        let all_comments = params.comment_ranges.comments_in_range(list_expr.range());
+        if !all_comments.is_empty() {
+            let item_ranges: Vec<_> = list_expr
+                .elts
+                .iter()
+                .map(|item| (item.start(), item.end()))
+                .collect();
+            output = reattach_comments(&output, &item_ranges, all_comments, params.source);
         }
     }
 
@@ -384,4 +302,66 @@ fn convert_to_class(params: FixParams<'_>) -> Fix {
         Edit::range_replacement(output, params.stmt.range()),
         applicability,
     )
+}
+
+/// Reinsert comments from an original list literal into a generated class body,
+/// attaching each comment to the field it was originally adjacent to.
+fn reattach_comments(
+    output: &str,
+    item_ranges: &[(TextSize, TextSize)],
+    all_comments: &[TextRange],
+    source: &str,
+) -> String {
+    let mut trailing: Vec<Option<&str>> = vec![None; item_ranges.len()];
+    let mut leading: Vec<Vec<&str>> = vec![Vec::new(); item_ranges.len()];
+    let mut trailing_own_line: Vec<Vec<&str>> = vec![Vec::new(); item_ranges.len()];
+
+    for comment_range in all_comments {
+        let start = comment_range.start();
+        let line_start = source.line_start(start);
+        let text = &source[*comment_range];
+
+        if let Some(i) = item_ranges
+            .iter()
+            .position(|&(_, end)| line_start <= end && start >= end)
+        {
+            trailing[i].get_or_insert(text);
+        } else if let Some(i) = item_ranges.iter().position(|&(s, _)| start < s) {
+            leading[i].push(text);
+        } else if start > item_ranges[item_ranges.len() - 1].1 {
+            trailing_own_line[item_ranges.len() - 1].push(text);
+        }
+    }
+
+    let mut lines = output.lines();
+    let header = lines.next().unwrap_or_default().to_string();
+    let mut new_lines = Vec::with_capacity(item_ranges.len() * 2 + 1);
+    new_lines.push(header);
+
+    for (field_idx, line) in lines.enumerate() {
+        let indent_str = " ".repeat(line.len() - line.trim_start().len());
+
+        new_lines.extend(
+            leading[field_idx]
+                .iter()
+                .map(|c| format!("{indent_str}{c}")),
+        );
+
+        let mut line = line.to_string();
+        if let Some(c) = trailing[field_idx] {
+            if !line.ends_with(' ') {
+                line.push(' ');
+            }
+            line.push_str(c);
+        }
+        new_lines.push(line);
+
+        new_lines.extend(
+            trailing_own_line[field_idx]
+                .iter()
+                .map(|c| format!("{indent_str}{c}")),
+        );
+    }
+
+    new_lines.join("\n")
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -87,16 +87,24 @@ pub(crate) fn convert_named_tuple_functional_to_class(
         return;
     };
 
-    let fields = match (args, keywords) {
+    let (fields, list_items) = match (args, keywords) {
         // Ex) `NamedTuple("MyType")`
-        ([_typename], []) => Suite::from([Stmt::Pass(ast::StmtPass {
-            range: TextRange::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-        })]),
+        ([_typename], []) => (
+            Suite::from([Stmt::Pass(ast::StmtPass {
+                range: TextRange::default(),
+                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+            })]),
+            None,
+        ),
         // Ex) `NamedTuple("MyType", [("a", int), ("b", str)])`
-        ([_typename, fields], []) => {
-            if let Some(fields) = create_fields_from_fields_arg(fields) {
-                fields
+        ([_typename, fields_arg], []) => {
+            if let Some(list_expr) = fields_arg.as_list_expr() {
+                if let Some(fields) = create_fields_from_fields_arg(fields_arg) {
+                    (fields, Some(list_expr))
+                } else {
+                    debug!("Skipping `NamedTuple` \"{typename}\": unable to parse fields");
+                    return;
+                }
             } else {
                 debug!("Skipping `NamedTuple` \"{typename}\": unable to parse fields");
                 return;
@@ -105,7 +113,7 @@ pub(crate) fn convert_named_tuple_functional_to_class(
         // Ex) `NamedTuple("MyType", a=int, b=str)`
         ([_typename], keywords) => {
             if let Some(fields) = create_fields_from_keywords(keywords) {
-                fields
+                (fields, None)
             } else {
                 debug!("Skipping `NamedTuple` \"{typename}\": unable to parse keywords");
                 return;
@@ -126,14 +134,16 @@ pub(crate) fn convert_named_tuple_functional_to_class(
     );
     // TODO(charlie): Preserve indentation, to remove the first-column requirement.
     if checker.locator().is_at_start_of_line(stmt.start()) {
-        diagnostic.set_fix(convert_to_class(
+        diagnostic.set_fix(convert_to_class(FixParams {
             stmt,
             typename,
-            fields,
+            body: fields,
             base_class,
-            checker.generator(),
-            checker.comment_ranges(),
-        ));
+            generator: checker.generator(),
+            comment_ranges: checker.comment_ranges(),
+            source: checker.locator().contents(),
+            list_items,
+        }));
     }
 }
 
@@ -251,24 +261,127 @@ fn create_class_def_stmt(typename: &str, body: Suite, base_class: &Expr) -> Stmt
     .into()
 }
 
-/// Generate a `Fix` to convert a `NamedTuple` assignment to a class definition.
-fn convert_to_class(
-    stmt: &Stmt,
-    typename: &str,
+struct FixParams<'a> {
+    stmt: &'a Stmt,
+    typename: &'a str,
     body: Suite,
-    base_class: &Expr,
-    generator: Generator,
-    comment_ranges: &CommentRanges,
-) -> Fix {
+    base_class: &'a Expr,
+    generator: Generator<'a>,
+    comment_ranges: &'a CommentRanges,
+    source: &'a str,
+    list_items: Option<&'a ast::ExprList>,
+}
+
+/// Generate a `Fix` to convert a `NamedTuple` assignment to a class definition.
+fn convert_to_class(params: FixParams<'_>) -> Fix {
+    let applicability = if params.comment_ranges.intersects(params.stmt.range()) {
+        Applicability::Unsafe
+    } else {
+        Applicability::Safe
+    };
+
+    let mut output = params.generator.stmt(&create_class_def_stmt(
+        params.typename,
+        params.body,
+        params.base_class,
+    ));
+
+    // Extract and append comments if we have list items
+    if let Some(list_expr) = params.list_items {
+        let items = &list_expr.elts;
+        if !items.is_empty() {
+            let all_comments = params.comment_ranges.comments_in_range(list_expr.range());
+            if !all_comments.is_empty() {
+                // Build per-field comments
+                let mut trailing: Vec<Option<&str>> = items.iter().map(|_| None).collect();
+                let mut leading: Vec<Vec<&str>> = items.iter().map(|_| Vec::new()).collect();
+                let mut trailing_own_line: Vec<Vec<&str>> =
+                    items.iter().map(|_| Vec::new()).collect();
+
+                for comment_range in all_comments {
+                    let start = comment_range.start();
+                    let line_start = params.source.line_start(start);
+                    let text = &params.source[*comment_range];
+
+                    // Trailing: same line as a field's end
+                    let mut found = false;
+                    for (i, item) in items.iter().enumerate() {
+                        if line_start <= item.end() && start >= item.end() {
+                            if trailing[i].is_none() {
+                                trailing[i] = Some(text);
+                            }
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if !found {
+                        // Leading: before some field's start
+                        let mut assigned = false;
+                        for (i, item) in items.iter().enumerate() {
+                            if start < item.start() {
+                                leading[i].push(text);
+                                assigned = true;
+                                break;
+                            }
+                        }
+                        // Trailing own-line: after last field
+                        if !assigned {
+                            let last = items.len() - 1;
+                            if start > items[last].end() {
+                                trailing_own_line[last].push(text);
+                            }
+                        }
+                    }
+                }
+
+                // Apply comments to output
+                let lines: Vec<String> = output.lines().map(String::from).collect();
+                let mut new_lines = Vec::with_capacity(lines.len());
+                let mut field_idx = 0;
+
+                for line in &lines {
+                    let trimmed = line.trim();
+                    if trimmed.contains(": ")
+                        && !trimmed.starts_with("class ")
+                        && !trimmed.starts_with("pass")
+                    {
+                        if field_idx < items.len() {
+                            let indent = line.len() - line.trim_start().len();
+                            let indent_str = " ".repeat(indent);
+
+                            for c in &leading[field_idx] {
+                                new_lines.push(format!("{indent_str}{c}"));
+                            }
+
+                            new_lines.push(line.clone());
+
+                            if let Some(c) = trailing[field_idx] {
+                                let last = new_lines.last_mut().unwrap();
+                                if !last.ends_with(' ') {
+                                    last.push(' ');
+                                }
+                                last.push_str(c);
+                            }
+
+                            for c in &trailing_own_line[field_idx] {
+                                new_lines.push(format!("{indent_str}{c}"));
+                            }
+
+                            field_idx += 1;
+                        }
+                    } else {
+                        new_lines.push(line.clone());
+                    }
+                }
+
+                output = new_lines.join("\n");
+            }
+        }
+    }
+
     Fix::applicable_edit(
-        Edit::range_replacement(
-            generator.stmt(&create_class_def_stmt(typename, body, base_class)),
-            stmt.range(),
-        ),
-        if comment_ranges.intersects(stmt.range()) {
-            Applicability::Unsafe
-        } else {
-            Applicability::Safe
-        },
+        Edit::range_replacement(output, params.stmt.range()),
+        applicability,
     )
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -97,7 +97,12 @@ pub(crate) fn convert_typed_dict_functional_to_class(
         return;
     };
 
-    let Some((body, total_keyword)) = match_fields_and_total(arguments) else {
+    let Some(TypedDictFields {
+        body,
+        total_keyword,
+        dict_items,
+    }) = match_fields_and_total(arguments)
+    else {
         return;
     };
 
@@ -109,15 +114,17 @@ pub(crate) fn convert_typed_dict_functional_to_class(
     );
     // TODO(charlie): Preserve indentation, to remove the first-column requirement.
     if checker.locator().is_at_start_of_line(stmt.start()) {
-        diagnostic.set_fix(convert_to_class(
+        diagnostic.set_fix(convert_to_class(FixParams {
             stmt,
             class_name,
             body,
             total_keyword,
             base_class,
-            checker.generator(),
-            checker.comment_ranges(),
-        ));
+            generator: checker.generator(),
+            comment_ranges: checker.comment_ranges(),
+            source: checker.locator().contents(),
+            dict_items,
+        }));
     }
 }
 
@@ -261,8 +268,14 @@ fn fields_from_keywords(keywords: &[Keyword]) -> Option<Suite> {
         .collect()
 }
 
+struct TypedDictFields<'a> {
+    body: Suite,
+    total_keyword: Option<&'a Keyword>,
+    dict_items: Option<(&'a [ast::DictItem], TextRange)>,
+}
+
 /// Match the fields and `total` keyword from a `TypedDict` call.
-fn match_fields_and_total(arguments: &Arguments) -> Option<(Suite, Option<&Keyword>)> {
+fn match_fields_and_total(arguments: &Arguments) -> Option<TypedDictFields<'_>> {
     match (&*arguments.args, &*arguments.keywords) {
         // Ex) `TypedDict("MyType", {"a": int, "b": str})`
         ([_typename, fields], [..]) => {
@@ -270,15 +283,23 @@ fn match_fields_and_total(arguments: &Arguments) -> Option<(Suite, Option<&Keywo
             match fields {
                 Expr::Dict(ast::ExprDict {
                     items,
-                    range: _,
+                    range,
                     node_index: _,
-                }) => Some((fields_from_dict_literal(items)?, total)),
+                }) => Some(TypedDictFields {
+                    body: fields_from_dict_literal(items)?,
+                    total_keyword: total,
+                    dict_items: Some((items, *range)),
+                }),
                 Expr::Call(ast::ExprCall {
                     func,
                     arguments: Arguments { keywords, .. },
                     range_start: _,
                     node_index: _,
-                }) => Some((fields_from_dict_call(func, keywords)?, total)),
+                }) => Some(TypedDictFields {
+                    body: fields_from_dict_call(func, keywords)?,
+                    total_keyword: total,
+                    dict_items: None,
+                }),
                 _ => None,
             }
         }
@@ -288,39 +309,145 @@ fn match_fields_and_total(arguments: &Arguments) -> Option<(Suite, Option<&Keywo
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
-            Some((Suite::from([node]), None))
+            Some(TypedDictFields {
+                body: Suite::from([node]),
+                total_keyword: None,
+                dict_items: None,
+            })
         }
         // Ex) `TypedDict("MyType", a=int, b=str)`
-        ([_typename], fields) => Some((fields_from_keywords(fields)?, None)),
+        ([_typename], fields) => Some(TypedDictFields {
+            body: fields_from_keywords(fields)?,
+            total_keyword: None,
+            dict_items: None,
+        }),
         // Ex) `TypedDict()`
         _ => None,
     }
 }
 
-/// Generate a `Fix` to convert a `TypedDict` from functional to class.
-fn convert_to_class(
-    stmt: &Stmt,
-    class_name: &str,
+struct FixParams<'a> {
+    stmt: &'a Stmt,
+    class_name: &'a str,
     body: Suite,
-    total_keyword: Option<&Keyword>,
-    base_class: &Expr,
-    generator: Generator,
-    comment_ranges: &CommentRanges,
-) -> Fix {
+    total_keyword: Option<&'a Keyword>,
+    base_class: &'a Expr,
+    generator: Generator<'a>,
+    comment_ranges: &'a CommentRanges,
+    source: &'a str,
+    dict_items: Option<(&'a [ast::DictItem], TextRange)>,
+}
+
+/// Generate a `Fix` to convert a `TypedDict` from functional to class.
+fn convert_to_class(params: FixParams<'_>) -> Fix {
+    let applicability = if params.comment_ranges.intersects(params.stmt.range()) {
+        Applicability::Unsafe
+    } else {
+        Applicability::Safe
+    };
+
+    let mut output = params.generator.stmt(&create_class_def_stmt(
+        params.class_name,
+        params.body,
+        params.total_keyword,
+        params.base_class,
+    ));
+
+    // Extract and append comments if we have dict items
+    if let Some((items, dict_range)) = params.dict_items {
+        if !items.is_empty() {
+            let all_comments = params.comment_ranges.comments_in_range(dict_range);
+            if !all_comments.is_empty() {
+                // Build per-field comments: trailing end-of-line, leading own-line, trailing own-line
+                let mut trailing: Vec<Option<&str>> = items.iter().map(|_| None).collect();
+                let mut leading: Vec<Vec<&str>> = items.iter().map(|_| Vec::new()).collect();
+                let mut trailing_own_line: Vec<Vec<&str>> =
+                    items.iter().map(|_| Vec::new()).collect();
+
+                for comment_range in all_comments {
+                    let start = comment_range.start();
+                    let line_start = params.source.line_start(start);
+                    let text = &params.source[*comment_range];
+
+                    // Trailing: same line as a field's value end
+                    let mut found = false;
+                    for (i, item) in items.iter().enumerate() {
+                        if line_start <= item.value.end() && start >= item.value.end() {
+                            if trailing[i].is_none() {
+                                trailing[i] = Some(text);
+                            }
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if !found {
+                        // Leading: before some field's start
+                        let mut assigned = false;
+                        for (i, item) in items.iter().enumerate() {
+                            if start < item.start() {
+                                leading[i].push(text);
+                                assigned = true;
+                                break;
+                            }
+                        }
+                        // Trailing own-line: after last field
+                        if !assigned {
+                            let last = items.len() - 1;
+                            if start > items[last].value.end() {
+                                trailing_own_line[last].push(text);
+                            }
+                        }
+                    }
+                }
+
+                // Apply comments to output
+                let lines: Vec<String> = output.lines().map(String::from).collect();
+                let mut new_lines = Vec::with_capacity(lines.len());
+                let mut field_idx = 0;
+
+                for line in &lines {
+                    let trimmed = line.trim();
+                    if trimmed.contains(": ")
+                        && !trimmed.starts_with("class ")
+                        && !trimmed.starts_with("pass")
+                    {
+                        if field_idx < items.len() {
+                            let indent = line.len() - line.trim_start().len();
+                            let indent_str = " ".repeat(indent);
+
+                            for c in &leading[field_idx] {
+                                new_lines.push(format!("{indent_str}{c}"));
+                            }
+
+                            new_lines.push(line.clone());
+
+                            if let Some(c) = trailing[field_idx] {
+                                let last = new_lines.last_mut().unwrap();
+                                if !last.ends_with(' ') {
+                                    last.push(' ');
+                                }
+                                last.push_str(c);
+                            }
+
+                            for c in &trailing_own_line[field_idx] {
+                                new_lines.push(format!("{indent_str}{c}"));
+                            }
+
+                            field_idx += 1;
+                        }
+                    } else {
+                        new_lines.push(line.clone());
+                    }
+                }
+
+                output = new_lines.join("\n");
+            }
+        }
+    }
+
     Fix::applicable_edit(
-        Edit::range_replacement(
-            generator.stmt(&create_class_def_stmt(
-                class_name,
-                body,
-                total_keyword,
-                base_class,
-            )),
-            stmt.range(),
-        ),
-        if comment_ranges.intersects(stmt.range()) {
-            Applicability::Unsafe
-        } else {
-            Applicability::Safe
-        },
+        Edit::range_replacement(output, params.stmt.range()),
+        applicability,
     )
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -353,101 +353,82 @@ fn convert_to_class(params: FixParams<'_>) -> Fix {
         params.base_class,
     ));
 
-    // Extract and append comments if we have dict items
-    if let Some((items, dict_range)) = params.dict_items {
-        if !items.is_empty() {
-            let all_comments = params.comment_ranges.comments_in_range(dict_range);
-            if !all_comments.is_empty() {
-                // Build per-field comments: trailing end-of-line, leading own-line, trailing own-line
-                let mut trailing: Vec<Option<&str>> = items.iter().map(|_| None).collect();
-                let mut leading: Vec<Vec<&str>> = items.iter().map(|_| Vec::new()).collect();
-                let mut trailing_own_line: Vec<Vec<&str>> =
-                    items.iter().map(|_| Vec::new()).collect();
-
-                for comment_range in all_comments {
-                    let start = comment_range.start();
-                    let line_start = params.source.line_start(start);
-                    let text = &params.source[*comment_range];
-
-                    // Trailing: same line as a field's value end
-                    let mut found = false;
-                    for (i, item) in items.iter().enumerate() {
-                        if line_start <= item.value.end() && start >= item.value.end() {
-                            if trailing[i].is_none() {
-                                trailing[i] = Some(text);
-                            }
-                            found = true;
-                            break;
-                        }
-                    }
-
-                    if !found {
-                        // Leading: before some field's start
-                        let mut assigned = false;
-                        for (i, item) in items.iter().enumerate() {
-                            if start < item.start() {
-                                leading[i].push(text);
-                                assigned = true;
-                                break;
-                            }
-                        }
-                        // Trailing own-line: after last field
-                        if !assigned {
-                            let last = items.len() - 1;
-                            if start > items[last].value.end() {
-                                trailing_own_line[last].push(text);
-                            }
-                        }
-                    }
-                }
-
-                // Apply comments to output
-                let lines: Vec<String> = output.lines().map(String::from).collect();
-                let mut new_lines = Vec::with_capacity(lines.len());
-                let mut field_idx = 0;
-
-                for line in &lines {
-                    let trimmed = line.trim();
-                    if trimmed.contains(": ")
-                        && !trimmed.starts_with("class ")
-                        && !trimmed.starts_with("pass")
-                    {
-                        if field_idx < items.len() {
-                            let indent = line.len() - line.trim_start().len();
-                            let indent_str = " ".repeat(indent);
-
-                            for c in &leading[field_idx] {
-                                new_lines.push(format!("{indent_str}{c}"));
-                            }
-
-                            new_lines.push(line.clone());
-
-                            if let Some(c) = trailing[field_idx] {
-                                let last = new_lines.last_mut().unwrap();
-                                if !last.ends_with(' ') {
-                                    last.push(' ');
-                                }
-                                last.push_str(c);
-                            }
-
-                            for c in &trailing_own_line[field_idx] {
-                                new_lines.push(format!("{indent_str}{c}"));
-                            }
-
-                            field_idx += 1;
-                        }
-                    } else {
-                        new_lines.push(line.clone());
-                    }
-                }
-
-                output = new_lines.join("\n");
-            }
-        }
+    if let Some(with_comments) = params
+        .dict_items
+        .filter(|(items, _)| !items.is_empty())
+        .and_then(|(items, dict_range)| {
+            let comments = params.comment_ranges.comments_in_range(dict_range);
+            (!comments.is_empty())
+                .then(|| reattach_comments(&output, items, comments, params.source))
+        })
+    {
+        output = with_comments;
     }
 
     Fix::applicable_edit(
         Edit::range_replacement(output, params.stmt.range()),
         applicability,
     )
+}
+
+/// Reinsert comments from the original dict literal into the generated class body,
+/// attaching each to the field it was originally next to.
+fn reattach_comments(
+    output: &str,
+    items: &[ast::DictItem],
+    all_comments: &[TextRange],
+    source: &str,
+) -> String {
+    let mut trailing: Vec<Option<&str>> = vec![None; items.len()];
+    let mut leading: Vec<Vec<&str>> = vec![Vec::new(); items.len()];
+    let mut trailing_own_line: Vec<Vec<&str>> = vec![Vec::new(); items.len()];
+
+    for comment_range in all_comments {
+        let start = comment_range.start();
+        let line_start = source.line_start(start);
+        let text = &source[*comment_range];
+
+        if let Some(i) = items
+            .iter()
+            .position(|item| line_start <= item.value.end() && start >= item.value.end())
+        {
+            trailing[i].get_or_insert(text);
+        } else if let Some(i) = items.iter().position(|item| start < item.start()) {
+            leading[i].push(text);
+        } else if start > items[items.len() - 1].value.end() {
+            trailing_own_line[items.len() - 1].push(text);
+        }
+    }
+
+    let mut lines = output.lines();
+    let header = lines.next().unwrap_or_default().to_string();
+    let mut new_lines = Vec::with_capacity(items.len() * 2 + 1);
+    new_lines.push(header);
+
+    for (field_idx, line) in lines.enumerate() {
+        let indent_str = " ".repeat(line.len() - line.trim_start().len());
+
+        new_lines.extend(
+            leading[field_idx]
+                .iter()
+                .map(|c| format!("{indent_str}{c}")),
+        );
+
+        let mut line = line.to_string();
+        if let Some(c) = trailing[field_idx] {
+            if !line.ends_with(' ') {
+                line.push(' ');
+            }
+            line.push_str(c);
+        }
+        new_lines.push(line);
+
+        new_lines.extend(
+            trailing_own_line[field_idx]
+                .iter()
+                .map(|c| format!("{indent_str}{c}")),
+        );
+    }
+
+    new_lines.join("\n")
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP013.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP013.py.snap
@@ -226,20 +226,26 @@ UP013 [*] Convert `X` from `TypedDict` functional to class syntax
    |
 45 |   # Unsafe fix if comments are present
 46 | / X = TypedDict("X", {
-47 | |     "some_config": int,  # important
-48 | | })
+47 | |     # important
+48 | |     "some_config": int,  # important
+49 | |     # important
+50 | |     "other_config": int, # important
+51 | |     # important
+52 | | })
    | |__^
-49 |
-50 |   # Private names should not be reported (OK)
-   |
 help: Convert `X` to class syntax
    |
 45 | # Unsafe fix if comments are present
    - X = TypedDict("X", {
-   -     "some_config": int,  # important
-   - })
 46 + class X(TypedDict):
-47 +     some_config: int
-48 |
+47 |     # important
+   -     "some_config": int,  # important
+48 +     some_config: int # important
+49 |     # important
+   -     "other_config": int, # important
+50 +     other_config: int # important
+51 |     # important
+   - })
+52 |
    |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP014.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP014.py.snap
@@ -99,17 +99,26 @@ UP014 [*] Convert `X` from `NamedTuple` functional to class syntax
    |
 35 |   # Unsafe fix if comments are present
 36 | / X = NamedTuple("X", [
-37 | |     ("some_config", int),  # important
-38 | | ])
+37 | |     # important
+38 | |     ("some_config", int),  # important
+39 | |     # important
+40 | |     ("other_config", int), # important
+41 | |     # important
+42 | | ])
    | |__^
 help: Convert `X` to class syntax
    |
 35 | # Unsafe fix if comments are present
    - X = NamedTuple("X", [
-   -     ("some_config", int),  # important
-   - ])
 36 + class X(NamedTuple):
-37 +     some_config: int
-38 |
+37 |     # important
+   -     ("some_config", int),  # important
+38 +     some_config: int # important
+39 |     # important
+   -     ("other_config", int), # important
+40 +     other_config: int # important
+41 |     # important
+   - ])
+42 |
    |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Preserve comments when converting TypedDict/NamedTuple from functional to class syntax. Fixes #9715.

```python
X = TypedDict("X", {
    # important
    "some_config": int,  # important
    # important
    "other_config": int, # important
    # important
})
```

```python
class X(TypedDict):
    # important
    some_config: int # important
    # important
    other_config: int # important
    # important
```

## Test Plan

Updated snapshots.