### PR TITLE
Store AST string literals in CharStr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,6 +3630,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.13.1",
  "bstr",
+ "char_str",
  "datatest-stable",
  "drop_bomb",
  "get-size2",

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -66,7 +66,7 @@ fn logging_f_string(
                             // If the literal text contains a '%' placeholder, bail out: mixing
                             // f-string interpolation with '%' placeholders is ambiguous for our
                             // automatic conversion, so don't offer a fix for this case.
-                            if lit.value.as_ref().contains('%') {
+                            if lit.value.contains('%') {
                                 return;
                             }
                             format_string.push_str(lit.value.as_ref());

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -319,7 +319,7 @@ fn elts_to_csv(elts: &[Expr], generator: Generator, flags: StringLiteralFlags) -
                 }
                 acc
             })
-            .into_boxed_str(),
+            .into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         flags,
@@ -370,7 +370,7 @@ fn check_names(checker: &Checker, call: &ExprCall, expr: &Expr, argvalues: &Expr
                                 .iter()
                                 .map(|name| {
                                     Expr::from(ast::StringLiteral {
-                                        value: Box::from(*name),
+                                        value: (*name).into(),
                                         range: TextRange::default(),
                                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                                         flags: checker.default_string_flags(),
@@ -402,7 +402,7 @@ fn check_names(checker: &Checker, call: &ExprCall, expr: &Expr, argvalues: &Expr
                                 .iter()
                                 .map(|name| {
                                     Expr::from(ast::StringLiteral {
-                                        value: Box::from(*name),
+                                        value: (*name).into(),
                                         range: TextRange::default(),
                                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                                         flags: checker.default_string_flags(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -234,7 +234,7 @@ fn check_os_environ_subscript(checker: &Checker, expr: &Expr) {
         slice.range(),
     );
     let node = ast::StringLiteral {
-        value: capital_env_var.into_boxed_str(),
+        value: capital_env_var.into(),
         flags: checker.default_string_flags().with_prefix({
             if env_var.is_unicode() {
                 StringLiteralPrefix::Unicode

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/split_static_string.rs
@@ -180,7 +180,7 @@ fn construct_replacement(elts: &[&str], flags: StringLiteralFlags) -> Expr {
             .map(|elt| {
                 let element_flags = replace_flags(elt, flags);
                 Expr::from(StringLiteral {
-                    value: Box::from(*elt),
+                    value: (*elt).into(),
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                     flags: element_flags,

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -429,7 +429,7 @@ impl<'a> QuoteAnnotator<'a> {
         generator.expr(&Expr::from(ast::StringLiteral {
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            value: annotation.into_boxed_str(),
+            value: annotation.into(),
             flags: self.flags,
         }))
     }

--- a/crates/ruff_linter/src/rules/flynt/helpers.rs
+++ b/crates/ruff_linter/src/rules/flynt/helpers.rs
@@ -16,7 +16,7 @@ fn to_interpolated_string_interpolation_element(inner: &Expr) -> ast::Interpolat
 /// Convert a string to a [`ast::InterpolatedStringLiteralElement `].
 pub(super) fn to_interpolated_string_literal_element(s: &str) -> ast::InterpolatedStringElement {
     ast::InterpolatedStringElement::Literal(ast::InterpolatedStringLiteralElement {
-        value: Box::from(s),
+        value: s.into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     })
@@ -63,7 +63,7 @@ pub(super) fn to_interpolated_string_element(
             node_index,
         }) => Some(ast::InterpolatedStringElement::Literal(
             ast::InterpolatedStringLiteralElement {
-                value: value.to_string().into_boxed_str(),
+                value: value.to_str().into(),
                 range: *range,
                 node_index: node_index.clone(),
             },

--- a/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
+++ b/crates/ruff_linter/src/rules/flynt/rules/static_join_to_fstring.rs
@@ -108,7 +108,7 @@ fn build_fstring(joiner: &str, joinees: &[Expr], flags: FStringFlags) -> Option<
         }
 
         let node = ast::StringLiteral {
-            value: content.into_boxed_str(),
+            value: content.into(),
             flags,
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unspecified_encoding.rs
@@ -186,7 +186,7 @@ fn generate_keyword_fix(checker: &Checker, call: &ast::ExprCall) -> Fix {
         &format!(
             "encoding={}",
             checker.generator().expr(&Expr::from(ast::StringLiteral {
-                value: Box::from("utf-8"),
+                value: "utf-8".into(),
                 flags: checker.default_string_flags(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -40,7 +40,7 @@ impl LiteralType {
     fn as_zero_value_expr(self, checker: &Checker) -> Expr {
         match self {
             LiteralType::Str => ast::StringLiteral {
-                value: Box::default(),
+                value: "".into(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 flags: checker.default_string_flags(),

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -560,7 +560,7 @@ impl<'a> From<&'a ast::InterpolatedStringElement> for ComparableInterpolatedStri
             ast::InterpolatedStringElement::Literal(ast::InterpolatedStringLiteralElement {
                 value,
                 ..
-            }) => Self::Literal(value.as_ref().into()),
+            }) => Self::Literal(value.as_str().into()),
             ast::InterpolatedStringElement::Interpolation(formatted_value) => {
                 formatted_value.into()
             }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -14,6 +14,7 @@ use std::slice::{Iter, IterMut};
 use std::sync::OnceLock;
 
 use bitflags::bitflags;
+use char_str::CharStr;
 use thin_vec::ThinVec;
 
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
@@ -354,7 +355,7 @@ pub struct InterpolatedElement {
 pub struct InterpolatedStringLiteralElement {
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    pub value: Box<str>,
+    pub value: CharStr,
 }
 
 impl InterpolatedStringLiteralElement {
@@ -1465,8 +1466,8 @@ impl StringLiteralValue {
 
     /// Returns the concatenated string value as a [`str`].
     ///
-    /// Note that this will perform an allocation on the first invocation if the
-    /// string value is implicitly concatenated.
+    /// This may allocate on the first invocation if the string value is implicitly
+    /// concatenated and does not fit inline.
     pub fn to_str(&self) -> &str {
         match &self.inner {
             StringLiteralValueInner::Single(value) => value.as_str(),
@@ -1722,7 +1723,7 @@ impl fmt::Debug for StringLiteralFlags {
 pub struct StringLiteral {
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    pub value: Box<str>,
+    pub value: CharStr,
     pub flags: StringLiteralFlags,
 }
 
@@ -1731,6 +1732,12 @@ impl Deref for StringLiteral {
 
     fn deref(&self) -> &Self::Target {
         &self.value
+    }
+}
+
+impl AsRef<str> for StringLiteral {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 
@@ -1780,16 +1787,13 @@ struct ConcatenatedStringLiteral {
     /// The individual [`StringLiteral`] parts that make up the concatenated string.
     strings: Vec<StringLiteral>,
     /// The concatenated string value.
-    value: OnceLock<Box<str>>,
+    value: OnceLock<CharStr>,
 }
 
 impl ConcatenatedStringLiteral {
     /// Extracts a string slice containing the entire concatenated string.
     fn to_str(&self) -> &str {
-        self.value.get_or_init(|| {
-            let concatenated: String = self.strings.iter().map(StringLiteral::as_str).collect();
-            concatenated.into_boxed_str()
-        })
+        self.value.get_or_init(|| CharStr::concat(&self.strings))
     }
 }
 

--- a/crates/ruff_python_formatter/tests/normalizer.rs
+++ b/crates/ruff_python_formatter/tests/normalizer.rs
@@ -66,7 +66,7 @@ impl Transformer for Normalizer {
 
                 if can_join {
                     string.value = ast::StringLiteralValue::single(ast::StringLiteral {
-                        value: Box::from(string.value.to_str()),
+                        value: string.value.to_str().into(),
                         range: string.range,
                         flags: StringLiteralFlags::empty(),
                         node_index: AtomicNodeIndex::NONE,
@@ -116,9 +116,9 @@ impl Transformer for Normalizer {
                                 self.elements.last_mut()
                             {
                                 let value = std::mem::take(&mut existing_literal.value);
-                                let mut value = value.into_string();
+                                let mut value = value.into_char_string();
                                 value.push_str(literal);
-                                existing_literal.value = value.into_boxed_str();
+                                existing_literal.value = value.freeze();
                                 existing_literal.range =
                                     TextRange::new(existing_literal.start(), range.end());
                             } else {
@@ -232,22 +232,19 @@ impl Transformer for Normalizer {
                 &string_literal.value,
                 "<DOCTEST-CODE-SNIPPET: Removed by normalizer>\n",
             )
-            .into_owned()
-            .into_boxed_str();
+            .into();
         string_literal.value = STRIP_RST_BLOCKS
             .replace_all(
                 &string_literal.value,
                 "<RSTBLOCK-CODE-SNIPPET: Removed by normalizer>\n",
             )
-            .into_owned()
-            .into_boxed_str();
+            .into();
         string_literal.value = STRIP_MARKDOWN_BLOCKS
             .replace_all(
                 &string_literal.value,
                 "<MARKDOWN-CODE-SNIPPET: Removed by normalizer>\n",
             )
-            .into_owned()
-            .into_boxed_str();
+            .into();
         // Normalize a string by (2) stripping any leading and trailing space from each
         // line, and (3) removing any blank lines from the start and end of the string.
         string_literal.value = string_literal
@@ -257,7 +254,6 @@ impl Transformer for Normalizer {
             .collect::<Vec<_>>()
             .join("\n")
             .trim()
-            .to_owned()
-            .into_boxed_str();
+            .into();
     }
 }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -19,6 +19,7 @@ ruff_text_size = { workspace = true, features = ["get-size"] }
 
 bitflags = { workspace = true }
 bstr = { workspace = true }
+char_str = { workspace = true }
 drop_bomb = { workspace = true }
 get-size2 = { workspace = true }
 memchr = { workspace = true }

--- a/crates/ruff_python_parser/src/string.rs
+++ b/crates/ruff_python_parser/src/string.rs
@@ -1,6 +1,7 @@
 //! Parsing of string literals, bytes literals, and implicit string concatenation.
 
 use bstr::ByteSlice;
+use char_str::{CharStr, CharString};
 use std::fmt;
 
 use ruff_python_ast::token::TokenKind;
@@ -289,7 +290,7 @@ impl<'src> StringParser<'src> {
             });
         };
 
-        let mut value = String::with_capacity(self.source.len());
+        let mut value = CharString::with_capacity(self.source.len());
         loop {
             // Add the characters before the escape sequence (or curly brace) to the string.
             let before_with_slash_or_brace = self.skip_bytes(index + 1);
@@ -367,7 +368,7 @@ impl<'src> StringParser<'src> {
         }
 
         Ok(ast::InterpolatedStringLiteralElement {
-            value: value.into_boxed_str(),
+            value: CharStr::new_inline(value.as_str()).unwrap_or_else(|| value.freeze()),
             range: self.range,
             node_index: AtomicNodeIndex::NONE,
         })
@@ -465,7 +466,7 @@ impl<'src> StringParser<'src> {
         };
 
         // If the string contains escape sequences, we need to parse them.
-        let mut value = String::with_capacity(self.source.len());
+        let mut value = CharString::with_capacity(self.source.len());
 
         loop {
             // Add the characters before the escape sequence to the string.
@@ -495,7 +496,7 @@ impl<'src> StringParser<'src> {
         }
 
         Ok(StringType::Str(ast::StringLiteral {
-            value: value.into_boxed_str(),
+            value: CharStr::new_inline(value.as_str()).unwrap_or_else(|| value.freeze()),
             range: self.range,
             flags: self.flags.into(),
             node_index: AtomicNodeIndex::NONE,
@@ -529,6 +530,7 @@ pub(crate) fn parse_interpolated_string_literal_element(
 
 #[cfg(test)]
 mod tests {
+    use char_str::CharStr;
     use ruff_python_ast::Suite;
 
     use crate::error::LexicalErrorType;
@@ -540,6 +542,52 @@ mod tests {
 
     fn parse_suite(source: &str) -> Result<Suite, ParseError> {
         parse_module(source).map(Parsed::into_suite)
+    }
+
+    #[test]
+    fn literal_storage_matches_decoded_length() {
+        for (source, expected) in [
+            ("''", ""),
+            ("r'short'", "short"),
+            ("'abcdefghijklmnop'", "abcdefghijklmnop"),
+            (r"'\u0061\u0062\u0063'", "abc"),
+            (r"'\U0001f980'", "🦀"),
+            (r"'\u0061abcdefghijklmnop'", "aabcdefghijklmnop"),
+            (
+                "'a literal longer than inline storage'",
+                "a literal longer than inline storage",
+            ),
+        ] {
+            let parsed = crate::parse_expression(source).unwrap();
+            let literal = parsed.expr().as_string_literal_expr().unwrap();
+            let value = &literal.value.as_slice()[0].value;
+            assert_eq!(value, expected);
+            assert_eq!(
+                value.is_heap_allocated(),
+                expected.len() > CharStr::INLINE_CAPACITY
+            );
+
+            if value.is_heap_allocated() {
+                let cloned = value.clone();
+                assert!(std::ptr::eq(value.as_ptr(), cloned.as_ptr()));
+            }
+        }
+    }
+
+    #[test]
+    fn decoded_interpolated_literals_fit_inline() {
+        let parsed = crate::parse_expression(r#"f"\u0061\u0062\u0063{x}{{a}}""#).unwrap();
+        let fstring = parsed.expr().as_f_string_expr().unwrap();
+        let values: Vec<_> = fstring
+            .value
+            .elements()
+            .filter_map(|element| element.as_literal())
+            .collect();
+        assert_eq!(values.len(), 2);
+        for (literal, expected) in values.iter().zip(["abc", "{a}"]) {
+            assert_eq!(literal.value, expected);
+            assert!(!literal.value.is_heap_allocated());
+        }
     }
 
     fn nested_format_spec(prefix: char, depth: usize) -> String {

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -920,7 +920,7 @@ impl<'a> LocalReferencesFinder<'a> {
         let [part] = string_expr.value.as_slice() else {
             return;
         };
-        if part.value.as_ref() != self.search.target_text {
+        if part.value.as_str() != self.search.target_text {
             return;
         }
 


### PR DESCRIPTION
Store ordinary string literals, interpolated literal fragments, and cached implicit concatenations in `CharStr`. On 64-bit targets this keeps the 16-byte handle while storing up to 16 UTF-8 bytes inline and sharing heap storage when literals are cloned.

Decode escaped text into `CharString` and choose inline storage from the decoded length before freezing longer values. Build cached concatenations with one exact-size allocation, and adapt literal consumers to the new representation.

This draft needs end-to-end parsing and memory measurements. Long literals acquire a reference-count header, and freezing long escaped text moves the payload to the immutable allocation layout; fewer short allocations do not establish a universal speed or memory improvement.

Related: #26871.
