### PR TITLE
[ty] Preserve callable identity across specialized types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -109,6 +109,122 @@ reveal_type(int_method is str_method)  # revealed: Literal[True]
 reveal_type(int_method is not str_method)  # revealed: Literal[False]
 ```
 
+## Bound method identity
+
+Accessing a method creates a bound method object, so even two references with the same bound method
+type need not identify the same object. A generic identity function and `functools.partial` both
+retain the bound method object passed to them. Its signature may be specialized by those calls, but
+that does not make an identity comparison with the saved method always false.
+
+```py
+from functools import partial
+from typing import TypeVar, final
+
+T = TypeVar("T")
+
+def identity(value: T) -> T:
+    return value
+
+class C:
+    @final
+    def method(self, value: int) -> int:
+        return value
+
+saved_method = C().method
+reveal_type(saved_method is saved_method)  # revealed: bool
+reveal_type(identity(saved_method) is saved_method)  # revealed: bool
+reveal_type(saved_method is identity(saved_method))  # revealed: bool
+reveal_type(identity(saved_method) is not saved_method)  # revealed: bool
+reveal_type(partial(saved_method).func is saved_method)  # revealed: bool
+
+reveal_type(identity(saved_method)(1))  # revealed: int
+
+class D:
+    @final
+    def method(self, value: int) -> int:
+        return value
+
+reveal_type(saved_method is D().method)  # revealed: Literal[False]
+```
+
+`NewType` constructors also leave the receiver object unchanged. Bound method types with different
+`NewType` tags on their receivers are statically disjoint, but can describe the same method object.
+
+```py
+from typing import NewType
+from ty_extensions import static_assert
+from ty_extensions._internal import TypeOf, is_disjoint_from
+
+Left = NewType("Left", C)
+Right = NewType("Right", C)
+
+static_assert(is_disjoint_from(TypeOf[Left(C()).method], TypeOf[Right(C()).method]))
+
+def compare(left: TypeOf[Left(C()).method], right: TypeOf[Right(C()).method]) -> None:
+    reveal_type(left is right)  # revealed: bool
+```
+
+## Identity of properties, saved method wrappers, and partials
+
+Specializing a generic class changes the static signatures of its property's accessor and unbound
+method. The property, a `functools.partial` of the method, and the wrappers saved on the class are
+each created once. Their views through `C[int]` and `C[str]` can therefore identify the same object.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from functools import partial
+
+class C[T]:
+    @property
+    def prop(self) -> T:
+        raise NotImplementedError
+
+    def method(self, value: T) -> T:
+        return value
+
+    callback = partial(method)
+    callback_call = callback.__call__
+    method_getter = method.__get__
+    method_caller = method.__call__
+
+reveal_type(C[int].prop is C[str].prop)  # revealed: bool
+reveal_type(C[int].prop is not C[str].prop)  # revealed: bool
+reveal_type(C[int].callback is C[str].callback)  # revealed: bool
+reveal_type(C[int].callback_call is C[str].callback_call)  # revealed: bool
+reveal_type(C[int].method_getter is C[str].method_getter)  # revealed: bool
+reveal_type(C[int].method_caller is C[str].method_caller)  # revealed: bool
+```
+
+The callable signatures remain specialized for calls. Different property definitions, partials
+wrapping different functions, and the two saved wrappers of `method` still describe distinct
+objects.
+
+```py
+class D:
+    @property
+    def prop(self) -> int:
+        return 0
+
+def other(value: int) -> int:
+    return value
+
+def another(value: int) -> int:
+    return value
+
+other_callback = partial(other)
+another_callback = partial(another)
+
+reveal_type(C[int].callback(C[int](), 1))  # revealed: int
+reveal_type(C[str].callback(C[str](), "value"))  # revealed: str
+reveal_type(C[int].prop is D.prop)  # revealed: Literal[False]
+reveal_type(other_callback is another_callback)  # revealed: Literal[False]
+reveal_type(C[int].method_getter is C[int].method_caller)  # revealed: Literal[False]
+```
+
 ## Identity comparisons with NewTypes
 
 Two variables cannot share the same memory address if they have disjoint nominal-instance backing

--- a/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/identity.md
@@ -111,10 +111,27 @@ reveal_type(int_method is not str_method)  # revealed: Literal[False]
 
 ## Bound method identity
 
-Accessing a method creates a bound method object, so even two references with the same bound method
-type need not identify the same object. A generic identity function and `functools.partial` both
-retain the bound method object passed to them. Its signature may be specialized by those calls, but
-that does not make an identity comparison with the saved method always false.
+Accessing a method on a class instance creates a new bound method object. Since multiple different
+instances can usually inhabit any given nominal-instance type, two variables with the same
+bound-method type do not necessarily occupy the same memory address at runtime:
+
+```py
+from typing import final
+
+class C:
+    @final
+    def method(self, value: int) -> int:
+        return value
+
+saved_method = C().method
+
+reveal_type(C().method is C().method)  # revealed: bool
+reveal_type(saved_method is saved_method)  # revealed: bool
+```
+
+A generic identity function and `functools.partial` both retain the bound-method object passed to
+them. The method's signature may be specialized by those calls, but that does not make an identity
+comparison with the saved method always false:
 
 ```py
 from functools import partial
@@ -125,17 +142,25 @@ T = TypeVar("T")
 def identity(value: T) -> T:
     return value
 
-class C:
-    @final
-    def method(self, value: int) -> int:
-        return value
-
-saved_method = C().method
-reveal_type(saved_method is saved_method)  # revealed: bool
 reveal_type(identity(saved_method) is saved_method)  # revealed: bool
+reveal_type(identity(saved_method) is C().method)  # revealed: bool
 reveal_type(saved_method is identity(saved_method))  # revealed: bool
+reveal_type(C().method is identity(saved_method))  # revealed: bool
+
 reveal_type(identity(saved_method) is not saved_method)  # revealed: bool
+reveal_type(identity(saved_method) is not C().method)  # revealed: bool
+reveal_type(saved_method is not identity(saved_method))  # revealed: bool
+reveal_type(C().method is not identity(saved_method))  # revealed: bool
+
 reveal_type(partial(saved_method).func is saved_method)  # revealed: bool
+reveal_type(partial(saved_method).func is C().method)  # revealed: bool
+reveal_type(saved_method is partial(saved_method).func)  # revealed: bool
+reveal_type(C().method is partial(saved_method).func)  # revealed: bool
+
+reveal_type(partial(saved_method).func is not saved_method)  # revealed: bool
+reveal_type(partial(saved_method).func is not C().method)  # revealed: bool
+reveal_type(saved_method is not partial(saved_method).func)  # revealed: bool
+reveal_type(C().method is not partial(saved_method).func)  # revealed: bool
 
 reveal_type(identity(saved_method)(1))  # revealed: int
 
@@ -145,6 +170,9 @@ class D:
         return value
 
 reveal_type(saved_method is D().method)  # revealed: Literal[False]
+reveal_type(C().method is D().method)  # revealed: Literal[False]
+reveal_type(saved_method is not D().method)  # revealed: Literal[True]
+reveal_type(C().method is not D().method)  # revealed: Literal[True]
 ```
 
 `NewType` constructors also leave the receiver object unchanged. Bound method types with different
@@ -166,9 +194,12 @@ def compare(left: TypeOf[Left(C()).method], right: TypeOf[Right(C()).method]) ->
 
 ## Identity of properties, saved method wrappers, and partials
 
-Specializing a generic class changes the static signatures of its property's accessor and unbound
-method. The property, a `functools.partial` of the method, and the wrappers saved on the class are
-each created once. Their views through `C[int]` and `C[str]` can therefore identify the same object.
+If a generic class defines a property `prop`, specializing that class changes the static signatures
+of `prop`'s accessor and the underlying function(s) wrapped by the property method.
+
+In the following example, the property, a `functools.partial` of the method, and the wrappers saved
+on the class are each created once. Their views through `C[int]` and `C[str]` can therefore identify
+the same object.
 
 ```toml
 [environment]
@@ -199,7 +230,7 @@ reveal_type(C[int].method_getter is C[str].method_getter)  # revealed: bool
 reveal_type(C[int].method_caller is C[str].method_caller)  # revealed: bool
 ```
 
-The callable signatures remain specialized for calls. Different property definitions, partials
+The callable signatures remain specialized for calls. Different property definitions, `partial`s
 wrapping different functions, and the two saved wrappers of `method` still describe distinct
 objects.
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -81,8 +81,16 @@ def overlapping_generic_types(integers: tuple[int, ...], strings: tuple[str, ...
 
 ## `is` with `functools.partial`
 
-A partial saved on a generic class is the same object through different specializations of that
-class. An identity check with one view must preserve the other view's argument types.
+In the following example, the class body creates `callback` only once, so `C[int].callback` and
+`C[str].callback` refer to a single `functools.partial` object at a single runtime memory address.
+Each specialization gives that object a different static call signature, however, leading to ty
+treating the two "views" as inhabiting different types.
+
+Assigning `C[int].callback` to the local `callback` means that calls through this variable use the
+`T = int` signature: `callback(C[int](), ...)` needs an `int` as its second argument. Looking up
+`C[str].callback` uses `T = str` to describe calls through that expression. The identity check shows
+that the expressions can refer to the same partial; it does not make the local `callback` accept the
+second expression's `str` argument type. The string call below is therefore still an error.
 
 ```toml
 [environment]
@@ -106,7 +114,7 @@ if callback is C[str].callback:
 ```
 
 Passing a saved partial or its `__call__` wrapper through a generic identity function also preserves
-its call signature on the true branch.
+its call signature on the if-true branch.
 
 ```py
 from typing import TypeVar
@@ -564,6 +572,16 @@ def excluded_newtype_in_unions(
     if value is other:
         reveal_type(value)  # revealed: int & ~UserId
         reveal_type(other)  # revealed: UserId
+```
+
+Excluding a union containing the tag still permits identity with a value carrying that tag. The
+other union member describes a different runtime type.
+
+```py
+def excluded_union(value: Not[UserId | bytes], other: UserId) -> None:
+    reveal_type(value is other)  # revealed: bool
+    if value is other:
+        reveal_type(value)  # revealed: int & ~UserId
 ```
 
 Unlike a negated `NewType`, a negated runtime class genuinely rules out identity with its instances.

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -79,6 +79,57 @@ def overlapping_generic_types(integers: tuple[int, ...], strings: tuple[str, ...
         reveal_type(strings)  # revealed: tuple[str, ...] & tuple[int, ...]
 ```
 
+## `is` with `functools.partial`
+
+A partial saved on a generic class is the same object through different specializations of that
+class. An identity check with one view must preserve the other view's argument types.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from functools import partial
+
+class C[T]:
+    def method(self, value: T) -> T:
+        return value
+
+    callback = partial(method)
+
+callback = C[int].callback
+if callback is C[str].callback:
+    reveal_type(callback)  # revealed: partial[(self, value: int) -> int]
+    reveal_type(callback(C[int](), 1))  # revealed: int
+    callback(C[int](), "wrong")  # error: [invalid-argument-type] "Expected `int`"
+```
+
+Passing a saved partial or its `__call__` wrapper through a generic identity function also preserves
+its call signature on the true branch.
+
+```py
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def identity(value: T) -> T:
+    return value
+
+def double(value: int) -> int:
+    return value * 2
+
+saved = partial(double)
+if saved is identity(saved):
+    reveal_type(saved)  # revealed: partial[(value: int) -> int]
+    saved("wrong")  # error: [invalid-argument-type] "Expected `int`"
+
+saved_call = saved.__call__
+if saved_call is identity(saved_call):
+    reveal_type(saved_call)  # revealed: (value: int) -> int
+    saved_call("wrong")  # error: [invalid-argument-type] "Expected `int`"
+```
+
 ## `is` with a `NewType`
 
 A `NewType` constructor returns its argument unchanged, so its tag belongs to one static view rather

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -27,6 +27,15 @@ impl<'db> Type<'db> {
     /// Upcast `self` to a type that conservatively describes its possible runtime objects in an
     /// identity comparison.
     ///
+    /// Python's [`is` operator][is operator] tests whether two expressions refer to the same
+    /// object. An object's identity is distinct from its type and value, as described in
+    /// [Python's data model][object identity].
+    /// We cannot inspect object identities during static analysis, but the operands' types can
+    /// tell us whether they could refer to the same object. For example, two variables of type
+    /// `Literal[1]` [might refer to the same integer object][literal identity];
+    /// variables of types `Literal[1]` and `Literal[2]` cannot, because one integer object cannot
+    /// have both values.
+    ///
     /// A `NewType` constructor returns its argument unchanged, so its tag can differ between two
     /// views of the same runtime object at the same runtime memory address. We therefore upcast a
     /// `NewType` to its concrete base.
@@ -37,10 +46,12 @@ impl<'db> Type<'db> {
     ///
     /// Function signature substitutions can likewise differ between views of the same function,
     /// bound method, property, or saved function wrapper. We therefore use the underlying function
-    /// literal without substituted signatures for identity. A bound method's `__self__` can also
-    /// have different static tags across views; we upcast its type while keeping the receiver used
-    /// for signature specialization. And a precise `functools.partial` stores a specialized
-    /// callable signature, but its wrapped function remains the same object across specializations.
+    /// literal without substituted signatures for identity. A [bound method][instance methods]
+    /// holds a reference to its underlying function (`__func__`) and its receiver (`__self__`).
+    /// The receiver can have different static tags across views; we upcast its type for the
+    /// comparison while keeping the method's specialized signature for calls. And a precise
+    /// `functools.partial` stores a specialized callable signature, but its wrapped function
+    /// remains the same object across specializations.
     ///
     /// We preserve negations that restrict the runtime memory addresses the object could possibly
     /// occupy (negations relating to runtime class or runtime value), such as `~None`, `~SomeClass`,
@@ -57,6 +68,11 @@ impl<'db> Type<'db> {
     /// We use this upcast both to decide whether identity is possible and to narrow the other
     /// operand when it succeeds. Each operand retains its own existing tags, substituted
     /// signatures, and type-variable relationships when the resulting constraint is applied.
+    ///
+    /// [is operator]: https://docs.python.org/3/reference/expressions.html#identity-comparisons
+    /// [object identity]: https://docs.python.org/3/reference/datamodel.html#objects-values-and-types
+    /// [literal identity]: https://docs.python.org/3/reference/expressions.html#literals-and-object-identity
+    /// [instance methods]: https://docs.python.org/3/reference/datamodel.html#instance-methods
     pub(crate) fn identity_comparison_type(
         self,
         db: &'db dyn Db,
@@ -64,17 +80,27 @@ impl<'db> Type<'db> {
     ) -> Type<'db> {
         struct IdentityComparisonUpcasting;
 
-        /// Whether an excluded type can still rule out identity with another static view of the
-        /// same runtime object.
+        /// Whether a negated type can still rule out identity with another variable.
         ///
-        /// An identity comparison can involve two static views of one runtime object at a single
-        /// runtime memory address. Upcasting the positive types accounts for this, but an
-        /// exclusion such as `~T` can only be kept if it still holds for the other view.
-        /// Excluding `int` rules out all runtime instances of `int`; excluding a `NewType` tag
-        /// may only rule out one static view of all runtime instances of `int`.
+        /// Two variables with different static types can refer to one object at the same runtime
+        /// memory address. Upcasting positive types accounts for this, but a negation such as
+        /// `~T` can only be kept if it also rules out the object at that address. A `NewType`
+        /// constructor returns its argument unchanged despite giving the result a new static type:
         ///
-        /// String literals require special handling due to the `LiteralString` types: excluding
-        /// a string literal also depends on whether literal-string origin is known.
+        /// ```python
+        /// from typing import NewType, reveal_type
+        ///
+        /// UserId = NewType("UserId", int)
+        ///
+        /// def compare(not_user_id: ~UserId, not_int: ~int, tagged: UserId) -> None:
+        ///     reveal_type(not_user_id is tagged)  # bool
+        ///     reveal_type(not_int is tagged)  # Literal[False]
+        /// ```
+        ///
+        /// `~UserId` only rules out the `NewType` tag; `~int` rules out all runtime instances of
+        /// `int`, including those returned by `UserId`. String literals require special handling
+        /// due to the `LiteralString` type: negating a string literal also depends on whether
+        /// literal-string origin is known.
         ///
         /// The variants are ordered from most to least reusable so `max` can combine their
         /// requirements for compound types.
@@ -95,8 +121,8 @@ impl<'db> Type<'db> {
             /// ```
             Stable,
 
-            /// A string-literal exclusion only rules out the runtime string when the containing
-            /// intersection also establishes literal-string origin:
+            /// A negation such as `~Literal["hello"]` only rules out the runtime string when the
+            /// containing intersection also establishes literal-string origin:
             ///
             /// ```python
             /// from typing import Literal, reveal_type
@@ -137,9 +163,22 @@ impl<'db> Type<'db> {
             }
         }
 
-        /// The type to use for identity checks, together with whether an exclusion of the
-        /// original type remains valid for another static view of the same object. For example,
-        /// upcasting `UserId` produces `int`, but `Not[UserId]` cannot be retained.
+        /// The type to use for identity checks, together with whether negating the original type
+        /// still rules out the same runtime object. A `NewType` constructor returns its argument
+        /// unchanged, so both an `int` and a `UserId` variable can refer to that integer:
+        ///
+        /// ```python
+        /// from typing import NewType, reveal_type
+        ///
+        /// UserId = NewType("UserId", int)
+        ///
+        /// def compare(plain: int, excluded: ~UserId, tagged: UserId) -> None:
+        ///     reveal_type(plain is tagged)  # bool
+        ///     reveal_type(excluded is tagged)  # bool
+        /// ```
+        ///
+        /// Upcasting `UserId` produces `int` for the positive comparison; `~UserId` cannot be
+        /// retained because it excludes no integer objects at runtime.
         #[derive(Clone, Copy, Debug)]
         struct UpcastResult<'db> {
             ty: Type<'db>,
@@ -167,7 +206,7 @@ impl<'db> Type<'db> {
         /// receivers, and accessors.
         ///
         /// [`TypeTransformer`] returns the original type on a recursive revisit; if
-        /// no negation rule has been computed for that type, its exclusion cannot
+        /// no negation rule has been computed for that type, its negation cannot
         /// be retained.
         #[derive(Default)]
         struct UpcastingVisitor<'db> {
@@ -388,7 +427,9 @@ impl<'db> Type<'db> {
                         upcast(
                             db,
                             env,
-                            typevar.require_bound_or_constraints(db, env).as_type(db, env),
+                            typevar
+                                .require_bound_or_constraints(db, env)
+                                .as_type(db, env),
                             visitor,
                         )
                         .ty,

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -11,11 +11,13 @@ use crate::types::cyclic::CycleDetector;
 use crate::types::equality::{
     ComparisonSoundnessPolicy, TupleEqualityEvaluator, equality_truthiness, inequality_truthiness,
 };
+use crate::types::known_instance::{FunctoolsPartialInstance, InternedType};
 use crate::types::tuple::{Tuple, TupleSpec};
 use crate::types::{
-    DynamicType, FunctionType, IntersectionBuilder, IntersectionType, KnownClass,
-    KnownInstanceType, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type,
-    TypeContext, TypeTransformer, TypeVarBoundOrConstraints, UnionBuilder,
+    BoundMethodType, CallableType, DynamicType, FunctionType, IntersectionBuilder,
+    IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueType,
+    LiteralValueTypeKind, MemberLookupPolicy, PropertyInstanceType, Type, TypeContext,
+    TypeTransformer, TypeVarBoundOrConstraints, UnionBuilder,
 };
 use ty_python_core::Truthiness;
 
@@ -29,8 +31,12 @@ impl<'db> Type<'db> {
     /// commitments such as `list[int]` and `list[str]` without some other code already being
     /// unsound.
     ///
-    /// Function signature substitutions can likewise differ between views of the same function
-    /// object. Use the underlying function literal without substituted signatures for identity.
+    /// Function signature substitutions can likewise differ between views of the same function,
+    /// bound method, property, or saved function wrapper. Use the underlying function literal
+    /// without substituted signatures for identity. A bound method's `__self__` can also have
+    /// different static tags across views; upcast its type while keeping the receiver used for
+    /// signature specialization. A precise `functools.partial` stores a specialized callable
+    /// signature, but its wrapped function remains the same object across specializations.
     ///
     /// Preserve negations that constrain the object itself, such as `~None`, `~SomeClass`, and
     /// `~Literal[1]`. A `NewType` tag, function signature, type-variable selection, type-guard proof,
@@ -53,6 +59,54 @@ impl<'db> Type<'db> {
     ) -> Type<'db> {
         struct IdentityComparisonUpcasting;
 
+        fn unspecialized_function<'db>(
+            db: &'db dyn Db,
+            function: FunctionType<'db>,
+        ) -> FunctionType<'db> {
+            FunctionType::new(db, function.literal(db), None)
+        }
+
+        fn upcast_property<'db>(
+            db: &'db dyn Db,
+            env: &ProgramEnvironment<'db>,
+            property: PropertyInstanceType<'db>,
+            visitor: &TypeTransformer<'db, IdentityComparisonUpcasting>,
+        ) -> PropertyInstanceType<'db> {
+            property.with_accessors(
+                db,
+                property.getter(db).map(|ty| upcast(db, env, ty, visitor)),
+                property.setter(db).map(|ty| upcast(db, env, ty, visitor)),
+                property.deleter(db).map(|ty| upcast(db, env, ty, visitor)),
+            )
+        }
+
+        fn upcast_partial<'db>(
+            db: &'db dyn Db,
+            env: &ProgramEnvironment<'db>,
+            partial: FunctoolsPartialInstance<'db>,
+        ) -> Option<FunctoolsPartialInstance<'db>> {
+            // A partial's wrapped function is fixed, but its reduced signature can differ between
+            // views. A structural callable does not identify a particular wrapped function.
+            let Type::FunctionLiteral(function) =
+                partial.wrapped(db).inner(db).resolve_type_alias(db)
+            else {
+                return None;
+            };
+            let Type::Callable(upper_callable) =
+                Type::Callable(CallableType::unknown(db)).top_materialization(db, env)
+            else {
+                return None;
+            };
+            Some(FunctoolsPartialInstance::new(
+                db,
+                InternedType::new(
+                    db,
+                    Type::FunctionLiteral(unspecialized_function(db, function)),
+                ),
+                upper_callable,
+            ))
+        }
+
         fn upcast<'db>(
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,
@@ -67,7 +121,66 @@ impl<'db> Type<'db> {
                     upcast(db, env, newtype.concrete_base_type(db), visitor)
                 }
                 Type::FunctionLiteral(function) => {
-                    Type::FunctionLiteral(FunctionType::new(db, function.literal(db), None))
+                    Type::FunctionLiteral(unspecialized_function(db, function))
+                }
+                Type::BoundMethod(method) => visitor.visit_type(db, ty, || {
+                    Type::BoundMethod(BoundMethodType::new(
+                        db,
+                        unspecialized_function(db, method.function(db)),
+                        upcast(db, env, method.self_instance(db), visitor),
+                        method.signature_receiver(db),
+                    ))
+                }),
+                Type::KnownBoundMethod(method) => visitor.visit_type(db, ty, || {
+                    Type::KnownBoundMethod(match method {
+                        KnownBoundMethodType::FunctionTypeDunderGet(function) => {
+                            KnownBoundMethodType::FunctionTypeDunderGet(unspecialized_function(
+                                db, function,
+                            ))
+                        }
+                        KnownBoundMethodType::FunctionTypeDunderCall(function) => {
+                            KnownBoundMethodType::FunctionTypeDunderCall(unspecialized_function(
+                                db, function,
+                            ))
+                        }
+                        KnownBoundMethodType::PropertyDunderGet(property) => {
+                            KnownBoundMethodType::PropertyDunderGet(upcast_property(
+                                db, env, property, visitor,
+                            ))
+                        }
+                        KnownBoundMethodType::PropertyDunderSet(property) => {
+                            KnownBoundMethodType::PropertyDunderSet(upcast_property(
+                                db, env, property, visitor,
+                            ))
+                        }
+                        KnownBoundMethodType::PropertyDunderDelete(property) => {
+                            KnownBoundMethodType::PropertyDunderDelete(upcast_property(
+                                db, env, property, visitor,
+                            ))
+                        }
+                        _ => method,
+                    })
+                }),
+                Type::PropertyInstance(property) => visitor.visit_type(db, ty, || {
+                    Type::PropertyInstance(upcast_property(db, env, property, visitor))
+                }),
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                    upcast_partial(db, env, partial).map_or_else(
+                        || {
+                            KnownClass::FunctoolsPartial
+                                .to_instance(db, env)
+                                .top_materialization(db, env)
+                        },
+                        |partial| Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
+                    )
+                }
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(partial)) => {
+                    upcast_partial(db, env, partial).map_or_else(
+                        || KnownClass::MethodWrapperType.to_instance(db, env),
+                        |partial| {
+                            Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(partial))
+                        },
+                    )
                 }
                 Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
                     let bound_or_constraints = typevar.require_bound_or_constraints(db, env);
@@ -93,6 +206,19 @@ impl<'db> Type<'db> {
                         match element.resolve_type_alias(db) {
                             Type::NewTypeInstance(_)
                             | Type::FunctionLiteral(_)
+                            | Type::BoundMethod(_)
+                            | Type::KnownBoundMethod(
+                                KnownBoundMethodType::FunctionTypeDunderGet(_)
+                                | KnownBoundMethodType::FunctionTypeDunderCall(_)
+                                | KnownBoundMethodType::PropertyDunderGet(_)
+                                | KnownBoundMethodType::PropertyDunderSet(_)
+                                | KnownBoundMethodType::PropertyDunderDelete(_),
+                            )
+                            | Type::PropertyInstance(_)
+                            | Type::KnownInstance(
+                                KnownInstanceType::FunctoolsPartial(_)
+                                | KnownInstanceType::FunctoolsPartialCall(_),
+                            )
                             | Type::TypeVar(_)
                             | Type::TypeIs(_)
                             | Type::TypeGuard(_) => continue,

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -1,7 +1,9 @@
 use crate::Db;
 use ruff_python_ast as ast;
 use ruff_text_size::TextRange;
+use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
+use std::cell::RefCell;
 
 use crate::ProgramEnvironment;
 use crate::types::call::{CallArguments, CallDunderError};
@@ -26,30 +28,33 @@ impl<'db> Type<'db> {
     /// identity comparison.
     ///
     /// A `NewType` constructor returns its argument unchanged, so its tag can differ between two
-    /// views of the same object: upcast a `NewType` to its concrete base. In contrast, preserve
-    /// invariant generic arguments because the same mutable object cannot satisfy incompatible
-    /// commitments such as `list[int]` and `list[str]` without some other code already being
-    /// unsound.
+    /// views of the same runtime object at the same runtime memory address. We therefore upcast a
+    /// `NewType` to its concrete base.
+    ///
+    /// By contrast, we preserve invariant generic arguments because the same mutable object cannot
+    /// satisfy incompatible commitments such as `list[int]` and `list[str]` without some other
+    /// code already being unsound.
     ///
     /// Function signature substitutions can likewise differ between views of the same function,
-    /// bound method, property, or saved function wrapper. Use the underlying function literal
-    /// without substituted signatures for identity. A bound method's `__self__` can also have
-    /// different static tags across views; upcast its type while keeping the receiver used for
-    /// signature specialization. A precise `functools.partial` stores a specialized callable
-    /// signature, but its wrapped function remains the same object across specializations.
+    /// bound method, property, or saved function wrapper. We therefore use the underlying function
+    /// literal without substituted signatures for identity. A bound method's `__self__` can also
+    /// have different static tags across views; we upcast its type while keeping the receiver used
+    /// for signature specialization. And a precise `functools.partial` stores a specialized
+    /// callable signature, but its wrapped function remains the same object across specializations.
     ///
-    /// Preserve negations that constrain the object itself, such as `~None`, `~SomeClass`, and
-    /// `~Literal[1]`. A `NewType` tag, function signature, type-variable selection, type-guard proof,
-    /// or literal-string origin can differ between views. A negated string literal excludes its
-    /// runtime value only when another constraint already establishes that the string has literal
-    /// origin.
+    /// We preserve negations that restrict the runtime memory addresses the object could possibly
+    /// occupy (negations relating to runtime class or runtime value), such as `~None`, `~SomeClass`,
+    /// and `~Literal[1]`. A `NewType` tag, function signature, type-variable selection, type-guard
+    /// proof, or literal-string origin can differ between views of the same memory address, however,
+    /// so these negations are discarded. String literals require special handling due to the
+    /// `LiteralString` type: a negated string literal excludes its runtime value only when another
+    /// constraint already establishes that the string has literal origin.
     ///
     /// A type variable can also hide a `NewType` tag: even a variable bounded by `int` can be
-    /// instantiated as an integer `NewType`. Expand variables to their upcast bounds or constraints
-    /// instead of transferring that potentially tagged relationship; an unbounded variable becomes
-    /// `object`.
+    /// instantiated as an integer `NewType`. We therefore expand `TypeVar`s to their upcast bounds
+    /// or constraints instead of transferring that potentially tagged relationship.
     ///
-    /// Use this upcast both to decide whether identity is possible and to narrow the other
+    /// We use this upcast both to decide whether identity is possible and to narrow the other
     /// operand when it succeeds. Each operand retains its own existing tags, substituted
     /// signatures, and type-variable relationships when the resulting constraint is applied.
     pub(crate) fn identity_comparison_type(
@@ -58,6 +63,143 @@ impl<'db> Type<'db> {
         env: &ProgramEnvironment<'db>,
     ) -> Type<'db> {
         struct IdentityComparisonUpcasting;
+
+        /// Whether an excluded type can still rule out identity with another static view of the
+        /// same runtime object.
+        ///
+        /// An identity comparison can involve two static views of one runtime object at a single
+        /// runtime memory address. Upcasting the positive types accounts for this, but an
+        /// exclusion such as `~T` can only be kept if it still holds for the other view.
+        /// Excluding `int` rules out all runtime instances of `int`; excluding a `NewType` tag
+        /// may only rule out one static view of all runtime instances of `int`.
+        ///
+        /// String literals require special handling due to the `LiteralString` types: excluding
+        /// a string literal also depends on whether literal-string origin is known.
+        ///
+        /// The variants are ordered from most to least reusable so `max` can combine their
+        /// requirements for compound types.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+        enum NegativeRetention {
+            /// The negation describes a runtime class or value, e.g. `~int` or `~Literal[2]`:
+            /// the first excludes all instances of `int`, while the second rules out all objects
+            /// whose `__class__` is exactly `int` which compare equal to `2`:
+            ///
+            /// ```python
+            /// from typing import NewType, reveal_type
+            /// from ty_extensions import Not
+            ///
+            /// UserId = NewType("UserId", int)
+            ///
+            /// def compare(value: Not[int], tagged: UserId) -> None:
+            ///     reveal_type(value is tagged)  # Literal[False]
+            /// ```
+            Stable,
+
+            /// A string-literal exclusion only rules out the runtime string when the containing
+            /// intersection also establishes literal-string origin:
+            ///
+            /// ```python
+            /// from typing import Literal, reveal_type
+            /// from typing_extensions import LiteralString
+            /// from ty_extensions import Intersection, Not
+            ///
+            /// def without_origin(value: Not[Literal["hello"]]) -> None:
+            ///     reveal_type(value is "hello")  # bool
+            ///
+            /// def with_origin(value: Intersection[LiteralString, Not[Literal["hello"]]]) -> None:
+            ///     reveal_type(value is "hello")  # Literal[False]
+            /// ```
+            RequiresLiteralStringOrigin,
+
+            /// The negation can describe another static view of the same object. A `NewType`
+            /// constructor returns its integer argument unchanged, so excluding its tag does not
+            /// exclude the integer at runtime:
+            ///
+            /// ```python
+            /// from typing import NewType, reveal_type
+            /// from ty_extensions import Not
+            ///
+            /// UserId = NewType("UserId", int)
+            ///
+            /// def compare(value: Not[UserId], tagged: UserId) -> None:
+            ///     reveal_type(value is tagged)  # bool
+            /// ```
+            Unstable,
+        }
+
+        impl NegativeRetention {
+            fn can_retain(self, has_literal_string_origin: bool) -> bool {
+                match self {
+                    Self::Stable => true,
+                    Self::RequiresLiteralStringOrigin => has_literal_string_origin,
+                    Self::Unstable => false,
+                }
+            }
+        }
+
+        /// The type to use for identity checks, together with whether an exclusion of the
+        /// original type remains valid for another static view of the same object. For example,
+        /// upcasting `UserId` produces `int`, but `Not[UserId]` cannot be retained.
+        #[derive(Clone, Copy, Debug)]
+        struct UpcastResult<'db> {
+            ty: Type<'db>,
+            negative_retention: NegativeRetention,
+        }
+
+        impl<'db> UpcastResult<'db> {
+            fn new(ty: Type<'db>, negative_retention: NegativeRetention) -> Self {
+                Self {
+                    ty,
+                    negative_retention,
+                }
+            }
+
+            fn stable(ty: Type<'db>) -> Self {
+                Self::new(ty, NegativeRetention::Stable)
+            }
+
+            fn unstable(ty: Type<'db>) -> Self {
+                Self::new(ty, NegativeRetention::Unstable)
+            }
+        }
+
+        /// A visitor which caches both parts of an upcast while traversing aliases,
+        /// receivers, and accessors.
+        ///
+        /// [`TypeTransformer`] returns the original type on a recursive revisit; if
+        /// no negation rule has been computed for that type, its exclusion cannot
+        /// be retained.
+        #[derive(Default)]
+        struct UpcastingVisitor<'db> {
+            types: TypeTransformer<'db, IdentityComparisonUpcasting>,
+            negative_retention: RefCell<FxHashMap<Type<'db>, NegativeRetention>>,
+        }
+
+        fn visit_type<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            visitor: &UpcastingVisitor<'db>,
+            compute: impl FnOnce() -> UpcastResult<'db>,
+        ) -> UpcastResult<'db> {
+            let upcast_type = visitor.types.visit_type(db, ty, || {
+                let upcast_result = compute();
+                visitor
+                    .negative_retention
+                    .borrow_mut()
+                    .insert(ty, upcast_result.negative_retention);
+                upcast_result.ty
+            });
+            UpcastResult::new(
+                upcast_type,
+                visitor
+                    .negative_retention
+                    .borrow()
+                    .get(&ty)
+                    .copied()
+                    // A recursive visit returns the original type without an upcast result.
+                    .unwrap_or(NegativeRetention::Unstable),
+            )
+        }
 
         fn unspecialized_function<'db>(
             db: &'db dyn Db,
@@ -70,13 +212,19 @@ impl<'db> Type<'db> {
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,
             property: PropertyInstanceType<'db>,
-            visitor: &TypeTransformer<'db, IdentityComparisonUpcasting>,
+            visitor: &UpcastingVisitor<'db>,
         ) -> PropertyInstanceType<'db> {
             property.with_accessors(
                 db,
-                property.getter(db).map(|ty| upcast(db, env, ty, visitor)),
-                property.setter(db).map(|ty| upcast(db, env, ty, visitor)),
-                property.deleter(db).map(|ty| upcast(db, env, ty, visitor)),
+                property
+                    .getter(db)
+                    .map(|ty| upcast(db, env, ty, visitor).ty),
+                property
+                    .setter(db)
+                    .map(|ty| upcast(db, env, ty, visitor).ty),
+                property
+                    .deleter(db)
+                    .map(|ty| upcast(db, env, ty, visitor).ty),
             )
         }
 
@@ -111,83 +259,149 @@ impl<'db> Type<'db> {
             db: &'db dyn Db,
             env: &ProgramEnvironment<'db>,
             ty: Type<'db>,
-            visitor: &TypeTransformer<'db, IdentityComparisonUpcasting>,
-        ) -> Type<'db> {
+            visitor: &UpcastingVisitor<'db>,
+        ) -> UpcastResult<'db> {
             match ty {
-                Type::TypeAlias(alias) => {
-                    visitor.visit_type(db, ty, || upcast(db, env, alias.value_type(db), visitor))
-                }
-                Type::NewTypeInstance(newtype) => {
-                    upcast(db, env, newtype.concrete_base_type(db), visitor)
-                }
-                Type::FunctionLiteral(function) => {
-                    Type::FunctionLiteral(unspecialized_function(db, function))
-                }
-                Type::BoundMethod(method) => visitor.visit_type(db, ty, || {
-                    Type::BoundMethod(BoundMethodType::new(
+                Type::TypeAlias(alias) => visit_type(db, ty, visitor, || {
+                    upcast(db, env, alias.value_type(db), visitor)
+                }),
+                Type::NewTypeInstance(newtype) => visit_type(db, ty, visitor, || {
+                    UpcastResult::unstable(
+                        upcast(db, env, newtype.concrete_base_type(db), visitor).ty,
+                    )
+                }),
+                Type::FunctionLiteral(function) => UpcastResult::unstable(Type::FunctionLiteral(
+                    unspecialized_function(db, function),
+                )),
+                Type::BoundMethod(method) => visit_type(db, ty, visitor, || {
+                    UpcastResult::unstable(Type::BoundMethod(BoundMethodType::new(
                         db,
                         unspecialized_function(db, method.function(db)),
-                        upcast(db, env, method.self_instance(db), visitor),
+                        upcast(db, env, method.self_instance(db), visitor).ty,
                         method.signature_receiver(db),
-                    ))
+                    )))
                 }),
-                Type::KnownBoundMethod(method) => visitor.visit_type(db, ty, || {
-                    Type::KnownBoundMethod(match method {
-                        KnownBoundMethodType::FunctionTypeDunderGet(function) => {
+                Type::KnownBoundMethod(method) => visit_type(db, ty, visitor, || {
+                    let (method, retention) = match method {
+                        KnownBoundMethodType::FunctionTypeDunderGet(function) => (
                             KnownBoundMethodType::FunctionTypeDunderGet(unspecialized_function(
                                 db, function,
-                            ))
-                        }
-                        KnownBoundMethodType::FunctionTypeDunderCall(function) => {
+                            )),
+                            NegativeRetention::Unstable,
+                        ),
+                        KnownBoundMethodType::FunctionTypeDunderCall(function) => (
                             KnownBoundMethodType::FunctionTypeDunderCall(unspecialized_function(
                                 db, function,
-                            ))
-                        }
-                        KnownBoundMethodType::PropertyDunderGet(property) => {
+                            )),
+                            NegativeRetention::Unstable,
+                        ),
+                        KnownBoundMethodType::PropertyDunderGet(property) => (
                             KnownBoundMethodType::PropertyDunderGet(upcast_property(
                                 db, env, property, visitor,
-                            ))
-                        }
-                        KnownBoundMethodType::PropertyDunderSet(property) => {
+                            )),
+                            NegativeRetention::Unstable,
+                        ),
+                        KnownBoundMethodType::PropertyDunderSet(property) => (
                             KnownBoundMethodType::PropertyDunderSet(upcast_property(
                                 db, env, property, visitor,
-                            ))
-                        }
-                        KnownBoundMethodType::PropertyDunderDelete(property) => {
+                            )),
+                            NegativeRetention::Unstable,
+                        ),
+                        KnownBoundMethodType::PropertyDunderDelete(property) => (
                             KnownBoundMethodType::PropertyDunderDelete(upcast_property(
                                 db, env, property, visitor,
-                            ))
+                            )),
+                            NegativeRetention::Unstable,
+                        ),
+                        KnownBoundMethodType::StrStartswith(_)
+                        | KnownBoundMethodType::ConstraintSetLowerBound
+                        | KnownBoundMethodType::ConstraintSetUpperBound
+                        | KnownBoundMethodType::ConstraintSetEquality
+                        | KnownBoundMethodType::ConstraintSetRange
+                        | KnownBoundMethodType::ConstraintSetAlways
+                        | KnownBoundMethodType::ConstraintSetNever
+                        | KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(_)
+                        | KnownBoundMethodType::ConstraintSetSatisfies(_)
+                        | KnownBoundMethodType::ConstraintSetExists(_)
+                        | KnownBoundMethodType::ConstraintSetForAll(_)
+                        | KnownBoundMethodType::ConstraintSetSolutionsFor(_)
+                        | KnownBoundMethodType::ConstraintSetSolutions(_)
+                        | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {
+                            (method, NegativeRetention::Stable)
                         }
-                        _ => method,
-                    })
+                    };
+                    UpcastResult::new(Type::KnownBoundMethod(method), retention)
                 }),
-                Type::PropertyInstance(property) => visitor.visit_type(db, ty, || {
-                    Type::PropertyInstance(upcast_property(db, env, property, visitor))
+                Type::PropertyInstance(property) => visit_type(db, ty, visitor, || {
+                    UpcastResult::unstable(Type::PropertyInstance(upcast_property(
+                        db, env, property, visitor,
+                    )))
                 }),
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
-                    upcast_partial(db, env, partial).map_or_else(
-                        || {
-                            KnownClass::FunctoolsPartial
-                                .to_instance(db, env)
-                                .top_materialization(db, env)
-                        },
-                        |partial| Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
+                    UpcastResult::unstable(
+                        upcast_partial(db, env, partial)
+                            .map(|partial| {
+                                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))
+                            })
+                            .unwrap_or_else(|| {
+                                KnownClass::FunctoolsPartial
+                                    .to_instance(db, env)
+                                    .top_materialization(db, env)
+                            }),
                     )
                 }
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(partial)) => {
-                    upcast_partial(db, env, partial).map_or_else(
-                        || KnownClass::MethodWrapperType.to_instance(db, env),
-                        |partial| {
-                            Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(partial))
-                        },
+                    UpcastResult::unstable(
+                        upcast_partial(db, env, partial)
+                            .map(|partial| {
+                                Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(
+                                    partial,
+                                ))
+                            })
+                            .unwrap_or_else(|| KnownClass::MethodWrapperType.to_instance(db, env)),
                     )
                 }
-                Type::TypeVar(typevar) => visitor.visit_type(db, ty, || {
-                    let bound_or_constraints = typevar.require_bound_or_constraints(db, env);
-                    upcast(db, env, bound_or_constraints.as_type(db, env), visitor)
+                Type::KnownInstance(
+                    KnownInstanceType::SubscriptedProtocol(_)
+                    | KnownInstanceType::SubscriptedGeneric(_)
+                    | KnownInstanceType::TypeVar(_)
+                    | KnownInstanceType::TypeAliasType(_)
+                    | KnownInstanceType::Deprecated(_)
+                    | KnownInstanceType::Field(_)
+                    | KnownInstanceType::ConstraintSet(_)
+                    | KnownInstanceType::ConstraintSetSolution(_)
+                    | KnownInstanceType::GenericContext(_)
+                    | KnownInstanceType::Specialization(_)
+                    | KnownInstanceType::UnionType(_)
+                    | KnownInstanceType::Literal(_)
+                    | KnownInstanceType::Annotated(_)
+                    | KnownInstanceType::TypeGenericAlias(_)
+                    | KnownInstanceType::Callable(_)
+                    | KnownInstanceType::LiteralStringAlias(_)
+                    | KnownInstanceType::NewType(_)
+                    | KnownInstanceType::Sentinel(_)
+                    | KnownInstanceType::NamedTupleSpec(_)
+                    | KnownInstanceType::Range { .. },
+                ) => UpcastResult::stable(ty),
+                Type::TypeVar(typevar) => visit_type(db, ty, visitor, || {
+                    UpcastResult::unstable(
+                        upcast(
+                            db,
+                            env,
+                            typevar.require_bound_or_constraints(db, env).as_type(db, env),
+                            visitor,
+                        )
+                        .ty,
+                    )
                 }),
                 Type::Union(union) => {
-                    union.map(db, env, |element| upcast(db, env, *element, visitor))
+                    let mut retention = NegativeRetention::Stable;
+                    let ty = union.map(db, env, |element| {
+                        let upcast_result = upcast(db, env, *element, visitor);
+                        retention = retention.max(upcast_result.negative_retention);
+                        upcast_result.ty
+                    });
+                    UpcastResult::new(ty, retention)
                 }
                 Type::Intersection(intersection) => {
                     let has_literal_string_origin = intersection
@@ -195,54 +409,61 @@ impl<'db> Type<'db> {
                         .iter()
                         .any(|element| element.is_subtype_of(db, env, Type::literal_string()));
                     let mut builder = IntersectionBuilder::new(db, env);
+                    let mut retention = NegativeRetention::Stable;
                     for element in intersection.positive(db) {
-                        builder = builder.add_positive(upcast(db, env, *element, visitor));
+                        let upcast_result = upcast(db, env, *element, visitor);
+                        retention = retention.max(upcast_result.negative_retention);
+                        builder = builder.add_positive(upcast_result.ty);
                     }
                     for element in intersection.negative(db) {
-                        // Static tags, function signatures, predicate proofs, and literal-string
-                        // origin can differ between views. Once literal origin is known, an
-                        // excluded string literal also excludes its runtime value and must be
-                        // preserved.
-                        match element.resolve_type_alias(db) {
-                            Type::NewTypeInstance(_)
-                            | Type::FunctionLiteral(_)
-                            | Type::BoundMethod(_)
-                            | Type::KnownBoundMethod(
-                                KnownBoundMethodType::FunctionTypeDunderGet(_)
-                                | KnownBoundMethodType::FunctionTypeDunderCall(_)
-                                | KnownBoundMethodType::PropertyDunderGet(_)
-                                | KnownBoundMethodType::PropertyDunderSet(_)
-                                | KnownBoundMethodType::PropertyDunderDelete(_),
-                            )
-                            | Type::PropertyInstance(_)
-                            | Type::KnownInstance(
-                                KnownInstanceType::FunctoolsPartial(_)
-                                | KnownInstanceType::FunctoolsPartialCall(_),
-                            )
-                            | Type::TypeVar(_)
-                            | Type::TypeIs(_)
-                            | Type::TypeGuard(_) => continue,
-                            Type::LiteralValue(literal)
-                                if literal.is_literal_string()
-                                    || literal.is_string() && !has_literal_string_origin =>
-                            {
-                                continue;
-                            }
-                            _ => builder.add_negative_in_place(*element),
+                        let upcast_result = upcast(db, env, *element, visitor);
+                        if upcast_result
+                            .negative_retention
+                            .can_retain(has_literal_string_origin)
+                        {
+                            builder.add_negative_in_place(*element);
+                        } else {
+                            retention = NegativeRetention::Unstable;
                         }
                     }
-                    builder.build()
+                    UpcastResult::new(builder.build(), retention)
                 }
-                _ => ty,
+                Type::LiteralValue(literal) => UpcastResult::new(
+                    ty,
+                    if literal.is_literal_string() {
+                        NegativeRetention::Unstable
+                    } else if literal.is_string() {
+                        NegativeRetention::RequiresLiteralStringOrigin
+                    } else {
+                        NegativeRetention::Stable
+                    },
+                ),
+                Type::TypeIs(_) | Type::TypeGuard(_) => UpcastResult::unstable(ty),
+                Type::Dynamic(_)
+                | Type::Divergent(_)
+                | Type::Never
+                | Type::WrapperDescriptor(_)
+                | Type::DataclassDecorator(_)
+                | Type::DataclassTransformer(_)
+                | Type::Callable(_)
+                | Type::ModuleLiteral(_)
+                | Type::ClassLiteral(_)
+                | Type::GenericAlias(_)
+                | Type::SubclassOf(_)
+                | Type::NominalInstance(_)
+                | Type::ProtocolInstance(_)
+                | Type::SpecialForm(_)
+                | Type::SlotDescriptor(_)
+                | Type::EnumComplement(_)
+                | Type::AlwaysTruthy
+                | Type::AlwaysFalsy
+                | Type::BoundSuper(_)
+                | Type::TypeForm(_)
+                | Type::TypedDict(_) => UpcastResult::stable(ty),
             }
         }
 
-        upcast(
-            db,
-            env,
-            self,
-            &TypeTransformer::<IdentityComparisonUpcasting>::default(),
-        )
+        upcast(db, env, self, &UpcastingVisitor::default()).ty
     }
 
     /// Return whether values of these types always, never, or possibly identify the same object.


### PR DESCRIPTION
## Bug

A generic class can expose one saved callable through several specializations. In this Python 3.12 example, the class body constructs one `partial`, so `C[int].callback` and `C[str].callback` retrieve the same object even though ty gives them different call signatures:

```python
from functools import partial
from typing import reveal_type

class C[T]:
    def method(self, value: T) -> T:
        return value

    callback = partial(method)

callback = C[int].callback
reveal_type(callback is C[str].callback)
if callback is C[str].callback:
    reveal_type(callback)
    callback(C[int](), "wrong")
```

On `main`, ty reveals `Literal[False]` for the comparison and `Never` for `callback` in the true branch. The comparison can actually succeed because both expressions retrieve the class's single partial. Treating the branch as unreachable also hides an argument error: `callback` has the `T = int` signature from its assignment, so its `value` argument must be an `int`.

The same mistaken disjointness can affect saved bound methods, properties, and method wrappers whose function signatures differ between static views of the same object.

## Fix

Use the underlying callable and receiver to determine whether identity is possible, without treating a substituted call signature as a distinct runtime object. Preserve each operand's existing call signature when narrowing after a successful comparison, and retain an exclusion only when it rules out the same runtime object across static views.

For the example above, ty now reveals `bool` for the comparison and `partial[(self, value: int) -> int]` for `callback` in the true branch. It reports `invalid-argument-type` for the string argument.
