### PR TITLE
[ty] Rebalance instrumented microbenchmark shards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1228,13 +1228,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: micro
+          - name: micro-a-l
             target: ty
-            filter: micro
+            filter: 'ty_micro\[[a-l]'
             mode: simulation
-          - name: micro
+          - name: micro-m-z
             target: ty
-            filter: micro
+            filter: 'ty_micro\[[^a-l]'
+            mode: simulation
+          - name: micro-a-l
+            target: ty
+            filter: 'ty_micro\[[a-l]'
+            mode: memory
+          - name: micro-m-z
+            target: ty
+            filter: 'ty_micro\[[^a-l]'
             mode: memory
           - name: constraint_set
             target: ty_constraint_set


### PR DESCRIPTION
## Summary

Split ty's instrumented microbenchmarks into two disjoint shards for both simulation and memory measurements. The existing CodSpeed benchmark identities stay unchanged.

This cuts walltime from 12min to ~7min, about 30s longer than the project simulation benchmarks. This should hopefully help with the benchmarks timing out on depot's Intel runners.

## Test Plan

Testing: Validated the workflow and confirmed that all 42 current microbenchmarks match exactly one shard per mode.
