### PR TITLE
Reuse parser name lookups when interning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "datatest-stable",
  "drop_bomb",
  "get-size2",
+ "hashbrown 0.17.1",
  "insta",
  "itertools 0.15.0",
  "memchr",

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -21,6 +21,7 @@ bitflags = { workspace = true }
 bstr = { workspace = true }
 drop_bomb = { workspace = true }
 get-size2 = { workspace = true }
+hashbrown = { workspace = true }
 memchr = { workspace = true }
 rustc-hash = { workspace = true }
 static_assertions = { workspace = true }

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::str::FromStr;
 
 use bitflags::bitflags;
+use hashbrown::HashSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
@@ -11,7 +12,7 @@ use ruff_python_ast::{
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use rustc_hash::FxHashSet;
+use rustc_hash::FxBuildHasher;
 use thin_vec::ThinVec;
 use unicode_normalization::UnicodeNormalization;
 
@@ -40,7 +41,7 @@ mod tests;
 
 #[derive(Debug, Default)]
 struct NameInterner {
-    names: FxHashSet<Name>,
+    names: HashSet<Name, FxBuildHasher>,
 }
 
 impl NameInterner {
@@ -50,13 +51,9 @@ impl NameInterner {
             return name;
         }
 
-        if let Some(name) = self.names.get(text) {
-            return name.clone();
-        }
-
-        let name = Name::new_heap(text);
-        self.names.insert(name.clone());
-        name
+        self.names
+            .get_or_insert_with(text, |text| Name::new_heap(text))
+            .clone()
     }
 }
 

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -4,24 +4,6 @@ use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, St
 
 use crate::{Mode, ParseOptions, parse, parse_expression, parse_module};
 
-use super::NameInterner;
-
-#[test]
-fn name_interner_shares_long_names() {
-    let mut interner = NameInterner::default();
-    assert_eq!(interner.intern("short"), "short");
-    assert!(interner.names.is_empty());
-
-    let text = "identifier_longer_than_the_inline_capacity";
-    let first = interner.intern(text);
-    let repeated = interner.intern(text);
-    let different = interner.intern("another_identifier_longer_than_the_inline_capacity");
-    assert_eq!(first, text);
-    assert!(std::ptr::eq(first.as_ptr(), repeated.as_ptr()));
-    assert_ne!(first, different);
-    assert_eq!(interner.names.len(), 2);
-}
-
 // Keep recursive ASTs shallow enough for Windows's 1 MiB test-thread stacks.
 const RECURSIVE_AST_TEST_DEPTH: usize = 1_000;
 

--- a/crates/ruff_python_parser/src/parser/tests.rs
+++ b/crates/ruff_python_parser/src/parser/tests.rs
@@ -4,6 +4,24 @@ use ruff_python_ast::{Expr, InterpolatedStringElement, IpyEscapeKind, Number, St
 
 use crate::{Mode, ParseOptions, parse, parse_expression, parse_module};
 
+use super::NameInterner;
+
+#[test]
+fn name_interner_shares_long_names() {
+    let mut interner = NameInterner::default();
+    assert_eq!(interner.intern("short"), "short");
+    assert!(interner.names.is_empty());
+
+    let text = "identifier_longer_than_the_inline_capacity";
+    let first = interner.intern(text);
+    let repeated = interner.intern(text);
+    let different = interner.intern("another_identifier_longer_than_the_inline_capacity");
+    assert_eq!(first, text);
+    assert!(std::ptr::eq(first.as_ptr(), repeated.as_ptr()));
+    assert_ne!(first, different);
+    assert_eq!(interner.names.len(), 2);
+}
+
 // Keep recursive ASTs shallow enough for Windows's 1 MiB test-thread stacks.
 const RECURSIVE_AST_TEST_DEPTH: usize = 1_000;
 


### PR DESCRIPTION
Use hashbrown's borrowed-entry insertion for long parser names so a missing name reuses its lookup when it is inserted. Construct the heap-backed `Name` only on a miss, while preserving the inline bypass and shared allocations for repeated long names.
