### PR TITLE
[ty] Respect descriptor protocol for `__set__` itself

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -651,7 +651,6 @@ class C:
 
     def update(self) -> None:
         # error: [invalid-assignment]
-        # error: [invalid-assignment]
         self.value += 1
 
 # TODO: Include `After` from the non-descriptor branch without including `DescriptorAfter`.

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1591,8 +1591,7 @@ def _(a: int | None):
 
 ## Instance attributes
 
-Both meta and class/instance attribute annotations are used as type context. For a metaclass
-descriptor, the setter's value parameter supplies the context:
+Both meta and class/instance attribute annotations are used as type context:
 
 ```py
 from typing import Literal, Any
@@ -1616,23 +1615,6 @@ def _(flag: bool):
         c.x = reveal_type([1])  # revealed: list[int]
 
         C.x = reveal_type([1])  # revealed: list[Literal[1]]
-```
-
-A property setter also provides context after specializing its owner. The setter below expects
-`list[object]`, so the fresh list can contain any object even though its initial element is `None`:
-
-```py
-class Owner[T]:
-    @property
-    def items(self) -> list[T]:
-        return []
-
-    @items.setter
-    def items(self, value: list[T]) -> None: ...
-
-def assign(owner: Owner[object]) -> None:
-    owner.items = reveal_type([None])  # revealed: list[object]
-    owner.items = 1  # error: [invalid-assignment]
 ```
 
 For union targets, each element of the union is considered as a separate type context:

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1618,6 +1618,23 @@ def _(flag: bool):
         C.x = reveal_type([1])  # revealed: list[Literal[1]]
 ```
 
+A property setter also provides context after specializing its owner. The setter below expects
+`list[object]`, so the fresh list can contain any object even though its initial element is `None`:
+
+```py
+class Owner[T]:
+    @property
+    def items(self) -> list[T]:
+        return []
+
+    @items.setter
+    def items(self, value: list[T]) -> None: ...
+
+def assign(owner: Owner[object]) -> None:
+    owner.items = reveal_type([None])  # revealed: list[object]
+    owner.items = 1  # error: [invalid-assignment]
+```
+
 For union targets, each element of the union is considered as a separate type context:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1591,7 +1591,8 @@ def _(a: int | None):
 
 ## Instance attributes
 
-Both meta and class/instance attribute annotations are used as type context:
+Both meta and class/instance attribute annotations are used as type context. For a metaclass
+descriptor, the setter's value parameter supplies the context:
 
 ```py
 from typing import Literal, Any
@@ -1614,8 +1615,6 @@ def _(flag: bool):
     def _(c: C):
         c.x = reveal_type([1])  # revealed: list[int]
 
-        # TODO: Use the parameter type of `__set__` as type context to avoid this error.
-        # error: [invalid-assignment]
         C.x = [1]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1615,7 +1615,7 @@ def _(flag: bool):
     def _(c: C):
         c.x = reveal_type([1])  # revealed: list[int]
 
-        C.x = [1]
+        C.x = reveal_type([1])  # revealed: list[Literal[1]]
 ```
 
 For union targets, each element of the union is considered as a separate type context:

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -1099,149 +1099,6 @@ wrapper_descriptor(f, None, f)
 wrapper_descriptor(f, None, type(f), "one too many")
 ```
 
-## Setter binding
-
-### Static setters and deleters
-
-A static setter receives the owner instance and assigned value. A static deleter receives only the
-owner instance. Neither receives the descriptor itself:
-
-```py
-class Descriptor:
-    @staticmethod
-    def __set__(instance: object, value: int) -> None: ...
-    @staticmethod
-    def __delete__(instance: object) -> None: ...
-
-class Owner:
-    value = Descriptor()
-
-owner = Owner()
-owner.value = 1
-del owner.value
-
-owner.value = "wrong"  # error: [invalid-assignment] "Expected `int`, found `Literal["wrong"]`"
-```
-
-### Descriptor-valued setters
-
-When `__set__` is itself a descriptor, Python invokes its `__get__` to obtain the setter. The
-returned callable receives the owner instance and assigned value:
-
-```py
-class BoundSetter:
-    def __call__(self, instance: object, value: int) -> None: ...
-
-class Setter:
-    def __get__(self, instance: object, owner: type | None = None) -> BoundSetter:
-        return BoundSetter()
-
-class Descriptor:
-    __set__ = Setter()
-
-class Owner:
-    value = Descriptor()
-
-Owner().value = 1
-Owner().value = "wrong"  # error: [invalid-assignment]
-```
-
-### Conditionally defined setters
-
-A conditional setter is called when present. When it is absent, an assignment can create an instance
-attribute, so the possibility of a missing setter does not make the assignment invalid:
-
-```py
-def assign(flag: bool) -> None:
-    class Descriptor:
-        if flag:
-            def __set__(self, instance: object, value: int) -> None: ...
-
-    class Owner:
-        value = Descriptor()
-
-    Owner().value = 1
-```
-
-### Union alternatives bind their own setters
-
-An ordinary method receives the descriptor implicitly, while a class method receives its class. An
-assignment must satisfy both possible setters, so only `str` is accepted by this union:
-
-```py
-class OrdinaryDescriptor:
-    def __set__(self, instance: object, value: int | str) -> None: ...
-
-class ClassDescriptor:
-    @classmethod
-    def __set__(cls, instance: object, value: str | bytes) -> None: ...
-
-class Owner:
-    value: OrdinaryDescriptor | ClassDescriptor
-
-owner = Owner()
-owner.value = "accepted"
-owner.value = 1  # error: [invalid-assignment]
-owner.value = b"wrong"  # error: [invalid-assignment]
-```
-
-### Intersection descriptors preserve their complete type
-
-The setter's `self` annotation requires both `Descriptor` and `Marker`, so binding retains both
-parts of the descriptor type:
-
-```py
-from __future__ import annotations
-from ty_extensions import Intersection
-
-class Marker: ...
-
-class Descriptor:
-    def __set__(self: Intersection[Descriptor, Marker], instance: object, value: int) -> None: ...
-
-def assign(descriptor: Intersection[Descriptor, Marker]) -> None:
-    class Owner:
-        value = descriptor
-
-    Owner().value = 1
-```
-
-### Setter binding in protocol compatibility
-
-A descriptor with a static setter can satisfy a writable protocol property. Its accepted value type
-determines compatibility with the protocol's setter:
-
-```py
-from typing import Protocol
-from ty_extensions import static_assert
-from ty_extensions._internal import is_subtype_of
-
-class Descriptor:
-    def __get__(self, instance: object, owner: type | None = None) -> int:
-        return 1
-
-    @staticmethod
-    def __set__(instance: object, value: int) -> None: ...
-
-class Owner:
-    value = Descriptor()
-
-class IntWriter(Protocol):
-    @property
-    def value(self) -> int: ...
-    @value.setter
-    def value(self, new_value: int) -> None: ...
-
-class StrWriter(Protocol):
-    @property
-    def value(self) -> int: ...
-    @value.setter
-    def value(self, new_value: str) -> None: ...
-
-static_assert(is_subtype_of(Owner, IntWriter))
-static_assert(not is_subtype_of(Owner, StrWriter))
-```
-
 ## Error handling and edge cases
 
 ### `__get__` is called with correct arguments
@@ -2085,6 +1942,31 @@ class Decorated:
 bound = Decorated().method
 reveal_type(bound)  # revealed: Decorator[(value: str)]
 bound(1)  # error: [invalid-argument-type]
+```
+
+### Static getters, setters and deleters
+
+```py
+class Descriptor:
+    @staticmethod
+    def __get__(descriptor: object, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    @staticmethod
+    def __set__(instance: object, value: int) -> None: ...
+    @staticmethod
+    def __delete__(instance: object) -> None: ...
+
+class Owner:
+    value = Descriptor()
+
+owner = Owner()
+reveal_type(owner.value)  # revealed: int
+reveal_type(Owner.value)  # revealed: int
+owner.value = 1
+del owner.value
+
+owner.value = "wrong"  # error: [invalid-assignment] "Expected `int`, found `Literal["wrong"]`"
 ```
 
 [descriptors]: https://docs.python.org/3/howto/descriptor.html

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -1099,6 +1099,149 @@ wrapper_descriptor(f, None, f)
 wrapper_descriptor(f, None, type(f), "one too many")
 ```
 
+## Setter binding
+
+### Static setters and deleters
+
+A static setter receives the owner instance and assigned value. A static deleter receives only the
+owner instance. Neither receives the descriptor itself:
+
+```py
+class Descriptor:
+    @staticmethod
+    def __set__(instance: object, value: int) -> None: ...
+    @staticmethod
+    def __delete__(instance: object) -> None: ...
+
+class Owner:
+    value = Descriptor()
+
+owner = Owner()
+owner.value = 1
+del owner.value
+
+owner.value = "wrong"  # error: [invalid-assignment] "Expected `int`, found `Literal["wrong"]`"
+```
+
+### Descriptor-valued setters
+
+When `__set__` is itself a descriptor, Python invokes its `__get__` to obtain the setter. The
+returned callable receives the owner instance and assigned value:
+
+```py
+class BoundSetter:
+    def __call__(self, instance: object, value: int) -> None: ...
+
+class Setter:
+    def __get__(self, instance: object, owner: type | None = None) -> BoundSetter:
+        return BoundSetter()
+
+class Descriptor:
+    __set__ = Setter()
+
+class Owner:
+    value = Descriptor()
+
+Owner().value = 1
+Owner().value = "wrong"  # error: [invalid-assignment]
+```
+
+### Conditionally defined setters
+
+A conditional setter is called when present. When it is absent, an assignment can create an instance
+attribute, so the possibility of a missing setter does not make the assignment invalid:
+
+```py
+def assign(flag: bool) -> None:
+    class Descriptor:
+        if flag:
+            def __set__(self, instance: object, value: int) -> None: ...
+
+    class Owner:
+        value = Descriptor()
+
+    Owner().value = 1
+```
+
+### Union alternatives bind their own setters
+
+An ordinary method receives the descriptor implicitly, while a class method receives its class. An
+assignment must satisfy both possible setters, so only `str` is accepted by this union:
+
+```py
+class OrdinaryDescriptor:
+    def __set__(self, instance: object, value: int | str) -> None: ...
+
+class ClassDescriptor:
+    @classmethod
+    def __set__(cls, instance: object, value: str | bytes) -> None: ...
+
+class Owner:
+    value: OrdinaryDescriptor | ClassDescriptor
+
+owner = Owner()
+owner.value = "accepted"
+owner.value = 1  # error: [invalid-assignment]
+owner.value = b"wrong"  # error: [invalid-assignment]
+```
+
+### Intersection descriptors preserve their complete type
+
+The setter's `self` annotation requires both `Descriptor` and `Marker`, so binding retains both
+parts of the descriptor type:
+
+```py
+from __future__ import annotations
+from ty_extensions import Intersection
+
+class Marker: ...
+
+class Descriptor:
+    def __set__(self: Intersection[Descriptor, Marker], instance: object, value: int) -> None: ...
+
+def assign(descriptor: Intersection[Descriptor, Marker]) -> None:
+    class Owner:
+        value = descriptor
+
+    Owner().value = 1
+```
+
+### Setter binding in protocol compatibility
+
+A descriptor with a static setter can satisfy a writable protocol property. Its accepted value type
+determines compatibility with the protocol's setter:
+
+```py
+from typing import Protocol
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Descriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> int:
+        return 1
+
+    @staticmethod
+    def __set__(instance: object, value: int) -> None: ...
+
+class Owner:
+    value = Descriptor()
+
+class IntWriter(Protocol):
+    @property
+    def value(self) -> int: ...
+    @value.setter
+    def value(self, new_value: int) -> None: ...
+
+class StrWriter(Protocol):
+    @property
+    def value(self) -> int: ...
+    @value.setter
+    def value(self, new_value: str) -> None: ...
+
+static_assert(is_subtype_of(Owner, IntWriter))
+static_assert(not is_subtype_of(Owner, StrWriter))
+```
+
 ## Error handling and edge cases
 
 ### `__get__` is called with correct arguments

--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/attribute_assignment.md
@@ -315,9 +315,9 @@ error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr
    |
 11 | instance.attr = "wrong"  # snapshot: invalid-assignment
    |                 ^^^^^^^ Expected `int`, found `Literal["wrong"]`
-info: Argument to function `Descriptor.__set__` is incorrect
+info: Argument to bound method `Descriptor.__set__` is incorrect
 info: This assignment implicitly calls `__set__` on a descriptor of type `Descriptor`
-info: Function defined here
+info: Method defined here
  --> src/mdtest_snippet.py:2:9
   |
 2 |     def __set__(self, instance: object, value: int) -> None:
@@ -344,7 +344,7 @@ error[invalid-assignment]: Invalid assignment to data descriptor attribute `attr
   --> src/mdtest_snippet.py:10:1
    |
 10 | instance.attr = 1  # snapshot: invalid-assignment
-   | ^^^^^^^^^^^^^ No argument provided for required parameter `extra` of function `WrongDescriptor.__set__`
+   | ^^^^^^^^^^^^^ No argument provided for required parameter `extra` of bound method `WrongDescriptor.__set__`
 info: This assignment implicitly calls `__set__` on a descriptor of type `WrongDescriptor`
 info: Parameter declared here
  --> src/mdtest_snippet.py:2:53
@@ -407,10 +407,10 @@ error[invalid-assignment]: Invalid assignment to data descriptor attribute `x` o
   |
 8 | c.x = (1, b"")  # snapshot: invalid-assignment
   |       ^^^^^^^^ Expected `tuple[int, str]`, found `tuple[Literal[1], Literal[b""]]`
-info: Argument to function `Descriptor.__set__` is incorrect
+info: Argument to bound method `Descriptor.__set__` is incorrect
 info: This assignment implicitly calls `__set__` on a descriptor of type `Descriptor`
 info: the second tuple element is not compatible: `Literal[b""]` is not assignable to `str`
-info: Function defined here
+info: Method defined here
  --> src/mdtest_snippet.py:2:9
   |
 2 |     def __set__(self, instance, value: tuple[int, str]) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3385,6 +3385,49 @@ def update_large_union_value(
     value.value = invalid  # error: [invalid-assignment]
 ```
 
+### Conditional setters in a descriptor union
+
+Both descriptors accept a list of integers when their setters are present. Assignment through the
+protocol still requires every possible descriptor to have a setter. An ordinary assignment allows
+the conditional setter to be absent, since that branch can create an instance attribute:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol
+
+def example(flag: bool) -> None:
+    class GenericDescriptor:
+        def __get__(self, instance: object, owner: type | None = None) -> object:
+            return 0
+
+        def __set__[T](self, instance: object, value: list[T]) -> None: ...
+
+    class ConditionalDescriptor:
+        def __get__(self, instance: object, owner: type | None = None) -> object:
+            return 0
+
+        if flag:
+            def __set__(self, instance: object, value: list[int]) -> None: ...
+
+    def descriptor(getter: object) -> GenericDescriptor | ConditionalDescriptor:
+        raise NotImplementedError
+
+    class P(Protocol):
+        @descriptor
+        def value(self) -> object: ...
+
+    class Owner:
+        value: GenericDescriptor | ConditionalDescriptor
+
+    def update(protocol: P, owner: Owner) -> None:
+        protocol.value = [1]  # error: [invalid-assignment] "Cannot assign to attribute `value` on type `P`"
+        owner.value = [1]
+```
+
 ### Overloaded setters selected by descriptor type
 
 An overload can also restrict the type of the descriptor itself. The decorator below returns

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3385,49 +3385,6 @@ def update_large_union_value(
     value.value = invalid  # error: [invalid-assignment]
 ```
 
-### Conditional setters in a descriptor union
-
-Both descriptors accept a list of integers when their setters are present. Assignment through the
-protocol still requires every possible descriptor to have a setter. An ordinary assignment allows
-the conditional setter to be absent, since that branch can create an instance attribute:
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-from typing import Protocol
-
-def example(flag: bool) -> None:
-    class GenericDescriptor:
-        def __get__(self, instance: object, owner: type | None = None) -> object:
-            return 0
-
-        def __set__[T](self, instance: object, value: list[T]) -> None: ...
-
-    class ConditionalDescriptor:
-        def __get__(self, instance: object, owner: type | None = None) -> object:
-            return 0
-
-        if flag:
-            def __set__(self, instance: object, value: list[int]) -> None: ...
-
-    def descriptor(getter: object) -> GenericDescriptor | ConditionalDescriptor:
-        raise NotImplementedError
-
-    class P(Protocol):
-        @descriptor
-        def value(self) -> object: ...
-
-    class Owner:
-        value: GenericDescriptor | ConditionalDescriptor
-
-    def update(protocol: P, owner: Owner) -> None:
-        protocol.value = [1]  # error: [invalid-assignment] "Cannot assign to attribute `value` on type `P`"
-        owner.value = [1]
-```
-
 ### Overloaded setters selected by descriptor type
 
 An overload can also restrict the type of the descriptor itself. The decorator below returns

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -863,7 +863,6 @@ pub(super) fn assignment_attribute_members<'db>(
     })
 }
 
-/// Look up the bound setter without consulting instance storage or gradual bases.
 pub(super) fn descriptor_setter<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -966,17 +966,27 @@ fn single_descriptor_setter_domain<'db>(
     descriptor_ty: Type<'db>,
     receiver_ty: Type<'db>,
 ) -> DescriptorSetterDomain<'db> {
-    let Place::Defined(DefinedPlace {
-        ty: setter_ty,
-        definedness: Definedness::AlwaysDefined,
-        ..
-    }) = (DescriptorSetCall {
-        descriptor_ty,
-        receiver_ty,
-    })
-    .setter(db, env)
-    else {
-        return DescriptorSetterDomain::Missing;
+    let (setter_ty, self_ty) = if let Type::PropertyInstance(property) = descriptor_ty {
+        // The synthesized `property.__set__` signature accepts `object`, but the property's
+        // setter provides the actual value type. An owner method's `Self` refers to that owner.
+        let Some(setter_ty) = property.setter(db) else {
+            return DescriptorSetterDomain::Missing;
+        };
+        (setter_ty, receiver_ty)
+    } else {
+        let Place::Defined(DefinedPlace {
+            ty: setter_ty,
+            definedness: Definedness::AlwaysDefined,
+            ..
+        }) = (DescriptorSetCall {
+            descriptor_ty,
+            receiver_ty,
+        })
+        .setter(db, env)
+        else {
+            return DescriptorSetterDomain::Missing;
+        };
+        (setter_ty, descriptor_ty)
     };
 
     let Some(callables) = setter_ty.try_upcast_to_callable(db, env) else {
@@ -986,8 +996,7 @@ fn single_descriptor_setter_domain<'db>(
     for callable in &callables {
         let mut write_types = Vec::new();
         for signature in callable.signatures(db) {
-            match descriptor_setter_signature_domain(db, env, signature, descriptor_ty, receiver_ty)
-            {
+            match descriptor_setter_signature_domain(db, env, signature, self_ty, receiver_ty) {
                 DescriptorSetterSignatureDomain::Inapplicable => {}
                 DescriptorSetterSignatureDomain::Known(write_ty) => write_types.push(write_ty),
                 DescriptorSetterSignatureDomain::Deferred => {
@@ -1009,12 +1018,12 @@ enum DescriptorSetterSignatureDomain<'db> {
     Deferred,
 }
 
-/// Derive the values accepted by one `__set__` overload when they fit in [`Type`].
+/// Derive the values accepted by one setter overload when they fit in [`Type`].
 fn descriptor_setter_signature_domain<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     signature: &Signature<'db>,
-    descriptor_ty: Type<'db>,
+    self_ty: Type<'db>,
     receiver_ty: Type<'db>,
 ) -> DescriptorSetterSignatureDomain<'db> {
     let parameters = signature.parameters();
@@ -1039,10 +1048,9 @@ fn descriptor_setter_signature_domain<'db>(
     let Some(receiver_parameter) = parameters.get_positional(0) else {
         return missing_required_parameter();
     };
-    let receiver_parameter =
-        receiver_parameter
-            .annotated_type()
-            .bind_self_typevars(db, env, descriptor_ty);
+    let receiver_parameter = receiver_parameter
+        .annotated_type()
+        .bind_self_typevars(db, env, self_ty);
     if contains_signature_typevar(db, env, signature, receiver_parameter) {
         return DescriptorSetterSignatureDomain::Deferred;
     }
@@ -1055,7 +1063,7 @@ fn descriptor_setter_signature_domain<'db>(
     };
     let write_ty = write_parameter
         .annotated_type()
-        .bind_self_typevars(db, env, descriptor_ty);
+        .bind_self_typevars(db, env, self_ty);
     if !contains_signature_typevar(db, env, signature, write_ty) {
         return DescriptorSetterSignatureDomain::Known(write_ty);
     }
@@ -1078,7 +1086,7 @@ fn descriptor_setter_signature_domain<'db>(
     match typevar.typevar(db).bound_or_constraints(db, env) {
         None => DescriptorSetterSignatureDomain::Known(Type::object()),
         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-            DescriptorSetterSignatureDomain::Known(bound.bind_self_typevars(db, env, descriptor_ty))
+            DescriptorSetterSignatureDomain::Known(bound.bind_self_typevars(db, env, self_ty))
         }
         Some(TypeVarBoundOrConstraints::Constraints(_)) => {
             DescriptorSetterSignatureDomain::Deferred

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -11,7 +11,7 @@ use crate::Db;
 use ty_module_resolver::KnownModule;
 use ty_python_core::use_def_map;
 
-use super::call::{Bindings, CallArguments, CallDunderError, CallError};
+use super::call::CallArguments;
 use super::callable::CallableTypeKind;
 use super::{
     IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Parameter, Signature,
@@ -863,65 +863,20 @@ pub(super) fn assignment_attribute_members<'db>(
     })
 }
 
-/// A setter call after descriptor discovery and write precedence have selected its receiver.
-///
-/// Python binds `__set__` to the descriptor before passing the owner and assigned value. Keeping
-/// these two explicit arguments separate from the bound receiver also preserves their diagnostic
-/// ranges. This differs from `__get__`, which Python calls with the descriptor as an explicit
-/// argument and must continue to use its own dispatch.
-#[derive(Clone, Copy)]
-pub(super) struct DescriptorSetCall<'db> {
-    pub(super) descriptor_ty: Type<'db>,
-    pub(super) receiver_ty: Type<'db>,
-}
-
-impl<'db> DescriptorSetCall<'db> {
-    /// Look up the bound setter without consulting instance storage or gradual bases.
-    pub(super) fn setter(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Place<'db> {
-        self.descriptor_ty
-            .member_lookup_with_policy(
-                db,
-                env,
-                "__set__",
-                MemberLookupPolicy::REQUIRE_CONCRETE | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-            )
-            .place
-    }
-
-    pub(super) fn try_call(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        value_ty: Type<'db>,
-    ) -> Result<Bindings<'db>, CallDunderError<'db>> {
-        // Keep the complete descriptor receiver when binding `self`, including intersection
-        // constraints. Splitting an intersection before binding can lose a required base class.
-        let Place::Defined(DefinedPlace {
-            ty: setter_ty,
-            definedness,
-            provenance,
-            ..
-        }) = self.setter(db, env)
-        else {
-            return Err(CallDunderError::MethodNotAvailable);
-        };
-        let bindings = setter_ty
-            .try_call(
-                db,
-                env,
-                &CallArguments::positional([self.receiver_ty, value_ty]),
-            )
-            .map_err(|CallError(kind, bindings)| {
-                CallDunderError::CallError(kind, bindings, provenance)
-            })?;
-        if definedness == Definedness::PossiblyUndefined {
-            return Err(CallDunderError::PossiblyUnbound {
-                bindings: Box::new(bindings),
-                unbound_on: None,
-            });
-        }
-        Ok(bindings)
-    }
+/// Look up the bound setter without consulting instance storage or gradual bases.
+pub(super) fn descriptor_setter<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    descriptor_ty: Type<'db>,
+) -> Place<'db> {
+    descriptor_ty
+        .member_lookup_with_policy(
+            db,
+            env,
+            "__set__",
+            MemberLookupPolicy::REQUIRE_CONCRETE | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+        )
+        .place
 }
 
 /// The values accepted by a descriptor setter, when representable as a single type.
@@ -978,11 +933,7 @@ fn single_descriptor_setter_domain<'db>(
             ty: setter_ty,
             definedness: Definedness::AlwaysDefined,
             ..
-        }) = (DescriptorSetCall {
-            descriptor_ty,
-            receiver_ty,
-        })
-        .setter(db, env)
+        }) = descriptor_setter(db, env, descriptor_ty)
         else {
             return DescriptorSetterDomain::Missing;
         };

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -11,7 +11,7 @@ use crate::Db;
 use ty_module_resolver::KnownModule;
 use ty_python_core::use_def_map;
 
-use super::call::CallArguments;
+use super::call::{Bindings, CallArguments, CallDunderError, CallError};
 use super::callable::CallableTypeKind;
 use super::{
     IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Parameter, Signature,
@@ -130,12 +130,8 @@ pub(super) enum ClassAttributeWriteMember<'db> {
 /// How an explicitly resolved member accepts a write.
 pub(super) enum ExplicitAttributeWriteRequirement<'db> {
     /// Invoke a concrete descriptor's `__set__` method.
-    ///
-    /// `setter_ty` is the unbound method and is called with `descriptor_ty`, the object, and the
-    /// assigned value.
     Descriptor {
         descriptor_ty: Type<'db>,
-        setter_ty: Type<'db>,
         qualifiers: TypeQualifiers,
     },
     /// Check the assigned value directly against the member's effective write type.
@@ -594,13 +590,12 @@ fn explicit_attribute_write_requirement<'db>(
         };
     }
 
-    if let Place::Defined(DefinedPlace { ty: setter_ty, .. }) = attr_ty
+    if let Place::Defined(_) = attr_ty
         .class_member_with_policy(db, env, "__set__", MemberLookupPolicy::REQUIRE_CONCRETE)
         .place
     {
         ExplicitAttributeWriteRequirement::Descriptor {
             descriptor_ty: attr_ty,
-            setter_ty,
             qualifiers,
         }
     } else {
@@ -868,6 +863,67 @@ pub(super) fn assignment_attribute_members<'db>(
     })
 }
 
+/// A setter call after descriptor discovery and write precedence have selected its receiver.
+///
+/// Python binds `__set__` to the descriptor before passing the owner and assigned value. Keeping
+/// these two explicit arguments separate from the bound receiver also preserves their diagnostic
+/// ranges. This differs from `__get__`, which Python calls with the descriptor as an explicit
+/// argument and must continue to use its own dispatch.
+#[derive(Clone, Copy)]
+pub(super) struct DescriptorSetCall<'db> {
+    pub(super) descriptor_ty: Type<'db>,
+    pub(super) receiver_ty: Type<'db>,
+}
+
+impl<'db> DescriptorSetCall<'db> {
+    /// Look up the bound setter without consulting instance storage or gradual bases.
+    pub(super) fn setter(self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> Place<'db> {
+        self.descriptor_ty
+            .member_lookup_with_policy(
+                db,
+                env,
+                "__set__",
+                MemberLookupPolicy::REQUIRE_CONCRETE | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            )
+            .place
+    }
+
+    pub(super) fn try_call(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        value_ty: Type<'db>,
+    ) -> Result<Bindings<'db>, CallDunderError<'db>> {
+        // Keep the complete descriptor receiver when binding `self`, including intersection
+        // constraints. Splitting an intersection before binding can lose a required base class.
+        let Place::Defined(DefinedPlace {
+            ty: setter_ty,
+            definedness,
+            provenance,
+            ..
+        }) = self.setter(db, env)
+        else {
+            return Err(CallDunderError::MethodNotAvailable);
+        };
+        let bindings = setter_ty
+            .try_call(
+                db,
+                env,
+                &CallArguments::positional([self.receiver_ty, value_ty]),
+            )
+            .map_err(|CallError(kind, bindings)| {
+                CallDunderError::CallError(kind, bindings, provenance)
+            })?;
+        if definedness == Definedness::PossiblyUndefined {
+            return Err(CallDunderError::PossiblyUnbound {
+                bindings: Box::new(bindings),
+                unbound_on: None,
+            });
+        }
+        Ok(bindings)
+    }
+}
+
 /// The values accepted by a descriptor setter, when representable as a single type.
 #[derive(Copy, Clone)]
 pub(super) enum DescriptorSetterDomain<'db> {
@@ -883,6 +939,7 @@ pub(super) fn descriptor_setter_domain<'db>(
     descriptor_ty: Type<'db>,
     receiver_ty: Type<'db>,
 ) -> DescriptorSetterDomain<'db> {
+    let descriptor_ty = descriptor_ty.resolve_type_alias(db);
     match descriptor_ty {
         Type::Union(union) => {
             let mut write_types = Vec::with_capacity(union.elements(db).len());
@@ -913,14 +970,11 @@ fn single_descriptor_setter_domain<'db>(
         ty: setter_ty,
         definedness: Definedness::AlwaysDefined,
         ..
-    }) = descriptor_ty
-        .member_lookup_with_policy(
-            db,
-            env,
-            "__set__",
-            MemberLookupPolicy::REQUIRE_CONCRETE | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
-        )
-        .place
+    }) = (DescriptorSetCall {
+        descriptor_ty,
+        receiver_ty,
+    })
+    .setter(db, env)
     else {
         return DescriptorSetterDomain::Missing;
     };

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2400,7 +2400,6 @@ pub(super) fn report_bad_dunder_set_call<'db>(
     dunder_set_failure: &CallError<'db>,
     object_type: Type<'db>,
     descriptor_type: Type<'db>,
-    includes_descriptor_argument: bool,
     target: &ast::ExprAttribute,
     value: &ast::Expr,
 ) {
@@ -2428,11 +2427,7 @@ pub(super) fn report_bad_dunder_set_call<'db>(
             ));
         }
     } else {
-        let argument_ranges = if includes_descriptor_argument {
-            &[target.range(), target.value.range(), value.range()][..]
-        } else {
-            &[target.value.range(), value.range()][..]
-        };
+        let argument_ranges = &[target.value.range(), value.range()];
         dunder_set_failure.report_diagnostics_with_override(
             context,
             target.into(),

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -5,8 +5,8 @@ use smallvec::{SmallVec, smallvec};
 use super::{ArgumentsIter, MultiInferenceGuard, TypeInferenceBuilder};
 use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers};
 use crate::types::attribute_write::{
-    AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetCall,
-    DescriptorSetterDomain, ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
+    AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetterDomain,
+    ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
     InstanceAttributeWriteMember, ProtocolMemberWriteRequirement, attribute_write_requirement,
     descriptor_setter_domain, property_setter_returns_never,
 };
@@ -434,12 +434,15 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     {
                         return false;
                     }
-                    self.descriptor_write_calls(*descriptor_ty, *receiver_ty)
-                        .all(|call| {
-                            match self.evaluate_descriptor_write(call, value_ty, emit_diagnostics) {
+                    self.descriptor_write_alternatives(*descriptor_ty)
+                        .all(|descriptor_ty| {
+                            match self.evaluate_descriptor_write(
+                                descriptor_ty,
+                                *receiver_ty,
+                                value_ty,
+                                emit_diagnostics,
+                            ) {
                                 Some(Definedness::AlwaysDefined) => true,
-                                // A protocol write capability requires the setter to be present
-                                // on every alternative.
                                 Some(Definedness::PossiblyUndefined) => {
                                     if emit_diagnostics {
                                         self.report(
@@ -806,12 +809,15 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
     ) -> bool {
         match requirement {
             ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. } => self
-                .descriptor_write_calls(*descriptor_ty, object_ty)
-                .all(|call| {
-                    // An ordinary descriptor only constrains the branch where its setter exists.
-                    // When absent, assignment can create an instance attribute.
-                    self.evaluate_descriptor_write(call, value_ty, emit_diagnostics)
-                        .is_some()
+                .descriptor_write_alternatives(*descriptor_ty)
+                .all(|descriptor_ty| {
+                    self.evaluate_descriptor_write(
+                        descriptor_ty,
+                        object_ty,
+                        value_ty,
+                        emit_diagnostics,
+                    )
+                    .is_some()
                 }),
             ExplicitAttributeWriteRequirement::AssignableTo { ty, .. } => {
                 let value_ty = self.infer_value(TypeContext::new(Some(*ty)), false);
@@ -820,13 +826,15 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         }
     }
 
-    /// Keep alternatives separate so each caller can stop at its first unacceptable setter.
-    /// Resolve nested aliases without splitting intersection receivers or reordering alternatives.
-    fn descriptor_write_calls(
+    /// Yield each possible descriptor type so writes can be checked one alternative at a time.
+    ///
+    /// For example, if an attribute has type `IntDescriptor | StrDescriptor`, an assignment must
+    /// satisfy both setters: either descriptor could be present at runtime. Checking them
+    /// separately lets the caller stop and report the first alternative that rejects the write.
+    fn descriptor_write_alternatives(
         &self,
         descriptor_ty: Type<'db>,
-        receiver_ty: Type<'db>,
-    ) -> impl Iterator<Item = DescriptorSetCall<'db>> + use<'db> {
+    ) -> impl Iterator<Item = Type<'db>> + use<'db> {
         let db = self.builder.db();
         let mut pending: SmallVec<[_; 1]> = smallvec![descriptor_ty];
         std::iter::from_fn(move || {
@@ -835,30 +843,38 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 if let Type::Union(union) = descriptor_ty {
                     pending.extend(union.elements(db).iter().rev().copied());
                 } else {
-                    return Some(DescriptorSetCall {
-                        descriptor_ty,
-                        receiver_ty,
-                    });
+                    return Some(descriptor_ty);
                 }
             }
             None
         })
     }
 
-    /// Return setter presence for a valid write, or report why the write is invalid and return `None`.
+    /// Check the setter call and return whether the setter is always or only possibly present.
+    /// Return `None` when the write fails, reporting the error if `emit_diagnostics` is enabled.
+    ///
+    /// For example, a descriptor can define `__set__(self, instance, value: int)` inside an
+    /// `if flag:` block. Assigning an integer returns `Some(PossiblyUndefined)`: the call is valid
+    /// when the setter exists, but the setter might be absent. An unconditional setter accepting
+    /// the same value returns `Some(AlwaysDefined)`. Passing a string to either setter returns
+    /// `None`, since the call is invalid when the setter exists.
     fn evaluate_descriptor_write(
         &mut self,
-        call: DescriptorSetCall<'db>,
+        descriptor_ty: Type<'db>,
+        receiver_ty: Type<'db>,
         value_ty: Type<'db>,
         emit_diagnostics: bool,
     ) -> Option<Definedness> {
         let env = self.builder.program_environment();
         let db = self.builder.db();
-        let DescriptorSetCall {
-            descriptor_ty,
-            receiver_ty,
-        } = call;
-        let setter_result = call.try_call(db, env, value_ty);
+        let setter_result = descriptor_ty.try_call_dunder_with_policy(
+            db,
+            env,
+            "__set__",
+            &mut CallArguments::positional([receiver_ty, value_ty]),
+            TypeContext::default(),
+            MemberLookupPolicy::REQUIRE_CONCRETE,
+        );
         // `Never` supports arbitrary operations only because there can be no runtime value to
         // mutate; it is not a concrete descriptor with a terminal setter.
         let setter_returns_never = !descriptor_ty.is_never()

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -4,9 +4,10 @@ use ruff_text_size::Ranged;
 use super::{ArgumentsIter, MultiInferenceGuard, TypeInferenceBuilder};
 use crate::place::{DefinedPlace, Place, PlaceAndQualifiers};
 use crate::types::attribute_write::{
-    AttributeWriteRequirement, ClassAttributeWriteMember, ExplicitAttributeWriteRequirement,
-    FallbackAttributeWriteRequirement, InstanceAttributeWriteMember,
-    ProtocolMemberWriteRequirement, attribute_write_requirement, property_setter_returns_never,
+    AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetCall,
+    DescriptorSetterDomain, ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
+    InstanceAttributeWriteMember, ProtocolMemberWriteRequirement, attribute_write_requirement,
+    descriptor_setter_domain, property_setter_returns_never,
 };
 use crate::types::call::{Bindings, CallArguments, CallDiagnosticOverride, CallError};
 use crate::types::class::FrozenDataclassDispatch;
@@ -73,7 +74,6 @@ enum AssignmentAttributeWriteDiagnostic<'db> {
     BadDunderSet {
         failure: CallError<'db>,
         descriptor_ty: Type<'db>,
-        includes_descriptor_argument: bool,
     },
     PossiblyMissing,
     BadSetAttr {
@@ -90,6 +90,12 @@ enum AssignmentAttributeWriteDiagnostic<'db> {
 enum ContextualInference {
     Commit,
     Speculate,
+}
+
+#[derive(Clone, Copy)]
+enum DescriptorWriteKind {
+    Ordinary,
+    Protocol,
 }
 
 /// Whether a resolved write target contributes or suppresses a property deprecation.
@@ -433,11 +439,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     {
                         return false;
                     }
-                    self.evaluate_protocol_descriptor_write(
+                    self.evaluate_descriptor_write(
                         *descriptor_ty,
                         *receiver_ty,
                         value_ty,
                         emit_diagnostics,
+                        DescriptorWriteKind::Protocol,
                     )
                 }
                 None => {
@@ -548,7 +555,13 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             ) {
             self.infer_and_try_call_setattr(setattr_receiver, emit_diagnostics)
         } else {
-            let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
+            let tcx = match member {
+                InstanceAttributeWriteMember::Explicit { member, .. } => {
+                    self.descriptor_type_context(object_ty, member)
+                }
+                _ => TypeContext::default(),
+            };
+            let value_ty = self.infer_value(tcx, emit_diagnostics);
             let setattr_result = setattr_receiver.try_call_dunder_with_policy(
                 db,
                 env,
@@ -693,7 +706,8 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     self.infer_value(TypeContext::default(), emit_diagnostics);
                     return false;
                 }
-                let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
+                let tcx = self.descriptor_type_context(object_ty, member);
+                let value_ty = self.infer_value(tcx, emit_diagnostics);
                 let member_valid =
                     self.evaluate_explicit_member(object_ty, member, value_ty, emit_diagnostics);
                 if let Some(fallback) = fallback {
@@ -759,6 +773,25 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         }
     }
 
+    fn descriptor_type_context(
+        &self,
+        receiver_ty: Type<'db>,
+        requirement: &ExplicitAttributeWriteRequirement<'db>,
+    ) -> TypeContext<'db> {
+        if let ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. } = requirement
+            && let DescriptorSetterDomain::Known(write_ty) = descriptor_setter_domain(
+                self.builder.db(),
+                self.builder.program_environment(),
+                *descriptor_ty,
+                receiver_ty,
+            )
+        {
+            TypeContext::new(Some(write_ty))
+        } else {
+            TypeContext::default()
+        }
+    }
+
     fn evaluate_explicit_member(
         &mut self,
         object_ty: Type<'db>,
@@ -767,17 +800,14 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         match requirement {
-            ExplicitAttributeWriteRequirement::Descriptor {
-                descriptor_ty,
-                setter_ty,
-                ..
-            } => self.evaluate_descriptor_write(
-                *descriptor_ty,
-                *setter_ty,
-                object_ty,
-                value_ty,
-                emit_diagnostics,
-            ),
+            ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. } => self
+                .evaluate_descriptor_write(
+                    *descriptor_ty,
+                    object_ty,
+                    value_ty,
+                    emit_diagnostics,
+                    DescriptorWriteKind::Ordinary,
+                ),
             ExplicitAttributeWriteRequirement::AssignableTo { ty, .. } => {
                 let value_ty = self.infer_value(TypeContext::new(Some(*ty)), false);
                 self.check_type_pair(value_ty, *ty, emit_diagnostics)
@@ -785,30 +815,33 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         }
     }
 
-    fn evaluate_protocol_descriptor_write(
+    fn evaluate_descriptor_write(
         &mut self,
         descriptor_ty: Type<'db>,
         receiver_ty: Type<'db>,
         value_ty: Type<'db>,
         emit_diagnostics: bool,
+        kind: DescriptorWriteKind,
     ) -> bool {
         let env = self.builder.program_environment();
         let db = self.builder.db();
         let descriptor_ty = descriptor_ty.resolve_type_alias(db);
         if let Type::Union(union) = descriptor_ty {
             for descriptor_ty in union.elements(db) {
-                if !self.evaluate_protocol_descriptor_write(
+                if !self.evaluate_descriptor_write(
                     *descriptor_ty,
                     receiver_ty,
                     value_ty,
                     false,
+                    kind,
                 ) {
                     if emit_diagnostics {
-                        self.evaluate_protocol_descriptor_write(
+                        self.evaluate_descriptor_write(
                             *descriptor_ty,
                             receiver_ty,
                             value_ty,
                             true,
+                            kind,
                         );
                     }
                     return false;
@@ -817,65 +850,20 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             return true;
         }
 
-        if property_setter_returns_never(db, env, descriptor_ty, receiver_ty, value_ty) {
-            if emit_diagnostics {
-                self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
-            }
-            return false;
+        let setter_result = DescriptorSetCall {
+            descriptor_ty,
+            receiver_ty,
         }
-
-        match descriptor_ty.try_call_dunder_with_policy(
-            db,
-            env,
-            "__set__",
-            &mut CallArguments::positional([receiver_ty, value_ty]),
-            TypeContext::default(),
-            MemberLookupPolicy::REQUIRE_CONCRETE,
-        ) {
-            Ok(_) => true,
-            Err(CallDunderError::CallError(kind, bindings, _)) => {
-                if emit_diagnostics {
-                    self.report(AssignmentAttributeWriteDiagnostic::BadDunderSet {
-                        failure: CallError(kind, bindings),
-                        descriptor_ty,
-                        includes_descriptor_argument: false,
-                    });
-                }
-                false
-            }
-            Err(CallDunderError::MethodNotAvailable | CallDunderError::PossiblyUnbound { .. }) => {
-                if emit_diagnostics {
-                    self.report(AssignmentAttributeWriteDiagnostic::CannotAssign);
-                }
-                false
-            }
-        }
-    }
-
-    fn evaluate_descriptor_write(
-        &mut self,
-        descriptor_ty: Type<'db>,
-        setter_ty: Type<'db>,
-        object_ty: Type<'db>,
-        value_ty: Type<'db>,
-        emit_diagnostics: bool,
-    ) -> bool {
-        let db = self.builder.db();
-        let env = self.builder.program_environment();
-        let setter_result = setter_ty.try_call(
-            db,
-            env,
-            &CallArguments::positional([descriptor_ty, object_ty, value_ty]),
-        );
+        .try_call(db, env, value_ty);
         // `Never` supports arbitrary operations only because there can be no runtime value to
         // mutate; it is not a concrete descriptor with a terminal setter.
         let setter_returns_never = !descriptor_ty.is_never()
             && match &setter_result {
                 Ok(bindings) => bindings.return_type(db, env).is_never(),
-                Err(error) => error.return_type(db, env).is_never(),
+                Err(error) => error.return_type(db, env).is_some_and(|ty| ty.is_never()),
             };
         if setter_returns_never
-            || property_setter_returns_never(db, env, descriptor_ty, object_ty, value_ty)
+            || property_setter_returns_never(db, env, descriptor_ty, receiver_ty, value_ty)
         {
             if emit_diagnostics {
                 self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
@@ -885,13 +873,25 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
 
         match setter_result {
             Ok(_) => true,
-            Err(error) => {
+            // A selected ordinary descriptor only constrains the branch where its setter exists.
+            // A protocol write capability requires the setter to be present on every branch.
+            Err(CallDunderError::PossiblyUnbound { .. })
+                if matches!(kind, DescriptorWriteKind::Ordinary) =>
+            {
+                true
+            }
+            Err(CallDunderError::CallError(kind, bindings, _)) => {
                 if emit_diagnostics {
                     self.report(AssignmentAttributeWriteDiagnostic::BadDunderSet {
-                        failure: error,
+                        failure: CallError(kind, bindings),
                         descriptor_ty,
-                        includes_descriptor_argument: true,
                     });
+                }
+                false
+            }
+            Err(CallDunderError::MethodNotAvailable | CallDunderError::PossiblyUnbound { .. }) => {
+                if emit_diagnostics {
+                    self.report(AssignmentAttributeWriteDiagnostic::CannotAssign);
                 }
                 false
             }
@@ -1066,14 +1066,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             AssignmentAttributeWriteDiagnostic::BadDunderSet {
                 failure,
                 descriptor_ty,
-                includes_descriptor_argument,
             } => {
                 report_bad_dunder_set_call(
                     &self.builder.context,
                     &failure,
                     self.object_ty,
                     descriptor_ty,
-                    includes_descriptor_argument,
                     self.target,
                     self.value,
                 );

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -1,8 +1,9 @@
 use ruff_python_ast as ast;
 use ruff_text_size::Ranged;
+use smallvec::{SmallVec, smallvec};
 
 use super::{ArgumentsIter, MultiInferenceGuard, TypeInferenceBuilder};
-use crate::place::{DefinedPlace, Place, PlaceAndQualifiers};
+use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers};
 use crate::types::attribute_write::{
     AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetCall,
     DescriptorSetterDomain, ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
@@ -90,12 +91,6 @@ enum AssignmentAttributeWriteDiagnostic<'db> {
 enum ContextualInference {
     Commit,
     Speculate,
-}
-
-#[derive(Clone, Copy)]
-enum DescriptorWriteKind {
-    Ordinary,
-    Protocol,
 }
 
 /// Whether a resolved write target contributes or suppresses a property deprecation.
@@ -439,13 +434,23 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     {
                         return false;
                     }
-                    self.evaluate_descriptor_write(
-                        *descriptor_ty,
-                        *receiver_ty,
-                        value_ty,
-                        emit_diagnostics,
-                        DescriptorWriteKind::Protocol,
-                    )
+                    self.descriptor_write_calls(*descriptor_ty, *receiver_ty)
+                        .all(|call| {
+                            match self.evaluate_descriptor_write(call, value_ty, emit_diagnostics) {
+                                Some(Definedness::AlwaysDefined) => true,
+                                // A protocol write capability requires the setter to be present
+                                // on every alternative.
+                                Some(Definedness::PossiblyUndefined) => {
+                                    if emit_diagnostics {
+                                        self.report(
+                                            AssignmentAttributeWriteDiagnostic::CannotAssign,
+                                        );
+                                    }
+                                    false
+                                }
+                                None => false,
+                            }
+                        })
                 }
                 None => {
                     self.infer_value(TypeContext::default(), emit_diagnostics);
@@ -801,13 +806,13 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
     ) -> bool {
         match requirement {
             ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. } => self
-                .evaluate_descriptor_write(
-                    *descriptor_ty,
-                    object_ty,
-                    value_ty,
-                    emit_diagnostics,
-                    DescriptorWriteKind::Ordinary,
-                ),
+                .descriptor_write_calls(*descriptor_ty, object_ty)
+                .all(|call| {
+                    // An ordinary descriptor only constrains the branch where its setter exists.
+                    // When absent, assignment can create an instance attribute.
+                    self.evaluate_descriptor_write(call, value_ty, emit_diagnostics)
+                        .is_some()
+                }),
             ExplicitAttributeWriteRequirement::AssignableTo { ty, .. } => {
                 let value_ty = self.infer_value(TypeContext::new(Some(*ty)), false);
                 self.check_type_pair(value_ty, *ty, emit_diagnostics)
@@ -815,46 +820,45 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         }
     }
 
-    fn evaluate_descriptor_write(
-        &mut self,
+    /// Keep alternatives separate so each caller can stop at its first unacceptable setter.
+    /// Resolve nested aliases without splitting intersection receivers or reordering alternatives.
+    fn descriptor_write_calls(
+        &self,
         descriptor_ty: Type<'db>,
         receiver_ty: Type<'db>,
-        value_ty: Type<'db>,
-        emit_diagnostics: bool,
-        kind: DescriptorWriteKind,
-    ) -> bool {
-        let env = self.builder.program_environment();
+    ) -> impl Iterator<Item = DescriptorSetCall<'db>> + use<'db> {
         let db = self.builder.db();
-        let descriptor_ty = descriptor_ty.resolve_type_alias(db);
-        if let Type::Union(union) = descriptor_ty {
-            for descriptor_ty in union.elements(db) {
-                if !self.evaluate_descriptor_write(
-                    *descriptor_ty,
-                    receiver_ty,
-                    value_ty,
-                    false,
-                    kind,
-                ) {
-                    if emit_diagnostics {
-                        self.evaluate_descriptor_write(
-                            *descriptor_ty,
-                            receiver_ty,
-                            value_ty,
-                            true,
-                            kind,
-                        );
-                    }
-                    return false;
+        let mut pending: SmallVec<[_; 1]> = smallvec![descriptor_ty];
+        std::iter::from_fn(move || {
+            while let Some(descriptor_ty) = pending.pop() {
+                let descriptor_ty = descriptor_ty.resolve_type_alias(db);
+                if let Type::Union(union) = descriptor_ty {
+                    pending.extend(union.elements(db).iter().rev().copied());
+                } else {
+                    return Some(DescriptorSetCall {
+                        descriptor_ty,
+                        receiver_ty,
+                    });
                 }
             }
-            return true;
-        }
+            None
+        })
+    }
 
-        let setter_result = DescriptorSetCall {
+    /// Return setter presence for a valid write, or report why the write is invalid and return `None`.
+    fn evaluate_descriptor_write(
+        &mut self,
+        call: DescriptorSetCall<'db>,
+        value_ty: Type<'db>,
+        emit_diagnostics: bool,
+    ) -> Option<Definedness> {
+        let env = self.builder.program_environment();
+        let db = self.builder.db();
+        let DescriptorSetCall {
             descriptor_ty,
             receiver_ty,
-        }
-        .try_call(db, env, value_ty);
+        } = call;
+        let setter_result = call.try_call(db, env, value_ty);
         // `Never` supports arbitrary operations only because there can be no runtime value to
         // mutate; it is not a concrete descriptor with a terminal setter.
         let setter_returns_never = !descriptor_ty.is_never()
@@ -868,18 +872,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             if emit_diagnostics {
                 self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
             }
-            return false;
+            return None;
         }
 
         match setter_result {
-            Ok(_) => true,
-            // A selected ordinary descriptor only constrains the branch where its setter exists.
-            // A protocol write capability requires the setter to be present on every branch.
-            Err(CallDunderError::PossiblyUnbound { .. })
-                if matches!(kind, DescriptorWriteKind::Ordinary) =>
-            {
-                true
-            }
+            Ok(_) => Some(Definedness::AlwaysDefined),
+            Err(CallDunderError::PossiblyUnbound { .. }) => Some(Definedness::PossiblyUndefined),
             Err(CallDunderError::CallError(kind, bindings, _)) => {
                 if emit_diagnostics {
                     self.report(AssignmentAttributeWriteDiagnostic::BadDunderSet {
@@ -887,13 +885,13 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         descriptor_ty,
                     });
                 }
-                false
+                None
             }
-            Err(CallDunderError::MethodNotAvailable | CallDunderError::PossiblyUnbound { .. }) => {
+            Err(CallDunderError::MethodNotAvailable) => {
                 if emit_diagnostics {
                     self.report(AssignmentAttributeWriteDiagnostic::CannotAssign);
                 }
-                false
+                None
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -8,8 +8,8 @@ use ruff_python_ast::name::Name;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::types::attribute_write::{
-    AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetterDomain,
-    ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
+    AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetCall,
+    DescriptorSetterDomain, ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
     InstanceAttributeWriteMember, ProtocolMemberWriteRequirement, attribute_write_requirement,
     descriptor_setter_domain,
 };
@@ -2591,23 +2591,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return self.never();
         }
         match requirement {
-            ExplicitAttributeWriteRequirement::Descriptor {
-                descriptor_ty,
-                setter_ty,
-                ..
-            } => {
+            ExplicitAttributeWriteRequirement::Descriptor { descriptor_ty, .. } => {
                 if let Some(property) = descriptor_ty.as_property_instance()
                     && let Some(set_type) = property_set_type(db, self.env, property, object_ty)
                 {
                     return self.check_type_pair(db, value_ty, set_type);
                 }
-                self.check_descriptor_property_write(
-                    db,
-                    *descriptor_ty,
-                    *setter_ty,
-                    object_ty,
-                    value_ty,
-                )
+                self.check_descriptor_property_write(db, *descriptor_ty, object_ty, value_ty)
             }
             ExplicitAttributeWriteRequirement::AssignableTo { ty, .. } => {
                 self.check_type_pair(db, value_ty, *ty)
@@ -2619,23 +2609,34 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         &self,
         db: &'db dyn Db,
         descriptor_ty: Type<'db>,
-        setter_ty: Type<'db>,
         object_ty: Type<'db>,
         value_ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
         let env = self.env;
-        if setter_ty
-            .try_call(
-                db,
-                env,
-                &CallArguments::positional([descriptor_ty, object_ty, Type::unknown()]),
-            )
-            .is_err()
-        {
+        let descriptor_ty = descriptor_ty.resolve_type_alias(db);
+        if let Type::Union(union) = descriptor_ty {
+            return union
+                .elements(db)
+                .iter()
+                .when_all(db, self.constraints, |descriptor_ty| {
+                    self.check_descriptor_property_write(db, *descriptor_ty, object_ty, value_ty)
+                });
+        }
+        let setter_call = DescriptorSetCall {
+            descriptor_ty,
+            receiver_ty: object_ty,
+        };
+        if matches!(
+            setter_call.try_call(db, env, Type::unknown()),
+            Err(CallDunderError::CallError(..) | CallDunderError::MethodNotAvailable)
+        ) {
             return self.never();
         }
+        let Place::Defined(DefinedPlace { ty: setter_ty, .. }) = setter_call.setter(db, env) else {
+            return self.never();
+        };
 
-        self.check_callable_write_parameter(db, setter_ty, 2, descriptor_ty, value_ty)
+        self.check_callable_write_parameter(db, setter_ty, 1, descriptor_ty, value_ty)
     }
 
     fn check_setattr_property_write(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -8,10 +8,10 @@ use ruff_python_ast::name::Name;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::types::attribute_write::{
-    AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetCall,
-    DescriptorSetterDomain, ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
+    AttributeWriteRequirement, ClassAttributeWriteMember, DescriptorSetterDomain,
+    ExplicitAttributeWriteRequirement, FallbackAttributeWriteRequirement,
     InstanceAttributeWriteMember, ProtocolMemberWriteRequirement, attribute_write_requirement,
-    descriptor_setter_domain,
+    descriptor_setter, descriptor_setter_domain,
 };
 use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::overrides::{VariableKind, effective_superclass_variable_kind};
@@ -2622,17 +2622,22 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     self.check_descriptor_property_write(db, *descriptor_ty, object_ty, value_ty)
                 });
         }
-        let setter_call = DescriptorSetCall {
-            descriptor_ty,
-            receiver_ty: object_ty,
-        };
         if matches!(
-            setter_call.try_call(db, env, Type::unknown()),
+            descriptor_ty.try_call_dunder_with_policy(
+                db,
+                env,
+                "__set__",
+                &mut CallArguments::positional([object_ty, Type::unknown()]),
+                TypeContext::default(),
+                MemberLookupPolicy::REQUIRE_CONCRETE,
+            ),
             Err(CallDunderError::CallError(..) | CallDunderError::MethodNotAvailable)
         ) {
             return self.never();
         }
-        let Place::Defined(DefinedPlace { ty: setter_ty, .. }) = setter_call.setter(db, env) else {
+        let Place::Defined(DefinedPlace { ty: setter_ty, .. }) =
+            descriptor_setter(db, env, descriptor_ty)
+        else {
             return self.never();
         };
 


### PR DESCRIPTION
## Summary

This PR properly models the fact that implicit `__set__` calls should also go through the descriptor protocol themselves, which handles edge cases like `__set__` methods that are `@staticmethod`s. We also add bidirectional inference support for (more) descriptor attribute assignments, which is where the ecosystem improvement comes from:

```py
class DataDescriptor:
    def __set__(self, instance: object, value: list[int | None]) -> None:
        pass

class Meta(type):
    x: DataDescriptor = DataDescriptor()

class C(metaclass=Meta): ...

C.x = [1]  # now accepted, previously an error (Expected `list[int | None]`, found `list[int]`)
```

closes https://github.com/astral-sh/ty/issues/4485.

## Ecosystem

25 false positives removed!

## Test Plan

New Markdown tests