### PR TITLE
Delegate Name string comparisons to CharStr

### DIFF
--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -179,7 +179,7 @@ impl salsa::HashEqLike<&str> for Name {
 
     #[inline]
     fn eq(&self, data: &&str) -> bool {
-        self.as_str() == *data
+        self == *data
     }
 }
 
@@ -261,7 +261,7 @@ impl std::fmt::Display for Name {
 impl PartialEq<str> for Name {
     #[inline]
     fn eq(&self, other: &str) -> bool {
-        self.as_str() == other
+        self.0 == other
     }
 }
 
@@ -275,7 +275,7 @@ impl PartialEq<Name> for str {
 impl PartialEq<&str> for Name {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
-        self.as_str() == *other
+        self.0 == *other
     }
 }
 
@@ -302,7 +302,7 @@ impl PartialEq<Name> for String {
 impl PartialEq<&String> for Name {
     #[inline]
     fn eq(&self, other: &&String) -> bool {
-        self.as_str() == *other
+        self == other.as_str()
     }
 }
 


### PR DESCRIPTION
Delegate `Name` equality with borrowed strings to `CharStr`, including Salsa lookups, so these callers use the compact string's comparison implementation.

This connects Ruff's name comparisons to the short-string fast paths in https://github.com/astral-sh/char_str/pull/40. Those fast paths require a later `char_str` release; this change is compatible with the current dependency.
