### PR TITLE
[ty] Store call metadata with the callee

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -539,8 +539,6 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                         range: _,
                         node_index: _,
                     },
-                range_start: _,
-                node_index: _,
             },
         ) => {
             if checker.any_rule_enabled(&[

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1741,12 +1741,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
 
         // Step 1: Binding
         match expr {
-            Expr::Call(ast::ExprCall {
-                func,
-                arguments: _,
-                range_start: _,
-                node_index: _,
-            }) => {
+            Expr::Call(ast::ExprCall { func, arguments: _ }) => {
                 if let Expr::Name(ast::ExprName {
                     id,
                     ctx,
@@ -1861,12 +1856,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
             }) => {
                 self.visit_boolean_test(operand);
             }
-            Expr::Call(ast::ExprCall {
-                func,
-                arguments,
-                range_start: _,
-                node_index: _,
-            }) => {
+            Expr::Call(ast::ExprCall { func, arguments }) => {
                 self.visit_expr(func);
 
                 let callable =

--- a/crates/ruff_linter/src/renamer.rs
+++ b/crates/ruff_linter/src/renamer.rs
@@ -289,9 +289,7 @@ impl Renamer {
             return None;
         };
 
-        let ast::ExprCall {
-            func, arguments, ..
-        } = value.as_call_expr()?;
+        let ast::ExprCall { func, arguments } = value.as_call_expr()?;
 
         let qualified_name = semantic.resolve_qualified_name(func)?;
 

--- a/crates/ruff_linter/src/rules/airflow/rules/dag_schedule_argument.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/dag_schedule_argument.rs
@@ -59,10 +59,7 @@ pub(crate) fn dag_no_schedule_argument(checker: &Checker, expr: &Expr) {
     }
 
     // Don't check non-call expressions.
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = expr else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/airflow/rules/function_signature_change_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/function_signature_change_in_3.rs
@@ -65,10 +65,7 @@ pub(crate) fn airflow_3_incompatible_function_signature(checker: &Checker, expr:
         return;
     }
 
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = expr else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/removal_in_3.rs
@@ -97,11 +97,7 @@ pub(crate) fn airflow_3_removal_expr(checker: &Checker, expr: &Expr) {
     }
 
     match expr {
-        Expr::Call(
-            call_expr @ ExprCall {
-                func, arguments, ..
-            },
-        ) => {
+        Expr::Call(call_expr @ ExprCall { func, arguments }) => {
             if let Some(qualified_name) = checker.semantic().resolve_qualified_name(func) {
                 check_call_arguments(checker, &qualified_name, arguments);
             }
@@ -1278,10 +1274,7 @@ fn is_context_key_access(checker: &Checker, expr: &Expr, key: &str) -> bool {
         }
     }
     // context.get("key")
-    if let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = expr
-    {
+    if let Expr::Call(ExprCall { func, arguments }) = expr {
         if let Expr::Attribute(ExprAttribute { value, attr, .. }) = func.as_ref() {
             if attr.as_str() == "get" {
                 if let Some(Expr::StringLiteral(ExprStringLiteral { value: arg_key, .. })) =

--- a/crates/ruff_linter/src/rules/airflow/rules/runtime_value_in_dag_or_task.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/runtime_value_in_dag_or_task.rs
@@ -101,9 +101,7 @@ fn find_runtime_varying_call<'a>(
     semantic: &SemanticModel,
 ) -> Option<(&'a Expr, &'static str)> {
     match expr {
-        Expr::Call(ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ExprCall { func, arguments }) => {
             if let Some(qualified_name) = semantic.resolve_qualified_name(func) {
                 let name = match qualified_name.segments() {
                     ["datetime", "datetime", "now"] => Some("datetime.now"),

--- a/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/suggested_to_update_3_0.rs
@@ -93,9 +93,7 @@ pub(crate) fn airflow_3_0_suggested_update_expr(checker: &Checker, expr: &Expr) 
     }
 
     match expr {
-        Expr::Call(ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ExprCall { func, arguments }) => {
             if let Some(qualified_name) = checker.semantic().resolve_qualified_name(func) {
                 check_call_arguments(checker, &qualified_name, arguments);
             }

--- a/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
+++ b/crates/ruff_linter/src/rules/airflow/rules/task_variable_name.rs
@@ -61,10 +61,7 @@ pub(crate) fn variable_name_task_id(checker: &Checker, targets: &[Expr], value: 
     };
 
     // If the value is not a call, we can't do anything.
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = value
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = value else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -418,10 +418,7 @@ impl<'a> Dependency<'a> {
 }
 
 fn depends_arguments<'a>(expr: &'a Expr, semantic: &SemanticModel) -> Option<&'a Arguments> {
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = expr else {
         return None;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/suspicious_function_call.rs
@@ -1212,14 +1212,13 @@ fn suspicious_function(
                 {
                     match arguments.find_argument_value("url", 0) {
                         // If the `url` argument is a `urllib.request.Request` object, allow `http` and `https` schemes.
-                        Some(Expr::Call(ExprCall {
-                            func, arguments, ..
-                        })) if checker
-                            .semantic()
-                            .resolve_qualified_name(func.as_ref())
-                            .is_some_and(|name| {
-                                name.segments() == ["urllib", "request", "Request"]
-                            }) =>
+                        Some(Expr::Call(ExprCall { func, arguments }))
+                            if checker
+                                .semantic()
+                                .resolve_qualified_name(func.as_ref())
+                                .is_some_and(|name| {
+                                    name.segments() == ["urllib", "request", "Request"]
+                                }) =>
                         {
                             if let Some(url_expr) = arguments.find_argument_value("url", 0)
                                 && expression_starts_with_http_prefix(url_expr, checker.semantic())

--- a/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
+++ b/crates/ruff_linter/src/rules/flake8_blind_except/rules/blind_except.rs
@@ -223,10 +223,7 @@ impl<'a> StatementVisitor<'a> for LogExceptionVisitor<'a> {
         }
         match stmt {
             Stmt::Expr(ast::StmtExpr { value, .. }) => {
-                if let Expr::Call(ast::ExprCall {
-                    func, arguments, ..
-                }) = value.as_ref()
-                {
+                if let Expr::Call(ast::ExprCall { func, arguments }) = value.as_ref() {
                     match func.as_ref() {
                         Expr::Attribute(ast::ExprAttribute { attr, .. })
                             if logging::is_logger_candidate(

--- a/crates/ruff_linter/src/rules/flake8_bugbear/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/helpers.rs
@@ -35,7 +35,6 @@ pub(crate) fn is_infinite_iterable(arg: &Expr, semantic: &SemanticModel) -> bool
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, keywords, .. },
-        ..
     }) = &arg
     else {
         return false;

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_false.rs
@@ -55,14 +55,14 @@ fn assertion_error(msg: Option<&Expr>) -> Stmt {
     Stmt::Raise(ast::StmtRaise {
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-        exc: Some(Box::new(Expr::Call(ast::ExprCall {
-            func: Box::new(Expr::Name(ast::ExprName {
+        exc: Some(Box::new(Expr::Call(ast::ExprCall::new(
+            Expr::Name(ast::ExprName {
                 id: "AssertionError".into(),
                 ctx: ExprContext::Load,
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            })),
-            arguments: Arguments {
+            }),
+            Arguments {
                 args: if let Some(msg) = msg {
                     [msg.clone()].into()
                 } else {
@@ -72,9 +72,9 @@ fn assertion_error(msg: Option<&Expr>) -> Stmt {
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             },
-            range_start: ruff_text_size::TextSize::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-        }))),
+            ruff_text_size::TextSize::default(),
+            ruff_python_ast::AtomicNodeIndex::NONE,
+        )))),
         cause: None,
     })
 }

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/assert_raises_exception.rs
@@ -108,13 +108,7 @@ fn detect_blind_exception(
 /// B017
 pub(crate) fn assert_raises_exception(checker: &Checker, items: &[WithItem]) {
     for item in items {
-        let Expr::Call(ast::ExprCall {
-            func,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) = &item.context_expr
-        else {
+        let Expr::Call(ast::ExprCall { func, arguments }) = &item.context_expr else {
             continue;
         };
 
@@ -132,12 +126,7 @@ pub(crate) fn assert_raises_exception(checker: &Checker, items: &[WithItem]) {
 
 /// B017 (call form)
 pub(crate) fn assert_raises_exception_call(checker: &Checker, call: &ast::ExprCall) {
-    let ast::ExprCall {
-        func,
-        arguments,
-        range_start: _,
-        node_index: _,
-    } = call;
+    let ast::ExprCall { func, arguments } = call;
     let semantic = checker.semantic();
 
     if arguments.args.len() < 2 && arguments.find_argument("func", 1).is_none() {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/function_uses_loop_variable.rs
@@ -125,12 +125,7 @@ impl<'a> Visitor<'a> for SuspiciousVariablesVisitor<'a> {
 
     fn visit_expr(&mut self, expr: &'a Expr) {
         match expr {
-            Expr::Call(ast::ExprCall {
-                func,
-                arguments,
-                range_start: _,
-                node_index: _,
-            }) => {
+            Expr::Call(ast::ExprCall { func, arguments }) => {
                 // Mark immediately-invoked lambdas as safe — the closure
                 // is consumed right away, so late-binding is not a concern.
                 if func.is_lambda_expr() {

--- a/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
+++ b/crates/ruff_linter/src/rules/flake8_bugbear/rules/loop_iterator_mutation.rs
@@ -73,9 +73,9 @@ pub(crate) fn loop_iterator_mutation(checker: &Checker, stmt_for: &StmtFor) {
         }
         // Ex) Given `for i, item in enumerate(items):`, `i` is the index and `items` is the
         // iterable.
-        Expr::Call(ExprCall {
-            func, arguments, ..
-        }) if checker.semantic().match_builtin_expr(func, "enumerate") => {
+        Expr::Call(ExprCall { func, arguments })
+            if checker.semantic().match_builtin_expr(func, "enumerate") =>
+        {
             // Ex) `items`
             let Some(iter) = arguments.args.first() else {
                 return;

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_dict_comprehension_for_iterable.rs
@@ -217,17 +217,17 @@ fn fix_unnecessary_dict_comprehension(value: &Expr, generator: &Comprehension) -
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
-    Expr::Call(ExprCall {
-        func: Box::new(Expr::Name(ExprName {
+    Expr::Call(ExprCall::new(
+        Expr::Name(ExprName {
             id: "dict.fromkeys".into(),
             ctx: ExprContext::Load,
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-        })),
-        arguments: args,
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    })
+        }),
+        args,
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    ))
 }
 
 fn contains_side_effecting_sub_expression(target: &Expr) -> bool {

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_double_cast_or_process.rs
@@ -84,7 +84,6 @@ pub(crate) fn unnecessary_double_cast_or_process(
         arguments: Arguments {
             keywords: inner_kw, ..
         },
-        ..
     }) = arg
     else {
         return;

--- a/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_comprehensions/rules/unnecessary_list_call.rs
@@ -48,12 +48,7 @@ impl Violation for UnnecessaryListCall {
 
 /// C411
 pub(crate) fn unnecessary_list_call(checker: &Checker, expr: &Expr, call: &ExprCall) {
-    let ExprCall {
-        func,
-        arguments,
-        range_start: _,
-        node_index: _,
-    } = call;
+    let ExprCall { func, arguments } = call;
 
     if !arguments.keywords.is_empty() {
         return;

--- a/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_errmsg/rules/string_in_exception.rs
@@ -189,7 +189,6 @@ pub(crate) fn string_in_exception(checker: &Checker, stmt: &Stmt, exc: &Expr) {
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, .. },
-        ..
     }) = exc
     else {
         return;

--- a/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
+++ b/crates/ruff_linter/src/rules/flake8_logging_format/rules/logging_call.rs
@@ -191,7 +191,6 @@ fn check_log_record_attr_clash(checker: &Checker, extra: &Keyword) {
         Expr::Call(ast::ExprCall {
             func,
             arguments: Arguments { keywords, .. },
-            ..
         }) if checker.semantic().match_builtin_expr(func, "dict") => {
             for keyword in keywords {
                 if let Some(attr) = &keyword.arg {

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/multiple_starts_ends_with.rs
@@ -91,8 +91,6 @@ pub(crate) fn multiple_starts_ends_with(checker: &Checker, expr: &Expr) {
                     range: _,
                     node_index: _,
                 },
-            range_start: _,
-            node_index: _,
         }) = &call
         else {
             continue;
@@ -152,8 +150,6 @@ pub(crate) fn multiple_starts_ends_with(checker: &Checker, expr: &Expr) {
                                 range: _,
                                 node_index: _,
                             },
-                        range_start: _,
-                        node_index: _,
                     }) = expr
                     else {
                         unreachable!(
@@ -196,17 +192,17 @@ pub(crate) fn multiple_starts_ends_with(checker: &Checker, expr: &Expr) {
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
-            let node3 = Expr::Call(ast::ExprCall {
-                func: Box::new(node2),
-                arguments: Arguments {
+            let node3 = Expr::Call(ast::ExprCall::new(
+                node2,
+                Arguments {
                     args: [node].into(),
                     keywords: std::iter::empty().collect(),
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 },
-                range_start: ruff_text_size::TextSize::default(),
-                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            });
+                ruff_text_size::TextSize::default(),
+                ruff_python_ast::AtomicNodeIndex::NONE,
+            ));
             let call = node3;
 
             // Generate the combined `BoolOp`.

--- a/crates/ruff_linter/src/rules/flake8_pie/rules/non_unique_enums.rs
+++ b/crates/ruff_linter/src/rules/flake8_pie/rules/non_unique_enums.rs
@@ -116,9 +116,7 @@ fn member_has_unknown_value(semantic: &SemanticModel, expr: &Expr) -> bool {
     match expr {
         Expr::EllipsisLiteral(_) => true,
 
-        Expr::Call(ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ExprCall { func, arguments }) => {
             if !semantic.match_typing_expr(func, "cast") {
                 return false;
             }

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/fixture.rs
@@ -741,12 +741,7 @@ fn pytest_fixture_parentheses(
 /// PT001, PT002, PT003
 fn check_fixture_decorator(checker: &Checker, func_name: &str, decorator: &Decorator) {
     match &decorator.expression {
-        Expr::Call(ast::ExprCall {
-            func: _,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) => {
+        Expr::Call(ast::ExprCall { func: _, arguments }) => {
             if checker.is_rule_enabled(Rule::PytestFixtureIncorrectParenthesesStyle) {
                 if !checker.settings().flake8_pytest_style.fixture_parentheses
                     && arguments.args.is_empty()

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/marks.rs
@@ -156,12 +156,7 @@ fn pytest_mark_parentheses(
 
 fn check_mark_parentheses(checker: &Checker, decorator: &Decorator, marker: &str) {
     match &decorator.expression {
-        Expr::Call(ast::ExprCall {
-            func: _,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) => {
+        Expr::Call(ast::ExprCall { func: _, arguments }) => {
             if !checker.settings().flake8_pytest_style.mark_parentheses
                 && arguments.args.is_empty()
                 && arguments.keywords.is_empty()

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/unittest_assert.rs
@@ -388,17 +388,17 @@ impl UnittestAssert {
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 };
-                let node1 = ast::ExprCall {
-                    func: Box::new(node.into()),
-                    arguments: Arguments {
+                let node1 = ast::ExprCall::new(
+                    node.into(),
+                    Arguments {
                         args: [(**obj).clone(), (**cls).clone()].into(),
                         keywords: std::iter::empty().collect(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                     },
-                    range_start: ruff_text_size::TextSize::default(),
-                    node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-                };
+                    ruff_text_size::TextSize::default(),
+                    ruff_python_ast::AtomicNodeIndex::NONE,
+                );
                 let isinstance = node1.into();
                 if matches!(self, UnittestAssert::IsInstance) {
                     Ok(assert(&isinstance, msg))
@@ -437,17 +437,17 @@ impl UnittestAssert {
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 };
-                let node2 = ast::ExprCall {
-                    func: Box::new(node1.into()),
-                    arguments: Arguments {
+                let node2 = ast::ExprCall::new(
+                    node1.into(),
+                    Arguments {
                         args: [(**regex).clone(), (**text).clone()].into(),
                         keywords: std::iter::empty().collect(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                     },
-                    range_start: ruff_text_size::TextSize::default(),
-                    node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-                };
+                    ruff_text_size::TextSize::default(),
+                    ruff_python_ast::AtomicNodeIndex::NONE,
+                );
                 let re_search = node2.into();
                 if matches!(self, UnittestAssert::Regex | UnittestAssert::RegexpMatches) {
                     Ok(assert(&re_search, msg))

--- a/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
+++ b/crates/ruff_linter/src/rules/flake8_raise/rules/unnecessary_paren_on_raise_exception.rs
@@ -60,13 +60,7 @@ impl AlwaysFixableViolation for UnnecessaryParenOnRaiseException {
 
 /// RSE102
 pub(crate) fn unnecessary_paren_on_raise_exception(checker: &Checker, expr: &Expr) {
-    let Expr::Call(ast::ExprCall {
-        func,
-        arguments,
-        range_start: _,
-        node_index: _,
-    }) = expr
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = expr else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -315,8 +315,6 @@ fn isinstance_target<'a>(call: &'a Expr, semantic: &'a SemanticModel) -> Option<
                 range: _,
                 node_index: _,
             },
-        range_start: _,
-        node_index: _,
     } = call.as_call_expr()?;
     if args.len() != 2 {
         return None;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_expr.rs
@@ -153,7 +153,6 @@ pub(crate) fn use_capital_environment_variables(checker: &Checker, expr: &Expr) 
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, .. },
-        ..
     }) = expr
     else {
         return;
@@ -257,8 +256,6 @@ pub(crate) fn dict_get_with_none_default(checker: &Checker, expr: &Expr) {
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, keywords, .. },
-        range_start: _,
-        node_index: _,
     }) = expr
     else {
         return;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_ifexp.rs
@@ -181,25 +181,23 @@ pub(crate) fn if_expr_with_true_false(
     } else if checker.semantic().has_builtin_binding("bool") {
         diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             checker.generator().expr(
-                &ast::ExprCall {
-                    func: Box::new(
-                        ast::ExprName {
-                            id: Name::new_static("bool"),
-                            ctx: ExprContext::Load,
-                            range: TextRange::default(),
-                            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-                        }
-                        .into(),
-                    ),
-                    arguments: Arguments {
+                &ast::ExprCall::new(
+                    ast::ExprName {
+                        id: Name::new_static("bool"),
+                        ctx: ExprContext::Load,
+                        range: TextRange::default(),
+                        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+                    }
+                    .into(),
+                    Arguments {
                         args: [test.clone()].into(),
                         keywords: std::iter::empty().collect(),
                         range: TextRange::default(),
                         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                     },
-                    range_start: ruff_text_size::TextSize::default(),
-                    node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-                }
+                    ruff_text_size::TextSize::default(),
+                    ruff_python_ast::AtomicNodeIndex::NONE,
+                )
                 .into(),
             ),
             expr.range(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -286,17 +286,17 @@ pub(crate) fn double_negation(checker: &Checker, expr: &Expr, op: UnaryOp, opera
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         };
-        let node1 = ast::ExprCall {
-            func: Box::new(node.into()),
-            arguments: Arguments {
+        let node1 = ast::ExprCall::new(
+            node.into(),
+            Arguments {
                 args: [*operand.clone()].into(),
                 keywords: std::iter::empty().collect(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             },
-            range_start: ruff_text_size::TextSize::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-        };
+            ruff_text_size::TextSize::default(),
+            ruff_python_ast::AtomicNodeIndex::NONE,
+        );
         diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
             checker.generator().expr(&node1.into()),
             expr.range(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -202,17 +202,17 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
-    let node3 = ast::ExprCall {
-        func: Box::new(node2.into()),
-        arguments: Arguments {
+    let node3 = ast::ExprCall::new(
+        node2.into(),
+        Arguments {
             args: [node1, node].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     let node4 = expected_var.clone();
     let node5 = ast::StmtAssign {
         targets: vec![node4],
@@ -311,17 +311,17 @@ pub(crate) fn if_exp_instead_of_dict_get(
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
-    let fixed_node = ast::ExprCall {
-        func: Box::new(dict_get_node.into()),
-        arguments: Arguments {
+    let fixed_node = ast::ExprCall::new(
+        dict_get_node.into(),
+        Arguments {
             args: [dict_key_node, default_value_node].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
 
     let contents = checker.generator().expr(&fixed_node.into());
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -61,8 +61,6 @@ fn key_in_dict(checker: &Checker, left: &Expr, right: &Expr, operator: CmpOp, pa
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, keywords, .. },
-        range_start: _,
-        node_index: _,
     }) = &right
     else {
         return;

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/needless_bool.rs
@@ -275,17 +275,17 @@ pub(crate) fn needless_bool(checker: &Checker, stmt: &Stmt) {
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             };
-            let call_node = ast::ExprCall {
-                func: Box::new(func_node.into()),
-                arguments: Arguments {
+            let call_node = ast::ExprCall::new(
+                func_node.into(),
+                Arguments {
                     args: [if_test.clone()].into(),
                     keywords: std::iter::empty().collect(),
                     range: TextRange::default(),
                     node_index: ruff_python_ast::AtomicNodeIndex::NONE,
                 },
-                range_start: ruff_text_size::TextSize::default(),
-                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            };
+                ruff_text_size::TextSize::default(),
+                ruff_python_ast::AtomicNodeIndex::NONE,
+            );
             Some(Expr::Call(call_node))
         } else {
             None

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/open_file_with_context_handler.rs
@@ -207,10 +207,7 @@ fn is_immediately_closed(semantic: &SemanticModel) -> bool {
         return false;
     };
 
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = expr else {
         return false;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -426,17 +426,17 @@ fn return_stmt(id: Name, test: &Expr, target: &Expr, iter: &Expr, generator: Gen
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
-    let node2 = ast::ExprCall {
-        func: Box::new(node1.into()),
-        arguments: Arguments {
+    let node2 = ast::ExprCall::new(
+        node1.into(),
+        Arguments {
             args: [node.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     let node3 = ast::StmtReturn {
         value: Some(Box::new(node2.into())),
         range: TextRange::default(),

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/zip_dict_keys_and_values.rs
@@ -70,7 +70,6 @@ pub(crate) fn zip_dict_keys_and_values(checker: &Checker, expr: &ast::ExprCall) 
     let ast::ExprCall {
         func,
         arguments: Arguments { args, keywords, .. },
-        ..
     } = expr;
     match &keywords[..] {
         [] => {}
@@ -141,10 +140,7 @@ pub(crate) fn zip_dict_keys_and_values(checker: &Checker, expr: &ast::ExprCall) 
 }
 
 fn get_var_attr_args(expr: &Expr) -> Option<(&ExprName, &Identifier, &Arguments)> {
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = expr else {
         return None;
     };
     let Expr::Attribute(ExprAttribute { value, attr, .. }) = func.as_ref() else {

--- a/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
+++ b/crates/ruff_linter/src/rules/flake8_unused_arguments/rules/unused_arguments.rs
@@ -405,10 +405,7 @@ pub(crate) fn is_not_implemented_stub_with_variable(
         return false;
     }
 
-    let ast::Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = &**exception
-    else {
+    let ast::Expr::Call(ast::ExprCall { func, arguments }) = &**exception else {
         return false;
     };
 

--- a/crates/ruff_linter/src/rules/flynt/helpers.rs
+++ b/crates/ruff_linter/src/rules/flynt/helpers.rs
@@ -35,8 +35,6 @@ fn is_simple_call(expr: &Expr) -> bool {
                     range: _,
                     node_index: _,
                 },
-            range_start: _,
-            node_index: _,
         }) => args.is_empty() && keywords.is_empty() && is_simple_callee(func),
         _ => false,
     }

--- a/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
+++ b/crates/ruff_linter/src/rules/pep8_naming/helpers.rs
@@ -107,10 +107,7 @@ pub(super) fn is_typed_dict_class(class_def: &ast::StmtClassDef, semantic: &Sema
 /// ```
 pub(super) fn is_django_model_import(name: &str, stmt: &Stmt, semantic: &SemanticModel) -> bool {
     fn match_model_import(name: &str, expr: &Expr, semantic: &SemanticModel) -> bool {
-        let Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) = expr
-        else {
+        let Expr::Call(ast::ExprCall { func, arguments }) = expr else {
             return false;
         };
 

--- a/crates/ruff_linter/src/rules/perflint/rules/incorrect_dict_iterator.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/incorrect_dict_iterator.rs
@@ -86,7 +86,6 @@ fn check_dict_items_usage(checker: &Checker, target: &Expr, iter: &Expr) {
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, .. },
-        ..
     }) = iter
     else {
         return;

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_comprehension.rs
@@ -147,8 +147,6 @@ pub(crate) fn manual_list_comprehension(checker: &Checker, for_stmt: &ast::StmtF
                 range: _,
                 node_index: _,
             },
-        range_start: _,
-        node_index: _,
     }) = value.as_ref()
     else {
         return;

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
@@ -75,8 +75,6 @@ pub(crate) fn manual_list_copy(checker: &Checker, for_stmt: &ast::StmtFor) {
                 range: _,
                 node_index: _,
             },
-        range_start: _,
-        node_index: _,
     }) = value.as_ref()
     else {
         return;

--- a/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/unnecessary_list_cast.rs
@@ -77,8 +77,6 @@ pub(crate) fn unnecessary_list_cast(checker: &Checker, iter: &Expr, body: &[Stmt
                 range: _,
                 node_index: _,
             },
-        range_start: _,
-        node_index: _,
     }) = iter
     else {
         return;

--- a/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/len_test.rs
@@ -82,9 +82,7 @@ impl AlwaysFixableViolation for LenTest {
 
 /// PLC1802
 pub(crate) fn len_test(checker: &Checker, call: &ExprCall) {
-    let ExprCall {
-        func, arguments, ..
-    } = call;
+    let ExprCall { func, arguments } = call;
     let semantic = checker.semantic();
 
     if !semantic.in_boolean_test() {

--- a/crates/ruff_linter/src/rules/pylint/rules/missing_maxsplit_arg.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/missing_maxsplit_arg.rs
@@ -90,10 +90,7 @@ fn is_string(expr: &Expr, semantic: &SemanticModel) -> bool {
 /// PLC0207
 pub(crate) fn missing_maxsplit_arg(checker: &Checker, value: &Expr, slice: &Expr, expr: &Expr) {
     // Check the sliced expression is a function
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = value
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = value else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
@@ -106,7 +106,6 @@ fn is_nan_float(expr: &Expr, semantic: &SemanticModel) -> bool {
     let Expr::Call(ast::ExprCall {
         func,
         arguments: ast::Arguments { args, keywords, .. },
-        ..
     }) = expr
     else {
         return false;

--- a/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nested_min_max.rs
@@ -138,8 +138,6 @@ fn collect_nested_args(min_max: MinMax, args: &[Expr], semantic: &SemanticModel)
                         range: _,
                         node_index: _,
                     },
-                range_start: _,
-                node_index: _,
             }) = arg
             {
                 if MinMax::try_from_call(func, keywords, semantic) == Some(min_max) {
@@ -191,7 +189,6 @@ pub(crate) fn nested_min_max(
         let Expr::Call(ast::ExprCall {
             func,
             arguments: Arguments { keywords, .. },
-            ..
         }) = arg
         else {
             return false;
@@ -200,17 +197,17 @@ pub(crate) fn nested_min_max(
     }) {
         let mut diagnostic =
             checker.report_diagnostic(NestedMinMax { func: min_max }, expr.range());
-        let flattened_expr = Expr::Call(ast::ExprCall {
-            func: Box::new(func.clone()),
-            arguments: Arguments {
+        let flattened_expr = Expr::Call(ast::ExprCall::new(
+            func.clone(),
+            Arguments {
                 args: collect_nested_args(min_max, args, checker.semantic()).into(),
                 keywords: keywords.iter().cloned().collect(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             },
-            range_start: ruff_text_size::TextSize::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-        });
+            ruff_text_size::TextSize::default(),
+            ruff_python_ast::AtomicNodeIndex::NONE,
+        ));
         diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
             checker.generator().expr(&flattened_expr),
             expr.range(),

--- a/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/no_method_decorator.rs
@@ -115,10 +115,7 @@ fn get_undecorated_methods(checker: &Checker, class_stmt: &Stmt, method_type: &M
     // gather all explicit *method calls
     for stmt in &class_def.body {
         if let Stmt::Assign(ast::StmtAssign { targets, value, .. }) = stmt {
-            if let Expr::Call(ast::ExprCall {
-                func, arguments, ..
-            }) = value.as_ref()
-            {
+            if let Expr::Call(ast::ExprCall { func, arguments }) = value.as_ref() {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     if id == method_name && checker.semantic().has_builtin_binding(method_name) {
                         if arguments.args.len() != 1 {

--- a/crates/ruff_linter/src/rules/pylint/rules/redefined_loop_name.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/redefined_loop_name.rs
@@ -265,7 +265,6 @@ fn assignment_is_cast_expr(value: &Expr, target: &Expr, semantic: &SemanticModel
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, .. },
-        ..
     }) = value
     else {
         return false;

--- a/crates/ruff_linter/src/rules/pylint/rules/type_bivariance.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_bivariance.rs
@@ -81,10 +81,7 @@ pub(crate) fn type_bivariance(checker: &Checker, value: &Expr) {
         return;
     }
 
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = value
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = value else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_name_incorrect_variance.rs
@@ -74,10 +74,7 @@ pub(crate) fn type_name_incorrect_variance(checker: &Checker, value: &Expr) {
         return;
     }
 
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = value
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = value else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/type_param_name_mismatch.rs
@@ -74,10 +74,7 @@ pub(crate) fn type_param_name_mismatch(checker: &Checker, value: &Expr, targets:
         return;
     };
 
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = value
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = value else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dict_index_lookup.rs
@@ -115,9 +115,7 @@ fn dict_items<'a>(
     call_expr: &'a Expr,
     tuple_expr: &'a Expr,
 ) -> Option<(&'a ast::ExprName, &'a ast::ExprName, &'a ast::ExprName)> {
-    let ast::ExprCall {
-        func, arguments, ..
-    } = call_expr.as_call_expr()?;
+    let ast::ExprCall { func, arguments } = call_expr.as_call_expr()?;
 
     if !arguments.is_empty() {
         return None;

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_lambda.rs
@@ -80,10 +80,7 @@ pub(crate) fn unnecessary_lambda(checker: &Checker, lambda: &ExprLambda) {
     } = lambda;
 
     // The lambda should consist of a single function call.
-    let Expr::Call(ast::ExprCall {
-        arguments, func, ..
-    }) = body.as_ref()
-    else {
+    let Expr::Call(ast::ExprCall { arguments, func }) = body.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_list_index_lookup.rs
@@ -118,9 +118,7 @@ fn enumerate_items<'a>(
     tuple_expr: &'a Expr,
     semantic: &SemanticModel,
 ) -> Option<(&'a ast::ExprName, &'a ast::ExprName, &'a ast::ExprName)> {
-    let ast::ExprCall {
-        func, arguments, ..
-    } = call_expr.as_call_expr()?;
+    let ast::ExprCall { func, arguments } = call_expr.as_call_expr()?;
 
     let Expr::Tuple(ast::ExprTuple { elts, .. }) = tuple_expr else {
         return None;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_named_tuple_functional_to_class.rs
@@ -149,8 +149,6 @@ fn match_named_tuple_assign<'a>(
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, keywords, .. },
-        range_start: _,
-        node_index: _,
     }) = value
     else {
         return None;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -131,13 +131,7 @@ fn match_typed_dict_assign<'a>(
     let [Expr::Name(ast::ExprName { id: class_name, .. })] = targets else {
         return None;
     };
-    let Expr::Call(ast::ExprCall {
-        func,
-        arguments,
-        range_start: _,
-        node_index: _,
-    }) = value
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = value else {
         return None;
     };
     if !semantic.match_typing_expr(func, "TypedDict") {
@@ -276,8 +270,6 @@ fn match_fields_and_total(arguments: &Arguments) -> Option<(Suite, Option<&Keywo
                 Expr::Call(ast::ExprCall {
                     func,
                     arguments: Arguments { keywords, .. },
-                    range_start: _,
-                    node_index: _,
                 }) => Some((fields_from_dict_call(func, keywords)?, total)),
                 _ => None,
             }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_with_maxsize_none.rs
@@ -72,8 +72,6 @@ pub(crate) fn lru_cache_with_maxsize_none(checker: &Checker, decorator_list: &[D
                     range: _,
                     node_index: _,
                 },
-            range_start: _,
-            node_index: _,
         }) = &decorator.expression
         else {
             continue;

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/lru_cache_without_parameters.rs
@@ -57,13 +57,7 @@ impl AlwaysFixableViolation for LRUCacheWithoutParameters {
 /// UP011
 pub(crate) fn lru_cache_without_parameters(checker: &Checker, decorator_list: &[Decorator]) {
     for decorator in decorator_list {
-        let Expr::Call(ast::ExprCall {
-            func,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) = &decorator.expression
-        else {
+        let Expr::Call(ast::ExprCall { func, arguments }) = &decorator.expression else {
             continue;
         };
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/native_literals.rs
@@ -197,8 +197,6 @@ pub(crate) fn native_literals(
                 range: _,
                 node_index: _,
             },
-        range_start: _,
-        node_index: _,
     } = call;
 
     let semantic = checker.semantic();

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/mod.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/mod.rs
@@ -301,9 +301,7 @@ pub(crate) fn expr_name_to_type_var<'a>(
                 default: None,
             });
         }
-        Expr::Call(ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ExprCall { func, arguments }) => {
             let kind = if semantic.match_typing_expr(func, "TypeVar") {
                 TypeParamKind::TypeVar
             } else if semantic.match_typing_expr(func, "TypeVarTuple") {

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -131,10 +131,7 @@ pub(crate) fn non_pep695_type_alias_type(checker: &Checker, stmt: &StmtAssign) {
 
     let StmtAssign { targets, value, .. } = stmt;
 
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = value.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/super_call_with_parameters.rs
@@ -222,10 +222,7 @@ pub(crate) fn super_call_with_parameters(checker: &Checker, call: &ast::ExprCall
     //
     // See: https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass
     if decorator_list.iter().any(|decorator| {
-        let Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) = &decorator.expression
-        else {
+        let Expr::Call(ast::ExprCall { func, arguments }) = &decorator.expression else {
             return false;
         };
 

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -29,17 +29,17 @@ pub(super) fn generate_method_call(name: Name, method: &str, generator: Generato
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make it into a call `name.method()`
-    let call = ast::ExprCall {
-        func: Box::new(attr.into()),
-        arguments: ast::Arguments {
+    let call = ast::ExprCall::new(
+        attr.into(),
+        ast::Arguments {
             args: [].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     // And finally, turn it into a statement.
     let stmt = ast::StmtExpr {
         value: Box::new(call.into()),
@@ -262,7 +262,6 @@ fn find_file_open<'a>(
     let ast::ExprCall {
         func,
         arguments: ast::Arguments { args, keywords, .. },
-        ..
     } = item.context_expr.as_call_expr()?;
 
     // Ignore calls with `*args` and `**kwargs`. In the exact case of `open(*filename, mode="w")`,
@@ -313,7 +312,6 @@ fn find_path_open<'a>(
     let ast::ExprCall {
         func,
         arguments: ast::Arguments { args, keywords, .. },
-        ..
     } = item.context_expr.as_call_expr()?;
     if args.iter().any(Expr::is_starred_expr)
         || keywords.iter().any(|keyword| keyword.arg.is_none())

--- a/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/bit_count.rs
@@ -99,10 +99,7 @@ pub(crate) fn bit_count(checker: &Checker, call: &ExprCall) {
         return;
     }
 
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = value.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -152,7 +152,6 @@ fn match_remove(if_stmt: &ast::StmtIf) -> Option<(&Expr, &ast::ExprName)> {
     let ast::ExprCall {
         func: attr,
         arguments: ast::Arguments { args, keywords, .. },
-        ..
     } = expr.as_call_expr()?;
 
     let ast::ExprAttribute {
@@ -189,17 +188,17 @@ fn make_suggestion(set: &ast::ExprName, element: &Expr, generator: Generator) ->
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make the actual call `set.discard(element)`
-    let call = ast::ExprCall {
-        func: Box::new(attr.into()),
-        arguments: ast::Arguments {
+    let call = ast::ExprCall::new(
+        attr.into(),
+        ast::Arguments {
             args: [element.clone()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     // And finally, turn it into a statement.
     let stmt = ast::StmtExpr {
         value: Box::new(call.into()),

--- a/crates/ruff_linter/src/rules/refurb/rules/fromisoformat_replace_z.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/fromisoformat_replace_z.rs
@@ -214,9 +214,7 @@ impl<'a> ReplaceTimeZone<'a> {
 ///
 /// It returns the value of the `date` argument and its parent.
 fn strip_z_date(call: &ExprCall) -> Option<(&Expr, &Expr)> {
-    let ExprCall {
-        func, arguments, ..
-    } = call;
+    let ExprCall { func, arguments } = call;
 
     let Expr::Attribute(ExprAttribute { value, attr, .. }) = &**func else {
         return None;

--- a/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/fstring_number_format.rs
@@ -96,10 +96,7 @@ pub(crate) fn fstring_number_format(checker: &Checker, subscript: &ast::ExprSubs
     }
 
     // The call must be exactly `hex(...)`, `bin(...)`, or `oct(...)`.
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = subscript.value.as_ref()
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = subscript.value.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/hashlib_digest_hex.rs
@@ -70,10 +70,7 @@ pub(crate) fn hashlib_digest_hex(checker: &Checker, call: &ExprCall) {
         return;
     }
 
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = value.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/implicit_cwd.rs
@@ -60,10 +60,7 @@ pub(crate) fn no_implicit_cwd(checker: &Checker, call: &ExprCall) {
         return;
     }
 
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = value.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
@@ -88,9 +88,7 @@ fn is_none(expr: &Expr, semantic: &SemanticModel) -> bool {
             Expr::NoneLiteral(_) if in_union_context => true,
 
             // Ex) `type(None)`
-            Expr::Call(ast::ExprCall {
-                func, arguments, ..
-            }) => {
+            Expr::Call(ast::ExprCall { func, arguments }) => {
                 if !semantic.match_builtin_expr(func, "type") {
                     return false;
                 }

--- a/crates/ruff_linter/src/rules/refurb/rules/list_reverse_copy.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/list_reverse_copy.rs
@@ -109,10 +109,7 @@ pub(crate) fn list_assign_reversed(checker: &Checker, assign: &StmtAssign) {
 /// For example, given `list(list(list([1, 2, 3])))`, this function
 /// would return the inner `[1, 2, 3]` expression.
 fn peel_lists(expr: &Expr) -> &Expr {
-    let Some(ExprCall {
-        func, arguments, ..
-    }) = expr.as_call_expr()
-    else {
+    let Some(ExprCall { func, arguments }) = expr.as_call_expr() else {
         return expr;
     };
 
@@ -138,9 +135,7 @@ fn extract_name_from_reversed<'a>(
     expr: &'a Expr,
     semantic: &SemanticModel,
 ) -> Option<&'a ExprName> {
-    let ExprCall {
-        func, arguments, ..
-    } = expr.as_call_expr()?;
+    let ExprCall { func, arguments } = expr.as_call_expr()?;
 
     if !arguments.keywords.is_empty() {
         return None;

--- a/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/read_whole_file.rs
@@ -176,17 +176,17 @@ fn make_suggestion(open: &FileOpen<'_>, generator: Generator) -> String {
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
-    let call = ast::ExprCall {
-        func: Box::new(name.into()),
-        arguments: ast::Arguments {
+    let call = ast::ExprCall::new(
+        name.into(),
+        ast::Arguments {
             args: [].into(),
             keywords: open.keywords.iter().copied().cloned().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     generator.expr(&call.into())
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_starmap.rs
@@ -317,17 +317,17 @@ fn construct_starmap_call(starmap_binding: Name, iter: &Expr, func: &Expr) -> as
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
-    ast::ExprCall {
-        func: Box::new(starmap.into()),
-        arguments: ast::Arguments {
+    ast::ExprCall::new(
+        starmap.into(),
+        ast::Arguments {
             args: [func.clone(), iter.clone()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    }
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    )
 }
 
 /// Wrap given function call with yet another call.
@@ -338,17 +338,17 @@ fn wrap_with_call_to(call: ast::ExprCall, func_name: Name) -> ast::ExprCall {
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
-    ast::ExprCall {
-        func: Box::new(name.into()),
-        arguments: ast::Arguments {
+    ast::ExprCall::new(
+        name.into(),
+        ast::Arguments {
             args: [call.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    }
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    )
 }
 
 #[derive(Debug)]
@@ -378,7 +378,6 @@ fn match_call(element: &Expr) -> Option<(&[Expr], &Expr)> {
     let ast::ExprCall {
         func,
         arguments: ast::Arguments { args, keywords, .. },
-        ..
     } = element.as_call_expr()?;
 
     if !keywords.is_empty() {

--- a/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/repeated_append.rs
@@ -267,10 +267,7 @@ fn match_append<'a>(semantic: &'a SemanticModel, stmt: &'a Stmt) -> Option<Appen
         return None;
     };
 
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = value.as_ref() else {
         return None;
     };
 
@@ -357,17 +354,17 @@ fn make_suggestion(group: &AppendGroup, generator: Generator) -> String {
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Make the actual call `var.extend((elt1, elt2, ..., eltN))`
-    let call = ast::ExprCall {
-        func: Box::new(attr.into()),
-        arguments: ast::Arguments {
+    let call = ast::ExprCall::new(
+        attr.into(),
+        ast::Arguments {
             args: [tuple.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     // And finally, turn it into a statement.
     let stmt = ast::StmtExpr {
         value: Box::new(call.into()),

--- a/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
@@ -122,12 +122,7 @@ fn single_item<'a>(expr: &'a Expr, semantic: &'a SemanticModel) -> Option<&'a Ex
             [item] => Some(item),
             _ => None,
         },
-        Expr::Call(ast::ExprCall {
-            func,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             if arguments.len() != 1 || !is_set_method(func, semantic) {
                 return None;
             }

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_to_remove_prefix_or_suffix.rs
@@ -356,16 +356,7 @@ fn affix_matches_slice_bound(data: &RemoveAffixData, semantic: &SemanticModel) -
             // Only support prefix removal for size at most `usize::MAX`
             .and_then(ast::Int::as_usize)
             .is_some_and(|x| x == string_val.chars().count()),
-        (
-            AffixKind::StartsWith,
-            ast::Expr::Call(ast::ExprCall {
-                range_start: _,
-                node_index: _,
-                func,
-                arguments,
-            }),
-            _,
-        ) => {
+        (AffixKind::StartsWith, ast::Expr::Call(ast::ExprCall { func, arguments }), _) => {
             arguments.len() == 1
                 && arguments.find_positional(0).is_some_and(|arg| {
                     let compr_affix = ast::comparable::ComparableExpr::from(affix);
@@ -406,13 +397,9 @@ fn affix_matches_slice_bound(data: &RemoveAffixData, semantic: &SemanticModel) -
                 node_index: _,
             }),
             _,
-        ) => operand.as_call_expr().is_some_and(
-            |ast::ExprCall {
-                 range_start: _,
-                 node_index: _,
-                 func,
-                 arguments,
-             }| {
+        ) => operand
+            .as_call_expr()
+            .is_some_and(|ast::ExprCall { func, arguments }| {
                 arguments.len() == 1
                     && arguments.find_positional(0).is_some_and(|arg| {
                         let compr_affix = ast::comparable::ComparableExpr::from(affix);
@@ -420,8 +407,7 @@ fn affix_matches_slice_bound(data: &RemoveAffixData, semantic: &SemanticModel) -
                         compr_affix == compr_arg
                     })
                     && semantic.match_builtin_expr(func, "len")
-            },
-        ),
+            }),
         _ => false,
     }
 }

--- a/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/sorted_min_max.rs
@@ -99,10 +99,7 @@ pub(crate) fn sorted_min_max(checker: &Checker, subscript: &ast::ExprSubscript) 
     }
 
     // Early return if the value is not a call expression.
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = value.as_ref() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
@@ -89,9 +89,7 @@ pub(crate) fn type_none_comparison(checker: &Checker, compare: &ast::ExprCompare
 /// `type` with a single argument.
 fn type_call_arg<'a>(expr: &'a Expr, semantic: &'a SemanticModel) -> Option<&'a Expr> {
     // The expression must be a single-argument call to `type`.
-    let ast::ExprCall {
-        func, arguments, ..
-    } = expr.as_call_expr()?;
+    let ast::ExprCall { func, arguments } = expr.as_call_expr()?;
     if arguments.len() != 1 {
         return None;
     }

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_enumerate.rs
@@ -97,10 +97,7 @@ pub(crate) fn unnecessary_enumerate(checker: &Checker, stmt_for: &ast::StmtFor) 
     let [index, value] = elts.as_slice() else {
         return;
     };
-    let Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = stmt_for.iter.as_ref()
-    else {
+    let Expr::Call(ast::ExprCall { func, arguments }) = stmt_for.iter.as_ref() else {
         return;
     };
 
@@ -237,45 +234,41 @@ fn generate_range_len_call(name: Name, generator: Generator) -> String {
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
     // Construct `len(name)`.
-    let len = ast::ExprCall {
-        func: Box::new(
-            ast::ExprName {
-                id: Name::new_static("len"),
-                ctx: ast::ExprContext::Load,
-                range: TextRange::default(),
-                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            }
-            .into(),
-        ),
-        arguments: Arguments {
+    let len = ast::ExprCall::new(
+        ast::ExprName {
+            id: Name::new_static("len"),
+            ctx: ast::ExprContext::Load,
+            range: TextRange::default(),
+            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+        }
+        .into(),
+        Arguments {
             args: [var.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     // Construct `range(len(name))`.
-    let range = ast::ExprCall {
-        func: Box::new(
-            ast::ExprName {
-                id: Name::new_static("range"),
-                ctx: ast::ExprContext::Load,
-                range: TextRange::default(),
-                node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-            }
-            .into(),
-        ),
-        arguments: Arguments {
+    let range = ast::ExprCall::new(
+        ast::ExprName {
+            id: Name::new_static("range"),
+            ctx: ast::ExprContext::Load,
+            range: TextRange::default(),
+            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+        }
+        .into(),
+        Arguments {
             args: [len.into()].into(),
             keywords: std::iter::empty().collect(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         },
-        range_start: ruff_text_size::TextSize::default(),
-        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-    };
+        ruff_text_size::TextSize::default(),
+        ruff_python_ast::AtomicNodeIndex::NONE,
+    );
     // And finally, turn it into a statement.
     let stmt = ast::StmtExpr {
         value: Box::new(range.into()),

--- a/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/unnecessary_from_float.rs
@@ -289,10 +289,7 @@ fn handle_non_finite_float_special_case(
         return None;
     }
 
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = arg_value
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = arg_value else {
         return None;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/verbose_decimal_constructor.rs
@@ -168,9 +168,7 @@ pub(crate) fn verbose_decimal_constructor(checker: &Checker, call: &ast::ExprCal
                 applicability,
             ));
         }
-        Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             // Must be a call to the `float` builtin.
             if !checker.semantic().match_builtin_expr(func, "float") {
                 return;

--- a/crates/ruff_linter/src/rules/ruff/rules/duplicate_entry_in_dunder_all.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/duplicate_entry_in_dunder_all.rs
@@ -91,7 +91,6 @@ pub(crate) fn duplicate_entry_in_dunder_all_extend_call(
     ast::ExprCall {
         func,
         arguments: ast::Arguments { args, keywords, .. },
-        ..
     }: &ast::ExprCall,
 ) {
     let ([value_passed], []) = (&**args, &**keywords) else {

--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -192,9 +192,7 @@ fn is_numeric_expr(expr: &Expr) -> bool {
 
 fn should_skip_comparison(expr: &Expr, semantic: &SemanticModel) -> bool {
     match expr {
-        Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             // Skip `pytest.approx`
             if let Some(qualified_name) = semantic.resolve_qualified_name(func) {
                 if matches!(qualified_name.segments(), ["pytest", "approx"]) {

--- a/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
@@ -74,12 +74,7 @@ fn is_empty(expr: &Expr, semantic: &SemanticModel) -> bool {
         Expr::BytesLiteral(ast::ExprBytesLiteral { value, .. }) => value.is_empty(),
         Expr::StringLiteral(ast::ExprStringLiteral { value, .. }) => value.is_empty(),
         Expr::FString(s) => is_empty_f_string(s),
-        Expr::Call(ast::ExprCall {
-            func,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             if arguments.is_empty() {
                 collection_methods
                     .iter()

--- a/crates/ruff_linter/src/rules/ruff/rules/legacy_form_pytest_raises.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/legacy_form_pytest_raises.rs
@@ -247,11 +247,9 @@ fn generate_with_statement(
             ast::ArgOrKeyword::Keyword(keyword) => Either::Right(keyword.clone()),
         });
 
-    let context_call = ast::ExprCall {
-        node_index: AtomicNodeIndex::NONE,
-        range_start: ruff_text_size::TextSize::default(),
-        func: legacy_call.func.clone(),
-        arguments: ast::Arguments {
+    let context_call = ast::ExprCall::new(
+        legacy_call.func.as_ref().clone(),
+        ast::Arguments {
             node_index: AtomicNodeIndex::NONE,
             range: TextRange::default(),
             args: expected.cloned().as_slice().into(),
@@ -267,19 +265,21 @@ fn generate_with_statement(
                 .as_slice()
                 .into(),
         },
-    };
+        ruff_text_size::TextSize::default(),
+        AtomicNodeIndex::NONE,
+    );
 
-    let func_call = ast::ExprCall {
-        node_index: AtomicNodeIndex::NONE,
-        range_start: ruff_text_size::TextSize::default(),
-        func: Box::new(func.clone()),
-        arguments: ast::Arguments {
+    let func_call = ast::ExprCall::new(
+        func.clone(),
+        ast::Arguments {
             node_index: AtomicNodeIndex::NONE,
             range: TextRange::default(),
             args: func_args.into(),
             keywords: func_keywords.into(),
         },
-    };
+        ruff_text_size::TextSize::default(),
+        AtomicNodeIndex::NONE,
+    );
 
     let body = if let Some(assign_targets) = assign_targets {
         Stmt::Assign(ast::StmtAssign {

--- a/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/logging_eager_conversion.rs
@@ -150,7 +150,6 @@ pub(crate) fn logging_eager_conversion(checker: &Checker, call: &ast::ExprCall) 
         if let Expr::Call(ast::ExprCall {
             func,
             arguments: str_call_args,
-            ..
         }) = arg
         {
             let CFormatType::String(format_conversion) = spec.format_type else {

--- a/crates/ruff_linter/src/rules/ruff/rules/map_int_version_parsing.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/map_int_version_parsing.rs
@@ -72,8 +72,6 @@ fn map_call_with_two_arguments<'a>(
                 range: _,
                 node_index: _,
             },
-        range_start: _,
-        node_index: _,
     } = call;
 
     if !keywords.is_empty() {
@@ -93,10 +91,7 @@ fn map_call_with_two_arguments<'a>(
 
 /// Whether `expr` has the form `__version__.split(".")` or `something.__version__.split(".")`.
 fn is_dunder_version_split_dot(expr: &ast::Expr) -> bool {
-    let ast::Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let ast::Expr::Call(ast::ExprCall { func, arguments }) = expr else {
         return false;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_dataclass_default.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_dataclass_default.rs
@@ -90,10 +90,9 @@ pub(crate) fn mutable_dataclass_default(checker: &Checker, class_def: &ast::Stmt
         };
 
         let value = match &**value {
-            Expr::Call(ast::ExprCall {
-                func, arguments, ..
-            }) if is_mutable_default_in_dataclass_field_enabled(checker.settings())
-                && is_dataclass_field(func, checker.semantic(), dataclass_kind) =>
+            Expr::Call(ast::ExprCall { func, arguments })
+                if is_mutable_default_in_dataclass_field_enabled(checker.settings())
+                    && is_dataclass_field(func, checker.semantic(), dataclass_kind) =>
             {
                 arguments.find_argument_value("default", 0)
             }

--- a/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/quadratic_list_summation.rs
@@ -111,12 +111,7 @@ impl AlwaysFixableViolation for QuadraticListSummation {
 
 /// RUF017
 pub(crate) fn quadratic_list_summation(checker: &Checker, call: &ast::ExprCall) {
-    let ast::ExprCall {
-        func,
-        arguments,
-        range_start: _,
-        node_index: _,
-    } = call;
+    let ast::ExprCall { func, arguments } = call;
 
     let Some(iterable) = arguments.args.first() else {
         return;
@@ -205,9 +200,9 @@ fn start_is_empty_list(arguments: &Arguments, semantic: &SemanticModel) -> bool 
     };
 
     match start_arg {
-        Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) => arguments.is_empty() && semantic.match_builtin_expr(func, "list"),
+        Expr::Call(ast::ExprCall { func, arguments }) => {
+            arguments.is_empty() && semantic.match_builtin_expr(func, "list")
+        }
         Expr::List(list) => list.is_empty() && list.ctx.is_load(),
         _ => false,
     }

--- a/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_all.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/sort_dunder_all.rs
@@ -133,7 +133,6 @@ pub(crate) fn sort_dunder_all_extend_call(
     ast::ExprCall {
         func,
         arguments: ast::Arguments { args, keywords, .. },
-        ..
     }: &ast::ExprCall,
 ) {
     let ([value_passed], []) = (&**args, &**keywords) else {

--- a/crates/ruff_linter/src/rules/ruff/rules/starmap_zip.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/starmap_zip.rs
@@ -134,8 +134,9 @@ fn replace_with_map(starmap: &ExprCall, zip: &ExprCall, checker: &Checker) -> Op
         zip.start(),
     )));
 
-    let full_zip_func_range = parenthesized_range((&zip.func).into(), zip.into(), checker.tokens())
-        .unwrap_or(zip.func.range());
+    let full_zip_func_range =
+        parenthesized_range(zip.func.as_ref().into(), zip.into(), checker.tokens())
+            .unwrap_or(zip.func.range());
 
     // Delete the `zip` callee
     remove_zip.push(Edit::range_deletion(full_zip_func_range));

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_cast_to_int.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_cast_to_int.rs
@@ -150,9 +150,7 @@ fn single_argument_to_int_call<'a>(
     call: &'a ExprCall,
     semantic: &SemanticModel,
 ) -> Option<&'a Expr> {
-    let ExprCall {
-        func, arguments, ..
-    } = call;
+    let ExprCall { func, arguments } = call;
 
     if !semantic.match_builtin_expr(func, "int") {
         return None;

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_iterable_allocation_for_first_element.rs
@@ -84,9 +84,7 @@ pub(crate) fn unnecessary_iterable_allocation_for_first_element(checker: &Checke
             value
         }
         // Ex) `list(x).pop(0)`
-        Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             if !arguments.keywords.is_empty() {
                 return;
             }
@@ -163,7 +161,6 @@ fn match_iteration_target(expr: &Expr, semantic: &SemanticModel) -> Option<Itera
         Expr::Call(ast::ExprCall {
             func,
             arguments: Arguments { args, .. },
-            ..
         }) => {
             let [arg] = &**args else {
                 return None;

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_literal_within_deque_call.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_literal_within_deque_call.rs
@@ -72,9 +72,7 @@ impl Violation for UnnecessaryEmptyIterableWithinDequeCall {
 
 /// RUF037
 pub(crate) fn unnecessary_literal_within_deque_call(checker: &Checker, deque: &ast::ExprCall) {
-    let ast::ExprCall {
-        func, arguments, ..
-    } = deque;
+    let ast::ExprCall { func, arguments } = deque;
 
     let Some(qualified) = checker.semantic().resolve_qualified_name(func) else {
         return;

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -349,17 +349,17 @@ impl<'a> ReFunc<'a> {
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         });
-        Expr::Call(ExprCall {
-            func: Box::new(method),
-            arguments: Arguments {
+        Expr::Call(ExprCall::new(
+            method,
+            Arguments {
                 args: args.into(),
                 keywords: std::iter::empty().collect(),
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             },
-            range_start: ruff_text_size::TextSize::default(),
-            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-        })
+            ruff_text_size::TextSize::default(),
+            ruff_python_ast::AtomicNodeIndex::NONE,
+        ))
     }
 }
 

--- a/crates/ruff_linter/src/rules/ruff/rules/zip_instead_of_pairwise.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/zip_instead_of_pairwise.rs
@@ -117,7 +117,6 @@ pub(crate) fn zip_instead_of_pairwise(checker: &Checker, call: &ast::ExprCall) {
     let ast::ExprCall {
         func,
         arguments: Arguments { args, .. },
-        ..
     } = call;
 
     // Require exactly two positional arguments.

--- a/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
+++ b/crates/ruff_linter/src/rules/tryceratops/rules/raise_vanilla_args.rs
@@ -60,7 +60,6 @@ pub(crate) fn raise_vanilla_args(checker: &Checker, expr: &Expr) {
     let Expr::Call(ast::ExprCall {
         func,
         arguments: Arguments { args, .. },
-        ..
     }) = expr
     else {
         return;

--- a/crates/ruff_python_ast/ast.toml
+++ b/crates/ruff_python_ast/ast.toml
@@ -435,9 +435,9 @@ end at the same offset.
 See also [Call](https://docs.python.org/3/library/ast.html#ast.Call)"""
 custom_debug = true
 custom_range = true
+custom_node_index = true
 fields = [
-  { name = "range_start", type = "ruff_text_size::TextSize", skip_visit = true },
-  { name = "func", type = "Expr" },
+  { name = "func", type = "CallFunction" },
   { name = "arguments", type = "Arguments" },
 ]
 

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -29,6 +29,7 @@ types_requiring_crate_prefix = {
     "FStringValue",
     "TStringValue",
     "Arguments",
+    "CallFunction",
     "CmpOp",
     "Comprehension",
     "DictItem",
@@ -61,6 +62,7 @@ type_to_visitor_function: dict[str, VisitorInfo] = {
     "Parameters": VisitorInfo("visit_parameters", True),
     "Stmt": VisitorInfo("visit_body", True),
     "Arguments": VisitorInfo("visit_arguments", True),
+    "CallFunction": VisitorInfo("visit_expr"),
 }
 
 
@@ -150,6 +152,7 @@ class Node:
     custom_debug: bool
     custom_source_order: bool
     custom_range: bool
+    custom_node_index: bool
     source_order: list[str] | None
 
     def __init__(self, group: Group, node_name: str, node: dict[str, Any]) -> None:
@@ -163,6 +166,7 @@ class Node:
         self.custom_debug = node.get("custom_debug", False)
         self.custom_source_order = node.get("custom_source_order", False)
         self.custom_range = node.get("custom_range", False)
+        self.custom_node_index = node.get("custom_node_index", False)
         self.derives = node.get("derives", [])
         self.doc = node.get("doc")
         self.source_order = node.get("source_order")
@@ -473,6 +477,8 @@ def write_owned_enum(out: list[str], ast: Ast) -> None:
         """)
 
     for node in ast.all_nodes:
+        if node.custom_node_index:
+            continue
         out.append(f"""
             impl crate::HasNodeIndex for {node.ty} {{
                 fn node_index(&self) -> &crate::AtomicNodeIndex {{
@@ -1062,7 +1068,8 @@ def write_node(out: list[str], ast: Ast) -> None:
             out.append('#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]')
             name = node.name
             out.append(f"pub struct {name} {{")
-            out.append("pub node_index: crate::AtomicNodeIndex,")
+            if not node.custom_node_index:
+                out.append("pub node_index: crate::AtomicNodeIndex,")
             if not node.custom_range:
                 out.append("pub range: ruff_text_size::TextRange,")
             for field in node.fields:
@@ -1111,7 +1118,8 @@ def write_source_order(out: list[str], ast: Ast) -> None:
                     fields_list += f"{field.name},\n"
             if not node.custom_range:
                 fields_list += "range: _,\n"
-            fields_list += "node_index: _,\n"
+            if not node.custom_node_index:
+                fields_list += "node_index: _,\n"
 
             for field in node.fields_in_source_order():
                 visitor_name = (

--- a/crates/ruff_python_ast/src/comparable.rs
+++ b/crates/ruff_python_ast/src/comparable.rs
@@ -1232,13 +1232,8 @@ impl<'a> From<&'a ast::Expr> for ComparableExpr<'a> {
                     .map(|(op, right)| ((*op).into(), right.into()))
                     .collect(),
             }),
-            ast::Expr::Call(ast::ExprCall {
-                func,
-                arguments,
-                range_start: _,
-                node_index: _,
-            }) => Self::Call(ExprCall {
-                func: func.into(),
+            ast::Expr::Call(ast::ExprCall { func, arguments }) => Self::Call(ExprCall {
+                func: Box::new(func.as_ref().into()),
                 arguments: arguments.into(),
             }),
             ast::Expr::FString(ast::ExprFString {

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -4380,12 +4380,6 @@ impl crate::HasNodeIndex for crate::ExprCompare {
     }
 }
 
-impl crate::HasNodeIndex for crate::ExprCall {
-    fn node_index(&self) -> &crate::AtomicNodeIndex {
-        &self.node_index
-    }
-}
-
 impl crate::HasNodeIndex for crate::ExprFString {
     fn node_index(&self) -> &crate::AtomicNodeIndex {
         &self.node_index
@@ -9793,9 +9787,7 @@ pub struct ExprCompare {
 #[derive(Clone, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 pub struct ExprCall {
-    pub node_index: crate::AtomicNodeIndex,
-    pub range_start: ruff_text_size::TextSize,
-    pub func: Box<Expr>,
+    pub func: crate::CallFunction,
     pub arguments: crate::Arguments,
 }
 
@@ -10835,12 +10827,7 @@ impl ExprCall {
     where
         V: SourceOrderVisitor<'a> + ?Sized,
     {
-        let ExprCall {
-            range_start: _,
-            func,
-            arguments,
-            node_index: _,
-        } = self;
+        let ExprCall { func, arguments } = self;
         visitor.visit_expr(func);
         visitor.visit_arguments(arguments);
     }

--- a/crates/ruff_python_ast/src/helpers.rs
+++ b/crates/ruff_python_ast/src/helpers.rs
@@ -74,9 +74,7 @@ impl SideEffect {
     fn from_expr(expr: &Expr, is_builtin: &dyn Fn(&str) -> bool) -> Self {
         match expr {
             // Empty initializers for known builtins are side-effect-free.
-            Expr::Call(ast::ExprCall {
-                func, arguments, ..
-            }) if arguments.is_empty() => {
+            Expr::Call(ast::ExprCall { func, arguments }) if arguments.is_empty() => {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     if is_iterable_initializer(id.as_str(), |id| is_builtin(id)) {
                         return Self::Absent;
@@ -395,8 +393,6 @@ where
             Expr::Call(ast::ExprCall {
                 func: call_func,
                 arguments,
-                range_start: _,
-                node_index: _,
             }) => {
                 // Note that this is the evaluation order but not necessarily the declaration order
                 // (e.g. for `f(*args, a=2, *args2, **kwargs)` it's not)
@@ -1493,9 +1489,7 @@ impl Truthiness {
                     Self::Truthy
                 }
             }
-            Expr::Call(ast::ExprCall {
-                func, arguments, ..
-            }) => {
+            Expr::Call(ast::ExprCall { func, arguments }) => {
                 if let Expr::Name(ast::ExprName { id, .. }) = func.as_ref() {
                     if is_iterable_initializer(id.as_str(), |id| is_builtin(id)) {
                         if arguments.is_empty() {

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use crate::AtomicNodeIndex;
 use crate::generated::{
     ExprBytesLiteral, ExprCall, ExprDict, ExprFString, ExprList, ExprName, ExprSet,
     ExprStringLiteral, ExprTString, ExprTuple, PatternMatchAs, PatternMatchOr, StmtClassDef,
 };
+use crate::{AtomicNodeIndex, HasNodeIndex};
 use std::borrow::Cow;
 use std::fmt;
 use std::fmt::Debug;
@@ -1438,21 +1438,101 @@ impl ExprStringLiteral {
     }
 }
 
-impl Ranged for ExprCall {
-    fn range(&self) -> TextRange {
-        TextRange::new(self.range_start, self.arguments.end())
+impl ExprCall {
+    /// Create a call whose callee shares an allocation with the call's source start and node index.
+    #[inline]
+    pub fn new(
+        func: Expr,
+        arguments: Arguments,
+        range_start: TextSize,
+        node_index: AtomicNodeIndex,
+    ) -> Self {
+        Self {
+            func: CallFunction(Box::new(CallFunctionData {
+                func,
+                range_start,
+                node_index,
+            })),
+            arguments,
+        }
+    }
+
+    pub(crate) fn set_range_start(&mut self, start: TextSize) {
+        self.func.0.range_start = start;
     }
 }
 
-#[expect(
-    clippy::missing_fields_in_debug,
-    reason = "`range_start` is represented by the reconstructed `range` field"
-)]
+/// The callee of a call expression, stored with the containing call's metadata.
+///
+/// Sharing the callee's allocation with the call's node index and source start leaves room
+/// for positional arguments to use a boxed slice while keeping `ExprCall` at 48 bytes on
+/// 64-bit targets. The callee retains its own node index and range inside `Expr`.
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+pub struct CallFunction(Box<CallFunctionData>);
+
+impl AsRef<Expr> for CallFunction {
+    #[inline]
+    fn as_ref(&self) -> &Expr {
+        &self.0.func
+    }
+}
+
+impl AsMut<Expr> for CallFunction {
+    #[inline]
+    fn as_mut(&mut self) -> &mut Expr {
+        &mut self.0.func
+    }
+}
+
+impl Deref for CallFunction {
+    type Target = Expr;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl DerefMut for CallFunction {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut()
+    }
+}
+
+impl fmt::Debug for CallFunction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(formatter)
+    }
+}
+
+#[derive(Clone, PartialEq)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+struct CallFunctionData {
+    func: Expr,
+    range_start: TextSize,
+    node_index: AtomicNodeIndex,
+}
+
+impl HasNodeIndex for ExprCall {
+    #[inline]
+    fn node_index(&self) -> &AtomicNodeIndex {
+        &self.func.0.node_index
+    }
+}
+
+impl Ranged for ExprCall {
+    fn range(&self) -> TextRange {
+        TextRange::new(self.func.0.range_start, self.arguments.end())
+    }
+}
+
 impl fmt::Debug for ExprCall {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("ExprCall")
-            .field("node_index", &self.node_index)
+            .field("node_index", self.node_index())
             .field("range", &self.range())
             .field("func", &self.func)
             .field("arguments", &self.arguments)
@@ -3611,7 +3691,7 @@ impl ParameterWithDefault {
 pub struct Arguments {
     pub range: TextRange,
     pub node_index: AtomicNodeIndex,
-    pub args: ThinVec<Expr>,
+    pub args: Box<[Expr]>,
     pub keywords: ThinVec<Keyword>,
 }
 
@@ -4044,11 +4124,58 @@ impl From<bool> for Singleton {
 mod tests {
     use ruff_text_size::{Ranged, TextRange, TextSize};
 
+    use thin_vec::ThinVec;
+
     use crate::generated::*;
     use crate::{
-        Arguments, AtomicNodeIndex, FString, FStringFlags, FStringPart, FStringPartMut,
-        FStringValue, Mod, Parameters, StringLiteral, StringLiteralFlags,
+        Arguments, AtomicNodeIndex, CallFunction, ExprContext, FString, FStringFlags, FStringPart,
+        FStringPartMut, FStringValue, HasNodeIndex, Mod, NodeIndex, Parameters, StringLiteral,
+        StringLiteralFlags,
     };
+
+    #[test]
+    fn call_and_callee_metadata() {
+        // In `((f))()`, the call starts before the callee's own range.
+        let func = Expr::Name(ExprName {
+            node_index: AtomicNodeIndex::NONE,
+            range: TextRange::new(2.into(), 3.into()),
+            id: "f".into(),
+            ctx: ExprContext::Load,
+        });
+        let mut call = ExprCall::new(
+            func,
+            Arguments {
+                range: TextRange::new(5.into(), 7.into()),
+                node_index: AtomicNodeIndex::NONE,
+                args: Box::default(),
+                keywords: ThinVec::default(),
+            },
+            0.into(),
+            AtomicNodeIndex::NONE,
+        );
+        call.node_index().set(NodeIndex::from(1));
+        call.func.node_index().set(NodeIndex::from(2));
+
+        assert_eq!(call.range(), TextRange::new(0.into(), 7.into()));
+        assert_eq!(call.func.range(), TextRange::new(2.into(), 3.into()));
+        assert_eq!(call.node_index().load(), NodeIndex::from(1));
+        assert_eq!(call.func.node_index().load(), NodeIndex::from(2));
+
+        let cloned = call.clone();
+        call.set_range_start(1.into());
+        call.node_index().set(NodeIndex::from(3));
+        *call.func = Expr::NoneLiteral(ExprNoneLiteral {
+            node_index: AtomicNodeIndex::NONE,
+            range: TextRange::new(2.into(), 3.into()),
+        });
+
+        assert_eq!(call.range(), TextRange::new(1.into(), 7.into()));
+        assert_eq!(call.node_index().load(), NodeIndex::from(3));
+        assert_eq!(cloned.range(), TextRange::new(0.into(), 7.into()));
+        assert_eq!(cloned.node_index().load(), NodeIndex::from(1));
+        assert!(cloned.func.is_name_expr());
+        assert_eq!(cloned.func.node_index().load(), NodeIndex::from(2));
+    }
 
     #[test]
     fn f_string_parts() {
@@ -4120,7 +4247,9 @@ mod tests {
         assert_eq!(std::mem::size_of::<Mod>(), 32);
         assert_eq!(std::mem::size_of::<Pattern>(), 72);
         assert_eq!(std::mem::size_of::<Parameters>(), 56);
-        assert_eq!(std::mem::size_of::<Arguments>(), 32);
+        assert_eq!(std::mem::size_of::<Arguments>(), 40);
+        assert_eq!(std::mem::size_of::<CallFunction>(), 8);
+        assert_eq!(std::mem::size_of::<super::CallFunctionData>(), 64);
         assert_eq!(std::mem::size_of::<Expr>(), 56);
         assert_eq!(std::mem::size_of::<ExprAttribute>(), 56);
         assert_eq!(std::mem::size_of::<ExprAwait>(), 24);

--- a/crates/ruff_python_ast/src/relocate.rs
+++ b/crates/ruff_python_ast/src/relocate.rs
@@ -66,13 +66,9 @@ impl Transformer for Relocator {
             Expr::Compare(ast::ExprCompare { range, .. }) => {
                 *range = self.range;
             }
-            Expr::Call(ast::ExprCall {
-                range_start,
-                arguments,
-                ..
-            }) => {
-                *range_start = self.range.start();
-                arguments.range = self.range;
+            Expr::Call(call) => {
+                call.set_range_start(self.range.start());
+                call.arguments.range = self.range;
             }
             Expr::FString(ast::ExprFString { range, .. }) => {
                 *range = self.range;

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -526,12 +526,7 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
                 visitor.visit_expr(expr);
             }
         }
-        Expr::Call(ast::ExprCall {
-            func,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             visitor.visit_expr(func);
             visitor.visit_arguments(arguments);
         }

--- a/crates/ruff_python_ast/src/visitor/transformer.rs
+++ b/crates/ruff_python_ast/src/visitor/transformer.rs
@@ -513,12 +513,7 @@ pub fn walk_expr<V: Transformer + ?Sized>(visitor: &V, expr: &mut Expr) {
                 visitor.visit_expr(expr);
             }
         }
-        Expr::Call(ast::ExprCall {
-            func,
-            arguments,
-            range_start: _,
-            node_index: _,
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             visitor.visit_expr(func);
             visitor.visit_arguments(arguments);
         }

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1193,12 +1193,7 @@ impl<'a> Generator<'a> {
                     }
                 });
             }
-            Expr::Call(ast::ExprCall {
-                func,
-                arguments,
-                range_start: _,
-                node_index: _,
-            }) => {
+            Expr::Call(ast::ExprCall { func, arguments }) => {
                 self.unparse_expr(func, precedence::MAX);
                 self.p("(");
                 if let (

--- a/crates/ruff_python_formatter/src/expression/expr_call.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_call.rs
@@ -23,12 +23,7 @@ impl FormatRuleWithOptions<ExprCall, PyFormatContext<'_>> for FormatExprCall {
 
 impl FormatNodeRule<ExprCall> for FormatExprCall {
     fn fmt_fields(&self, item: &ExprCall, f: &mut PyFormatter) -> FormatResult<()> {
-        let ExprCall {
-            range_start: _,
-            node_index: _,
-            func,
-            arguments,
-        } = item;
+        let ExprCall { func, arguments } = item;
 
         let comments = f.context().comments().clone();
         let dangling = comments.dangling(item);
@@ -37,7 +32,9 @@ impl FormatNodeRule<ExprCall> for FormatExprCall {
 
         let fmt_func = format_with(|f: &mut PyFormatter| {
             // Format the function expression.
-            if f.context().is_expression_parenthesized(func.into()) {
+            if f.context()
+                .is_expression_parenthesized(func.as_ref().into())
+            {
                 func.format().with_options(Parentheses::Always).fmt(f)
             } else {
                 match func.as_ref() {

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -707,12 +707,7 @@ impl<'input> CanOmitOptionalParenthesesVisitor<'input> {
                     comparisons.len() as u32,
                 );
             }
-            Expr::Call(ast::ExprCall {
-                range_start: _,
-                node_index: _,
-                func,
-                arguments: _,
-            }) => {
+            Expr::Call(ast::ExprCall { func, arguments: _ }) => {
                 self.any_parenthesized_expressions = true;
                 // Only walk the function, the arguments are always parenthesized
                 self.visit_expr(func);
@@ -1022,7 +1017,7 @@ impl CallChainLayout {
         // our first break after this value.
         let mut root_value_parenthesized = false;
         loop {
-            match expr {
+            let inner = match expr {
                 ExprRef::Attribute(ast::ExprAttribute { value, .. }) => {
                     // ```
                     // f().g
@@ -1039,6 +1034,7 @@ impl CallChainLayout {
                     }
 
                     expr = ExprRef::from(value.as_ref());
+                    continue;
                 }
                 // ```
                 // f()
@@ -1048,27 +1044,27 @@ impl CallChainLayout {
                 // ^^^^^^^^^^ expr
                 // ^^^^ value
                 // ```
-                ExprRef::Call(ast::ExprCall { func: inner, .. })
-                | ExprRef::Subscript(ast::ExprSubscript { value: inner, .. }) => {
-                    // We preserve these parentheses so don't recurse
-                    // e.g. (a)[0].x().y().z()
-                    //         ^stop here
-                    if context.is_expression_parenthesized(inner.into()) {
-                        break;
-                    }
-
-                    // Accumulate the `call_like_count`, but we only
-                    // want to count things like `a()[0]()()` once.
-                    if !inner.is_call_expr() && !inner.is_subscript_expr() {
-                        call_like_count += 1;
-                    }
-
-                    expr = ExprRef::from(inner.as_ref());
-                }
+                ExprRef::Call(call) => call.func.as_ref(),
+                ExprRef::Subscript(subscript) => subscript.value.as_ref(),
                 _ => {
                     break;
                 }
+            };
+
+            // We preserve these parentheses so don't recurse
+            // e.g. (a)[0].x().y().z()
+            //         ^stop here
+            if context.is_expression_parenthesized(inner.into()) {
+                break;
             }
+
+            // Accumulate the `call_like_count`, but we only
+            // want to count things like `a()[0]()()` once.
+            if !inner.is_call_expr() && !inner.is_subscript_expr() {
+                call_like_count += 1;
+            }
+
+            expr = ExprRef::from(inner);
         }
 
         if computed_attribute_values_after_parentheses + u32::from(root_value_parenthesized) < 2 {
@@ -1382,9 +1378,9 @@ pub(crate) fn is_splittable_expression(expr: &Expr, context: &PyFormatContext) -
         Expr::UnaryOp(unary) => is_splittable_expression(unary.operand.as_ref(), context),
         Expr::Yield(ast::ExprYield { value, .. }) => value.is_some(),
 
-        Expr::Call(ast::ExprCall {
-            arguments, func, ..
-        }) => !arguments.is_empty() || context.is_expression_parenthesized(func.as_ref().into()),
+        Expr::Call(ast::ExprCall { arguments, func }) => {
+            !arguments.is_empty() || context.is_expression_parenthesized(func.as_ref().into())
+        }
 
         // String like literals can expand if they are implicit concatenated.
         Expr::FString(fstring) => fstring.value.is_implicit_concatenated(),
@@ -1431,10 +1427,11 @@ pub(crate) fn left_most<'expr>(expression: &'expr Expr, trivia: &TriviaRanges) -
         let left = match current {
             Expr::BinOp(ast::ExprBinOp { left, .. })
             | Expr::If(ast::ExprIf { body: left, .. })
-            | Expr::Call(ast::ExprCall { func: left, .. })
             | Expr::Attribute(ast::ExprAttribute { value: left, .. })
             | Expr::Subscript(ast::ExprSubscript { value: left, .. })
             | Expr::Compare(ast::ExprCompare { left, .. }) => Some(&**left),
+
+            Expr::Call(call) => Some(call.func.as_ref()),
 
             Expr::BoolOp(expr_bool_op) => expr_bool_op.values.first(),
 

--- a/crates/ruff_python_parser/src/parser/expression.rs
+++ b/crates/ruff_python_parser/src/parser/expression.rs
@@ -711,12 +711,7 @@ impl<'src> Parser<'src> {
         let arguments = self.parse_arguments(ArgumentsContext::Call);
         debug_assert_eq!(self.node_range(start).end(), arguments.end());
 
-        ast::ExprCall {
-            func: Box::new(func),
-            arguments,
-            range_start: start,
-            node_index: AtomicNodeIndex::NONE,
-        }
+        ast::ExprCall::new(func, arguments, start, AtomicNodeIndex::NONE)
     }
 
     /// Parses an argument list.
@@ -734,7 +729,7 @@ impl<'src> Parser<'src> {
             return ast::Arguments {
                 range: self.node_range(start),
                 node_index: AtomicNodeIndex::NONE,
-                args: ThinVec::new(),
+                args: Box::default(),
                 keywords: ThinVec::default(),
             };
         }
@@ -871,7 +866,7 @@ impl<'src> Parser<'src> {
         let arguments = ast::Arguments {
             range: self.node_range(start),
             node_index: AtomicNodeIndex::NONE,
-            args: self.expr_scratch.take_thin_vec(args_snapshot),
+            args: self.expr_scratch.take(args_snapshot),
             keywords,
         };
 

--- a/crates/ruff_python_parser/src/parser/recovery.rs
+++ b/crates/ruff_python_parser/src/parser/recovery.rs
@@ -96,11 +96,9 @@ pub(super) fn pattern_to_expr(pattern: Pattern) -> Expr {
         }) => {
             debug_assert_eq!(range.end(), arguments.end());
 
-            Expr::Call(ast::ExprCall {
-                range_start: range.start(),
-                node_index: node_index.clone(),
-                func: cls,
-                arguments: ast::Arguments {
+            Expr::Call(ast::ExprCall::new(
+                *cls,
+                ast::Arguments {
                     range: arguments.range,
                     node_index: node_index.clone(),
                     args: arguments
@@ -119,7 +117,9 @@ pub(super) fn pattern_to_expr(pattern: Pattern) -> Expr {
                         })
                         .collect(),
                 },
-            })
+                range.start(),
+                node_index,
+            ))
         }
         Pattern::MatchStar(ast::PatternMatchStar {
             range,

--- a/crates/ruff_python_semantic/src/analyze/class.rs
+++ b/crates/ruff_python_semantic/src/analyze/class.rs
@@ -403,9 +403,7 @@ fn has_metaclass_new_signature(class_def: &ast::StmtClassDef, semantic: &Semanti
 pub fn is_metaclass(class_def: &ast::StmtClassDef, semantic: &SemanticModel) -> IsMetaclass {
     let mut maybe = false;
     let is_base_class = any_base_class(class_def, semantic, |expr| match expr {
-        Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) => {
+        Expr::Call(ast::ExprCall { func, arguments }) => {
             maybe = true;
             // Ex) `class Foo(type(Protocol)): ...`
             arguments.len() == 1 && semantic.match_builtin_expr(func.as_ref(), "type")

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -388,10 +388,7 @@ pub fn is_immutable_newtype_call(
         return false;
     };
 
-    let Expr::Call(ExprCall {
-        func, arguments, ..
-    }) = value.as_ref()
-    else {
+    let Expr::Call(ExprCall { func, arguments }) = value.as_ref() else {
         return false;
     };
 

--- a/crates/ruff_python_semantic/src/model/all.rs
+++ b/crates/ruff_python_semantic/src/model/all.rs
@@ -168,13 +168,12 @@ impl SemanticModel<'_> {
                 return (None, DunderAllFlags::empty());
             }
             // Allow `tuple()`, `list()`, and their generic forms, like `list[int]()`.
-            Expr::Call(ast::ExprCall {
-                func, arguments, ..
-            }) if arguments.keywords.is_empty()
-                && arguments.args.len() <= 1
-                && self
-                    .resolve_builtin_symbol(map_subscript(func))
-                    .is_some_and(|symbol| matches!(symbol, "tuple" | "list")) =>
+            Expr::Call(ast::ExprCall { func, arguments })
+                if arguments.keywords.is_empty()
+                    && arguments.args.len() <= 1
+                    && self
+                        .resolve_builtin_symbol(map_subscript(func))
+                        .is_some_and(|symbol| matches!(symbol, "tuple" | "list")) =>
             {
                 let [arg] = arguments.args.as_ref() else {
                     return (None, DunderAllFlags::empty());

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -1188,7 +1188,7 @@ impl GotoTarget<'_> {
                     let grandparent_expr = covering_node.ancestors().nth(2);
                     let attribute_expr = attribute.into();
                     if let Some(AnyNodeRef::ExprCall(call)) = grandparent_expr {
-                        if ruff_python_ast::ExprRef::from(&call.func) == attribute_expr {
+                        if ruff_python_ast::ExprRef::from(call.func.as_ref()) == attribute_expr {
                             return Some(GotoTarget::Call {
                                 call,
                                 callable: attribute_expr,

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -1460,10 +1460,7 @@ impl<'db> SymbolVisitor<'db> {
                     // We can't update `__all__` if it doesn't already exist.
                     return;
                 }
-                let Some(ast::ExprCall {
-                    func, arguments, ..
-                }) = expr.value.as_call_expr()
-                else {
+                let Some(ast::ExprCall { func, arguments }) = expr.value.as_call_expr() else {
                     return;
                 };
                 let Some(ast::ExprAttribute {

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -1995,7 +1995,6 @@ impl LegacyNamespacePackageVisitor {
         let ast::Expr::Call(ast::ExprCall {
             func: extend_func,
             arguments: extend_arguments,
-            ..
         }) = value
         else {
             return;
@@ -2016,7 +2015,6 @@ impl LegacyNamespacePackageVisitor {
             ast::Expr::Call(ruff_python_ast::ExprCall {
                 func: maybe_import,
                 arguments: import_arguments,
-                ..
             }) => {
                 let ast::Expr::Name(maybe_import) = &**maybe_import else {
                     return;
@@ -2067,7 +2065,6 @@ impl LegacyNamespacePackageVisitor {
         let ast::Expr::Call(ast::ExprCall {
             func,
             arguments: declare_arguments,
-            ..
         }) = value
         else {
             return;
@@ -2090,7 +2087,6 @@ impl LegacyNamespacePackageVisitor {
         let ast::Expr::Call(ast::ExprCall {
             func: maybe_import,
             arguments: import_arguments,
-            ..
         }) = &**maybe_pkg_resources
         else {
             return;

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -6093,7 +6093,6 @@ fn dunder_all_extend_argument(value: &ast::Expr) -> Option<&ast::Expr> {
                 range: _,
                 node_index: _,
             },
-        ..
     } = value.as_call_expr()?;
 
     let ast::ExprAttribute { value, attr, .. } = func.as_attribute_expr()?;
@@ -6231,10 +6230,7 @@ fn is_if_not_type_checking(expr: &ast::Expr) -> bool {
 }
 
 fn is_empty_collection_constructor_call(expr: &ast::Expr) -> bool {
-    let ast::Expr::Call(ast::ExprCall {
-        func, arguments, ..
-    }) = expr
-    else {
+    let ast::Expr::Call(ast::ExprCall { func, arguments }) = expr else {
         return false;
     };
 

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -353,10 +353,7 @@ impl<'db> StatementVisitor<'db> for DunderAllNamesCollector<'db> {
                     // We can't update `__all__` if it doesn't already exist.
                     return;
                 }
-                let Some(ast::ExprCall {
-                    func, arguments, ..
-                }) = expr.as_call_expr()
-                else {
+                let Some(ast::ExprCall { func, arguments }) = expr.as_call_expr() else {
                     return;
                 };
                 let Some(ast::ExprAttribute {

--- a/crates/ty_python_semantic/src/types/dedicated/pytest/fixtures.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pytest/fixtures.rs
@@ -661,7 +661,7 @@ fn mock_patch_count<'db>(
             let new_position = if is_known_class_instance(
                 db,
                 function_definition,
-                decorators.expression_type(&call.func),
+                decorators.expression_type(call.func.as_ref()),
                 "_patcher",
                 &[KnownModule::UnittestMock],
             ) {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3802,10 +3802,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let env = self.program_environment();
         // Infer deferred bounds/constraints/defaults of a legacy TypeVar / ParamSpec / NewType,
         // and field types for functional TypedDict.
-        let ast::Expr::Call(ast::ExprCall {
-            func, arguments, ..
-        }) = value
-        else {
+        let ast::Expr::Call(ast::ExprCall { func, arguments }) = value else {
             return;
         };
         let func_ty = self
@@ -9064,12 +9061,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
         let env = self.program_environment();
-        let ast::ExprCall {
-            range_start: _,
-            node_index: _,
-            func,
-            arguments,
-        } = call_expression;
+        let ast::ExprCall { func, arguments } = call_expression;
 
         // Semantic indexing recognizes only bare empty constructor calls. Confirm that the name
         // still resolves to the corresponding builtin before using later collection constraints.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4007,11 +4007,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 ast::Expr::Call(ast::ExprCall {
                     func,
                     arguments: ast::Arguments { args, keywords, .. },
-                    ..
                 }) => {
                     if keywords.is_empty()
                         && let [single_argument] = &**args
-                        && let Type::ClassLiteral(called_class) = inference.expression_type(func)
+                        && let Type::ClassLiteral(called_class) =
+                            inference.expression_type(func.as_ref())
                         && called_class.is_known(db, KnownClass::Type)
                     {
                         Some(single_argument)


### PR DESCRIPTION
Keep positional arguments as `Box<[Expr]>` while preserving the 56-byte `Expr` layout from #28335. This builds on #28403.

Store the call's node index and start offset alongside the callee in its existing allocation. `ExprCall` remains 48 bytes, `Arguments` grows from 32 to 40 bytes, and the callee allocation grows from 56 to 64 bytes on 64-bit targets. The callee retains its own range and node index. Keyword arguments remain a `ThinVec`.

This trades positional-argument metadata indirection for call-metadata indirection: argument length is inline again, while reading a call's start offset or node index follows the callee pointer. It does not add a retained allocation. Calls with no positional arguments request eight more heap bytes; calls with positional arguments save eight bytes by removing the `ThinVec` header. Allocator rounding can change the actual memory impact.

## Performance

Compared with #28403 (`2874a5af`), this change (`b7ae5c0f`) produces the following results on an idle x86-64 Linux devbox. All variants use the same harness, Rust 1.98.0, profiling profile, jemalloc, and pinned CPU. The run alternates all six orders of parent, candidate, and main twice. Of 144 samples, 116 pass the CPU-idle/steal checks; comparisons use only matched pairs that both pass.

| Benchmark | Native time | Exploratory 95% interval | Cachegrind instructions |
| --- | ---: | ---: | ---: |
| Parser, large | -1.71% | -2.54% to -0.96% | -0.30% |
| Parser, Pydantic | +1.11% | +0.51% to +1.64% | +0.51% |
| Formatter, large | +5.43% | +4.80% to +6.07% | -0.03% |
| Formatter, Pydantic | +2.87% | +2.47% to +3.27% | +0.19% |

Negative values mean less time or fewer instructions. Native intervals bootstrap paired log ratios, with eight or nine accepted pairs per benchmark. Formatter parsing is outside the native timed section. Cachegrind counts cover the whole process over 50 iterations, including initial parsing and drops, with two repetitions; they are not CodSpeed's simulated cycles.

The [CI memory report](https://github.com/astral-sh/ruff/pull/28404#issuecomment-5577864875) shows parsed-module memory falling 0.15–0.24% across flake8, trio, sphinx, and prefect, and total reported memory falling 0.03–0.07%.

These measurements do not support adopting this layout as-is: the small memory savings come with formatter slowdowns. Near-flat formatter instruction counts leave dependent loads and generated-code layout as possible explanations; this experiment does not establish the cause of the earlier regressions.
