### PR TITLE
[ty] Discover configs in models derived from legacy generic classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
+++ b/crates/ty_python_semantic/resources/mdtest/external/pydantic.md
@@ -1442,6 +1442,39 @@ HasGenericRoot(root=GenericRoot("1"))
 HasGenericRoot(root=GenericRoot(None))
 ```
 
+## Generic models
+
+Generic models inherit model configuration with both PEP 695 and legacy generic syntax. An explicit
+`Generic[T]` base does not override the inherited configuration.
+
+```py
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+class ForbidExtras(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+class Model[T](ForbidExtras):
+    value: T
+
+Model[int](value=1)
+Model[int](value=1, something_else=7)  # error: [unknown-argument]
+
+T = TypeVar("T")
+
+class LegacyModel(ForbidExtras, Generic[T]):
+    value: T
+
+LegacyModel[int](value=1)
+LegacyModel[int](value=1, something_else=7)  # error: [unknown-argument]
+
+class InheritsLegacyModel(LegacyModel[int]): ...
+
+InheritsLegacyModel(value=1)
+InheritsLegacyModel(value=1, something_else=7)  # error: [unknown-argument]
+```
+
 ## Model configuration
 
 The tests in this section use `extra` as an exemplary setting, but primarily test how model

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -613,6 +613,13 @@ fn model_config<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> ModelCo
     // Pydantic merges the effective config from each direct base from left to right. A later base
     // therefore takes precedence over an earlier base.
     for base in class.explicit_bases(db) {
+        if matches!(
+            base,
+            Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
+        ) {
+            continue;
+        }
+
         let Some(base) = base.to_class_type(db) else {
             config = ModelConfig::unknown();
             continue;


### PR DESCRIPTION
## Summary

Skip `Generic[T]` bases when discovering Pydantic model configuration so legacy generic classes preserve inherited settings.

closes https://github.com/astral-sh/ty/issues/4483

## Test plan

Regression tests