### PR TITLE
[ty] Share names in synthesized constructor parameters

### DIFF
--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1910,8 +1910,7 @@ impl<'db> StaticClassLiteral<'db> {
                     add_parameter_with_name(field_name.clone(), default_ty);
                 } else {
                     // Use the alias name if provided, otherwise use the field name.
-                    let parameter_name =
-                        Name::new(alias.map(|alias| &**alias).unwrap_or(&**field_name));
+                    let parameter_name = alias.map_or_else(|| field_name.clone(), Name::new);
                     add_parameter_with_name(parameter_name, default_ty);
                 }
             }


### PR DESCRIPTION
When synthesizing constructor parameters for dataclasses and named tuples, we rebuild each unaliased field name from `&str`. Names longer than 16 bytes therefore allocate again even though the field already owns shared storage.

Clone the existing `Name` when no alias is present so the generated parameter shares its allocation with the field. Aliased parameters retain their existing names.
