### PR TITLE
[ty] Defer string ownership when inserting places

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1,6 +1,7 @@
 use std::cell::{OnceCell, RefCell};
 use std::sync::Arc;
 
+use char_str::CharString;
 use except_handlers::{ExceptionContextStackManager, ExceptionHandlers};
 use itertools::Itertools;
 use ruff_python_ast::helpers::{Truthiness, any_over_expr, is_dotted_name};
@@ -276,6 +277,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     scopes: IndexVec<FileScopeId, Scope>,
     scope_ids_by_scope: IndexVec<FileScopeId, ScopeId<'db>>,
     place_tables: IndexVec<FileScopeId, PlaceTableBuilder>,
+    /// Reused across scopes when looking up concatenated member paths.
+    member_path_buffer: CharString,
     ast_ids: IndexVec<FileScopeId, AstIdsBuilder>,
     // Box to avoid copying large builders when this index grows.
     use_def_maps: IndexVec<FileScopeId, Box<UseDefMapBuilder<'db>>>,
@@ -339,6 +342,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             scopes: IndexVec::new(),
             place_tables: IndexVec::new(),
+            member_path_buffer: CharString::new(),
             ast_ids: IndexVec::new(),
             scope_ids_by_scope: IndexVec::new(),
             use_def_maps: IndexVec::new(),
@@ -1380,8 +1384,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     /// Add a symbol to the place table and the use-def map.
     /// Return the [`ScopedPlaceId`] that uniquely identifies the symbol in both.
-    fn add_symbol(&mut self, name: Name) -> ScopedSymbolId {
-        let (symbol_id, added) = self.current_place_table_mut().add_symbol(Symbol::new(name));
+    fn add_symbol(&mut self, name: &Name) -> ScopedSymbolId {
+        let (symbol_id, added) = self.current_place_table_mut().add_symbol_name(name);
         if added {
             self.current_use_def_map_mut().add_place(symbol_id.into());
         }
@@ -1671,7 +1675,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         };
         node.value.as_ref()?;
 
-        let place = self.add_symbol(name.id.clone()).into();
+        let place = self.add_symbol(&name.id).into();
         let definition =
             self.create_definition(place, AnnotatedAssignmentDefinitionNodeRef { node });
         self.mark_place_declared(place);
@@ -1923,7 +1927,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 continue;
             }
 
-            let place: ScopedPlaceId = self.add_symbol(name.clone()).into();
+            let place: ScopedPlaceId = self.add_symbol(&name).into();
             let definition = Definition::new(
                 self.db,
                 self.current_scope_id(),
@@ -1999,7 +2003,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             let binding_status = self.comprehension_binding_status(&name, &declarations);
 
-            let symbol = self.add_symbol(name.clone());
+            let symbol = self.add_symbol(&name);
             debug_assert!(
                 declarations
                     .iter()
@@ -2998,7 +3002,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 };
                 self.scopes_by_expression
                     .record_expression(name, self.current_scope());
-                let symbol = self.add_symbol(name.id.clone());
+                let symbol = self.add_symbol(&name.id);
                 // TODO create Definition for PEP 695 typevars
                 // note that the "bound" on the typevar is a totally different thing than whether
                 // or not a name is "bound" by a typevar declaration; the latter is always true.
@@ -3159,7 +3163,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             self.declare_parameter(parameter);
         }
         if let Some(vararg) = parameters.vararg.as_ref() {
-            let symbol = self.add_symbol(vararg.name.id().clone());
+            let symbol = self.add_symbol(vararg.name.id());
             self.current_place_table_mut()
                 .symbol_mut(symbol)
                 .mark_parameter();
@@ -3169,7 +3173,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             );
         }
         if let Some(kwarg) = parameters.kwarg.as_ref() {
-            let symbol = self.add_symbol(kwarg.name.id().clone());
+            let symbol = self.add_symbol(kwarg.name.id());
             self.current_place_table_mut()
                 .symbol_mut(symbol)
                 .mark_parameter();
@@ -3181,7 +3185,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     }
 
     fn declare_parameter(&mut self, parameter: &'ast ast::ParameterWithDefault) {
-        let symbol = self.add_symbol(parameter.name().id().clone());
+        let symbol = self.add_symbol(parameter.name().id());
 
         self.add_definition(
             symbol.into(),
@@ -3208,7 +3212,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             index += 1;
         }
         if let Some(vararg) = parameters.vararg.as_ref() {
-            let symbol = self.add_symbol(vararg.name.id().clone());
+            let symbol = self.add_symbol(vararg.name.id());
             self.current_place_table_mut()
                 .symbol_mut(symbol)
                 .mark_parameter();
@@ -3227,7 +3231,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             index += 1;
         }
         if let Some(kwarg) = parameters.kwarg.as_ref() {
-            let symbol = self.add_symbol(kwarg.name.id().clone());
+            let symbol = self.add_symbol(kwarg.name.id());
             self.current_place_table_mut()
                 .symbol_mut(symbol)
                 .mark_parameter();
@@ -3248,7 +3252,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         parameter: &'ast ast::ParameterWithDefault,
         lambda: &'ast ast::ExprLambda,
     ) {
-        let symbol = self.add_symbol(parameter.name().id().clone());
+        let symbol = self.add_symbol(parameter.name().id());
 
         self.add_definition(
             symbol.into(),
@@ -3416,60 +3420,57 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // equivalent because `walk_expr` is a no-op; for attribute/subscript places,
                 // child evaluation can introduce bindings (for example via walrus operators),
                 // and those bindings need to exist before we register parent/member associations.
-                let mut deferred_effects = None;
-                if let Some(mut place_expr) = PlaceExpr::try_from_expr(expr) {
-                    if let Some(method_scope_id) = self.is_method_or_eagerly_executed_in_method()
-                        && let PlaceExpr::Member(member) = &mut place_expr
-                        && member.is_instance_attribute_candidate()
-                        && let Some(attribute) = expr.as_attribute_expr()
-                    {
-                        // We specifically mark direct attribute assignments to the first
-                        // parameter of a method, i.e. typically `self` or `cls`.
-                        // However, we must check that the symbol hasn't been shadowed by an
-                        // intermediate scope (e.g., a comprehension variable: `for self in [...]`)
-                        // and that the AST base is still the original name rather than a
-                        // rebinding expression such as `(self := other).x`.
-                        let accessed_object_refers_to_first_parameter =
-                            self.current_first_parameter_name.is_some_and(|first| {
-                                attribute
-                                    .value
-                                    .as_name_expr()
-                                    .is_some_and(|name| name.id == first)
-                                    && !self.is_symbol_bound_in_intermediate_eager_scopes(
-                                        first,
-                                        method_scope_id,
-                                    )
-                            });
+                // We specifically mark direct attribute assignments to the first
+                // parameter of a method, i.e. typically `self` or `cls`.
+                // However, we must check that the symbol hasn't been shadowed by an
+                // intermediate scope (e.g., a comprehension variable: `for self in [...]`)
+                // and that the AST base is still the original name rather than a
+                // rebinding expression such as `(self := other).x`.
+                // Resolve shadowing before walking, while the original scope state is available.
+                let is_instance_attribute = if let Some(method_scope_id) =
+                    self.is_method_or_eagerly_executed_in_method()
+                    && let Some(attribute) = expr.as_attribute_expr()
+                {
+                    self.current_first_parameter_name.is_some_and(|first| {
+                        attribute
+                            .value
+                            .as_name_expr()
+                            .is_some_and(|name| name.id == first)
+                            && !self.is_symbol_bound_in_intermediate_eager_scopes(
+                                first,
+                                method_scope_id,
+                            )
+                    })
+                } else {
+                    false
+                };
 
-                        if accessed_object_refers_to_first_parameter {
-                            member.mark_instance_attribute();
-                        }
+                let (is_use, is_definition) = match (ctx, self.current_assignment()) {
+                    (ast::ExprContext::Store, Some(CurrentAssignment::AugAssign(_))) => {
+                        // Record the target load now; the definition is recorded separately
+                        // after visiting the right-hand side.
+                        (true, false)
                     }
-
-                    let (is_use, is_definition) = match (ctx, self.current_assignment()) {
-                        (ast::ExprContext::Store, Some(CurrentAssignment::AugAssign(_))) => {
-                            // Record the target load now; the definition is recorded separately
-                            // after visiting the right-hand side.
-                            (true, false)
-                        }
-                        (ast::ExprContext::Load, _) => (true, false),
-                        (ast::ExprContext::Store, _) => (false, true),
-                        (ast::ExprContext::Del, _) => (true, true),
-                        (ast::ExprContext::Invalid, _) => (false, false),
-                    };
-                    deferred_effects = Some((place_expr, is_use, is_definition));
-                }
+                    (ast::ExprContext::Load, _) => (true, false),
+                    (ast::ExprContext::Store, _) => (false, true),
+                    (ast::ExprContext::Del, _) => (true, true),
+                    (ast::ExprContext::Invalid, _) => (false, false),
+                };
 
                 walk_expr(self, expr);
 
-                let is_use = deferred_effects
-                    .as_ref()
-                    .is_some_and(|(_, is_use, _)| *is_use);
                 let can_raise = self.place_access_can_raise(expr, is_use);
                 self.record_exception_checkpoint_if(can_raise);
 
-                if let Some((place_expr, is_use, is_definition)) = deferred_effects {
-                    let place_id = self.add_place(place_expr);
+                let scope_id = self.current_scope();
+                if let Some((place_id, added)) = self.place_tables[scope_id].add_expr(
+                    expr,
+                    is_instance_attribute,
+                    &mut self.member_path_buffer,
+                ) {
+                    if added {
+                        self.current_use_def_map_mut().add_place(place_id);
+                    }
 
                     if is_use {
                         self.record_place_use(place_id, expr);
@@ -3904,7 +3905,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // The symbol for the function name itself has to be evaluated
                 // at the end to match the runtime evaluation of parameter defaults
                 // and return-type annotations.
-                let symbol = self.add_symbol(name.id.clone());
+                let symbol = self.add_symbol(&name.id);
 
                 // Record a use of the function name in the scope that it is defined in, so that it
                 // can be used to find previously defined functions with the same name. This is
@@ -3949,7 +3950,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 self.record_exception_checkpoint();
 
                 // In Python runtime semantics, a class is registered after its scope is evaluated.
-                let symbol = self.add_symbol(class.name.id.clone());
+                let symbol = self.add_symbol(&class.name.id);
                 self.add_definition(symbol.into(), class);
             }
             ast::Stmt::TypeAlias(type_alias) => {
@@ -3957,8 +3958,8 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     type_alias
                         .name
                         .as_name_expr()
-                        .map(|name| name.id.clone())
-                        .unwrap_or("<unknown>".into()),
+                        .map(|name| &name.id)
+                        .unwrap_or(&Name::new_static("<unknown>")),
                 );
                 self.add_definition(symbol.into(), type_alias);
                 self.visit_expr(&type_alias.name);
@@ -3991,7 +3992,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         (Name::new(alias.name.id.split('.').next().unwrap()), false)
                     };
 
-                    let symbol = self.add_symbol(symbol_name);
+                    let symbol = self.add_symbol(&symbol_name);
                     self.add_definition(
                         symbol.into(),
                         ImportDefinitionNodeRef {
@@ -4059,7 +4060,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                         if !is_immediately_shadowed {
                             let direct_submodule_name = Name::new(direct_submodule);
-                            let symbol = self.add_symbol(direct_submodule_name);
+                            let symbol = self.add_symbol(&direct_submodule_name);
 
                             let module_index = if node.level == 0 {
                                 // "whatever.thispackage.x.y" we want `x`
@@ -4139,7 +4140,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         //
                         // For more details, see the doc-comment on `StarImportPlaceholderPredicate`.
                         for export in exported_names(self.db, referenced_program_file) {
-                            let symbol_id = self.add_symbol(export.clone());
+                            let symbol_id = self.add_symbol(export);
                             let node_ref = StarImportDefinitionNodeRef { node, symbol_id };
                             let star_import = StarImportPlaceholderPredicate::new(
                                 self.db,
@@ -4210,7 +4211,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         && alias.name.id == "annotations"
                         && node.module.as_deref() == Some("__future__");
 
-                    let symbol = self.add_symbol(symbol_name.clone());
+                    let symbol = self.add_symbol(symbol_name);
 
                     self.add_definition(
                         symbol.into(),
@@ -4332,7 +4333,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 }
 
                 if let ast::Expr::Name(name) = &*node.target {
-                    let symbol_id = self.add_symbol(name.id.clone());
+                    let symbol_id = self.add_symbol(&name.id);
                     let symbol = self.current_place_table().symbol(symbol_id);
                     // Check whether the variable has been declared global.
                     if symbol.is_global() {
@@ -5083,7 +5084,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         // which is invalid syntax. However, it's still pretty obvious here that the user
                         // *wanted* `e` to be bound, so we should still create a definition here nonetheless.
                         let symbol = if let Some(symbol_name) = symbol_name {
-                            let symbol = self.add_symbol(symbol_name.id.clone());
+                            let symbol = self.add_symbol(&symbol_name.id);
 
                             self.add_definition(
                                 symbol.into(),
@@ -5300,7 +5301,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for name in names {
                     self.scopes_by_expression
                         .record_expression(name, self.current_scope());
-                    let symbol_id = self.add_symbol(name.id.clone());
+                    let symbol_id = self.add_symbol(&name.id);
                     let symbol = self.current_place_table().symbol(symbol_id);
                     // Check whether the variable has already been accessed in this scope.
                     if (symbol.is_bound() || symbol.is_declared() || symbol.is_used())
@@ -5355,7 +5356,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 for name in names {
                     self.scopes_by_expression
                         .record_expression(name, self.current_scope());
-                    let symbol_id = self.add_symbol(name.id.clone());
+                    let symbol_id = self.add_symbol(&name.id);
                     let symbol = self.current_place_table().symbol(symbol_id);
                     // Check whether the variable has already been accessed in this scope.
                     if (symbol.is_bound() || symbol.is_declared() || symbol.is_used())
@@ -5706,7 +5707,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             node_index: _,
         }) = pattern
         {
-            let symbol = self.add_symbol(name.id().clone());
+            let symbol = self.add_symbol(name.id());
             let state = self.current_match_case.as_ref().unwrap();
             self.add_definition(
                 symbol.into(),
@@ -5727,7 +5728,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             rest: Some(name), ..
         }) = pattern
         {
-            let symbol = self.add_symbol(name.id().clone());
+            let symbol = self.add_symbol(name.id());
             let state = self.current_match_case.as_ref().unwrap();
             self.add_definition(
                 symbol.into(),

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -511,12 +511,11 @@ impl MemberReverseTable {
     fn entry<'a>(
         &'a mut self,
         members: &IndexVec<ScopedMemberId, Member>,
-        member: &Member,
+        member: &MemberExprRef<'_>,
     ) -> Entry<'a, ScopedMemberId> {
-        let member = member.expression.as_ref();
         self.0.entry(
-            hash_single(&member),
-            |id| members[*id].expression.as_ref() == member,
+            hash_single(member),
+            |id| members[*id].expression.as_ref() == *member,
             |id| hash_single(&members[*id].expression.as_ref()),
         )
     }
@@ -620,7 +619,9 @@ impl MemberTableBuilder {
     ///
     /// Members are identified by their expression, which is hashed to find the entry in the table.
     pub(super) fn add(&mut self, member: Member) -> (ScopedMemberId, bool) {
-        let entry = self.reverse.entry(&self.table.members, &member);
+        let entry = self
+            .reverse
+            .entry(&self.table.members, &member.expression.as_ref());
 
         match entry {
             Entry::Occupied(entry) => {
@@ -638,6 +639,48 @@ impl MemberTableBuilder {
                 (id, true)
             }
         }
+    }
+
+    /// Adds an AST member, allocating its retained path and segments only on a miss.
+    pub(super) fn add_expr(
+        &mut self,
+        expr: ast::ExprRef<'_>,
+        is_instance_attribute: bool,
+        path_buffer: &mut CharString,
+    ) -> Option<(ScopedMemberId, bool)> {
+        let mut parts = SmallVec::new_const();
+        let mut segments = SmallVec::new_const();
+        let mut path_len = TextSize::new(0);
+        MemberExprBuilder::collect_expr(expr, &mut parts, &mut segments, &mut path_len)?;
+        if segments.is_empty() {
+            return None;
+        }
+
+        path_buffer.clear();
+        path_buffer.reserve(path_len.to_usize());
+        for part in &parts {
+            path_buffer.push_str(part.as_ref());
+        }
+        let expression = MemberExprRef {
+            path: path_buffer.as_str(),
+            segments: SegmentsRef::Heap(&segments),
+        };
+
+        let (id, is_new) = match self.reverse.entry(&self.table.members, &expression) {
+            Entry::Occupied(entry) => (*entry.get(), false),
+            Entry::Vacant(entry) => {
+                let id = self.table.members.push(Member::new(MemberExpr {
+                    path: CharStr::from(path_buffer.as_str()),
+                    segments: Segments::from_vec(segments),
+                }));
+                entry.insert(id);
+                (id, true)
+            }
+        };
+        if is_instance_attribute {
+            self.table.members[id].mark_instance_attribute();
+        }
+        Some((id, is_new))
     }
 
     pub(super) fn build(self) -> MemberTable {
@@ -1036,7 +1079,63 @@ fn hash_single<T: Hash>(value: &T) -> u64 {
 mod tests {
     use std::assert_matches;
 
+    use ruff_python_parser::parse_expression;
+
     use super::*;
+
+    #[test]
+    fn ast_insertion_reuses_members_and_preserves_segment_boundaries() {
+        let first = parse_expression("long_object_name.attribute['value']").unwrap();
+        let second = parse_expression("long_object_name.attributevalue['']").unwrap();
+        let mut table = MemberTableBuilder::default();
+        let mut path_buffer = CharString::new();
+
+        let (first_id, is_new) = table
+            .add_expr(first.expr().into(), false, &mut path_buffer)
+            .unwrap();
+        assert!(is_new);
+        table.member_mut(first_id).mark_bound();
+
+        // These expressions have identical concatenated paths, but different segment boundaries.
+        let (second_id, is_new) = table
+            .add_expr(second.expr().into(), false, &mut path_buffer)
+            .unwrap();
+        assert!(is_new);
+        assert_ne!(first_id, second_id);
+        assert_eq!(
+            table.member(first_id).expression.path,
+            table.member(second_id).expression.path
+        );
+
+        assert_eq!(
+            table.add_expr(first.expr().into(), false, &mut path_buffer),
+            Some((first_id, false)),
+        );
+        assert!(table.member(first_id).is_bound());
+
+        // The existing owned insertion and borrowed lookup must use the same hash and equality.
+        let owned = MemberExpr::try_from_expr(second.expr().into()).unwrap();
+        assert_eq!(table.add(Member::new(owned.clone())), (second_id, false));
+        assert_eq!(table.build().member_id(&owned), Some(second_id));
+    }
+
+    #[test]
+    fn ast_insertion_updates_instance_attribute_flags() {
+        let parsed = parse_expression("self.long_attribute_name").unwrap();
+        let mut table = MemberTableBuilder::default();
+        let mut path_buffer = CharString::new();
+        let (id, _) = table
+            .add_expr(parsed.expr().into(), false, &mut path_buffer)
+            .unwrap();
+        table.member_mut(id).mark_declared();
+        assert!(!table.member(id).is_instance_attribute());
+        assert_eq!(
+            table.add_expr(parsed.expr().into(), true, &mut path_buffer),
+            Some((id, false)),
+        );
+        assert!(table.member(id).is_instance_attribute());
+        assert!(table.member(id).is_declared());
+    }
 
     #[test]
     fn test_member_expr_ref_hash_and_eq_small_heap() {

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -6,9 +6,11 @@ use crate::member::{
 use crate::predicate::PatternPredicate;
 use crate::symbol::{ScopedSymbolId, Symbol, SymbolTable, SymbolTableBuilder};
 use crate::{Db, PossiblyNarrowedPlaces};
+use char_str::CharString;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_index::IndexVec;
 use ruff_python_ast as ast;
+use ruff_python_ast::name::Name;
 use smallvec::SmallVec;
 use std::hash::Hash;
 use std::iter::FusedIterator;
@@ -342,7 +344,15 @@ impl PlaceTableBuilder {
 
     pub(crate) fn add_symbol(&mut self, symbol: Symbol) -> (ScopedSymbolId, bool) {
         let (id, is_new) = self.symbols.add(symbol);
+        self.register_symbol(id, is_new)
+    }
 
+    pub(crate) fn add_symbol_name(&mut self, name: &Name) -> (ScopedSymbolId, bool) {
+        let (id, is_new) = self.symbols.add_name(name);
+        self.register_symbol(id, is_new)
+    }
+
+    fn register_symbol(&mut self, id: ScopedSymbolId, is_new: bool) -> (ScopedSymbolId, bool) {
         if is_new {
             let new_id = self.associated_symbol_members.push(SmallVec::new_const());
             debug_assert_eq!(new_id, id);
@@ -353,7 +363,10 @@ impl PlaceTableBuilder {
 
     fn add_member(&mut self, member: Member) -> (ScopedMemberId, bool) {
         let (id, is_new) = self.member.add(member);
+        self.register_member(id, is_new)
+    }
 
+    fn register_member(&mut self, id: ScopedMemberId, is_new: bool) -> (ScopedMemberId, bool) {
         if is_new {
             let new_id = self.associated_sub_members.push(SmallVec::new_const());
             debug_assert_eq!(new_id, id);
@@ -376,6 +389,25 @@ impl PlaceTableBuilder {
         }
 
         (id, is_new)
+    }
+
+    /// Inserts an AST place without creating owned strings for existing entries.
+    pub(crate) fn add_expr(
+        &mut self,
+        expr: &ast::Expr,
+        is_instance_attribute: bool,
+        path_buffer: &mut CharString,
+    ) -> Option<(ScopedPlaceId, bool)> {
+        if let ast::Expr::Name(name) = expr {
+            let (id, is_new) = self.add_symbol_name(&name.id);
+            Some((id.into(), is_new))
+        } else {
+            let (id, is_new) =
+                self.member
+                    .add_expr(expr.into(), is_instance_attribute, path_buffer)?;
+            let (id, is_new) = self.register_member(id, is_new);
+            Some((id.into(), is_new))
+        }
     }
 
     pub(crate) fn add_place(&mut self, place: PlaceExpr) -> (ScopedPlaceId, bool) {

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -179,11 +179,11 @@ impl SymbolReverseTable {
     fn entry<'a>(
         &'a mut self,
         symbols: &IndexVec<ScopedSymbolId, Symbol>,
-        symbol: &Symbol,
+        name: &Name,
     ) -> Entry<'a, ScopedSymbolId> {
         self.0.entry(
-            Self::hash_name(symbol.name()),
-            |id| &symbols[*id].name == symbol.name(),
+            Self::hash_name(name),
+            |id| &symbols[*id].name == name,
             |id| Self::hash_name(&symbols[*id].name),
         )
     }
@@ -274,7 +274,7 @@ impl SymbolTableBuilder {
 
     /// Add a new symbol to this scope or update the flags if a symbol with the same name already exists.
     pub(super) fn add(&mut self, symbol: Symbol) -> (ScopedSymbolId, bool) {
-        let entry = self.reverse.entry(&self.table.symbols, &symbol);
+        let entry = self.reverse.entry(&self.table.symbols, symbol.name());
 
         match entry {
             Entry::Occupied(entry) => {
@@ -288,6 +288,18 @@ impl SymbolTableBuilder {
             }
             Entry::Vacant(entry) => {
                 let id = self.table.symbols.push(symbol);
+                entry.insert(id);
+                (id, true)
+            }
+        }
+    }
+
+    /// Adds a name, cloning its storage only when the symbol is new to this scope.
+    pub(super) fn add_name(&mut self, name: &Name) -> (ScopedSymbolId, bool) {
+        match self.reverse.entry(&self.table.symbols, name) {
+            Entry::Occupied(entry) => (*entry.get(), false),
+            Entry::Vacant(entry) => {
+                let id = self.table.symbols.push(Symbol::new(name.clone()));
                 entry.insert(id);
                 (id, true)
             }


### PR DESCRIPTION
Building the semantic index currently clones names and allocates concatenated member paths before checking whether their places already exist in the scope. Repeated references to a long identifier incur reference-count updates, and repeated member accesses allocate strings that are immediately discarded.

Borrow symbol names during insertion and clone only for new entries. Build member lookup paths in one reusable `CharString` shared across scopes, then create the retained `CharStr` and segment storage only when inserting a new member. Lookups continue to hash the complete concatenated path and compare segment boundaries through the existing member representation.

Keep place registration after child evaluation, preserve existing symbol and member flags, and update parent associations only for new entries. The allocation reductions still need end-to-end performance measurement.
