### PR TITLE
[`refurb`] Only mark `math-constant` fix safe for exact literals (FURB152)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB152.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB152.py
@@ -43,3 +43,13 @@ e = 2.71820001  # OK
 e = 2.718200000000001  # OK
 
 e = 2.7182000000000001  # FURB152
+
+# Each of these already denotes exactly the same float as the constant it matches,
+# so substituting the constant cannot change a result and the fix is safe. Every
+# shorter approximation above computes a different value once rewritten, so those
+# fixes are offered as unsafe.
+r = 3.141592653589793  # FURB152
+
+e = 2.718281828459045  # FURB152
+
+t = 6.283185307179586  # FURB152

--- a/crates/ruff_linter/src/rules/refurb/rules/math_constant.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/math_constant.rs
@@ -26,10 +26,24 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 /// A = math.pi * r**2
 /// ```
 ///
+/// ## Known problems
+/// A literal is matched on its digits alone, so a value that merely happens to
+/// begin with the same digits as a mathematical constant is flagged even when it
+/// means something else entirely. A measurement that rounds to `3.14`, or a price
+/// of `2.718`, is indistinguishable here from an approximation of π or e.
+///
+/// ## Fix safety
+/// This rule's fix is marked as safe only when the literal already denotes exactly
+/// the same float as the constant, so that replacing it cannot change a result.
+/// Shorter approximations are rewritten under an unsafe fix, because `math.pi` is
+/// not equal to `3.14`: a literal that was deliberately chosen — a rounded
+/// measurement, a threshold, a test fixture — computes a different value once it
+/// becomes a constant.
+///
 /// ## References
 /// - [Python documentation: `math` constants](https://docs.python.org/3/library/math.html#constants)
 #[derive(ViolationMetadata)]
-#[violation_metadata(preview_since = "v0.1.6", category = Category::Correctness)]
+#[violation_metadata(preview_since = "v0.1.6", category = Category::Suspicious)]
 pub(crate) struct MathConstant {
     literal: String,
     constant: &'static str,
@@ -64,24 +78,39 @@ pub(crate) fn math_constant(checker: &Checker, literal: &ast::ExprNumberLiteral)
             },
             literal.range(),
         );
-        diagnostic.try_set_fix(|| convert_to_constant(literal, constant.name(), checker));
+        diagnostic.try_set_fix(|| convert_to_constant(literal, value, constant, checker));
     }
 }
 
 fn convert_to_constant(
     literal: &ast::ExprNumberLiteral,
-    constant: &'static str,
+    value: f64,
+    constant: Constant,
     checker: &Checker,
 ) -> Result<Fix> {
     let (edit, binding) = checker.importer().get_or_import_symbol(
-        &ImportRequest::import("math", constant),
+        &ImportRequest::import("math", constant.name()),
         literal.start(),
         checker.semantic(),
     )?;
-    Ok(Fix::safe_edits(
-        Edit::range_replacement(binding, literal.range()),
-        [edit],
-    ))
+    let replacement = Edit::range_replacement(binding, literal.range());
+
+    // The rule matches any literal that rounds to the constant, so `3.14` is reported
+    // just as `3.141592653589793` is. Substituting the constant only leaves the
+    // program computing the same values in the latter case; in the former it silently
+    // replaces the author's number with a different one.
+    #[expect(
+        clippy::float_cmp,
+        reason = "an exact comparison is the point: only a literal that is already the \
+                  same float can be replaced without changing what the program computes"
+    )]
+    let is_exact = value == constant.value();
+
+    if is_exact {
+        Ok(Fix::safe_edits(replacement, [edit]))
+    } else {
+        Ok(Fix::unsafe_edits(replacement, [edit]))
+    }
 }
 
 fn matches_constant(constant: f64, value: f64) -> bool {
@@ -124,6 +153,15 @@ impl Constant {
             Constant::Pi => "pi",
             Constant::E => "e",
             Constant::Tau => "tau",
+        }
+    }
+
+    /// The value `math.<name>` evaluates to, for comparing against a matched literal.
+    fn value(self) -> f64 {
+        match self {
+            Constant::Pi => std::f64::consts::PI,
+            Constant::E => std::f64::consts::E,
+            Constant::Tau => std::f64::consts::TAU,
         }
     }
 }

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__math-constant_FURB152.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__math-constant_FURB152.py.snap
@@ -20,6 +20,7 @@ help: Use `math.pi`
 4 + A = math.pi * r ** 2  # FURB152
 5 |
   |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `6.28` with `math.tau`
  --> FURB152.py:5:5
@@ -42,6 +43,7 @@ help: Use `math.tau`
 6 + C = math.tau * r  # FURB152
 7 |
   |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `2.71` with `math.e`
  --> FURB152.py:7:5
@@ -63,6 +65,7 @@ help: Use `math.e`
 8 + e = math.e  # FURB152
 9 |
   |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.141` with `math.pi`
   --> FURB152.py:11:5
@@ -84,6 +87,7 @@ help: Use `math.pi`
 12 + r = math.pi  # FURB152
 13 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.142` with `math.pi`
   --> FURB152.py:13:5
@@ -105,6 +109,7 @@ help: Use `math.pi`
 14 + r = math.pi  # FURB152
 15 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.1415` with `math.pi`
   --> FURB152.py:15:5
@@ -126,6 +131,7 @@ help: Use `math.pi`
 16 + r = math.pi  # FURB152
 17 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.1416` with `math.pi`
   --> FURB152.py:17:5
@@ -147,6 +153,7 @@ help: Use `math.pi`
 18 + r = math.pi  # FURB152
 19 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.141592` with `math.pi`
   --> FURB152.py:19:5
@@ -168,6 +175,7 @@ help: Use `math.pi`
 20 + r = math.pi  # FURB152
 21 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.141593` with `math.pi`
   --> FURB152.py:21:5
@@ -189,6 +197,7 @@ help: Use `math.pi`
 22 + r = math.pi  # FURB152
 23 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.14159265` with `math.pi`
   --> FURB152.py:23:5
@@ -210,6 +219,7 @@ help: Use `math.pi`
 24 + r = math.pi  # FURB152
 25 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `3.141592653589793238462643383279` with `math.pi`
   --> FURB152.py:25:5
@@ -252,6 +262,7 @@ help: Use `math.e`
 32 + e = math.e  # FURB152
 33 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `2.7182` with `math.e`
   --> FURB152.py:33:5
@@ -273,6 +284,7 @@ help: Use `math.e`
 34 + e = math.e  # FURB152
 35 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `2.7183` with `math.e`
   --> FURB152.py:35:5
@@ -294,6 +306,7 @@ help: Use `math.e`
 36 + e = math.e  # FURB152
 37 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 FURB152 [*] Replace `2.7182000000000001` with `math.e`
   --> FURB152.py:45:5
@@ -302,6 +315,9 @@ FURB152 [*] Replace `2.7182000000000001` with `math.e`
 44 |
 45 | e = 2.7182000000000001  # FURB152
    |     ^^^^^^^^^^^^^^^^^^
+46 |
+47 | # Each of these already denotes exactly the same float as the constant it matches,
+   |
 help: Use `math.e`
    |
 1  + import math
@@ -310,4 +326,65 @@ help: Use `math.e`
 45 |
    - e = 2.7182000000000001  # FURB152
 46 + e = math.e  # FURB152
+47 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+
+FURB152 [*] Replace `3.141592653589793` with `math.pi`
+  --> FURB152.py:51:5
+   |
+49 | # shorter approximation above computes a different value once rewritten, so those
+50 | # fixes are offered as unsafe.
+51 | r = 3.141592653589793  # FURB152
+   |     ^^^^^^^^^^^^^^^^^
+52 |
+53 | e = 2.718281828459045  # FURB152
+   |
+help: Use `math.pi`
+   |
+1  + import math
+2  | r = 3.1  # OK
+--------------------------------------------------------------------------------
+51 | # fixes are offered as unsafe.
+   - r = 3.141592653589793  # FURB152
+52 + r = math.pi  # FURB152
+53 |
+   |
+
+FURB152 [*] Replace `2.718281828459045` with `math.e`
+  --> FURB152.py:53:5
+   |
+51 | r = 3.141592653589793  # FURB152
+52 |
+53 | e = 2.718281828459045  # FURB152
+   |     ^^^^^^^^^^^^^^^^^
+54 |
+55 | t = 6.283185307179586  # FURB152
+   |
+help: Use `math.e`
+   |
+1  + import math
+2  | r = 3.1  # OK
+--------------------------------------------------------------------------------
+53 |
+   - e = 2.718281828459045  # FURB152
+54 + e = math.e  # FURB152
+55 |
+   |
+
+FURB152 [*] Replace `6.283185307179586` with `math.tau`
+  --> FURB152.py:55:5
+   |
+53 | e = 2.718281828459045  # FURB152
+54 |
+55 | t = 6.283185307179586  # FURB152
+   |     ^^^^^^^^^^^^^^^^^
+help: Use `math.tau`
+   |
+1  + import math
+2  | r = 3.1  # OK
+--------------------------------------------------------------------------------
+55 |
+   - t = 6.283185307179586  # FURB152
+56 + t = math.tau  # FURB152
    |


### PR DESCRIPTION
## Summary

`matches_constant` treats a literal as a match if it equals π, e, or τ rounded or truncated anywhere from 2 to 15 decimal places. Truncating π at two places gives `3.14`, so `3.14` matches and gets rewritten to `math.pi`.

On its own that's just an aggressive heuristic. What made it bite is that the fix was always `Fix::safe_edits`, and ruff applies safe fixes under a plain `--fix` with nothing to review. The reporter had a crop-harvest constant of `3.14` that turned into `math.pi` (3.141592653589793), and a `2.718` that turned into `math.e`. Their numbers changed and nothing told them.

The fix here is to decide safety per literal: it stays safe only when the literal already parses to exactly the same `f64` as the constant, so the rewrite provably can't change a result. Every approximation — `3.14`, `2.718`, and friends — is now unsafe and needs `--unsafe-fixes`. I also moved the rule from `correctness` to `suspicious`, per @ntBre's comment.

One deviation worth flagging: the suggestion was to mark the fix unsafe outright. I went with conditional safety instead, because a blanket rule would flag `3.141592653589793 → math.pi` as behaviour-changing when it demonstrably isn't. `fstring_number_format` and `for_loop_set_mutations` in the same directory already do conditional safety, so this matches what's nearby. Happy to switch to a blanket unsafe if you'd rather keep it simple.

### References

Closes: #28127

## Test Plan

```
cargo test -p ruff_linter refurb
    test result: ok. 45 passed; 0 failed

cargo clippy -p ruff_linter --all-targets -- -D warnings   # clean
cargo dev generate-all                                      # no changes
uv run --only-dev --locked prek run --files <changed files> # all hooks pass
```

In the fixture, 14 literals flip to unsafe. Four stay safe because they're exact: `3.141592653589793`, `3.141592653589793238462643383279`, `2.718281828459045`, and `6.283185307179586`.