### PR TITLE
[ty] Pair comparison operators with their right operands

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1646,20 +1646,17 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
         }
         Expr::Compare(
             compare @ ast::ExprCompare {
-                ops,
-                operands,
+                left,
+                comparisons,
                 range: _,
                 node_index: _,
             },
         ) => {
-            let Some((left, comparators)) = operands.split_first() else {
-                return;
-            };
             if checker.any_rule_enabled(&[Rule::NoneComparison, Rule::TrueFalseComparison]) {
                 pycodestyle::rules::literal_comparisons(checker, compare);
             }
             if checker.is_rule_enabled(Rule::IsLiteral) {
-                pyflakes::rules::invalid_literal_comparison(checker, left, ops, comparators, expr);
+                pyflakes::rules::invalid_literal_comparison(checker, left, comparisons, expr);
             }
             if checker.is_rule_enabled(Rule::TypeComparison) {
                 pycodestyle::rules::type_comparison(checker, compare);
@@ -1671,32 +1668,28 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 Rule::SysVersionInfoMinorCmpInt,
                 Rule::SysVersionCmpStr10,
             ]) {
-                flake8_2020::rules::compare(checker, left, ops, comparators);
+                flake8_2020::rules::compare(checker, left, comparisons);
             }
             if checker.is_rule_enabled(Rule::HardcodedPasswordString) {
-                flake8_bandit::rules::compare_to_hardcoded_password_string(
-                    checker,
-                    left,
-                    comparators,
-                );
+                flake8_bandit::rules::compare_to_hardcoded_password_string(checker, compare);
             }
             if checker.is_rule_enabled(Rule::ComparisonWithItself) {
-                pylint::rules::comparison_with_itself(checker, left, ops, comparators);
+                pylint::rules::comparison_with_itself(checker, compare);
             }
             if checker.is_rule_enabled(Rule::LiteralMembership) {
                 pylint::rules::literal_membership(checker, compare);
             }
             if checker.is_rule_enabled(Rule::ComparisonOfConstant) {
-                pylint::rules::comparison_of_constant(checker, left, ops, comparators);
+                pylint::rules::comparison_of_constant(checker, compare);
             }
             if checker.is_rule_enabled(Rule::CompareToEmptyString) {
-                pylint::rules::compare_to_empty_string(checker, left, ops, comparators);
+                pylint::rules::compare_to_empty_string(checker, compare);
             }
             if checker.is_rule_enabled(Rule::MagicValueComparison) {
-                pylint::rules::magic_value_comparison(checker, left, comparators);
+                pylint::rules::magic_value_comparison(checker, compare);
             }
             if checker.is_rule_enabled(Rule::NanComparison) {
-                pylint::rules::nan_comparison(checker, left, comparators);
+                pylint::rules::nan_comparison(checker, compare);
             }
             if checker.is_rule_enabled(Rule::InEmptyCollection) {
                 ruff::rules::in_empty_collection(checker, compare);
@@ -1705,25 +1698,19 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 flake8_simplify::rules::key_in_dict_compare(checker, compare);
             }
             if checker.is_rule_enabled(Rule::YodaConditions) {
-                flake8_simplify::rules::yoda_conditions(checker, expr, left, ops, comparators);
+                flake8_simplify::rules::yoda_conditions(checker, expr, left, comparisons);
             }
             if checker.is_rule_enabled(Rule::FloatEqualityComparison) {
                 ruff::rules::float_equality_comparison(checker, compare);
             }
             if checker.is_rule_enabled(Rule::PandasNuniqueConstantSeriesCheck) {
-                pandas_vet::rules::nunique_constant_series_check(
-                    checker,
-                    expr,
-                    left,
-                    ops,
-                    comparators,
-                );
+                pandas_vet::rules::nunique_constant_series_check(checker, expr, left, comparisons);
             }
             if checker.is_rule_enabled(Rule::TypeNoneComparison) {
                 refurb::rules::type_none_comparison(checker, compare);
             }
             if checker.is_rule_enabled(Rule::SingleItemMembershipTest) {
-                refurb::rules::single_item_membership_test(checker, expr, left, ops, comparators);
+                refurb::rules::single_item_membership_test(checker, expr, left, comparisons);
             }
         }
         Expr::NumberLiteral(number_literal @ ast::ExprNumberLiteral { .. }) => {

--- a/crates/ruff_linter/src/rules/airflow/rules/runtime_value_in_dag_or_task.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/runtime_value_in_dag_or_task.rs
@@ -230,8 +230,8 @@ fn find_runtime_varying_call<'a>(
         Expr::Yield(ast::ExprYield { value, .. }) => value
             .as_ref()
             .and_then(|v| find_runtime_varying_call(v, semantic)),
-        Expr::Compare(ast::ExprCompare { operands, .. }) => operands
-            .iter()
+        Expr::Compare(compare) => compare
+            .operands()
             .find_map(|operand| find_runtime_varying_call(operand, semantic)),
         Expr::FString(ast::ExprFString { value, .. }) => value
             .elements()

--- a/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
@@ -238,7 +238,7 @@ impl Violation for SysVersionCmpStr10 {
 }
 
 /// YTT103, YTT201, YTT203, YTT204, YTT302
-pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators: &[Expr]) {
+pub(crate) fn compare(checker: &Checker, left: &Expr, comparisons: &[(CmpOp, Expr)]) {
     match left {
         Expr::Subscript(ast::ExprSubscript { value, slice, .. })
             if is_sys(value, "version_info", checker.semantic()) =>
@@ -249,15 +249,15 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
             }) = slice.as_ref()
             {
                 if *i == 0 {
-                    if let (
-                        [operator @ (CmpOp::Eq | CmpOp::NotEq)],
-                        [
+                    if let [
+                        (
+                            operator @ (CmpOp::Eq | CmpOp::NotEq),
                             Expr::NumberLiteral(ast::ExprNumberLiteral {
                                 value: ast::Number::Int(n),
                                 ..
                             }),
-                        ],
-                    ) = (ops, comparators)
+                        ),
+                    ] = comparisons
                     {
                         if *n == 3 && checker.is_rule_enabled(Rule::SysVersionInfo0Eq3) {
                             checker.report_diagnostic(
@@ -269,15 +269,15 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
                         }
                     }
                 } else if *i == 1 {
-                    if let (
-                        [CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE],
-                        [
+                    if let [
+                        (
+                            CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE,
                             Expr::NumberLiteral(ast::ExprNumberLiteral {
                                 value: ast::Number::Int(_),
                                 ..
                             }),
-                        ],
-                    ) = (ops, comparators)
+                        ),
+                    ] = comparisons
                     {
                         checker.report_diagnostic_if_enabled(SysVersionInfo1CmpInt, left.range());
                     }
@@ -288,15 +288,15 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
         Expr::Attribute(ast::ExprAttribute { value, attr, .. })
             if is_sys(value, "version_info", checker.semantic()) && attr == "minor" =>
         {
-            if let (
-                [CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE],
-                [
+            if let [
+                (
+                    CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE,
                     Expr::NumberLiteral(ast::ExprNumberLiteral {
                         value: ast::Number::Int(_),
                         ..
                     }),
-                ],
-            ) = (ops, comparators)
+                ),
+            ] = comparisons
             {
                 checker.report_diagnostic_if_enabled(SysVersionInfoMinorCmpInt, left.range());
             }
@@ -306,10 +306,12 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
     }
 
     if is_sys(left, "version", checker.semantic()) {
-        if let (
-            [CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE],
-            [Expr::StringLiteral(ast::ExprStringLiteral { value, .. })],
-        ) = (ops, comparators)
+        if let [
+            (
+                CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE,
+                Expr::StringLiteral(ast::ExprStringLiteral { value, .. }),
+            ),
+        ] = comparisons
         {
             if value.len() == 1 {
                 checker.report_diagnostic_if_enabled(SysVersionCmpStr10, left.range());

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -1,5 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{self as ast, Expr};
+use ruff_python_ast::{self as ast, Expr, ExprCompare};
 use ruff_text_size::Ranged;
 
 use crate::Violation;
@@ -73,16 +73,12 @@ fn password_target(target: &Expr) -> Option<&str> {
 }
 
 /// S105
-pub(crate) fn compare_to_hardcoded_password_string(
-    checker: &Checker,
-    left: &Expr,
-    comparators: &[Expr],
-) {
-    for comp in comparators {
+pub(crate) fn compare_to_hardcoded_password_string(checker: &Checker, compare: &ExprCompare) {
+    for (_, comp) in &compare.comparisons {
         if string_literal(comp).is_none_or(str::is_empty) {
             continue;
         }
-        let Some(name) = password_target(left) else {
+        let Some(name) = password_target(&compare.left) else {
             continue;
         };
         checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -116,11 +116,14 @@ impl Violation for BadVersionInfoOrder {
 
 /// PYI006, PYI066
 pub(crate) fn bad_version_info_comparison(checker: &Checker, test: &Expr, has_else_clause: bool) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
+    let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = test
+    else {
         return;
     };
 
-    let ([op], [left, _right]) = (&**ops, &**operands) else {
+    let [(op, _right)] = &**comparisons else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -46,12 +46,15 @@ impl Violation for ComplexIfStatementInStub {
 
 /// PYI002
 pub(crate) fn complex_if_statement_in_stub(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare { operands, .. }) = test else {
+    let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = test
+    else {
         checker.report_diagnostic(ComplexIfStatementInStub, test.range());
         return;
     };
 
-    let [left, _] = &**operands else {
+    let [_] = &**comparisons else {
         checker.report_diagnostic(ComplexIfStatementInStub, test.range());
         return;
     };

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -101,11 +101,14 @@ impl Violation for UnrecognizedPlatformName {
 
 /// PYI007, PYI008
 pub(crate) fn unrecognized_platform(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
+    let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = test
+    else {
         return;
     };
 
-    let ([op], [left, right]) = (&**ops, &**operands) else {
+    let [(op, right)] = &**comparisons else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -126,11 +126,14 @@ impl Violation for WrongTupleLengthVersionComparison {
 
 /// PYI003, PYI004, PYI005
 pub(crate) fn unrecognized_version_info(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
+    let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = test
+    else {
         return;
     };
 
-    let ([op], [left, comparator]) = (&**ops, &**operands) else {
+    let [(op, comparator)] = &**comparisons else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -172,8 +172,8 @@ fn assert(expr: &Expr, msg: Option<&Expr>) -> Stmt {
 
 fn compare(left: &Expr, cmp_op: CmpOp, right: &Expr) -> Expr {
     Expr::Compare(ast::ExprCompare {
-        ops: [cmp_op].into(),
-        operands: Box::from([left.clone(), right.clone()]),
+        left: Box::new(left.clone()),
+        comparisons: [(cmp_op, right.clone())].into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     })

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -459,18 +459,18 @@ pub(crate) fn duplicate_isinstance_call(checker: &Checker, expr: &Expr) {
 
 fn match_eq_target(expr: &Expr) -> Option<(&Name, &Expr)> {
     let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
+        left,
+        comparisons,
         range: _,
         node_index: _,
     }) = expr
     else {
         return None;
     };
-    if **ops != [CmpOp::Eq] {
+    let [(CmpOp::Eq, comparator)] = &**comparisons else {
         return None;
-    }
-    let [Expr::Name(ast::ExprName { id, .. }), comparator] = &**operands else {
+    };
+    let Expr::Name(ast::ExprName { id, .. }) = left.as_ref() else {
         return None;
     };
     if !comparator.is_name_expr() {
@@ -541,8 +541,8 @@ pub(crate) fn compare_with_tuple(checker: &Checker, expr: &Expr) {
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         };
         let node2 = ast::ExprCompare {
-            ops: [CmpOp::In].into(),
-            operands: Box::from([node1.into(), node.into()]),
+            left: Box::new(node1.into()),
+            comparisons: [(CmpOp::In, node.into())].into(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -153,17 +153,17 @@ pub(crate) fn negation_with_equal_op(checker: &Checker, expr: &Expr, op: UnaryOp
         return;
     }
     let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
+        left,
+        comparisons,
         range: _,
         node_index: _,
     }) = operand
     else {
         return;
     };
-    if !matches!(&ops[..], [CmpOp::Eq]) {
+    let [(CmpOp::Eq, right)] = &**comparisons else {
         return;
-    }
+    };
     if is_exception_check(checker.semantic().current_statement()) {
         return;
     }
@@ -179,14 +179,14 @@ pub(crate) fn negation_with_equal_op(checker: &Checker, expr: &Expr, op: UnaryOp
 
     let mut diagnostic = checker.report_diagnostic(
         NegateEqualOp {
-            left: checker.generator().expr(&operands[0]),
-            right: checker.generator().expr(&operands[1]),
+            left: checker.generator().expr(left),
+            right: checker.generator().expr(right),
         },
         expr.range(),
     );
     let node = ast::ExprCompare {
-        ops: [CmpOp::NotEq].into(),
-        operands: operands.clone(),
+        left: left.clone(),
+        comparisons: [(CmpOp::NotEq, right.clone())].into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
@@ -207,17 +207,17 @@ pub(crate) fn negation_with_not_equal_op(
         return;
     }
     let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
+        left,
+        comparisons,
         range: _,
         node_index: _,
     }) = operand
     else {
         return;
     };
-    if !matches!(&**ops, [CmpOp::NotEq]) {
+    let [(CmpOp::NotEq, right)] = &**comparisons else {
         return;
-    }
+    };
     if is_exception_check(checker.semantic().current_statement()) {
         return;
     }
@@ -233,14 +233,14 @@ pub(crate) fn negation_with_not_equal_op(
 
     let mut diagnostic = checker.report_diagnostic(
         NegateNotEqualOp {
-            left: checker.generator().expr(&operands[0]),
-            right: checker.generator().expr(&operands[1]),
+            left: checker.generator().expr(left),
+            right: checker.generator().expr(right),
         },
         expr.range(),
     );
     let node = ast::ExprCompare {
-        ops: [CmpOp::Eq].into(),
-        operands: operands.clone(),
+        left: left.clone(),
+        comparisons: [(CmpOp::Eq, right.clone())].into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/collapsible_if.rs
@@ -274,11 +274,11 @@ fn find_last_nested_if(body: &[Stmt]) -> Option<&Expr> {
 
 /// Returns `true` if an expression is an `if __name__ == "__main__":` check.
 fn is_main_check(expr: &Expr) -> bool {
-    if let Expr::Compare(ast::ExprCompare { operands, .. }) = expr
-        && let [
-            Expr::Name(ast::ExprName { id, .. }),
-            Expr::StringLiteral(ast::ExprStringLiteral { value, .. }),
-        ] = &**operands
+    if let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = expr
+        && let Expr::Name(ast::ExprName { id, .. }) = left.as_ref()
+        && let [(_, Expr::StringLiteral(ast::ExprStringLiteral { value, .. }))] = &**comparisons
     {
         id == "__name__" && value == "__main__"
     } else {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -131,15 +131,16 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
     };
 
     let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
+        left,
+        comparisons,
         range: _,
         node_index: _,
     }) = &**test
     else {
         return;
     };
-    let [test_key, test_dict] = &**operands else {
+    let test_key = left.as_ref();
+    let [(op, test_dict)] = &**comparisons else {
         return;
     };
 
@@ -150,9 +151,9 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
         return;
     }
 
-    let (expected_var, expected_value, default_var, default_value) = match ops[..] {
-        [CmpOp::In] => (body_var, body_value, orelse_var, orelse_value.as_ref()),
-        [CmpOp::NotIn] => (orelse_var, orelse_value, body_var, body_value.as_ref()),
+    let (expected_var, expected_value, default_var, default_value) = match op {
+        CmpOp::In => (body_var, body_value, orelse_var, orelse_value.as_ref()),
+        CmpOp::NotIn => (orelse_var, orelse_value, body_var, body_value.as_ref()),
         _ => {
             return;
         }
@@ -258,21 +259,22 @@ pub(crate) fn if_exp_instead_of_dict_get(
     orelse: &Expr,
 ) {
     let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
+        left,
+        comparisons,
         range: _,
         node_index: _,
     }) = test
     else {
         return;
     };
-    let [test_key, test_dict] = &**operands else {
+    let test_key = left.as_ref();
+    let [(op, test_dict)] = &**comparisons else {
         return;
     };
 
-    let (body, default_value) = match &**ops {
-        [CmpOp::In] => (body, orelse),
-        [CmpOp::NotIn] => (orelse, body),
+    let (body, default_value) = match op {
+        CmpOp::In => (body, orelse),
+        CmpOp::NotIn => (orelse, body),
         _ => {
             return;
         }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -60,20 +60,20 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &Checker, stmt_if: &
     } = stmt_if;
 
     let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
+        left,
+        comparisons,
         range: _,
         node_index: _,
     }) = test.as_ref()
     else {
         return;
     };
-    let [Expr::Name(ast::ExprName { id: target, .. }), expr] = &**operands else {
+    let Expr::Name(ast::ExprName { id: target, .. }) = left.as_ref() else {
         return;
     };
-    if **ops != [CmpOp::Eq] {
+    let [(CmpOp::Eq, expr)] = &**comparisons else {
         return;
-    }
+    };
     let Some(literal_expr) = expr.as_literal_expr() else {
         return;
     };
@@ -143,15 +143,18 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &Checker, stmt_if: &
             }
             // `elif`
             Some(Expr::Compare(ast::ExprCompare {
-                ops,
-                operands,
+                left,
+                comparisons,
                 range: _,
                 node_index: _,
             })) => {
-                let [Expr::Name(ast::ExprName { id, .. }), expr] = &**operands else {
+                let Expr::Name(ast::ExprName { id, .. }) = left.as_ref() else {
                     return;
                 };
-                if id != target || **ops != [CmpOp::Eq] {
+                let [(CmpOp::Eq, expr)] = &**comparisons else {
+                    return;
+                };
+                if id != target {
                     return;
                 }
                 let Some(literal_expr) = expr.as_literal_expr() else {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -177,7 +177,7 @@ pub(crate) fn key_in_dict_comprehension(checker: &Checker, comprehension: &Compr
 
 /// SIM118 in a comparison.
 pub(crate) fn key_in_dict_compare(checker: &Checker, compare: &ast::ExprCompare) {
-    let [op] = &*compare.ops else {
+    let [(op, right)] = &*compare.comparisons else {
         return;
     };
 
@@ -185,9 +185,7 @@ pub(crate) fn key_in_dict_compare(checker: &Checker, compare: &ast::ExprCompare)
         return;
     }
 
-    let [left, right] = &*compare.operands else {
-        return;
-    };
+    let left = compare.left.as_ref();
 
     key_in_dict(checker, left, right, *op, compare.into());
 }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -234,19 +234,23 @@ pub(crate) fn needless_bool(checker: &Checker, stmt: &Stmt) {
                     ..
                 }) => Some((**operand).clone()),
 
-                Expr::Compare(ast::ExprCompare { ops, operands, .. })
-                    if let [
+                Expr::Compare(ast::ExprCompare {
+                    left, comparisons, ..
+                }) if let [
+                    (
                         op @ (ast::CmpOp::Eq
                         | ast::CmpOp::NotEq
                         | ast::CmpOp::In
                         | ast::CmpOp::NotIn
                         | ast::CmpOp::Is
                         | ast::CmpOp::IsNot),
-                    ] = ops.as_ref() =>
+                        right,
+                    ),
+                ] = comparisons.as_ref() =>
                 {
                     Some(Expr::Compare(ast::ExprCompare {
-                        ops: [op.negate()].into(),
-                        operands: operands.clone(),
+                        left: left.clone(),
+                        comparisons: [(op.negate(), right.clone())].into(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                     }))

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -150,13 +150,13 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &Checker, stmt: &Stmt) {
                 {
                     *operand.clone()
                 } else if let Expr::Compare(ast::ExprCompare {
-                    ops,
-                    operands,
+                    left,
+                    comparisons,
                     range: _,
                     node_index: _,
                 }) = &loop_.test
                 {
-                    if let ([op], [_, _]) = (&**ops, &**operands) {
+                    if let [(op, right)] = &**comparisons {
                         let op = match op {
                             CmpOp::Eq => CmpOp::NotEq,
                             CmpOp::NotEq => CmpOp::Eq,
@@ -170,8 +170,8 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &Checker, stmt: &Stmt) {
                             CmpOp::NotIn => CmpOp::In,
                         };
                         let node = ast::ExprCompare {
-                            ops: [op].into(),
-                            operands: operands.clone(),
+                            left: left.clone(),
+                            comparisons: [(op, right.clone())].into(),
                             range: TextRange::default(),
                             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                         };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -209,10 +209,9 @@ pub(crate) fn yoda_conditions(
     checker: &Checker,
     expr: &Expr,
     left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
+    comparisons: &[(CmpOp, Expr)],
 ) {
-    let ([op], [right]) = (ops, comparators) else {
+    let [(op, right)] = comparisons else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
@@ -67,14 +67,13 @@ pub(crate) fn nunique_constant_series_check(
     checker: &Checker,
     expr: &Expr,
     left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
+    comparisons: &[(CmpOp, Expr)],
 ) {
     if !checker.semantic().seen_module(Modules::PANDAS) {
         return;
     }
 
-    let ([op], [right]) = (ops, comparators) else {
+    let [(op, right)] = comparisons else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -213,14 +213,9 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
     let mut diagnostics = vec![];
 
     // Check `left`.
-    let Some((left, comparators)) = compare.operands.split_first() else {
-        return;
-    };
+    let left = compare.left.as_ref();
     let mut comparator = left;
-    let [op, ..] = &*compare.ops else {
-        return;
-    };
-    let [next, ..] = comparators else {
+    let [(op, next), ..] = &*compare.comparisons else {
         return;
     };
 
@@ -247,7 +242,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                 if let Expr::BooleanLiteral(ast::ExprBooleanLiteral { value, .. }) = comparator {
                     match op {
                         EqCmpOp::Eq => {
-                            let cond = if compare.ops.len() == 1 {
+                            let cond = if compare.comparisons.len() == 1 {
                                 Some(SourceCodeSnippet::from_str(checker.locator().slice(next)))
                             } else {
                                 None
@@ -264,7 +259,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                             diagnostics.push(diagnostic);
                         }
                         EqCmpOp::NotEq => {
-                            let cond = if compare.ops.len() == 1 {
+                            let cond = if compare.comparisons.len() == 1 {
                                 Some(SourceCodeSnippet::from_str(checker.locator().slice(next)))
                             } else {
                                 None
@@ -287,7 +282,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
     }
 
     // Check each comparator in order.
-    for (index, (op, next)) in compare.ops.iter().zip(comparators).enumerate() {
+    for (index, (op, next)) in compare.comparisons.iter().enumerate() {
         if helpers::is_constant_non_singleton(comparator) {
             comparator = next;
             continue;
@@ -325,7 +320,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                                 }
                             }
 
-                            let cond = if compare.ops.len() == 1 {
+                            let cond = if compare.comparisons.len() == 1 {
                                 Some(SourceCodeSnippet::from_str(
                                     checker.locator().slice(comparator),
                                 ))
@@ -344,7 +339,7 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                             diagnostics.push(diagnostic);
                         }
                         EqCmpOp::NotEq => {
-                            let cond = if compare.ops.len() == 1 {
+                            let cond = if compare.comparisons.len() == 1 {
                                 Some(SourceCodeSnippet::from_str(
                                     checker.locator().slice(comparator),
                                 ))
@@ -373,19 +368,17 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
     // TODO(charlie): Respect `noqa` directives. If one of the operators has a
     // `noqa`, but another doesn't, both will be removed here.
     if !bad_ops.is_empty() {
-        let ops = compare
-            .ops
+        let comparisons = compare
+            .comparisons
             .iter()
             .enumerate()
-            .map(|(idx, op)| bad_ops.get(&idx).unwrap_or(op))
-            .copied()
-            .collect::<Vec<_>>();
+            .map(|(idx, (op, right))| (*bad_ops.get(&idx).unwrap_or(op), right));
 
         let tokens = checker.tokens();
         let source = checker.source();
 
-        let content = match (&*compare.ops, comparators) {
-            ([op], [comparator]) => {
+        let content = match &*compare.comparisons {
+            [(op, comparator)] => {
                 if let Some(kind) = is_redundant_boolean_comparison(*op, left) {
                     let needs_wrap = left.range().start() != compare.range().start();
                     generate_redundant_comparison(
@@ -395,10 +388,10 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
                     let needs_wrap = comparator.range().end() != compare.range().end();
                     generate_redundant_comparison(compare, tokens, source, left, kind, needs_wrap)
                 } else {
-                    generate_comparison(left, &ops, comparators, compare.into(), tokens, source)
+                    generate_comparison(left, comparisons, compare.into(), tokens, source)
                 }
             }
-            _ => generate_comparison(left, &ops, comparators, compare.into(), tokens, source),
+            _ => generate_comparison(left, comparisons, compare.into(), tokens, source),
         };
 
         for diagnostic in &mut diagnostics {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
@@ -87,8 +87,8 @@ pub(crate) fn not_tests(checker: &Checker, unary_op: &ast::ExprUnaryOp) {
     }
 
     let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
+        left,
+        comparisons,
         range: _,
         node_index: _,
     }) = unary_op.operand.as_ref()
@@ -96,19 +96,14 @@ pub(crate) fn not_tests(checker: &Checker, unary_op: &ast::ExprUnaryOp) {
         return;
     };
 
-    let Some((left, comparators)) = operands.split_first() else {
-        return;
-    };
-
-    match &**ops {
-        [CmpOp::In] if checker.is_rule_enabled(Rule::NotInTest) => {
+    match &**comparisons {
+        [(CmpOp::In, right)] if checker.is_rule_enabled(Rule::NotInTest) => {
             let mut diagnostic = checker.report_diagnostic(NotInTest, unary_op.operand.range());
             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 pad(
                     generate_comparison(
                         left,
-                        &[CmpOp::NotIn],
-                        comparators,
+                        std::iter::once((CmpOp::NotIn, right)),
                         unary_op.into(),
                         checker.tokens(),
                         checker.source(),
@@ -119,14 +114,13 @@ pub(crate) fn not_tests(checker: &Checker, unary_op: &ast::ExprUnaryOp) {
                 unary_op.range(),
             )));
         }
-        [CmpOp::Is] if checker.is_rule_enabled(Rule::NotIsTest) => {
+        [(CmpOp::Is, right)] if checker.is_rule_enabled(Rule::NotIsTest) => {
             let mut diagnostic = checker.report_diagnostic(NotIsTest, unary_op.operand.range());
             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
                 pad(
                     generate_comparison(
                         left,
-                        &[CmpOp::IsNot],
-                        comparators,
+                        std::iter::once((CmpOp::IsNot, right)),
                         unary_op.into(),
                         checker.tokens(),
                         checker.source(),

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 
 use ruff_python_ast::{self as ast, CmpOp, Expr};
@@ -64,12 +63,9 @@ impl Violation for TypeComparison {
 /// E721
 pub(crate) fn type_comparison(checker: &Checker, compare: &ast::ExprCompare) {
     for (left, right) in compare
-        .operands
         .iter()
-        .tuple_windows()
-        .zip(&compare.ops)
-        .filter(|(_, op)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
-        .map(|((left, right), _)| (left, right))
+        .filter(|(_, op, _)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
+        .map(|(left, _, right)| (left, right))
     {
         // If either expression is a type...
         if is_type(left, checker.semantic()) || is_type(right, checker.semantic()) {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -79,13 +79,12 @@ impl AlwaysFixableViolation for IsLiteral {
 pub(crate) fn invalid_literal_comparison(
     checker: &Checker,
     left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
+    comparisons: &[(CmpOp, Expr)],
     expr: &Expr,
 ) {
     let mut lazy_located = None;
     let mut left = left;
-    for (index, (op, right)) in ops.iter().zip(comparators).enumerate() {
+    for (index, (op, right)) in comparisons.iter().enumerate() {
         if matches!(op, CmpOp::Is | CmpOp::IsNot)
             && (helpers::is_constant_non_singleton(left)
                 || helpers::is_constant_non_singleton(right)

--- a/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
@@ -78,11 +78,11 @@ pub(crate) fn boolean_chained_comparison(checker: &Checker, expr_bool_op: &ExprB
                 are_compare_expr_simplifiable(left_compare, right_compare)
             })
     {
-        let Some(Expr::Name(left_compare_right)) = left_compare.operands.last() else {
+        let Some((_, Expr::Name(left_compare_right))) = left_compare.comparisons.last() else {
             continue;
         };
 
-        let Some(Expr::Name(right_compare_left)) = right_compare.operands.first() else {
+        let Expr::Name(right_compare_left) = right_compare.left.as_ref() else {
             continue;
         };
 
@@ -144,9 +144,10 @@ pub(crate) fn boolean_chained_comparison(checker: &Checker, expr_bool_op: &ExprB
 
 /// Checks whether two compare expressions are simplifiable
 fn are_compare_expr_simplifiable(left: &ExprCompare, right: &ExprCompare) -> bool {
-    left.ops
+    left.comparisons
         .iter()
-        .chain(right.ops.iter())
+        .chain(right.comparisons.iter())
+        .map(|(op, _)| op)
         .tuple_windows::<(_, _)>()
         .all(|(left_operator, right_operator)| {
             matches!(

--- a/crates/ruff_linter/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -1,6 +1,5 @@
 use anyhow::bail;
-use itertools::Itertools;
-use ruff_python_ast::{self as ast, CmpOp, Expr};
+use ruff_python_ast::{self as ast, CmpOp, Expr, ExprCompare};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
@@ -60,12 +59,7 @@ impl Violation for CompareToEmptyString {
 }
 
 /// PLC1901
-pub(crate) fn compare_to_empty_string(
-    checker: &Checker,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
+pub(crate) fn compare_to_empty_string(checker: &Checker, compare: &ExprCompare) {
     // Omit string comparison rules within subscripts. This is mostly commonly used within
     // DataFrame and np.ndarray indexing.
     if checker
@@ -77,11 +71,7 @@ pub(crate) fn compare_to_empty_string(
     }
 
     let mut first = true;
-    for ((lhs, rhs), op) in std::iter::once(left)
-        .chain(comparators)
-        .tuple_windows::<(&Expr, &Expr)>()
-        .zip(ops)
-    {
+    for (lhs, op, rhs) in compare.iter() {
         if let Ok(op) = EmptyStringCmpOp::try_from(op) {
             if std::mem::take(&mut first) {
                 // Check the left-most expression.

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_of_constant.rs
@@ -1,5 +1,4 @@
-use itertools::Itertools;
-use ruff_python_ast::{CmpOp, Expr};
+use ruff_python_ast::{CmpOp, ExprCompare};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
@@ -52,17 +51,8 @@ impl Violation for ComparisonOfConstant {
 }
 
 /// PLR0133
-pub(crate) fn comparison_of_constant(
-    checker: &Checker,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
-    for ((left, right), op) in std::iter::once(left)
-        .chain(comparators)
-        .tuple_windows()
-        .zip(ops)
-    {
+pub(crate) fn comparison_of_constant(checker: &Checker, compare: &ExprCompare) {
+    for (left, op, right) in compare.iter() {
         if left.is_literal_expr() && right.is_literal_expr() {
             checker.report_diagnostic(
                 ComparisonOfConstant {

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -1,7 +1,5 @@
-use itertools::Itertools;
-
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{CmpOp, Expr};
+use ruff_python_ast::{Expr, ExprCompare};
 use ruff_text_size::Ranged;
 
 use crate::Violation;
@@ -49,17 +47,8 @@ impl Violation for ComparisonWithItself {
 }
 
 /// PLR0124
-pub(crate) fn comparison_with_itself(
-    checker: &Checker,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
-    for ((left, right), op) in std::iter::once(left)
-        .chain(comparators)
-        .tuple_windows()
-        .zip(ops)
-    {
+pub(crate) fn comparison_with_itself(checker: &Checker, compare: &ExprCompare) {
+    for (left, op, right) in compare.iter() {
         match (left, right) {
             // Ex) `foo == foo`
             (Expr::Name(left_name), Expr::Name(right_name)) if left_name.id == right_name.id => {

--- a/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
@@ -110,17 +110,18 @@ pub(crate) fn if_stmt_min_max(checker: &Checker, stmt_if: &ast::StmtIf) {
         return;
     };
 
-    let Some(ast::ExprCompare { ops, operands, .. }) = test.as_compare_expr() else {
+    let Some(ast::ExprCompare {
+        left, comparisons, ..
+    }) = test.as_compare_expr()
+    else {
         return;
     };
 
     // Ignore, e.g., `foo < bar < baz`.
-    let [op] = &**ops else {
+    let [(op, right)] = &**comparisons else {
         return;
     };
-    let [left, right] = &**operands else {
-        return;
-    };
+    let left = left.as_ref();
 
     // extract helpful info from expression of the form
     // `if cmp_left op cmp_right: target = assignment_value`

--- a/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
@@ -51,11 +51,8 @@ impl AlwaysFixableViolation for LiteralMembership {
 
 /// PLR6201
 pub(crate) fn literal_membership(checker: &Checker, compare: &ast::ExprCompare) {
-    if !matches!(&*compare.ops, [CmpOp::In | CmpOp::NotIn]) {
-        return;
-    }
-
-    let [left, right] = &*compare.operands else {
+    let left = compare.left.as_ref();
+    let [(CmpOp::In | CmpOp::NotIn, right)] = &*compare.comparisons else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use ruff_python_ast::helpers::map_subscript;
-use ruff_python_ast::{self as ast, Expr, Int, LiteralExpressionRef, UnaryOp};
+use ruff_python_ast::{self as ast, Expr, ExprCompare, Int, LiteralExpressionRef, UnaryOp};
 use ruff_python_semantic::SemanticModel;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
@@ -120,8 +120,8 @@ fn is_sys_version_comparand(expr: &Expr, semantic: &SemanticModel) -> bool {
 }
 
 /// PLR2004
-pub(crate) fn magic_value_comparison(checker: &Checker, left: &Expr, comparators: &[Expr]) {
-    for (left, right) in std::iter::once(left).chain(comparators).tuple_windows() {
+pub(crate) fn magic_value_comparison(checker: &Checker, compare: &ExprCompare) {
+    for (left, right) in compare.operands().tuple_windows() {
         // If both of the comparators are literals, skip rule for the whole expression.
         // R0133: comparison-of-constants
         if as_literal(left).is_some() && as_literal(right).is_some() {
@@ -130,7 +130,7 @@ pub(crate) fn magic_value_comparison(checker: &Checker, left: &Expr, comparators
     }
 
     let mut previous = None;
-    let mut operands = std::iter::once(left).chain(comparators).peekable();
+    let mut operands = compare.operands().peekable();
     while let Some(comparison_expr) = operands.next() {
         if let Some(value) = as_literal(comparison_expr)
             && is_magic_value(value, &checker.settings().pylint.allow_magic_value_types)

--- a/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
@@ -1,6 +1,6 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 
-use ruff_python_ast::{self as ast, Expr};
+use ruff_python_ast::{self as ast, Expr, ExprCompare};
 use ruff_python_semantic::SemanticModel;
 use ruff_text_size::Ranged;
 
@@ -50,8 +50,8 @@ impl Violation for NanComparison {
 }
 
 /// PLW0177
-pub(crate) fn nan_comparison(checker: &Checker, left: &Expr, comparators: &[Expr]) {
-    nan_comparison_impl(checker, std::iter::once(left).chain(comparators));
+pub(crate) fn nan_comparison(checker: &Checker, compare: &ExprCompare) {
+    nan_comparison_impl(checker, compare.operands());
 }
 
 /// PLW0177

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -202,11 +202,15 @@ pub(crate) fn repeated_equality_comparison(checker: &Checker, bool_op: &ast::Exp
                     op: bool_op.op,
                     values: before
                         .chain(std::iter::once(Expr::Compare(ast::ExprCompare {
-                            ops: match bool_op.op {
-                                BoolOp::Or => [CmpOp::In].into(),
-                                BoolOp::And => [CmpOp::NotIn].into(),
-                            },
-                            operands: Box::from([expr.clone(), comparator]),
+                            left: Box::new(expr.clone()),
+                            comparisons: [(
+                                match bool_op.op {
+                                    BoolOp::Or => CmpOp::In,
+                                    BoolOp::And => CmpOp::NotIn,
+                                },
+                                comparator,
+                            )]
+                            .into(),
                             range: bool_op.range(),
                             node_index: AtomicNodeIndex::NONE,
                         })))
@@ -229,12 +233,15 @@ fn to_allowed_value<'a>(
     value: &'a Expr,
     semantic: &SemanticModel,
 ) -> Option<(&'a Expr, &'a Expr)> {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = value else {
+    let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = value
+    else {
         return None;
     };
 
     // Ignore, e.g., `foo == bar == baz`.
-    let [op] = &**ops else {
+    let [(op, right)] = &**comparisons else {
         return None;
     };
 
@@ -246,9 +253,7 @@ fn to_allowed_value<'a>(
     }
 
     // Ignore self-comparisons, e.g., `foo == foo`.
-    let [left, right] = &**operands else {
-        return None;
-    };
+    let left = left.as_ref();
     if ComparableExpr::from(left) == ComparableExpr::from(right) {
         return None;
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -92,8 +92,8 @@ enum Reason {
 pub(crate) fn outdated_version_block(checker: &Checker, stmt_if: &StmtIf) {
     for branch in if_elif_branches(stmt_if) {
         let Expr::Compare(ast::ExprCompare {
-            ops,
-            operands,
+            left,
+            comparisons,
             range: _,
             node_index: _,
         }) = &branch.test
@@ -101,7 +101,7 @@ pub(crate) fn outdated_version_block(checker: &Checker, stmt_if: &StmtIf) {
             continue;
         };
 
-        let ([op], [left, comparison]) = (&**ops, &**operands) else {
+        let [(op, comparison)] = &**comparisons else {
             continue;
         };
 

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -66,8 +66,8 @@ pub(super) fn replace_with_identity_check(
     };
 
     let new_expr = Expr::Compare(ast::ExprCompare {
-        ops: [op].into(),
-        operands: [left.clone(), ast::ExprNoneLiteral::default().into()].into(),
+        left: Box::new(left.clone()),
+        comparisons: [(op, ast::ExprNoneLiteral::default().into())].into(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     });

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -132,13 +132,11 @@ fn compare(lhs: &ComparableExpr, rhs: &ComparableExpr) -> bool {
 
 /// Match `if` condition to be `expr in name`, returns a tuple of (`expr`, `name`) on success.
 fn match_check(if_stmt: &ast::StmtIf) -> Option<(&Expr, &ast::ExprName)> {
-    let ast::ExprCompare { ops, operands, .. } = if_stmt.test.as_compare_expr()?;
+    let ast::ExprCompare {
+        left, comparisons, ..
+    } = if_stmt.test.as_compare_expr()?;
 
-    if **ops != [CmpOp::In] {
-        return None;
-    }
-
-    let [left, Expr::Name(right @ ast::ExprName { .. })] = &**operands else {
+    let [(CmpOp::In, Expr::Name(right @ ast::ExprName { .. }))] = &**comparisons else {
         return None;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
@@ -87,12 +87,15 @@ impl Violation for IfExprMinMax {
 
 /// FURB136
 pub(crate) fn if_expr_min_max(checker: &Checker, if_exp: &ast::ExprIf) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = if_exp.test.as_ref() else {
+    let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = if_exp.test.as_ref()
+    else {
         return;
     };
 
     // Ignore, e.g., `foo < bar < baz`.
-    let [op] = &**ops else {
+    let [(op, right)] = &**comparisons else {
         return;
     };
 
@@ -106,9 +109,7 @@ pub(crate) fn if_expr_min_max(checker: &Checker, if_exp: &ast::ExprIf) {
         _ => return,
     };
 
-    let [left, right] = &**operands else {
-        return;
-    };
+    let left = left.as_ref();
 
     let body_cmp = ComparableExpr::from(if_exp.body.as_ref());
     let orelse_cmp = ComparableExpr::from(if_exp.orelse.as_ref());

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -430,12 +430,10 @@ fn cmp_op(expr: &ast::ExprCompare, params: &Parameters) -> Option<&'static str> 
     let [arg1, arg2] = params.args.as_slice() else {
         return None;
     };
-    let [op] = &*expr.ops else {
+    let [(op, right)] = &*expr.comparisons else {
         return None;
     };
-    let [left, right] = &*expr.operands else {
-        return None;
-    };
+    let left = expr.left.as_ref();
 
     match op {
         ast::CmpOp::Eq => match_arguments(arg1, arg2, left, right).then_some("eq"),

--- a/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
@@ -70,10 +70,9 @@ pub(crate) fn single_item_membership_test(
     checker: &Checker,
     expr: &Expr,
     left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
+    comparisons: &[(CmpOp, Expr)],
 ) {
-    let ([op], [right]) = (ops, comparators) else {
+    let [(op, right)] = comparisons else {
         return;
     };
 
@@ -93,8 +92,7 @@ pub(crate) fn single_item_membership_test(
         pad(
             generate_comparison(
                 left,
-                &[membership_test.replacement_op()],
-                std::slice::from_ref(item),
+                std::iter::once((membership_test.replacement_op(), item)),
                 expr.into(),
                 checker.tokens(),
                 checker.source(),

--- a/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
@@ -54,7 +54,7 @@ impl AlwaysFixableViolation for TypeNoneComparison {
 
 /// FURB169
 pub(crate) fn type_none_comparison(checker: &Checker, compare: &ast::ExprCompare) {
-    let ([op], [left, right]) = (&*compare.ops, &*compare.operands) else {
+    let [(op, right)] = &*compare.comparisons else {
         return;
     };
 
@@ -64,7 +64,7 @@ pub(crate) fn type_none_comparison(checker: &Checker, compare: &ast::ExprCompare
         _ => return,
     };
 
-    let Some(left_arg) = type_call_arg(left, checker.semantic()) else {
+    let Some(left_arg) = type_call_arg(&compare.left, checker.semantic()) else {
         return;
     };
     let Some(right_arg) = type_call_arg(right, checker.semantic()) else {

--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, CmpOp, Expr};
 use ruff_python_semantic::{
@@ -126,20 +125,16 @@ pub(crate) fn float_equality_comparison(checker: &Checker, compare: &ast::ExprCo
     let locator = checker.locator();
     let semantic = checker.semantic();
 
-    for (left, right, operator) in compare
-        .operands
+    for (left, operator, right) in compare
         .iter()
-        .tuple_windows()
-        .zip(&compare.ops)
-        .filter(|(_, op)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
-        .filter(|((left, right), _)| {
+        .filter(|(_, op, _)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
+        .filter(|(left, _, right)| {
             if should_skip_comparison(left, semantic) || should_skip_comparison(right, semantic) {
                 return false;
             }
 
             has_float(left, semantic) || has_float(right, semantic)
         })
-        .map(|((left, right), op)| (left, right, op))
     {
         checker.report_diagnostic(
             FloatEqualityComparison {

--- a/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/if_key_in_dict_del.rs
@@ -84,15 +84,11 @@ fn extract_dict_and_key_from_test(test: &Expr) -> Option<(&Dict, &Key)> {
         return None;
     };
 
-    let [key, Expr::Name(dict)] = comp.operands.as_ref() else {
+    let [(CmpOp::In, Expr::Name(dict))] = comp.comparisons.as_ref() else {
         return None;
     };
 
-    if !matches!(comp.ops.as_ref(), [CmpOp::In]) {
-        return None;
-    }
-
-    Some((dict, key))
+    Some((dict, &comp.left))
 }
 
 fn extract_dict_and_key_from_del(targets: &[Expr]) -> Option<(&Dict, &Key)> {

--- a/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
@@ -38,17 +38,13 @@ impl Violation for InEmptyCollection {
 
 /// RUF060
 pub(crate) fn in_empty_collection(checker: &Checker, compare: &ast::ExprCompare) {
-    let [op] = &*compare.ops else {
+    let [(op, right)] = &*compare.comparisons else {
         return;
     };
 
     if !matches!(op, CmpOp::In | CmpOp::NotIn) {
         return;
     }
-
-    let [_, right] = &*compare.operands else {
-        return;
-    };
 
     let semantic = checker.semantic();
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -69,15 +69,15 @@ pub(crate) fn unnecessary_key_check(checker: &Checker, expr: &Expr) {
     };
 
     // Left should be, e.g., `key in dct`.
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = left else {
+    let Expr::Compare(ast::ExprCompare {
+        left, comparisons, ..
+    }) = left
+    else {
         return;
     };
 
-    if !matches!(&**ops, [CmpOp::In]) {
-        return;
-    }
-
-    let [key_left, obj_left] = &**operands else {
+    let key_left = left.as_ref();
+    let [(CmpOp::In, obj_left)] = &**comparisons else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -332,8 +332,8 @@ impl<'a> ReFunc<'a> {
     /// Return a new compare expr of the form `left op right`
     fn compare_expr(left: &Expr, op: CmpOp, right: &Expr) -> Expr {
         Expr::Compare(ExprCompare {
-            ops: [op].into(),
-            operands: Box::new([left.clone(), right.clone()]),
+            left: Box::new(left.clone()),
+            comparisons: [(op, right.clone())].into(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })
@@ -441,22 +441,15 @@ fn get_comparison_to_none(semantic: &SemanticModel) -> Option<(ComparisonToNone,
     let parent_expr = semantic.current_expression_parent()?;
 
     let Expr::Compare(ExprCompare {
-        ops,
-        operands,
-        range,
-        ..
+        comparisons, range, ..
     }) = parent_expr
     else {
         return None;
     };
 
-    let Some(Expr::NoneLiteral(_)) = operands.get(1) else {
-        return None;
-    };
-
-    match ops.as_ref() {
-        [CmpOp::Is] => Some((ComparisonToNone::Is, *range)),
-        [CmpOp::IsNot] => Some((ComparisonToNone::IsNot, *range)),
+    match comparisons.as_ref() {
+        [(CmpOp::Is, Expr::NoneLiteral(_))] => Some((ComparisonToNone::Is, *range)),
+        [(CmpOp::IsNot, Expr::NoneLiteral(_))] => Some((ComparisonToNone::IsNot, *range)),
         _ => None,
     }
 }

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -413,14 +413,15 @@ fields = [{ name = "value", type = "Expr" }]
 [Expr.nodes.ExprCompare]
 doc = """A comparison or chain of comparisons.
 
-`operands` contains all operands in source order, including the leftmost operand.
-For example, `a < b <= c` has operands `[a, b, c]` and operators `[Lt, LtE]`.
-There is at least one operator, and `operands.len() == ops.len() + 1`.
+`left` is the initial operand, and `comparisons` pairs each operator with its right operand.
+For example, `a < b <= c` has `left = a` and comparisons `[(Lt, b), (LtE, c)]`.
+The parser always produces at least one comparison, synthesizing an invalid name expression
+for a missing operand during error recovery.
 
 See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare)."""
 fields = [
-  { name = "ops", type = "Box<[CmpOp]>" },
-  { name = "operands", type = "Box<[Expr]>" },
+  { name = "left", type = "Expr" },
+  { name = "comparisons", type = "Box<[(crate::CmpOp, Expr)]>" },
 ]
 # The fields must be visited simultaneously
 custom_source_order = true

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -941,8 +941,8 @@ pub struct ExprYieldFrom<'a> {
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct ExprCompare<'a> {
-    ops: Vec<ComparableCmpOp>,
-    operands: Vec<ComparableExpr<'a>>,
+    left: Box<ComparableExpr<'a>>,
+    comparisons: Vec<(ComparableCmpOp, ComparableExpr<'a>)>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -1221,13 +1221,16 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                 value: value.into(),
             }),
             ast::Expr::Compare(ast::ExprCompare {
-                ops,
-                operands,
+                left,
+                comparisons,
                 range: _,
                 node_index: _,
             }) => Self::Compare(ExprCompare {
-                ops: ops.iter().copied().map(Into::into).collect(),
-                operands: operands.iter().map(Into::into).collect(),
+                left: left.into(),
+                comparisons: comparisons
+                    .iter()
+                    .map(|(op, right)| ((*op).into(), right.into()))
+                    .collect(),
             }),
             ast::Expr::Call(ast::ExprCall {
                 func,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -9769,9 +9769,10 @@ pub struct ExprYieldFrom {
 
 /// A comparison or chain of comparisons.
 ///
-/// `operands` contains all operands in source order, including the leftmost operand.
-/// For example, `a < b <= c` has operands `[a, b, c]` and operators `[Lt, LtE]`.
-/// There is at least one operator, and `operands.len() == ops.len() + 1`.
+/// `left` is the initial operand, and `comparisons` pairs each operator with its right operand.
+/// For example, `a < b <= c` has `left = a` and comparisons `[(Lt, b), (LtE, c)]`.
+/// The parser always produces at least one comparison, synthesizing an invalid name expression
+/// for a missing operand during error recovery.
 ///
 /// See also [Compare](https://docs.python.org/3/library/ast.html#ast.Compare).
 #[derive(Clone, Debug, PartialEq)]
@@ -9779,8 +9780,8 @@ pub struct ExprYieldFrom {
 pub struct ExprCompare {
     pub node_index: crate::AtomicNodeIndex,
     pub range: ruff_text_size::TextRange,
-    pub ops: Box<[crate::CmpOp]>,
-    pub operands: Box<[Expr]>,
+    pub left: Box<Expr>,
+    pub comparisons: Box<[(crate::CmpOp, Expr)]>,
 }
 
 /// A call expression whose end offset is derived from its arguments.

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -389,9 +389,9 @@ where
             }) => value
                 .as_ref()
                 .is_some_and(|value| any_over_expr(value, func)),
-            Expr::Compare(ast::ExprCompare { operands, .. }) => {
-                operands.iter().any(|expr| any_over_expr(expr, &mut *func))
-            }
+            Expr::Compare(compare) => compare
+                .operands()
+                .any(|expr| any_over_expr(expr, &mut *func)),
             Expr::Call(ast::ExprCall {
                 func: call_func,
                 arguments,
@@ -1655,16 +1655,18 @@ pub fn is_empty_f_string(expr: &ast::ExprFString) -> bool {
     })
 }
 
-pub fn generate_comparison(
+pub fn generate_comparison<'a>(
     left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
+    comparisons: impl DoubleEndedIterator<Item = (CmpOp, &'a Expr)> + Clone,
     parent: AnyNodeRef,
     tokens: &Tokens,
     source: &str,
 ) -> String {
     let start = left.start();
-    let end = comparators.last().map_or_else(|| left.end(), Ranged::end);
+    let end = comparisons
+        .clone()
+        .next_back()
+        .map_or_else(|| left.end(), |(_, right)| right.end());
     let mut contents = String::with_capacity(usize::from(end - start));
 
     // Add the left side of the comparison.
@@ -1672,7 +1674,7 @@ pub fn generate_comparison(
         &source[parenthesized_range(left.into(), parent, tokens).unwrap_or(left.range())],
     );
 
-    for (op, comparator) in ops.iter().zip(comparators) {
+    for (op, comparator) in comparisons {
         // Add the operator.
         contents.push_str(match op {
             CmpOp::Eq => " == ",

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -70,23 +70,35 @@ impl ast::ExprBoolOp {
 }
 
 impl ast::ExprCompare {
+    /// Iterate over all operands in source order, including the initial left operand.
+    pub fn operands(&self) -> impl DoubleEndedIterator<Item = &ast::Expr> + Clone {
+        std::iter::once(self.left.as_ref()).chain(self.comparisons.iter().map(|(_, right)| right))
+    }
+
+    /// Iterate over the left operand, operator, and right operand of each comparison.
+    ///
+    /// For `a < b <= c`, this yields `(a, Lt, b)` followed by `(b, LtE, c)`.
+    pub fn iter(&self) -> impl Iterator<Item = (&ast::Expr, &ast::CmpOp, &ast::Expr)> + Clone {
+        self.operands()
+            .zip(self.comparisons.iter())
+            .map(|(left, (op, right))| (left, op, right))
+    }
+
     pub(crate) fn visit_source_order<'a, V>(&'a self, visitor: &mut V)
     where
         V: SourceOrderVisitor<'a> + ?Sized,
     {
         let ast::ExprCompare {
-            ops,
-            operands,
+            left,
+            comparisons,
             range: _,
             node_index: _,
         } = self;
 
-        if let Some((left, comparators)) = operands.split_first() {
-            visitor.visit_expr(left);
-            for (op, comparator) in ops.iter().zip(comparators) {
-                visitor.visit_cmp_op(op);
-                visitor.visit_expr(comparator);
-            }
+        visitor.visit_expr(left);
+        for (op, comparator) in comparisons {
+            visitor.visit_cmp_op(op);
+            visitor.visit_expr(comparator);
         }
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -4129,7 +4129,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<ExprBooleanLiteral>(), 16);
         assert_eq!(std::mem::size_of::<ExprBytesLiteral>(), 48);
         assert_eq!(std::mem::size_of::<ExprCall>(), 48);
-        assert_eq!(std::mem::size_of::<ExprCompare>(), 48);
+        assert_eq!(std::mem::size_of::<ExprCompare>(), 40);
         assert_eq!(std::mem::size_of::<ExprDict>(), 40);
         assert_eq!(std::mem::size_of::<ExprDictComp>(), 48);
         assert_eq!(std::mem::size_of::<ExprEllipsisLiteral>(), 12);

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -513,19 +513,17 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             node_index: _,
         }) => visitor.visit_expr(value),
         Expr::Compare(ast::ExprCompare {
-            ops,
-            operands,
+            left,
+            comparisons,
             range: _,
             node_index: _,
         }) => {
-            if let Some((left, comparators)) = operands.split_first() {
-                visitor.visit_expr(left);
-                for cmp_op in ops {
-                    visitor.visit_cmp_op(cmp_op);
-                }
-                for expr in comparators {
-                    visitor.visit_expr(expr);
-                }
+            visitor.visit_expr(left);
+            for (cmp_op, _) in comparisons {
+                visitor.visit_cmp_op(cmp_op);
+            }
+            for (_, expr) in comparisons {
+                visitor.visit_expr(expr);
             }
         }
         Expr::Call(ast::ExprCall {

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -500,19 +500,17 @@ pub fn walk_expr<V: Transformer + ?Sized>(visitor: &V, expr: &mut Expr) {
             node_index: _,
         }) => visitor.visit_expr(value),
         Expr::Compare(ast::ExprCompare {
-            ops,
-            operands,
+            left,
+            comparisons,
             range: _,
             node_index: _,
         }) => {
-            if let Some((left, comparators)) = operands.split_first_mut() {
-                visitor.visit_expr(left);
-                for cmp_op in &mut **ops {
-                    visitor.visit_cmp_op(cmp_op);
-                }
-                for expr in comparators {
-                    visitor.visit_expr(expr);
-                }
+            visitor.visit_expr(left);
+            for (cmp_op, _) in &mut **comparisons {
+                visitor.visit_cmp_op(cmp_op);
+            }
+            for (_, expr) in comparisons {
+                visitor.visit_expr(expr);
             }
         }
         Expr::Call(ast::ExprCall {

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1167,15 +1167,15 @@ impl<'a> Generator<'a> {
                 });
             }
             Expr::Compare(ast::ExprCompare {
-                ops,
-                operands,
+                left,
+                comparisons,
                 range: _,
                 node_index: _,
             }) => {
                 group_if!(precedence::CMP, {
                     let new_lvl = precedence::CMP + 1;
-                    self.unparse_expr(&operands[0], new_lvl);
-                    for (op, cmp) in ops.iter().zip(&operands[1..]) {
+                    self.unparse_expr(left, new_lvl);
+                    for (op, cmp) in comparisons {
                         let op = match op {
                             CmpOp::Eq => " == ",
                             CmpOp::NotEq => " != ",

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -44,11 +44,11 @@ impl<'a> BinaryLike<'a> {
             trivia: &TriviaRanges,
             parts: &mut SmallVec<[OperandOrOperator<'a>; 8]>,
         ) {
-            parts.reserve(compare.ops.len() * 2 + 1);
+            parts.reserve(compare.comparisons.len() * 2 + 1);
 
             rec(
                 Operand::Left {
-                    expression: &compare.operands[0],
+                    expression: &compare.left,
                     leading_comments,
                 },
                 comments,
@@ -56,17 +56,10 @@ impl<'a> BinaryLike<'a> {
                 parts,
             );
 
-            assert_eq!(
-                compare.operands.len(),
-                compare.ops.len() + 1,
-                "Compare expression with an unbalanced number of comparators and operations."
-            );
-
-            if let Some((last_expression, middle_expressions)) = compare.operands[1..].split_last()
+            if let Some(((last_operator, last_expression), middle_comparisons)) =
+                compare.comparisons.split_last()
             {
-                let (last_operator, middle_operators) = compare.ops.split_last().unwrap();
-
-                for (operator, expression) in middle_operators.iter().zip(middle_expressions) {
+                for (operator, expression) in middle_comparisons {
                     parts.push(OperandOrOperator::Operator(Operator {
                         symbol: OperatorSymbol::Comparator(*operator),
                         trailing_comments: &[],

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -26,12 +26,12 @@ impl NeedsParentheses for ExprCompare {
     ) -> OptionalParentheses {
         if parent.is_expr_await() {
             OptionalParentheses::Always
-        } else if let Ok(string) = StringLike::try_from(&self.operands[0]) {
+        } else if let Ok(string) = StringLike::try_from(self.left.as_ref()) {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
             if !string.is_implicit_concatenated()
                 && string.is_multiline(context)
                 && !context.comments().has(string)
-                && self.operands.get(1).is_some_and(|right| {
+                && self.comparisons.first().is_some_and(|(_, right)| {
                     has_parentheses(right, context).is_some() && !context.comments().has(right)
                 })
             {

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -699,12 +699,12 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
             Expr::Compare(ast::ExprCompare {
                 range: _,
                 node_index: _,
-                ops,
-                operands: _,
+                comparisons,
+                left: _,
             }) => {
                 self.update_max_precedence_with_count(
                     OperatorPrecedence::Comparator,
-                    ops.len() as u32,
+                    comparisons.len() as u32,
                 );
             }
             Expr::Call(ast::ExprCall {
@@ -1433,10 +1433,10 @@ pub(crate) fn left_most<'expr>(expression: &'expr Expr, trivia: &TriviaRanges) -
             | Expr::If(ast::ExprIf { body: left, .. })
             | Expr::Call(ast::ExprCall { func: left, .. })
             | Expr::Attribute(ast::ExprAttribute { value: left, .. })
-            | Expr::Subscript(ast::ExprSubscript { value: left, .. }) => Some(&**left),
+            | Expr::Subscript(ast::ExprSubscript { value: left, .. })
+            | Expr::Compare(ast::ExprCompare { left, .. }) => Some(&**left),
 
             Expr::BoolOp(expr_bool_op) => expr_bool_op.values.first(),
-            Expr::Compare(compare) => compare.operands.first(),
 
             Expr::Generator(generator) if !generator.parenthesized => Some(&*generator.elt),
 

--- a/crates/ruff_python_parser/resources/valid/expressions/compare.py
+++ b/crates/ruff_python_parser/resources/valid/expressions/compare.py
@@ -28,3 +28,6 @@ x is not await y
 
 # All operators have the same precedence
 a < b == c > d is e not in f is not g <= h >= i != j
+
+# Nested comparisons preserve the surrounding operands and operators.
+a < b < (c <= d < e) < f

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -1240,9 +1240,8 @@ impl<'src> Parser<'src> {
     ) -> ast::ExprCompare {
         self.bump_cmp_op(op);
 
-        let operands_snapshot = self.expr_scratch.snapshot();
-        self.expr_scratch.push(lhs);
-        let mut operators = vec![op];
+        let comparisons_snapshot = self.comparison_scratch.snapshot();
+        let mut op = op;
 
         let mut progress = ParserProgress::default();
 
@@ -1255,7 +1254,7 @@ impl<'src> Parser<'src> {
                     context,
                 )
                 .expr;
-            self.expr_scratch.push(comparator);
+            self.comparison_scratch.push((op, comparator));
 
             let next_token = self.current_token_kind();
             if matches!(next_token, TokenKind::In) && context.is_in_excluded() {
@@ -1269,12 +1268,12 @@ impl<'src> Parser<'src> {
             };
 
             self.bump_cmp_op(next_op);
-            operators.push(next_op);
+            op = next_op;
         }
 
         ast::ExprCompare {
-            ops: operators.into_boxed_slice(),
-            operands: self.expr_scratch.take(operands_snapshot),
+            left: Box::new(lhs),
+            comparisons: self.comparison_scratch.take(comparisons_snapshot),
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
         }

--- a/crates/ruff_python_parser/src/parser/mod.rs
+++ b/crates/ruff_python_parser/src/parser/mod.rs
@@ -7,8 +7,8 @@ use hashbrown::HashSet;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{
-    Alias, AtomicNodeIndex, ElifElseClause, Expr, Int, IpyEscapeKind, Keyword, Mod, ModExpression,
-    ModModule, ParameterWithDefault, Stmt, StringFlags,
+    Alias, AtomicNodeIndex, CmpOp, ElifElseClause, Expr, Int, IpyEscapeKind, Keyword, Mod,
+    ModExpression, ModModule, ParameterWithDefault, Stmt, StringFlags,
 };
 use ruff_python_trivia::is_python_whitespace;
 use ruff_text_size::{Ranged, TextRange, TextSize};
@@ -104,6 +104,9 @@ pub(crate) struct Parser<'src> {
     /// Reusable, nesting-safe scratch storage for expression lists.
     expr_scratch: ScratchBuffer<Expr>,
 
+    /// Reusable scratch storage for comparison operators and their right operands.
+    comparison_scratch: ScratchBuffer<(CmpOp, Expr)>,
+
     /// Reusable, nesting-safe scratch storage for call keywords.
     keyword_scratch: ScratchBuffer<Keyword>,
 
@@ -148,6 +151,7 @@ impl<'src> Parser<'src> {
             recursion_depth: 0,
             current_token_id: TokenId::default(),
             expr_scratch: ScratchBuffer::with_capacity(16),
+            comparison_scratch: ScratchBuffer::new(),
             keyword_scratch: ScratchBuffer::new(),
             parameter_scratch: ScratchBuffer::new(),
             stmt_scratch: ScratchBuffer::with_capacity(32),

--- a/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
+++ b/crates/ruff_python_parser/src/parser/snapshots/ruff_python_parser__parser__tests__ipython_escape_commands.snap
@@ -172,25 +172,25 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 598..620,
-                                            ops: [
-                                                NotEq,
-                                            ],
-                                            operands: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 598..599,
-                                                        id: Name("a"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 619..620,
-                                                        id: Name("b"),
-                                                        ctx: Load,
-                                                    },
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 598..599,
+                                                    id: Name("a"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            comparisons: [
+                                                (
+                                                    NotEq,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 619..620,
+                                                            id: Name("b"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                 ),
                                             ],
                                         },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_equals.snap
@@ -25,27 +25,27 @@ expression: suite
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 3..11,
-                                                    ops: [
-                                                        Eq,
-                                                    ],
-                                                    operands: [
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..5,
-                                                                value: Int(
-                                                                    42,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 9..11,
-                                                                value: Int(
-                                                                    42,
-                                                                ),
-                                                            },
+                                                    left: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..5,
+                                                            value: Int(
+                                                                42,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    comparisons: [
+                                                        (
+                                                            Eq,
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 9..11,
+                                                                    value: Int(
+                                                                        42,
+                                                                    ),
+                                                                },
+                                                            ),
                                                         ),
                                                     ],
                                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_fstring_not_equals.snap
@@ -25,27 +25,27 @@ expression: suite
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 3..9,
-                                                    ops: [
-                                                        NotEq,
-                                                    ],
-                                                    operands: [
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..4,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 8..9,
-                                                                value: Int(
-                                                                    2,
-                                                                ),
-                                                            },
+                                                    left: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..4,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    comparisons: [
+                                                        (
+                                                            NotEq,
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 8..9,
+                                                                    value: Int(
+                                                                        2,
+                                                                    ),
+                                                                },
+                                                            ),
                                                         ),
                                                     ],
                                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_equals.snap
@@ -25,27 +25,27 @@ expression: suite
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 3..11,
-                                                    ops: [
-                                                        Eq,
-                                                    ],
-                                                    operands: [
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..5,
-                                                                value: Int(
-                                                                    42,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 9..11,
-                                                                value: Int(
-                                                                    42,
-                                                                ),
-                                                            },
+                                                    left: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..5,
+                                                            value: Int(
+                                                                42,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    comparisons: [
+                                                        (
+                                                            Eq,
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 9..11,
+                                                                    value: Int(
+                                                                        42,
+                                                                    ),
+                                                                },
+                                                            ),
                                                         ),
                                                     ],
                                                 },

--- a/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_not_equals.snap
+++ b/crates/ruff_python_parser/src/snapshots/ruff_python_parser__string__tests__parse_tstring_not_equals.snap
@@ -25,27 +25,27 @@ expression: suite
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 3..9,
-                                                    ops: [
-                                                        NotEq,
-                                                    ],
-                                                    operands: [
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 3..4,
-                                                                value: Int(
-                                                                    1,
-                                                                ),
-                                                            },
-                                                        ),
-                                                        NumberLiteral(
-                                                            ExprNumberLiteral {
-                                                                node_index: NodeIndex(None),
-                                                                range: 8..9,
-                                                                value: Int(
-                                                                    2,
-                                                                ),
-                                                            },
+                                                    left: NumberLiteral(
+                                                        ExprNumberLiteral {
+                                                            node_index: NodeIndex(None),
+                                                            range: 3..4,
+                                                            value: Int(
+                                                                1,
+                                                            ),
+                                                        },
+                                                    ),
+                                                    comparisons: [
+                                                        (
+                                                            NotEq,
+                                                            NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 8..9,
+                                                                    value: Int(
+                                                                        2,
+                                                                    ),
+                                                                },
+                                                            ),
                                                         ),
                                                     ],
                                                 },

--- a/crates/ruff_python_parser/tests/fixtures.rs
+++ b/crates/ruff_python_parser/tests/fixtures.rs
@@ -509,13 +509,8 @@ impl<'ast> SourceOrderVisitor<'ast> for ValidateAstVisitor<'ast> {
     fn enter_node(&mut self, node: AnyNodeRef<'ast>) -> TraversalSignal {
         if let AnyNodeRef::ExprCompare(compare) = node {
             assert!(
-                !compare.ops.is_empty(),
+                !compare.comparisons.is_empty(),
                 "Comparison without an operator: {compare:#?}"
-            );
-            assert_eq!(
-                compare.operands.len(),
-                compare.ops.len() + 1,
-                "Comparison operands and operators are unbalanced: {compare:#?}",
             );
         }
 

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_order.py.snap
@@ -18,32 +18,32 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..10,
-                            ops: [
-                                In,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 0..1,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                UnaryOp(
-                                    ExprUnaryOp {
-                                        node_index: NodeIndex(None),
-                                        range: 5..10,
-                                        op: Not,
-                                        operand: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 9..10,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 0..1,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    In,
+                                    UnaryOp(
+                                        ExprUnaryOp {
+                                            node_index: NodeIndex(None),
+                                            range: 5..10,
+                                            op: Not,
+                                            operand: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 9..10,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -68,25 +68,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 38..41,
-                            ops: [
-                                Gt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 38..38,
-                                        id: Name(""),
-                                        ctx: Invalid,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 40..41,
-                                        id: Name("y"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 38..38,
+                                    id: Name(""),
+                                    ctx: Invalid,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Gt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 40..41,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_rhs_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__invalid_rhs_expression.py.snap
@@ -18,58 +18,58 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..20,
-                            ops: [
-                                NotIn,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 0..1,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Lambda(
-                                    ExprLambda {
-                                        node_index: NodeIndex(None),
-                                        range: 9..20,
-                                        parameters: Some(
-                                            Parameters {
-                                                range: 16..17,
-                                                node_index: NodeIndex(None),
-                                                posonlyargs: [],
-                                                args: [
-                                                    ParameterWithDefault {
-                                                        range: 16..17,
-                                                        node_index: NodeIndex(None),
-                                                        parameter: Parameter {
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 0..1,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotIn,
+                                    Lambda(
+                                        ExprLambda {
+                                            node_index: NodeIndex(None),
+                                            range: 9..20,
+                                            parameters: Some(
+                                                Parameters {
+                                                    range: 16..17,
+                                                    node_index: NodeIndex(None),
+                                                    posonlyargs: [],
+                                                    args: [
+                                                        ParameterWithDefault {
                                                             range: 16..17,
                                                             node_index: NodeIndex(None),
-                                                            name: Identifier {
-                                                                id: Name("y"),
+                                                            parameter: Parameter {
                                                                 range: 16..17,
                                                                 node_index: NodeIndex(None),
+                                                                name: Identifier {
+                                                                    id: Name("y"),
+                                                                    range: 16..17,
+                                                                    node_index: NodeIndex(None),
+                                                                },
+                                                                annotation: None,
                                                             },
-                                                            annotation: None,
+                                                            default: None,
                                                         },
-                                                        default: None,
-                                                    },
-                                                ],
-                                                vararg: None,
-                                                kwonlyargs: [],
-                                                kwarg: None,
-                                            },
-                                        ),
-                                        body: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 19..20,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
+                                                    ],
+                                                    vararg: None,
+                                                    kwonlyargs: [],
+                                                    kwarg: None,
+                                                },
+                                            ),
+                                            body: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 19..20,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -84,33 +84,33 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 22..34,
-                            ops: [
-                                Eq,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 22..23,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Yield(
-                                    ExprYield {
-                                        node_index: NodeIndex(None),
-                                        range: 27..34,
-                                        value: Some(
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 33..34,
-                                                    id: Name("y"),
-                                                    ctx: Load,
-                                                },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 22..23,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Eq,
+                                    Yield(
+                                        ExprYield {
+                                            node_index: NodeIndex(None),
+                                            range: 27..34,
+                                            value: Some(
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 33..34,
+                                                        id: Name("y"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             ),
-                                        ),
-                                    },
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_0.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_0.py.snap
@@ -18,25 +18,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..3,
-                            ops: [
-                                Gt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 0..1,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 3..3,
-                                        id: Name(""),
-                                        ctx: Invalid,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 0..1,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Gt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 3..3,
+                                            id: Name(""),
+                                            ctx: Invalid,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__missing_rhs_2.py.snap
@@ -18,25 +18,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..8,
-                            ops: [
-                                IsNot,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 0..1,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 8..8,
-                                        id: Name(""),
-                                        ctx: Invalid,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 0..1,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    IsNot,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 8..8,
+                                            id: Name(""),
+                                            ctx: Invalid,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__multiple_equals.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__multiple_equals.py.snap
@@ -19,25 +19,25 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 25..29,
-                                ops: [
-                                    Eq,
-                                ],
-                                operands: [
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 25..26,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 29..29,
-                                            id: Name(""),
-                                            ctx: Invalid,
-                                        },
+                                left: Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 25..26,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
+                                comparisons: [
+                                    (
+                                        Eq,
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 29..29,
+                                                id: Name(""),
+                                                ctx: Invalid,
+                                            },
+                                        ),
                                     ),
                                 ],
                             },
@@ -62,25 +62,25 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 33..37,
-                                ops: [
-                                    NotEq,
-                                ],
-                                operands: [
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 33..34,
-                                            id: Name("x"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 37..37,
-                                            id: Name(""),
-                                            ctx: Invalid,
-                                        },
+                                left: Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 33..34,
+                                        id: Name("x"),
+                                        ctx: Load,
+                                    },
+                                ),
+                                comparisons: [
+                                    (
+                                        NotEq,
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 37..37,
+                                                id: Name(""),
+                                                ctx: Invalid,
+                                            },
+                                        ),
                                     ),
                                 ],
                             },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__named_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__named_expression.py.snap
@@ -18,25 +18,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..10,
-                            ops: [
-                                NotIn,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 0..1,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 9..10,
-                                        id: Name("y"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 0..1,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 9..10,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -85,25 +85,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 21..26,
-                            ops: [
-                                Gt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 21..22,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 25..26,
-                                        id: Name("y"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 21..22,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Gt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 25..26,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__starred_expression.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__compare__starred_expression.py.snap
@@ -18,32 +18,32 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..7,
-                            ops: [
-                                GtE,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 0..1,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Starred(
-                                    ExprStarred {
-                                        node_index: NodeIndex(None),
-                                        range: 5..7,
-                                        value: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 6..7,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 0..1,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    GtE,
+                                    Starred(
+                                        ExprStarred {
+                                            node_index: NodeIndex(None),
+                                            range: 5..7,
+                                            value: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 6..7,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -58,32 +58,32 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 8..19,
-                            ops: [
-                                NotIn,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 8..9,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Starred(
-                                    ExprStarred {
-                                        node_index: NodeIndex(None),
-                                        range: 17..19,
-                                        value: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 18..19,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 8..9,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotIn,
+                                    Starred(
+                                        ExprStarred {
+                                            node_index: NodeIndex(None),
+                                            range: 17..19,
+                                            value: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 18..19,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -102,25 +102,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 22..27,
-                                    ops: [
-                                        Lt,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 22..23,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 26..27,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 22..23,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            Lt,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 26..27,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },
@@ -142,25 +142,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 29..39,
-                                    ops: [
-                                        IsNot,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 29..30,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 38..39,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 29..30,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            IsNot,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 38..39,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__dict__double_star.py.snap
@@ -417,25 +417,25 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 245..251,
-                                            ops: [
-                                                In,
-                                            ],
-                                            operands: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 245..246,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 250..251,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 245..246,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            comparisons: [
+                                                (
+                                                    In,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 250..251,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                 ),
                                             ],
                                         },
@@ -461,25 +461,25 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 256..266,
-                                            ops: [
-                                                NotIn,
-                                            ],
-                                            operands: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 256..257,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 265..266,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 256..257,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            comparisons: [
+                                                (
+                                                    NotIn,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 265..266,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                 ),
                                             ],
                                         },
@@ -505,25 +505,25 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 271..276,
-                                            ops: [
-                                                Lt,
-                                            ],
-                                            operands: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 271..272,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 275..276,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 271..272,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            comparisons: [
+                                                (
+                                                    Lt,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 275..276,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                 ),
                                             ],
                                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__list__star_expression_precedence.py.snap
@@ -65,25 +65,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 96..102,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 96..97,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 101..102,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 96..97,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 101..102,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple_starred_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__parenthesized__tuple_starred_expr.py.snap
@@ -27,25 +27,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 159..165,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 159..160,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 164..165,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 159..160,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 164..165,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -69,25 +69,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 171..177,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 171..172,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 176..177,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 171..172,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 176..177,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -663,25 +663,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 364..370,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 364..365,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 369..370,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 364..365,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 369..370,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -705,25 +705,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 376..382,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 376..377,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 381..382,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 376..377,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 381..382,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@expressions__set__star_expression_precedence.py.snap
@@ -64,25 +64,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 95..101,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 95..96,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 100..101,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 95..96,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 100..101,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target.py.snap
@@ -280,25 +280,25 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 110..116,
-                                        ops: [
-                                            In,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 110..111,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 115..116,
-                                                    id: Name("y"),
-                                                    ctx: Load,
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 110..111,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                In,
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 115..116,
+                                                        id: Name("y"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_binary_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_binary_expr.py.snap
@@ -19,25 +19,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 4..14,
-                            ops: [
-                                NotIn,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 4..5,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 13..14,
-                                        id: Name("y"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 4..5,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 13..14,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -76,25 +76,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 29..35,
-                            ops: [
-                                Eq,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 29..30,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 34..35,
-                                        id: Name("y"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 29..30,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Eq,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 34..35,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_in_keyword.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@for_stmt_invalid_target_in_keyword.py.snap
@@ -35,25 +35,25 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 6..12,
-                                            ops: [
-                                                In,
-                                            ],
-                                            operands: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 6..7,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 11..12,
-                                                        id: Name("y"),
-                                                        ctx: Load,
-                                                    },
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 6..7,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            comparisons: [
+                                                (
+                                                    In,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 11..12,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                 ),
                                             ],
                                         },
@@ -101,25 +101,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 34..40,
-                                    ops: [
-                                        In,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 34..35,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 39..40,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 34..35,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            In,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 39..40,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },
@@ -166,25 +166,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 62..68,
-                            ops: [
-                                In,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 62..63,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 67..68,
-                                        id: Name("y"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 62..63,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    In,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 67..68,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -228,25 +228,25 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 88..94,
-                                        ops: [
-                                            In,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 88..89,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 93..94,
-                                                    id: Name("y"),
-                                                    ctx: Load,
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 88..89,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                In,
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 93..94,
+                                                        id: Name("y"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },
@@ -303,25 +303,25 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 117..123,
-                                        ops: [
-                                            In,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 117..118,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 122..123,
-                                                    id: Name("y"),
-                                                    ctx: Load,
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 117..118,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                In,
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 122..123,
+                                                        id: Name("y"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },
@@ -377,25 +377,25 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 146..152,
-                                        ops: [
-                                            In,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 146..147,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 151..152,
-                                                    id: Name("y"),
-                                                    ctx: Load,
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 146..147,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                In,
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 151..152,
+                                                        id: Name("y"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_assignment_targets.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_assignment_targets.py.snap
@@ -799,34 +799,36 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 549..558,
-                                ops: [
-                                    Lt,
-                                    Lt,
-                                ],
-                                operands: [
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 549..550,
-                                            id: Name("a"),
-                                            ctx: Load,
-                                        },
+                                left: Name(
+                                    ExprName {
+                                        node_index: NodeIndex(None),
+                                        range: 549..550,
+                                        id: Name("a"),
+                                        ctx: Load,
+                                    },
+                                ),
+                                comparisons: [
+                                    (
+                                        Lt,
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 553..554,
+                                                id: Name("b"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 553..554,
-                                            id: Name("b"),
-                                            ctx: Load,
-                                        },
-                                    ),
-                                    Name(
-                                        ExprName {
-                                            node_index: NodeIndex(None),
-                                            range: 557..558,
-                                            id: Name("c"),
-                                            ctx: Load,
-                                        },
+                                    (
+                                        Lt,
+                                        Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 557..558,
+                                                id: Name("c"),
+                                                ctx: Load,
+                                            },
+                                        ),
                                     ),
                                 ],
                             },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_augmented_assignment_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@statements__invalid_augmented_assignment_target.py.snap
@@ -697,34 +697,36 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 358..367,
-                            ops: [
-                                Lt,
-                                Lt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 358..359,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 358..359,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 362..363,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 362..363,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 366..367,
-                                        id: Name("c"),
-                                        ctx: Load,
-                                    },
+                                (
+                                    Lt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 366..367,
+                                            id: Name("c"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@while_stmt_missing_colon.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@while_stmt_missing_colon.py.snap
@@ -18,26 +18,26 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 12..18,
-                            ops: [
-                                Lt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 12..13,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 16..18,
-                                        value: Int(
-                                            30,
-                                        ),
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 12..13,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 16..18,
+                                            value: Int(
+                                                30,
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@ambiguous_lpar_with_items_binary_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@ambiguous_lpar_with_items_binary_expr.py.snap
@@ -76,25 +76,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 149..161,
-                                    ops: [
-                                        IsNot,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 150..151,
-                                                id: Name("a"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 160..161,
-                                                id: Name("b"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 150..151,
+                                            id: Name("a"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            IsNot,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 160..161,
+                                                    id: Name("b"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__await.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__await.py.snap
@@ -341,33 +341,33 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 108..120,
-                            ops: [
-                                Eq,
-                            ],
-                            operands: [
-                                Await(
-                                    ExprAwait {
-                                        node_index: NodeIndex(None),
-                                        range: 108..115,
-                                        value: NumberLiteral(
-                                            ExprNumberLiteral {
-                                                node_index: NodeIndex(None),
-                                                range: 114..115,
-                                                value: Int(
-                                                    1,
-                                                ),
-                                            },
-                                        ),
-                                    },
-                                ),
-                                NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 119..120,
-                                        value: Int(
-                                            1,
-                                        ),
-                                    },
+                            left: Await(
+                                ExprAwait {
+                                    node_index: NodeIndex(None),
+                                    range: 108..115,
+                                    value: NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 114..115,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Eq,
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 119..120,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__compare.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__compare.py.snap
@@ -8,7 +8,7 @@ input_file: crates/ruff_python_parser/resources/valid/expressions/compare.py
 Module(
     ModModule {
         node_index: NodeIndex(None),
-        range: 0..542,
+        range: 0..638,
         body: [
             Expr(
                 StmtExpr {
@@ -18,25 +18,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 9..15,
-                            ops: [
-                                Eq,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 9..10,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 14..15,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 9..10,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Eq,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 14..15,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -51,25 +51,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 16..21,
-                            ops: [
-                                Lt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 16..17,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 20..21,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 16..17,
+                                    id: Name("b"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 20..21,
+                                            id: Name("a"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -84,25 +84,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 22..27,
-                            ops: [
-                                Gt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 22..23,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 26..27,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 22..23,
+                                    id: Name("b"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Gt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 26..27,
+                                            id: Name("a"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -117,25 +117,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 28..34,
-                            ops: [
-                                GtE,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 28..29,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 33..34,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 28..29,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    GtE,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 33..34,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -150,25 +150,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 35..41,
-                            ops: [
-                                LtE,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 35..36,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 40..41,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 35..36,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    LtE,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 40..41,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -183,25 +183,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 42..48,
-                            ops: [
-                                NotEq,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 42..43,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 47..48,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 42..43,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotEq,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 47..48,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -216,25 +216,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 49..55,
-                            ops: [
-                                Is,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 49..50,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 54..55,
-                                        id: Name("c"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 49..50,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Is,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 54..55,
+                                            id: Name("c"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -249,25 +249,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 56..62,
-                            ops: [
-                                In,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 56..57,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 61..62,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 56..57,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    In,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 61..62,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -282,25 +282,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 63..73,
-                            ops: [
-                                NotIn,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 63..64,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 72..73,
-                                        id: Name("c"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 63..64,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 72..73,
+                                            id: Name("c"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -315,25 +315,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 74..84,
-                            ops: [
-                                IsNot,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 74..75,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 83..84,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 74..75,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    IsNot,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 83..84,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -348,61 +348,69 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 110..156,
-                            ops: [
-                                NotIn,
-                                IsNot,
-                                NotIn,
-                                NotIn,
-                                IsNot,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 110..111,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 110..111,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 119..120,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 119..120,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                                (
+                                    IsNot,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 128..129,
+                                            id: Name("c"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 128..129,
-                                        id: Name("c"),
-                                        ctx: Load,
-                                    },
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 137..138,
+                                            id: Name("d"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 137..138,
-                                        id: Name("d"),
-                                        ctx: Load,
-                                    },
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 146..147,
+                                            id: Name("e"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 146..147,
-                                        id: Name("e"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 155..156,
-                                        id: Name("f"),
-                                        ctx: Load,
-                                    },
+                                (
+                                    IsNot,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 155..156,
+                                            id: Name("f"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -417,79 +425,81 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 177..203,
-                            ops: [
-                                Lt,
-                                NotIn,
-                            ],
-                            operands: [
-                                BinOp(
-                                    ExprBinOp {
-                                        node_index: NodeIndex(None),
-                                        range: 177..182,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 177..178,
-                                                id: Name("a"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        op: BitOr,
-                                        right: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 181..182,
-                                                id: Name("b"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
+                            left: BinOp(
+                                ExprBinOp {
+                                    node_index: NodeIndex(None),
+                                    range: 177..182,
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 177..178,
+                                            id: Name("a"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    op: BitOr,
+                                    right: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 181..182,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    BinOp(
+                                        ExprBinOp {
+                                            node_index: NodeIndex(None),
+                                            range: 185..190,
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 185..186,
+                                                    id: Name("c"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            op: BitOr,
+                                            right: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 189..190,
+                                                    id: Name("d"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
                                 ),
-                                BinOp(
-                                    ExprBinOp {
-                                        node_index: NodeIndex(None),
-                                        range: 185..190,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 185..186,
-                                                id: Name("c"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        op: BitOr,
-                                        right: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 189..190,
-                                                id: Name("d"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
-                                ),
-                                BinOp(
-                                    ExprBinOp {
-                                        node_index: NodeIndex(None),
-                                        range: 198..203,
-                                        left: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 198..199,
-                                                id: Name("e"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        op: BitAnd,
-                                        right: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 202..203,
-                                                id: Name("f"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
+                                (
+                                    NotIn,
+                                    BinOp(
+                                        ExprBinOp {
+                                            node_index: NodeIndex(None),
+                                            range: 198..203,
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 198..199,
+                                                    id: Name("e"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            op: BitAnd,
+                                            right: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 202..203,
+                                                    id: Name("f"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -509,25 +519,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 383..393,
-                                    ops: [
-                                        NotIn,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 383..384,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 392..393,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 383..384,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            NotIn,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 392..393,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },
@@ -564,25 +574,25 @@ Module(
                                                 ExprCompare {
                                                     node_index: NodeIndex(None),
                                                     range: 400..410,
-                                                    ops: [
-                                                        NotIn,
-                                                    ],
-                                                    operands: [
-                                                        Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 400..401,
-                                                                id: Name("y"),
-                                                                ctx: Load,
-                                                            },
-                                                        ),
-                                                        Name(
-                                                            ExprName {
-                                                                node_index: NodeIndex(None),
-                                                                range: 409..410,
-                                                                id: Name("z"),
-                                                                ctx: Load,
-                                                            },
+                                                    left: Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 400..401,
+                                                            id: Name("y"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                    comparisons: [
+                                                        (
+                                                            NotIn,
+                                                            Name(
+                                                                ExprName {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 409..410,
+                                                                    id: Name("z"),
+                                                                    ctx: Load,
+                                                                },
+                                                            ),
                                                         ),
                                                     ],
                                                 },
@@ -611,31 +621,31 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 417..429,
-                            ops: [
-                                Eq,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 417..418,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Await(
-                                    ExprAwait {
-                                        node_index: NodeIndex(None),
-                                        range: 422..429,
-                                        value: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 428..429,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 417..418,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Eq,
+                                    Await(
+                                        ExprAwait {
+                                            node_index: NodeIndex(None),
+                                            range: 422..429,
+                                            value: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 428..429,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -650,31 +660,31 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 430..446,
-                            ops: [
-                                IsNot,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 430..431,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Await(
-                                    ExprAwait {
-                                        node_index: NodeIndex(None),
-                                        range: 439..446,
-                                        value: Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 445..446,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 430..431,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    IsNot,
+                                    Await(
+                                        ExprAwait {
+                                            node_index: NodeIndex(None),
+                                            range: 439..446,
+                                            value: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 445..446,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -689,97 +699,198 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 489..541,
-                            ops: [
-                                Lt,
-                                Eq,
-                                Gt,
-                                Is,
-                                NotIn,
-                                IsNot,
-                                LtE,
-                                GtE,
-                                NotEq,
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 489..490,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 493..494,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    Eq,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 498..499,
+                                            id: Name("c"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    Gt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 502..503,
+                                            id: Name("d"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    Is,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 507..508,
+                                            id: Name("e"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 516..517,
+                                            id: Name("f"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    IsNot,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 525..526,
+                                            id: Name("g"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    LtE,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 530..531,
+                                            id: Name("h"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    GtE,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 535..536,
+                                            id: Name("i"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
+                                (
+                                    NotEq,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 540..541,
+                                            id: Name("j"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                ),
                             ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 489..490,
-                                        id: Name("a"),
-                                        ctx: Load,
-                                    },
+                        },
+                    ),
+                },
+            ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 613..637,
+                    value: Compare(
+                        ExprCompare {
+                            node_index: NodeIndex(None),
+                            range: 613..637,
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 613..614,
+                                    id: Name("a"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 617..618,
+                                            id: Name("b"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 493..494,
-                                        id: Name("b"),
-                                        ctx: Load,
-                                    },
+                                (
+                                    Lt,
+                                    Compare(
+                                        ExprCompare {
+                                            node_index: NodeIndex(None),
+                                            range: 622..632,
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 622..623,
+                                                    id: Name("c"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            comparisons: [
+                                                (
+                                                    LtE,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 627..628,
+                                                            id: Name("d"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ),
+                                                (
+                                                    Lt,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 631..632,
+                                                            id: Name("e"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
+                                                ),
+                                            ],
+                                        },
+                                    ),
                                 ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 498..499,
-                                        id: Name("c"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 502..503,
-                                        id: Name("d"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 507..508,
-                                        id: Name("e"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 516..517,
-                                        id: Name("f"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 525..526,
-                                        id: Name("g"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 530..531,
-                                        id: Name("h"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 535..536,
-                                        id: Name("i"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 540..541,
-                                        id: Name("j"),
-                                        ctx: Load,
-                                    },
+                                (
+                                    Lt,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 636..637,
+                                            id: Name("f"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__dictionary_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__dictionary_comprehension.py.snap
@@ -309,25 +309,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 98..104,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 98..99,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 103..104,
-                                                            id: Name("w"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 98..99,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 103..104,
+                                                                id: Name("w"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -488,25 +488,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 170..175,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 170..171,
-                                                            id: Name("k"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 174..175,
-                                                            id: Name("h"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 170..171,
+                                                        id: Name("k"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 174..175,
+                                                                id: Name("h"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -618,25 +618,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 225..230,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 225..226,
-                                                            id: Name("k"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 229..230,
-                                                            id: Name("h"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 225..226,
+                                                        id: Name("k"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 229..230,
+                                                                id: Name("h"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__f_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__f_string.py.snap
@@ -326,27 +326,27 @@ Module(
                                                         ExprCompare {
                                                             node_index: NodeIndex(None),
                                                             range: 79..83,
-                                                            ops: [
-                                                                NotEq,
-                                                            ],
-                                                            operands: [
-                                                                NumberLiteral(
-                                                                    ExprNumberLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 79..80,
-                                                                        value: Int(
-                                                                            3,
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                NumberLiteral(
-                                                                    ExprNumberLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 82..83,
-                                                                        value: Int(
-                                                                            4,
-                                                                        ),
-                                                                    },
+                                                            left: NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 79..80,
+                                                                    value: Int(
+                                                                        3,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            comparisons: [
+                                                                (
+                                                                    NotEq,
+                                                                    NumberLiteral(
+                                                                        ExprNumberLiteral {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 82..83,
+                                                                            value: Int(
+                                                                                4,
+                                                                            ),
+                                                                        },
+                                                                    ),
                                                                 ),
                                                             ],
                                                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__generator.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__generator.py.snap
@@ -141,25 +141,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 77..83,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 77..78,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 82..83,
-                                                            id: Name("y"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 77..78,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 82..83,
+                                                                id: Name("y"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -295,25 +295,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 160..165,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 160..161,
-                                                            id: Name("a"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 164..165,
-                                                            id: Name("b"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 160..161,
+                                                        id: Name("a"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 164..165,
+                                                                id: Name("b"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -416,25 +416,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 232..237,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 232..233,
-                                                            id: Name("a"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 236..237,
-                                                            id: Name("b"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 232..233,
+                                                        id: Name("a"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 236..237,
+                                                                id: Name("b"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__if.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__if.py.snap
@@ -161,27 +161,27 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 71..76,
-                                    ops: [
-                                        Lt,
-                                    ],
-                                    operands: [
-                                        NumberLiteral(
-                                            ExprNumberLiteral {
-                                                node_index: NodeIndex(None),
-                                                range: 71..72,
-                                                value: Int(
-                                                    1,
-                                                ),
-                                            },
-                                        ),
-                                        NumberLiteral(
-                                            ExprNumberLiteral {
-                                                node_index: NodeIndex(None),
-                                                range: 75..76,
-                                                value: Int(
-                                                    0,
-                                                ),
-                                            },
+                                    left: NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 71..72,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            Lt,
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    node_index: NodeIndex(None),
+                                                    range: 75..76,
+                                                    value: Int(
+                                                        0,
+                                                    ),
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },
@@ -302,25 +302,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 109..115,
-                                    ops: [
-                                        LtE,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 109..110,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 114..115,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 109..110,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            LtE,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 114..115,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list.py.snap
@@ -932,25 +932,25 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 385..395,
-                                        ops: [
-                                            In,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 385..389,
-                                                    id: Name("item"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 393..395,
-                                                    id: Name("xs"),
-                                                    ctx: Load,
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 385..389,
+                                                id: Name("item"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                In,
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 393..395,
+                                                        id: Name("xs"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__list_comprehension.py.snap
@@ -200,25 +200,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 67..73,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 67..68,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 72..73,
-                                                            id: Name("w"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 67..68,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 72..73,
+                                                                id: Name("w"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -353,25 +353,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 131..136,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 131..132,
-                                                            id: Name("k"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 135..136,
-                                                            id: Name("h"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 131..132,
+                                                        id: Name("k"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 135..136,
+                                                                id: Name("h"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -473,25 +473,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 183..188,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 183..184,
-                                                            id: Name("k"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 187..188,
-                                                            id: Name("h"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 183..184,
+                                                        id: Name("k"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 187..188,
+                                                                id: Name("h"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -537,25 +537,25 @@ Module(
                                         ExprCompare {
                                             node_index: NodeIndex(None),
                                             range: 202..208,
-                                            ops: [
-                                                In,
-                                            ],
-                                            operands: [
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 202..203,
-                                                        id: Name("x"),
-                                                        ctx: Load,
-                                                    },
-                                                ),
-                                                Name(
-                                                    ExprName {
-                                                        node_index: NodeIndex(None),
-                                                        range: 207..208,
-                                                        id: Name("a"),
-                                                        ctx: Load,
-                                                    },
+                                            left: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 202..203,
+                                                    id: Name("x"),
+                                                    ctx: Load,
+                                                },
+                                            ),
+                                            comparisons: [
+                                                (
+                                                    In,
+                                                    Name(
+                                                        ExprName {
+                                                            node_index: NodeIndex(None),
+                                                            range: 207..208,
+                                                            id: Name("a"),
+                                                            ctx: Load,
+                                                        },
+                                                    ),
                                                 ),
                                             ],
                                         },
@@ -745,23 +745,23 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 281..299,
-                                                ops: [
-                                                    IsNot,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 281..287,
-                                                            id: Name("entity"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    NoneLiteral(
-                                                        ExprNoneLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 295..299,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 281..287,
+                                                        id: Name("entity"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        IsNot,
+                                                        NoneLiteral(
+                                                            ExprNoneLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 295..299,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__set_comprehension.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__set_comprehension.py.snap
@@ -95,25 +95,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 33..39,
-                                                ops: [
-                                                    In,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 33..34,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 38..39,
-                                                            id: Name("w"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 33..34,
+                                                        id: Name("x"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        In,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 38..39,
+                                                                id: Name("w"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -248,25 +248,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 97..102,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 97..98,
-                                                            id: Name("k"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 101..102,
-                                                            id: Name("h"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 97..98,
+                                                        id: Name("k"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 101..102,
+                                                                id: Name("h"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },
@@ -368,25 +368,25 @@ Module(
                                             ExprCompare {
                                                 node_index: NodeIndex(None),
                                                 range: 149..154,
-                                                ops: [
-                                                    Gt,
-                                                ],
-                                                operands: [
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 149..150,
-                                                            id: Name("k"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 153..154,
-                                                            id: Name("h"),
-                                                            ctx: Load,
-                                                        },
+                                                left: Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 149..150,
+                                                        id: Name("k"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
+                                                comparisons: [
+                                                    (
+                                                        Gt,
+                                                        Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 153..154,
+                                                                id: Name("h"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
                                                     ),
                                                 ],
                                             },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__t_string.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__t_string.py.snap
@@ -326,27 +326,27 @@ Module(
                                                         ExprCompare {
                                                             node_index: NodeIndex(None),
                                                             range: 79..83,
-                                                            ops: [
-                                                                NotEq,
-                                                            ],
-                                                            operands: [
-                                                                NumberLiteral(
-                                                                    ExprNumberLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 79..80,
-                                                                        value: Int(
-                                                                            3,
-                                                                        ),
-                                                                    },
-                                                                ),
-                                                                NumberLiteral(
-                                                                    ExprNumberLiteral {
-                                                                        node_index: NodeIndex(None),
-                                                                        range: 82..83,
-                                                                        value: Int(
-                                                                            4,
-                                                                        ),
-                                                                    },
+                                                            left: NumberLiteral(
+                                                                ExprNumberLiteral {
+                                                                    node_index: NodeIndex(None),
+                                                                    range: 79..80,
+                                                                    value: Int(
+                                                                        3,
+                                                                    ),
+                                                                },
+                                                            ),
+                                                            comparisons: [
+                                                                (
+                                                                    NotEq,
+                                                                    NumberLiteral(
+                                                                        ExprNumberLiteral {
+                                                                            node_index: NodeIndex(None),
+                                                                            range: 82..83,
+                                                                            value: Int(
+                                                                                4,
+                                                                            ),
+                                                                        },
+                                                                    ),
                                                                 ),
                                                             ],
                                                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield.py.snap
@@ -373,25 +373,25 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 122..128,
-                                        ops: [
-                                            Eq,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 122..123,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 127..128,
-                                                    id: Name("y"),
-                                                    ctx: Load,
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 122..123,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                Eq,
+                                                Name(
+                                                    ExprName {
+                                                        node_index: NodeIndex(None),
+                                                        range: 127..128,
+                                                        id: Name("y"),
+                                                        ctx: Load,
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield_from.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@expressions__yield_from.py.snap
@@ -303,25 +303,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 150..156,
-                                    ops: [
-                                        Eq,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 150..151,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 155..156,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 150..151,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            Eq,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 155..156,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@for_in_target_valid_expr.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@for_in_target_valid_expr.py.snap
@@ -31,25 +31,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 6..12,
-                                    ops: [
-                                        In,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 6..7,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 11..12,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 6..7,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            In,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 11..12,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },
@@ -95,25 +95,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 34..40,
-                                    ops: [
-                                        In,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 34..35,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 39..40,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 34..35,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            In,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 39..40,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },
@@ -168,25 +168,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 63..69,
-                                    ops: [
-                                        In,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 63..64,
-                                                id: Name("x"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 68..69,
-                                                id: Name("y"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 63..64,
+                                            id: Name("x"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            In,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 68..69,
+                                                    id: Name("y"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_1.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_1.py.snap
@@ -18,25 +18,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 0..17,
-                            ops: [
-                                NotIn,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 0..5,
-                                        id: Name("match"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 13..17,
-                                        id: Name("case"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 0..5,
+                                    id: Name("match"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotIn,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 13..17,
+                                            id: Name("case"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_2.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@match_classify_as_identifier_2.py.snap
@@ -32,25 +32,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 6..18,
-                            ops: [
-                                NotEq,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 6..11,
-                                        id: Name("match"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 15..18,
-                                        id: Name("foo"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 6..11,
+                                    id: Name("match"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    NotEq,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 15..18,
+                                            id: Name("foo"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },
@@ -335,25 +335,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 132..148,
-                            ops: [
-                                IsNot,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 132..137,
-                                        id: Name("match"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 145..148,
-                                        id: Name("foo"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 132..137,
+                                    id: Name("match"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    IsNot,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 145..148,
+                                            id: Name("foo"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__ambiguous_lpar_with_items.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__ambiguous_lpar_with_items.py.snap
@@ -577,26 +577,26 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 959..969,
-                                    ops: [
-                                        Eq,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 959..963,
-                                                id: Name("item"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        NumberLiteral(
-                                            ExprNumberLiteral {
-                                                node_index: NodeIndex(None),
-                                                range: 967..969,
-                                                value: Int(
-                                                    10,
-                                                ),
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 959..963,
+                                            id: Name("item"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            Eq,
+                                            NumberLiteral(
+                                                ExprNumberLiteral {
+                                                    node_index: NodeIndex(None),
+                                                    range: 967..969,
+                                                    value: Int(
+                                                        10,
+                                                    ),
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__assert.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__assert.py.snap
@@ -18,27 +18,27 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 7..12,
-                            ops: [
-                                Lt,
-                            ],
-                            operands: [
-                                NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 7..8,
-                                        value: Int(
-                                            1,
-                                        ),
-                                    },
-                                ),
-                                NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 11..12,
-                                        value: Int(
-                                            2,
-                                        ),
-                                    },
+                            left: NumberLiteral(
+                                ExprNumberLiteral {
+                                    node_index: NodeIndex(None),
+                                    range: 7..8,
+                                    value: Int(
+                                        1,
+                                    ),
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 11..12,
+                                            value: Int(
+                                                2,
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__for.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__for.py.snap
@@ -236,25 +236,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 151..157,
-                            ops: [
-                                LtE,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 151..152,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 156..157,
-                                        id: Name("y"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 151..152,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    LtE,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 156..157,
+                                            id: Name("y"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__if.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__if.py.snap
@@ -149,26 +149,26 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 56..61,
-                            ops: [
-                                Lt,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 56..57,
-                                        id: Name("x"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                NumberLiteral(
-                                    ExprNumberLiteral {
-                                        node_index: NodeIndex(None),
-                                        range: 60..61,
-                                        value: Int(
-                                            1,
-                                        ),
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 56..57,
+                                    id: Name("x"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    Lt,
+                                    NumberLiteral(
+                                        ExprNumberLiteral {
+                                            node_index: NodeIndex(None),
+                                            range: 60..61,
+                                            value: Int(
+                                                1,
+                                            ),
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__match.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__match.py.snap
@@ -3278,41 +3278,41 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 2282..2292,
-                                        ops: [
-                                            Eq,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 2282..2283,
-                                                    id: Name("z"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            BinOp(
-                                                ExprBinOp {
-                                                    node_index: NodeIndex(None),
-                                                    range: 2287..2292,
-                                                    left: Name(
-                                                        ExprName {
-                                                            node_index: NodeIndex(None),
-                                                            range: 2287..2288,
-                                                            id: Name("x"),
-                                                            ctx: Load,
-                                                        },
-                                                    ),
-                                                    op: Mod,
-                                                    right: NumberLiteral(
-                                                        ExprNumberLiteral {
-                                                            node_index: NodeIndex(None),
-                                                            range: 2291..2292,
-                                                            value: Int(
-                                                                2,
-                                                            ),
-                                                        },
-                                                    ),
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 2282..2283,
+                                                id: Name("z"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                Eq,
+                                                BinOp(
+                                                    ExprBinOp {
+                                                        node_index: NodeIndex(None),
+                                                        range: 2287..2292,
+                                                        left: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 2287..2288,
+                                                                id: Name("x"),
+                                                                ctx: Load,
+                                                            },
+                                                        ),
+                                                        op: Mod,
+                                                        right: NumberLiteral(
+                                                            ExprNumberLiteral {
+                                                                node_index: NodeIndex(None),
+                                                                range: 2291..2292,
+                                                                value: Int(
+                                                                    2,
+                                                                ),
+                                                            },
+                                                        ),
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },
@@ -7945,27 +7945,27 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 5096..5101,
-                                        ops: [
-                                            Lt,
-                                        ],
-                                        operands: [
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 5096..5097,
-                                                    value: Int(
-                                                        1,
-                                                    ),
-                                                },
-                                            ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 5100..5101,
-                                                    value: Int(
-                                                        2,
-                                                    ),
-                                                },
+                                        left: NumberLiteral(
+                                            ExprNumberLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 5096..5097,
+                                                value: Int(
+                                                    1,
+                                                ),
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                Lt,
+                                                NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 5100..5101,
+                                                        value: Int(
+                                                            2,
+                                                        ),
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },
@@ -8864,25 +8864,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 5738..5752,
-                                    ops: [
-                                        Eq,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 5738..5743,
-                                                id: Name("query"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 5747..5752,
-                                                id: Name("event"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 5738..5743,
+                                            id: Name("query"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            Eq,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 5747..5752,
+                                                    id: Name("event"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__raise.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__raise.py.snap
@@ -79,27 +79,27 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 41..46,
-                                ops: [
-                                    Lt,
-                                ],
-                                operands: [
-                                    NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 41..42,
-                                            value: Int(
-                                                1,
-                                            ),
-                                        },
-                                    ),
-                                    NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 45..46,
-                                            value: Int(
-                                                2,
-                                            ),
-                                        },
+                                left: NumberLiteral(
+                                    ExprNumberLiteral {
+                                        node_index: NodeIndex(None),
+                                        range: 41..42,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                comparisons: [
+                                    (
+                                        Lt,
+                                        NumberLiteral(
+                                            ExprNumberLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 45..46,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
                                     ),
                                 ],
                             },
@@ -342,27 +342,27 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 186..191,
-                                ops: [
-                                    Lt,
-                                ],
-                                operands: [
-                                    NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 186..187,
-                                            value: Int(
-                                                1,
-                                            ),
-                                        },
-                                    ),
-                                    NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 190..191,
-                                            value: Int(
-                                                2,
-                                            ),
-                                        },
+                                left: NumberLiteral(
+                                    ExprNumberLiteral {
+                                        node_index: NodeIndex(None),
+                                        range: 186..187,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                comparisons: [
+                                    (
+                                        Lt,
+                                        NumberLiteral(
+                                            ExprNumberLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 190..191,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
                                     ),
                                 ],
                             },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__return.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__return.py.snap
@@ -168,27 +168,27 @@ Module(
                             ExprCompare {
                                 node_index: NodeIndex(None),
                                 range: 80..85,
-                                ops: [
-                                    Lt,
-                                ],
-                                operands: [
-                                    NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 80..81,
-                                            value: Int(
-                                                1,
-                                            ),
-                                        },
-                                    ),
-                                    NumberLiteral(
-                                        ExprNumberLiteral {
-                                            node_index: NodeIndex(None),
-                                            range: 84..85,
-                                            value: Int(
-                                                2,
-                                            ),
-                                        },
+                                left: NumberLiteral(
+                                    ExprNumberLiteral {
+                                        node_index: NodeIndex(None),
+                                        range: 80..81,
+                                        value: Int(
+                                            1,
+                                        ),
+                                    },
+                                ),
+                                comparisons: [
+                                    (
+                                        Lt,
+                                        NumberLiteral(
+                                            ExprNumberLiteral {
+                                                node_index: NodeIndex(None),
+                                                range: 84..85,
+                                                value: Int(
+                                                    2,
+                                                ),
+                                            },
+                                        ),
                                     ),
                                 ],
                             },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__type.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__type.py.snap
@@ -2780,25 +2780,25 @@ Module(
                                 ExprCompare {
                                     node_index: NodeIndex(None),
                                     range: 1683..1697,
-                                    ops: [
-                                        Eq,
-                                    ],
-                                    operands: [
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 1683..1688,
-                                                id: Name("query"),
-                                                ctx: Load,
-                                            },
-                                        ),
-                                        Name(
-                                            ExprName {
-                                                node_index: NodeIndex(None),
-                                                range: 1692..1697,
-                                                id: Name("event"),
-                                                ctx: Load,
-                                            },
+                                    left: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 1683..1688,
+                                            id: Name("query"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    comparisons: [
+                                        (
+                                            Eq,
+                                            Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 1692..1697,
+                                                    id: Name("event"),
+                                                    ctx: Load,
+                                                },
+                                            ),
                                         ),
                                     ],
                                 },
@@ -2917,25 +2917,25 @@ Module(
                         ExprCompare {
                             node_index: NodeIndex(None),
                             range: 1732..1741,
-                            ops: [
-                                In,
-                            ],
-                            operands: [
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 1732..1736,
-                                        id: Name("type"),
-                                        ctx: Load,
-                                    },
-                                ),
-                                Name(
-                                    ExprName {
-                                        node_index: NodeIndex(None),
-                                        range: 1740..1741,
-                                        id: Name("C"),
-                                        ctx: Load,
-                                    },
+                            left: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 1732..1736,
+                                    id: Name("type"),
+                                    ctx: Load,
+                                },
+                            ),
+                            comparisons: [
+                                (
+                                    In,
+                                    Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 1740..1741,
+                                            id: Name("C"),
+                                            ctx: Load,
+                                        },
+                                    ),
                                 ),
                             ],
                         },

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__while.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@statement__while.py.snap
@@ -53,26 +53,26 @@ Module(
                                     ExprCompare {
                                         node_index: NodeIndex(None),
                                         range: 25..30,
-                                        ops: [
-                                            Gt,
-                                        ],
-                                        operands: [
-                                            Name(
-                                                ExprName {
-                                                    node_index: NodeIndex(None),
-                                                    range: 25..26,
-                                                    id: Name("x"),
-                                                    ctx: Load,
-                                                },
-                                            ),
-                                            NumberLiteral(
-                                                ExprNumberLiteral {
-                                                    node_index: NodeIndex(None),
-                                                    range: 29..30,
-                                                    value: Int(
-                                                        1,
-                                                    ),
-                                                },
+                                        left: Name(
+                                            ExprName {
+                                                node_index: NodeIndex(None),
+                                                range: 25..26,
+                                                id: Name("x"),
+                                                ctx: Load,
+                                            },
+                                        ),
+                                        comparisons: [
+                                            (
+                                                Gt,
+                                                NumberLiteral(
+                                                    ExprNumberLiteral {
+                                                        node_index: NodeIndex(None),
+                                                        range: 29..30,
+                                                        value: Int(
+                                                            1,
+                                                        ),
+                                                    },
+                                                ),
                                             ),
                                         ],
                                     },

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2232,7 +2232,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         }),
                     ) => PredicateNode::Condition(expression),
                     (ExpressionContext::Condition, ast::Expr::Compare(compare))
-                        if compare.ops.len() > 1 =>
+                        if compare.comparisons.len() > 1 =>
                     {
                         PredicateNode::ChainedComparisonCondition(expression)
                     }
@@ -2537,11 +2537,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 operand,
                 ..
             }) => Self::condition_evaluation_is_known_safe(operand),
-            ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) => {
-                ops.iter()
-                    .all(|op| matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot))
-                    && operands
-                        .iter()
+            ast::Expr::Compare(compare) => {
+                compare
+                    .comparisons
+                    .iter()
+                    .all(|(op, _)| matches!(op, ast::CmpOp::Is | ast::CmpOp::IsNot))
+                    && compare
+                        .operands()
                         .all(Self::expression_evaluation_is_known_safe)
             }
             _ => false,
@@ -3633,16 +3635,16 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         || !Self::condition_evaluation_is_known_safe(&unary.operand),
                 );
             }
-            ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) => {
-                if let Some((left, comparators)) = operands.split_first() {
-                    self.visit_expr(left);
-                    for (op, comparator) in ops.iter().zip(comparators) {
-                        self.visit_expr(comparator);
-                        self.record_exception_checkpoint_if(!matches!(
-                            op,
-                            ast::CmpOp::Is | ast::CmpOp::IsNot
-                        ));
-                    }
+            ast::Expr::Compare(ast::ExprCompare {
+                left, comparisons, ..
+            }) => {
+                self.visit_expr(left);
+                for (op, comparator) in comparisons {
+                    self.visit_expr(comparator);
+                    self.record_exception_checkpoint_if(!matches!(
+                        op,
+                        ast::CmpOp::Is | ast::CmpOp::IsNot
+                    ));
                 }
             }
             ast::Expr::BoolOp(node) => self.visit_bool_expression(node, context),

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -671,17 +671,20 @@ impl<'db, 'a> PossiblyNarrowedPlacesBuilder<'db, 'a> {
     fn expr_compare(&self, expr_compare: &ast::ExprCompare) -> PossiblyNarrowedPlaces {
         let mut places = PossiblyNarrowedPlaces::default();
 
-        for operand in &expr_compare.operands {
+        for operand in expr_compare.operands() {
             self.add_narrowing_target(operand, &mut places);
         }
 
         let can_narrow_tagged_union_base = matches!(
-            &*expr_compare.ops,
-            [ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot]
+            &*expr_compare.comparisons,
+            [(
+                ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot,
+                _
+            )]
         );
 
         // Tagged-union checks can also narrow the base of a subscript or attribute on either side.
-        for expr in &expr_compare.operands {
+        for expr in expr_compare.operands() {
             if can_narrow_tagged_union_base
                 && let ast::Expr::Subscript(subscript) = expr.expression_value()
                 && let Some(place_expr) = PlaceExpr::try_from_expr(&subscript.value)

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11542,16 +11542,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_compare_expression(&mut self, compare: &ast::ExprCompare) -> Type<'db> {
         let db = self.db();
-        let ast::ExprCompare {
-            range: _,
-            node_index: _,
-            ops,
-            operands,
-        } = compare;
-
-        if let Some(left) = operands.first() {
-            self.infer_expression(left, TypeContext::default());
-        }
+        self.infer_expression(&compare.left, TypeContext::default());
         let mut last_comparison_ty = Type::unknown();
 
         // https://docs.python.org/3/reference/expressions.html#comparisons
@@ -11567,9 +11558,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = self.infer_chained_boolean_types(
             ast::BoolOp::And,
             false,
-            operands.iter().tuple_windows::<(_, _)>().zip(ops),
+            compare.iter(),
             |_| false,
-            |builder, ((left, right), op), _peer_ty| {
+            |builder, (left, op, right), _peer_ty| {
                 let left_ty = builder.expression_type(left);
                 let right_ty = builder.infer_expression(right, TypeContext::default());
 
@@ -11608,7 +11599,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             },
         );
 
-        if ops.len() > 1 {
+        if compare.comparisons.len() > 1 {
             // Individual comparisons within a chain have no expression nodes whose result types
             // reachability can look up later. Retain their combined condition truthiness here;
             // `and`/`or` conditions can instead be reconstructed by walking their operand nodes.

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -122,9 +122,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ));
             }
 
-            if let ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test
-                && ops.len() == 1
-                && let [left, single_comparator] = &**operands
+            if let ast::Expr::Compare(ast::ExprCompare {
+                left, comparisons, ..
+            }) = test
+                && let [(_, single_comparator)] = &**comparisons
             {
                 if let (Type::LiteralValue(left_type), Type::LiteralValue(right_type)) = (
                     self.expression_type(left),
@@ -135,7 +136,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // For the specific case of a string-literal type compared with a bytes-literal type,
                     // cite their nominal-instance supertypes rather than their `Literal` types,
                     // since their `Literal` types look quite similar in their display representations.
-                    for node in [left, single_comparator] {
+                    for node in [left.as_ref(), single_comparator] {
                         if let Some(class) = self.expression_type(node).nominal_class(db, env) {
                             diagnostic.annotate(
                                 self.context
@@ -145,7 +146,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         }
                     }
                 } else {
-                    for node in [left, single_comparator] {
+                    for node in [left.as_ref(), single_comparator] {
                         match node {
                             ast::Expr::NoneLiteral(_)
                             | ast::Expr::BooleanLiteral(_)
@@ -619,11 +620,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         let env = self.program_environment();
 
-        if let ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test
-            && let [single_op] = &**ops
-            && let [left, single_comparator] = &**operands
+        if let ast::Expr::Compare(ast::ExprCompare {
+            left, comparisons, ..
+        }) = test
+            && let [(single_op, single_comparator)] = &**comparisons
             && let (ast::Expr::Call(call), other) | (other, ast::Expr::Call(call)) =
-                (left, single_comparator)
+                (left.as_ref(), single_comparator)
             && matches!(single_op, ast::CmpOp::Eq | ast::CmpOp::NotEq)
             && let ast::Arguments { args, keywords, .. } = &call.arguments
             && keywords.is_empty()
@@ -978,8 +980,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let candidates = match operand {
             ast::Expr::Name(_) => [Some(operand), None],
-            ast::Expr::Compare(compare) if compare.ops.len() == 1 => {
-                [compare.operands.first(), compare.operands.get(1)]
+            ast::Expr::Compare(compare) if let [(_, right)] = &*compare.comparisons => {
+                [Some(compare.left.as_ref()), Some(right)]
             }
             ast::Expr::Call(call) => [call.arguments.args.first(), None],
             _ => return None,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4032,19 +4032,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let ast::ExprCompare {
             range: _,
             node_index: _,
-            ops,
-            operands,
+            left,
+            comparisons,
         } = expr_compare;
 
         // Performance optimization: early return if there are no potential narrowing targets.
-        if operands
-            .iter()
+        if expr_compare
+            .operands()
             .all(|operand| !is_narrowing_target_candidate(operand))
         {
             return None;
         }
 
-        if !is_positive && ops.len() > 1 {
+        if !is_positive && comparisons.len() > 1 {
             // We can't negate a constraint made by a multi-comparator expression, since we can't
             // know which comparison part is the one being negated.
             // For example, the negation of  `x is 1 is y is 2`, would be `(x is not 1) or (y is not 1) or (y is not 2)`
@@ -4054,9 +4054,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         let inference = infer_expression_types(db, expression, TypeContext::default());
 
-        let comparator_tuples = operands
-            .iter()
-            .tuple_windows::<(&ruff_python_ast::Expr, &ruff_python_ast::Expr)>();
         let mut constraints = NarrowingConstraints::default();
 
         // Narrow unions of tuples based on element checks. For example:
@@ -4064,9 +4061,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //     def _(t: tuple[int, int] | tuple[None, None]):
         //         if t[0] is not None:
         //             reveal_type(t)  # tuple[int, int]
-        if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
-            && let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is)
-            && let ast::Expr::Subscript(subscript) = operands[0].expression_value()
+        if let [(op @ (ast::CmpOp::Is | ast::CmpOp::IsNot), right)] = &**comparisons
+            && let is_positive_check = is_positive == (*op == ast::CmpOp::Is)
+            && let ast::Expr::Subscript(subscript) = left.expression_value()
             && let Type::Union(union) = inference
                 .expression_type(&*subscript.value)
                 .resolve_type_alias(db)
@@ -4075,7 +4072,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .expression_type(&*subscript.slice)
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
-            && let rhs_ty = inference.expression_type(&operands[1])
+            && let rhs_ty = inference.expression_type(right)
         {
             let filtered = union.filter(db, |elem| {
                 elem.tuple_instance_spec(db, &self.env)
@@ -4093,7 +4090,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
-        if let [op] = &**ops
+        if let [(op, right)] = &**comparisons
             && let Some(comparison) = LengthComparison::from_op(*op, is_positive)
         {
             let mut narrow_len_call =
@@ -4133,15 +4130,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
 
             // E.g., `len(items) == 2`
-            if let ast::Expr::Call(call) = operands[0].expression_value() {
-                narrow_len_call(call, inference.expression_type(&operands[1]), comparison);
+            if let ast::Expr::Call(call) = left.expression_value() {
+                narrow_len_call(call, inference.expression_type(right), comparison);
             }
 
             // E.g., `2 == len(items)`
-            if let ast::Expr::Call(call) = operands[1].expression_value() {
+            if let ast::Expr::Call(call) = right.expression_value() {
                 narrow_len_call(
                     call,
-                    inference.expression_type(&operands[0]),
+                    inference.expression_type(left.as_ref()),
                     comparison.reflected(),
                 );
             }
@@ -4159,10 +4156,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //
         // Importantly, `my_typeddict_union["tag"]` isn't the place we're going to constrain.
         // Instead, we're going to constrain `my_typeddict_union` itself.
-        if matches!(&**ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq]) {
+        if let [(op @ (ast::CmpOp::Eq | ast::CmpOp::NotEq), right)] = &**comparisons {
             // For `==`, we use equality semantics on the `if` branch (is_positive=true).
             // For `!=`, we use equality semantics on the `else` branch (is_positive=false).
-            let is_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
+            let is_equality = is_positive == (*op == ast::CmpOp::Eq);
 
             let mut narrow_subscript = |subscript: &ast::ExprSubscript, other_type: Type<'db>| {
                 let value_type = inference.expression_type(&*subscript.value);
@@ -4187,18 +4184,22 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             };
 
-            if let ast::Expr::Subscript(subscript) = operands[0].expression_value() {
-                narrow_subscript(subscript, inference.expression_type(&operands[1]));
+            if let ast::Expr::Subscript(subscript) = left.expression_value() {
+                narrow_subscript(subscript, inference.expression_type(right));
             }
 
-            if let ast::Expr::Subscript(subscript) = operands[1].expression_value() {
-                narrow_subscript(subscript, inference.expression_type(&operands[0]));
+            if let ast::Expr::Subscript(subscript) = right.expression_value() {
+                narrow_subscript(subscript, inference.expression_type(left.as_ref()));
             }
         }
 
         if let [
-            operator @ (ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot),
-        ] = &**ops
+            (
+                operator
+                @ (ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot),
+                right,
+            ),
+        ] = &**comparisons
         {
             let comparison = if matches!(operator, ast::CmpOp::Is | ast::CmpOp::IsNot) {
                 NominalAttributeComparison::Identity
@@ -4223,17 +4224,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             };
 
-            if let ast::Expr::Attribute(attribute) = &operands[0]
-                && operands[1].as_named_expr().is_none_or(|named| {
+            if let ast::Expr::Attribute(attribute) = left.as_ref()
+                && right.as_named_expr().is_none_or(|named| {
                     PlaceExpr::try_from_expr(&named.target)
                         != PlaceExpr::try_from_expr(&attribute.value)
                 })
             {
-                narrow_attribute(attribute, inference.expression_type(&operands[1]));
+                narrow_attribute(attribute, inference.expression_type(right));
             }
 
-            if let ast::Expr::Attribute(attribute) = &operands[1] {
-                narrow_attribute(attribute, inference.expression_type(&operands[0]));
+            if let ast::Expr::Attribute(attribute) = right {
+                narrow_attribute(attribute, inference.expression_type(left.as_ref()));
             }
         }
 
@@ -4249,17 +4250,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         // def _(u: Foo | Bar):
         //     if "foo" not in u:
         //         reveal_type(u)  # revealed: Bar
-        if matches!(&**ops, [ast::CmpOp::In | ast::CmpOp::NotIn])
-            && let Some(key) = inference.expression_type(&operands[0]).as_string_literal()
-            && let rhs_expr = operands[1].expression_value()
-            && let rhs_type = inference.expression_type(&operands[1])
+        if let [(op @ (ast::CmpOp::In | ast::CmpOp::NotIn), right)] = &**comparisons
+            && let Some(key) = inference.expression_type(left.as_ref()).as_string_literal()
+            && let rhs_expr = right.expression_value()
+            && let rhs_type = inference.expression_type(right)
             && is_or_contains_typeddict(db, rhs_type)
         {
             let key = key.value(db);
             let apply_constraint =
                 |constraints: &mut NarrowingConstraints<'db>,
                  constraint: NarrowingConstraint<'db>| {
-                    let comparator_place = PlaceExpr::try_from_expr(&operands[1])
+                    let comparator_place = PlaceExpr::try_from_expr(right)
                         .and_then(|place_expr| self.places().place_id(&place_expr));
                     if let Some(place) = comparator_place {
                         constraints.insert(place, constraint.clone());
@@ -4274,7 +4275,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     }
                 };
 
-            if is_positive == (ops[0] == ast::CmpOp::In) {
+            if is_positive == (*op == ast::CmpOp::In) {
                 let narrowed = self.narrow_with_present_key(rhs_type, key);
                 if narrowed != rhs_type.resolve_type_alias(db) {
                     apply_constraint(&mut constraints, NarrowingConstraint::replacement(narrowed));
@@ -4343,7 +4344,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         };
         let mut last_rhs_ty: Option<Type> = None;
 
-        for (op, (left, right)) in std::iter::zip(&**ops, comparator_tuples) {
+        for (left, op, right) in expr_compare.iter() {
             let lhs_ty = last_rhs_ty.unwrap_or_else(|| expression_type(left, &self.env));
             let rhs_ty = expression_type(right, &self.env);
             let lhs_narrowing_rhs_ty = if matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn) {


### PR DESCRIPTION
## Summary

We store the initial comparison operand separately and pair each operator with its right operand in `Box<[(CmpOp, Expr)]>`. For `a < b <= c`, `left` is `a` and `comparisons` is `[(Lt, b), (LtE, c)]`. This guarantees an initial operand and prevents mismatched operator and operand counts, simplifying visitors, formatting, lint rules, and type inference.

The parser collects the pairs in reusable scratch storage. Error recovery continues to synthesize an invalid name expression for a missing operand, and a nested-comparison fixture checks that inner comparisons preserve the surrounding chain.

On 64-bit targets, `ExprCompare` shrinks from 48 to 40 bytes while `Expr` remains 56 bytes. Both layouts use two heap allocations per comparison expression. The paired layout adds seven bytes of heap payload per operator through tuple padding, before allocator rounding.

This follows #28335 and implements [Alex's proposed layout](https://github.com/astral-sh/ruff/pull/28335#discussion_r3950463915).
