### PR TITLE
[ty] Bind protocol classmethods to the full receiver

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -429,6 +429,75 @@ reveal_type(GenericCircle[int].bar())  # revealed: GenericCircle[int]
 reveal_type(GenericCircle.baz(1))  # revealed: GenericShape[Literal[1]]
 ```
 
+### Protocol class methods
+
+A class method accessed through `type[Factory]` returns a `Factory` instance. Retrieving the method
+before calling it preserves that return type, as does invoking its `__call__` attribute:
+
+```py
+from collections.abc import Callable
+from typing import Protocol, Self
+
+class Factory(Protocol):
+    @classmethod
+    def make(cls: type[Self]) -> Self: ...
+
+def factory(cls: type[Factory]) -> Callable[[], Factory]:
+    reveal_type(cls.make)  # revealed: () -> Factory
+    reveal_type(cls.make())  # revealed: Factory
+    method = cls.make
+    reveal_type(method())  # revealed: Factory
+    reveal_type(method.__call__())  # revealed: Factory
+    return method
+```
+
+### Protocol class methods on intersection receivers
+
+When a class implements a protocol and inherits from another class, the class method's `Self` return
+type describes instances of both. The bound callable satisfies both a `Callable` annotation and a
+callback protocol that require this intersection return type:
+
+```py
+from collections.abc import Callable
+from typing import Protocol, Self
+from ty_extensions import Intersection
+
+class Factory(Protocol):
+    @classmethod
+    def make(cls: type[Self]) -> Self: ...
+
+class Mixin: ...
+
+class Callback[R](Protocol):
+    def __call__(self) -> R: ...
+
+def factory(cls: Intersection[type[Factory], type[Mixin]]) -> Callback[Intersection[Factory, Mixin]]:
+    reveal_type(cls.make)  # revealed: () -> Factory & Mixin
+    reveal_type(cls.make())  # revealed: Factory & Mixin
+    method = cls.make
+    reveal_type(method())  # revealed: Factory & Mixin
+    reveal_type(method.__call__())  # revealed: Factory & Mixin
+    callback: Callable[[], Intersection[Factory, Mixin]] = method
+    return method
+```
+
+The remaining parameters keep their annotations after binding the class receiver. An implicit `cls`
+annotation also preserves the complete intersection in the return type:
+
+```py
+class ValueFactory(Protocol):
+    @classmethod
+    def make(cls, value: int) -> Self: ...
+
+def value_factory(cls: Intersection[type[ValueFactory], type[Mixin]]) -> Callable[[int], Intersection[ValueFactory, Mixin]]:
+    reveal_type(cls.make(1))  # revealed: ValueFactory & Mixin
+    method = cls.make
+    reveal_type(method(1))  # revealed: ValueFactory & Mixin
+    reveal_type(method.__call__(1))  # revealed: ValueFactory & Mixin
+    method("bad")  # error: [invalid-argument-type]
+    return method
+```
+
 ### Calling `super()` in overridden methods with `Self` return type
 
 This is a regression test for <https://github.com/astral-sh/ty/issues/2122>.

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -4859,6 +4859,139 @@ def _(factory: type[ClassObjectFactory]) -> None:
     exact_factory(factory)
 ```
 
+## Class-method callable assignments with explicit receivers
+
+A protocol class method with an explicit receiver annotation can only satisfy a `Callable`
+annotation when the class object satisfies that receiver annotation. Matching the visible parameters
+and return type is not enough, including when the class object is an intersection:
+
+```py
+from collections.abc import Callable
+from typing import Protocol
+from ty_extensions import Intersection
+
+class Factory(Protocol):
+    @classmethod
+    def make(cls: type[int]) -> str: ...
+
+class Mixin: ...
+
+def ordinary(cls: type[Factory]) -> Callable[[], str]:
+    return cls.make  # error: [invalid-return-type]
+
+def intersection(cls: Intersection[type[Factory], type[Mixin]]) -> Callable[[], str]:
+    return cls.make  # error: [invalid-return-type]
+
+def compatible(cls: Intersection[type[Factory], type[int]]) -> Callable[[], str]:
+    return cls.make
+```
+
+## Class-method overloads with explicit receivers
+
+Only overloads whose receiver annotation accepts the class object contribute to the bound method's
+signature. Here the class object can use the integer overload:
+
+```py
+from collections.abc import Callable
+from typing import Protocol, overload
+from ty_extensions import Intersection
+
+class Factory(Protocol):
+    @classmethod
+    @overload
+    def make(cls: type[int], value: int) -> int: ...
+    @classmethod
+    @overload
+    def make(cls: type[str], value: str) -> str: ...
+
+def use_int_factory(cls: Intersection[type[Factory], type[int]]) -> Callable[[int], int]:
+    reveal_type(cls.make)  # revealed: (value: int) -> int
+    reveal_type(cls.make(1))  # revealed: int
+    wrong: Callable[[str], str] = cls.make  # error: [invalid-assignment]
+    return cls.make
+```
+
+## Callable attributes on protocol class objects
+
+A callable attribute retains its complete parameter list when accessed through a protocol class
+object. Unlike a class-method declaration, it has no implicit class receiver to substitute:
+
+```py
+from collections.abc import Callable
+from typing import ClassVar, Protocol
+from ty_extensions import Intersection
+
+class Callbacks(Protocol):
+    callback: ClassVar[Callable[[int], str]]
+
+class Mixin: ...
+
+def use_callbacks(cls: Intersection[type[Callbacks], type[Mixin]]) -> Callable[[int], str]:
+    callback = cls.callback
+    reveal_type(callback)  # revealed: (int, /) -> str
+    reveal_type(callback(1))  # revealed: str
+    reveal_type(callback.__call__(1))  # revealed: str
+    callback()  # error: [missing-argument]
+    return callback
+```
+
+## Bound protocol methods stored on another class
+
+Storing a bound method on another class does not change its receiver. A method whose original
+receiver is incompatible with its annotation cannot satisfy a `Callable` annotation, even if the
+class that stores it would satisfy that receiver annotation.
+
+The top materialization of this protocol has an `object` return type, but its method still requires
+a class object as its receiver:
+
+```py
+from collections.abc import Callable
+from typing import Any, Protocol
+from ty_extensions import Intersection, Top
+
+class Method(Protocol):
+    def method(self: type) -> Any: ...
+
+class Mixin: ...
+
+def stored_method(value: Intersection[Top[Method], Mixin]) -> Callable[[], object]:
+    class Holder:
+        callback = value.method
+
+    return Holder.callback  # error: [invalid-return-type]
+
+def direct_method(value: Intersection[Top[Method], Mixin]) -> Callable[[], object]:
+    return value.method  # error: [invalid-return-type]
+```
+
+## Static implementations of protocol class methods
+
+A static method with a compatible signature can implement a protocol class method. Calls through the
+protocol therefore rely on the bound signature without requiring a nominal bound-method object:
+
+```py
+from typing import Protocol
+
+class Factory(Protocol):
+    @classmethod
+    def make(cls, value: int) -> str: ...
+
+class StaticFactory:
+    @staticmethod
+    def make(value: int) -> str:
+        return str(value)
+
+def invoke(factory: type[Factory]) -> str:
+    method = factory.make
+    reveal_type(method)  # revealed: (value: int) -> str
+    reveal_type(method.__call__(1))  # revealed: str
+    method.__self__  # error: [unresolved-attribute]
+    method.__func__  # error: [unresolved-attribute]
+    return method(1)
+
+reveal_type(invoke(StaticFactory))  # revealed: str
+```
+
 ## Class objects and `Self`-returning instance-method protocol members
 
 A class object can satisfy a protocol with a regular instance-method member if the class object's

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3680,14 +3680,26 @@ impl<'db> Type<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> Option<PlaceAndQualifiers<'db>> {
+        self.find_name_in_mro_with_policy_and_receiver(db, env, name, policy, None)
+    }
+
+    fn find_name_in_mro_with_policy_and_receiver(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+        policy: MemberLookupPolicy,
+        receiver: Option<Type<'db>>,
+    ) -> Option<PlaceAndQualifiers<'db>> {
         if let Some(fallback) = (*self).materialized_divergent_fallback() {
-            return fallback.find_name_in_mro_with_policy(db, env, name, policy);
+            return fallback
+                .find_name_in_mro_with_policy_and_receiver(db, env, name, policy, receiver);
         }
 
         match self {
             Type::Union(union) => {
                 Some(union.map_with_boundness_and_qualifiers(db, env, |elem| {
-                    elem.find_name_in_mro_with_policy(db, env, name, policy)
+                    elem.find_name_in_mro_with_policy_and_receiver(db, env, name, policy, receiver)
                         // If some elements are classes, and some are not, we simply fall back to `Unbound` for the non-class
                         // elements instead of short-circuiting the whole result to `None`. We would need a more detailed
                         // return type otherwise, and since `find_name_in_mro` is usually called via `class_member`, this is
@@ -3697,7 +3709,7 @@ impl<'db> Type<'db> {
             }
             Type::Intersection(inter) => {
                 Some(inter.map_with_boundness_and_qualifiers(db, env, |elem| {
-                    elem.find_name_in_mro_with_policy(db, env, name, policy)
+                    elem.find_name_in_mro_with_policy_and_receiver(db, env, name, policy, receiver)
                         // Fall back to Unbound, similar to the union case (see above).
                         .unwrap_or_default()
                 }))
@@ -3767,7 +3779,7 @@ impl<'db> Type<'db> {
             ),
 
             Type::SubclassOf(subclass_of_ty) => {
-                subclass_of_ty.find_name_in_mro_with_policy(db, env, name, policy)
+                subclass_of_ty.find_name_in_mro_with_policy(db, env, name, policy, receiver)
             }
 
             // Note: `super(pivot, owner).__class__` is `builtins.super`, not the owner's class.
@@ -3792,7 +3804,7 @@ impl<'db> Type<'db> {
 
             Type::TypeAlias(alias) => alias
                 .value_type(db)
-                .find_name_in_mro_with_policy(db, env, name, policy),
+                .find_name_in_mro_with_policy_and_receiver(db, env, name, policy, receiver),
 
             Type::FunctionLiteral(_)
             | Type::Callable(_)
@@ -4019,8 +4031,21 @@ impl<'db> Type<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        self.class_object_member_with_receiver(db, env, name, policy, None)
+    }
+
+    /// Bind structural protocol methods to the full receiver during member lookup. Namespace
+    /// inspection leaves the receiver unspecified so explicit receiver constraints remain open.
+    fn class_object_member_with_receiver(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        name: &str,
+        policy: MemberLookupPolicy,
+        receiver: Option<Type<'db>>,
+    ) -> PlaceAndQualifiers<'db> {
         let class_attr = self
-            .find_name_in_mro_with_policy(db, env, name, policy)
+            .find_name_in_mro_with_policy_and_receiver(db, env, name, policy, receiver)
             .expect(
                 "Calling `class_object_member` on class literals and subclass-of types \
                 should always find an MRO",
@@ -6020,7 +6045,13 @@ impl<'db> Type<'db> {
                         .into();
                     }
 
-                    let class_attr_plain = this.class_object_member(db, env, name_str, policy);
+                    let class_attr_plain = this.class_object_member_with_receiver(
+                        db,
+                        env,
+                        name_str,
+                        policy,
+                        Some(receiver),
+                    );
 
                     let self_instance = receiver.to_instance_approximation(db, env).expect(
                         "The receiver for a class-object lookup should always be instantiable",

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -286,7 +286,8 @@ impl<'db> BoundMethodType<'db> {
 
         self.callable_with_signatures(
             db,
-            self.bound_signatures_with_receiver(db, &env, receiver_type, typing_self_type),
+            self.unbound_signatures(db)
+                .bind_method(db, &env, receiver_type, typing_self_type),
         )
     }
 
@@ -300,7 +301,8 @@ impl<'db> BoundMethodType<'db> {
     ) -> CallableType<'db> {
         self.callable_with_signatures(
             db,
-            self.bound_signatures_with_receiver(db, env, receiver_type, typing_self_type),
+            self.unbound_signatures(db)
+                .bind_method(db, env, receiver_type, typing_self_type),
         )
     }
 
@@ -318,55 +320,6 @@ impl<'db> BoundMethodType<'db> {
     /// Shares the signatures retained in the method's interned callable.
     pub(crate) fn bound_signatures(self, db: &'db dyn Db) -> &'db CallableSignature<'db> {
         self.into_callable_type(db).signatures(db)
-    }
-
-    fn bound_signatures_with_receiver(
-        self,
-        db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
-        receiver_type: Type<'db>,
-        typing_self_type: Type<'db>,
-    ) -> CallableSignature<'db> {
-        let function_signature = self.unbound_signatures(db);
-
-        let [signature] = function_signature.overloads.as_slice() else {
-            if !function_signature
-                .overloads
-                .iter()
-                .any(Signature::has_explicit_positional_receiver_annotation)
-            {
-                return CallableSignature::from_overloads(function_signature.overloads.iter().map(
-                    |signature| {
-                        signature.bind_self_with_receiver(
-                            db,
-                            env,
-                            Some(receiver_type),
-                            Some(typing_self_type),
-                        )
-                    },
-                ));
-            }
-
-            return CallableSignature::from_overloads(
-                function_signature
-                    .overloads
-                    .iter()
-                    .filter_map(|signature| {
-                        signature.bind_self_if_compatible(db, env, receiver_type, typing_self_type)
-                    })
-                    .flat_map(|signature| signature.overloads),
-            );
-        };
-
-        let specialized = if signature.has_receiver_determined_method_typevar(db, env) {
-            signature.specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
-        } else {
-            None
-        };
-
-        specialized
-            .unwrap_or_else(|| CallableSignature::single(signature.clone()))
-            .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type))
     }
 
     pub(super) fn recursive_type_normalized_impl(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -637,9 +637,7 @@ impl<'db> ProtocolInterfaceView<'db> {
         receiver: Option<Type<'db>>,
     ) -> Option<PlaceAndQualifiers<'db>> {
         self.member_by_name(db, name).map(|member| {
-            let read = member
-                .access_with_receiver(db, env, ProtocolMemberAccessMode::Class, receiver)
-                .read;
+            let read = member.class_access(db, env, receiver).read;
             PlaceAndQualifiers {
                 place: read
                     .and_then(|read| read.resolve(db, env))
@@ -2227,37 +2225,33 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         env: &ProgramEnvironment<'db>,
         mode: ProtocolMemberAccessMode,
     ) -> ProtocolMemberAccess<'db> {
-        self.access_with_receiver(db, env, mode, None)
+        let capabilities = self.data.capabilities(db, env);
+        let access = match mode {
+            ProtocolMemberAccessMode::Instance => capabilities.instance,
+            ProtocolMemberAccessMode::Class => capabilities.class,
+        };
+        self.materialization
+            .map_or(access, |kind| access.materialize(db, env, kind))
     }
 
-    fn access_with_receiver(
+    fn class_access(
         &self,
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
-        mode: ProtocolMemberAccessMode,
         receiver: Option<Type<'db>>,
     ) -> ProtocolMemberAccess<'db> {
         let access = if let ProtocolMemberKind::Method(member, ProtocolMethodKind::Class) =
             self.data.kind
             && let Type::Callable(callable) = member.ty()
-            && let Some((receiver, self_type)) = receiver.and_then(|receiver| match mode {
-                ProtocolMemberAccessMode::Instance => {
-                    Some((receiver.to_meta_type(db, env), receiver))
-                }
-                ProtocolMemberAccessMode::Class => receiver
-                    .to_instance_approximation(db, env)
-                    .map(|self_type| (receiver, self_type)),
-            }) {
+            && let Some(receiver) = receiver
+            && let Some(self_type) = receiver.to_instance_approximation(db, env)
+        {
             // Protocols specify callable behavior without requiring a nominal bound method:
             // a static method can also implement a classmethod requirement.
             let callable = protocol_bind_method(db, env.program(db), callable, receiver, self_type);
             ProtocolMemberAccess::new(Some(member.with_ty(Type::Callable(callable))), None)
         } else {
-            let capabilities = self.data.capabilities(db, env);
-            match mode {
-                ProtocolMemberAccessMode::Instance => capabilities.instance,
-                ProtocolMemberAccessMode::Class => capabilities.class,
-            }
+            return self.access(db, env, ProtocolMemberAccessMode::Class);
         };
         self.materialization
             .map_or(access, |kind| access.materialize(db, env, kind))

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -625,7 +625,8 @@ impl<'db> ProtocolInterfaceView<'db> {
 
     /// Looks up a member guaranteed to exist on every inhabitant of `type[Protocol]`.
     ///
-    /// Methods retain their unbound signatures and `ClassVar`s retain their class-side types.
+    /// Ordinary methods retain their unbound signatures; class methods bind to `receiver` when
+    /// provided. `ClassVar`s retain their class-side types.
     /// Properties are only required on the constructed instance, so they are undefined even when
     /// the nominal protocol origin provides a property descriptor.
     pub(super) fn meta_member(
@@ -633,9 +634,12 @@ impl<'db> ProtocolInterfaceView<'db> {
         db: &'db dyn Db,
         env: &ProgramEnvironment<'db>,
         name: &str,
+        receiver: Option<Type<'db>>,
     ) -> Option<PlaceAndQualifiers<'db>> {
         self.member_by_name(db, name).map(|member| {
-            let read = member.access(db, env, ProtocolMemberAccessMode::Class).read;
+            let read = member
+                .access_with_receiver(db, env, ProtocolMemberAccessMode::Class, receiver)
+                .read;
             PlaceAndQualifiers {
                 place: read
                     .and_then(|read| read.resolve(db, env))
@@ -696,6 +700,16 @@ pub(super) fn walk_protocol_instance_member<'db, V: super::visitor::TypeVisitor<
 ) {
     let env = visitor.program_environment();
     match member.data.kind {
+        ProtocolMemberKind::Method(_, ProtocolMethodKind::Class) => {
+            // Class access and instance access both remove `cls`. Keep explicit receiver
+            // constraints in the derived view so they participate in traversal and variance.
+            if let Some(method) = member
+                .access(db, env, ProtocolMemberAccessMode::Instance)
+                .read
+            {
+                visitor.visit_type(db, method.ty());
+            }
+        }
         ProtocolMemberKind::Method(method, _) => {
             let method = member
                 .materialization
@@ -778,7 +792,7 @@ impl<'db> ProtocolInterface<'db> {
             .map(|(name, callable)| {
                 (
                     Name::new(name),
-                    ProtocolMemberData::method(db, env, callable, None),
+                    ProtocolMemberData::method(db, callable, None),
                 )
             })
             .collect();
@@ -1514,15 +1528,11 @@ pub(super) struct ProtocolMemberData<'db> {
 impl<'db> ProtocolMemberData<'db> {
     fn method(
         db: &'db dyn Db,
-        env: &ProgramEnvironment<'db>,
         callable: CallableType<'db>,
         definition: Option<Definition<'db>>,
     ) -> Self {
         let (method_kind, callable) = if callable.is_classmethod_like(db) {
-            (
-                ProtocolMethodKind::Class,
-                protocol_bind_self(db, env.program(db), callable, None),
-            )
+            (ProtocolMethodKind::Class, callable)
         } else if callable.is_staticmethod_like(db) {
             (ProtocolMethodKind::Static, callable.into_regular(db))
         } else {
@@ -1576,15 +1586,28 @@ impl<'db> ProtocolMemberData<'db> {
     ) -> ProtocolMemberCapabilities<'db> {
         match self.kind {
             ProtocolMemberKind::Method(member, kind) => {
-                let instance_method = match (member.ty(), kind) {
-                    (Type::Callable(callable), ProtocolMethodKind::Instance) => member.with_ty(
-                        Type::Callable(protocol_bind_self(db, env.program(db), callable, None)),
-                    ),
+                let bound_method = match (member.ty(), kind) {
+                    (
+                        Type::Callable(callable),
+                        ProtocolMethodKind::Instance | ProtocolMethodKind::Class,
+                    ) => member.with_ty(Type::Callable(protocol_bind_self(
+                        db,
+                        env.program(db),
+                        callable,
+                        None,
+                    ))),
                     _ => member,
                 };
                 ProtocolMemberCapabilities {
-                    instance: ProtocolMemberAccess::new(Some(instance_method), None),
-                    class: ProtocolMemberAccess::new(Some(member), None),
+                    instance: ProtocolMemberAccess::new(Some(bound_method), None),
+                    class: ProtocolMemberAccess::new(
+                        Some(if kind == ProtocolMethodKind::Class {
+                            bound_method
+                        } else {
+                            member
+                        }),
+                        None,
+                    ),
                 }
             }
             ProtocolMemberKind::Property { read, write } => ProtocolMemberCapabilities {
@@ -1710,6 +1733,8 @@ impl<'db> ProtocolMemberData<'db> {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 enum ProtocolMemberKind<'db> {
+    /// Keep the receiver parameter until deriving a view of the method. In particular, class
+    /// method lookup needs both the class object and its instance type to bind `cls` and `Self`.
     Method(ProtocolMemberType<'db>, ProtocolMethodKind),
     Property {
         read: Option<ProtocolMemberType<'db>>,
@@ -2202,10 +2227,37 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         env: &ProgramEnvironment<'db>,
         mode: ProtocolMemberAccessMode,
     ) -> ProtocolMemberAccess<'db> {
-        let capabilities = self.data.capabilities(db, env);
-        let access = match mode {
-            ProtocolMemberAccessMode::Instance => capabilities.instance,
-            ProtocolMemberAccessMode::Class => capabilities.class,
+        self.access_with_receiver(db, env, mode, None)
+    }
+
+    fn access_with_receiver(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        mode: ProtocolMemberAccessMode,
+        receiver: Option<Type<'db>>,
+    ) -> ProtocolMemberAccess<'db> {
+        let access = if let ProtocolMemberKind::Method(member, ProtocolMethodKind::Class) =
+            self.data.kind
+            && let Type::Callable(callable) = member.ty()
+            && let Some((receiver, self_type)) = receiver.and_then(|receiver| match mode {
+                ProtocolMemberAccessMode::Instance => {
+                    Some((receiver.to_meta_type(db, env), receiver))
+                }
+                ProtocolMemberAccessMode::Class => receiver
+                    .to_instance_approximation(db, env)
+                    .map(|self_type| (receiver, self_type)),
+            }) {
+            // Protocols specify callable behavior without requiring a nominal bound method:
+            // a static method can also implement a classmethod requirement.
+            let callable = protocol_bind_method(db, env.program(db), callable, receiver, self_type);
+            ProtocolMemberAccess::new(Some(member.with_ty(Type::Callable(callable))), None)
+        } else {
+            let capabilities = self.data.capabilities(db, env);
+            match mode {
+                ProtocolMemberAccessMode::Instance => capabilities.instance,
+                ProtocolMemberAccessMode::Class => capabilities.class,
+            }
         };
         self.materialization
             .map_or(access, |kind| access.materialize(db, env, kind))
@@ -3662,14 +3714,14 @@ fn cached_protocol_interface<'db>(
                 definition,
             ),
             Type::Callable(callable) if bound_on_class.is_yes() && callable.is_method_like(db) => {
-                ProtocolMemberData::method(db, &env, callable, definition)
+                ProtocolMemberData::method(db, callable, definition)
             }
             Type::FunctionLiteral(function)
                 if bound_on_class.is_yes()
                     || function.is_staticmethod(db)
                     || function.is_classmethod(db) =>
             {
-                ProtocolMemberData::method(db, &env, function.into_callable_type(db), definition)
+                ProtocolMemberData::method(db, function.into_callable_type(db), definition)
             }
             _ if bound_on_class.is_yes()
                 && definition.is_some_and(|definition| definition.kind(db).is_function_def()) =>
@@ -3729,6 +3781,30 @@ fn protocol_bind_self<'db>(
 ) -> CallableType<'db> {
     let env = ProgramEnvironment::from_program(program);
     callable.bind_self(db, &env, self_type).into_regular(db)
+}
+
+/// Derive a structural callable using the same receiver binding as a nominal bound method.
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial=|db, _, _, _, _, _| CallableType::bottom(db),
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn protocol_bind_method<'db>(
+    db: &'db dyn Db,
+    program: Program<'db>,
+    callable: CallableType<'db>,
+    receiver_type: Type<'db>,
+    self_type: Type<'db>,
+) -> CallableType<'db> {
+    let env = ProgramEnvironment::from_program(program);
+    callable
+        .with_signatures(
+            db,
+            callable
+                .signatures(db)
+                .bind_method(db, &env, receiver_type, self_type),
+        )
+        .into_regular(db)
 }
 
 /// Cache receiver and `Self` binding only for protocol-member compatibility checks.

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -505,6 +505,55 @@ impl<'db> CallableSignature<'db> {
         }
     }
 
+    /// Binds a method receiver, specializing receiver-determined type variables and filtering
+    /// overloads whose explicit receiver annotation is incompatible.
+    ///
+    /// `typing_self_type` replaces `typing.Self` and can differ from the runtime receiver type
+    /// for class methods.
+    pub(crate) fn bind_method(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        receiver_type: Type<'db>,
+        typing_self_type: Type<'db>,
+    ) -> Self {
+        let [signature] = self.overloads.as_slice() else {
+            if !self
+                .overloads
+                .iter()
+                .any(Signature::has_explicit_positional_receiver_annotation)
+            {
+                return Self::from_overloads(self.overloads.iter().map(|signature| {
+                    signature.bind_self_with_receiver(
+                        db,
+                        env,
+                        Some(receiver_type),
+                        Some(typing_self_type),
+                    )
+                }));
+            }
+
+            return Self::from_overloads(
+                self.overloads
+                    .iter()
+                    .filter_map(|signature| {
+                        signature.bind_self_if_compatible(db, env, receiver_type, typing_self_type)
+                    })
+                    .flat_map(|signature| signature.overloads),
+            );
+        };
+
+        let specialized = if signature.has_receiver_determined_method_typevar(db, env) {
+            signature.specialize_for_bound_receiver(db, env, receiver_type, typing_self_type)
+        } else {
+            None
+        };
+
+        specialized
+            .unwrap_or_else(|| Self::single(signature.clone()))
+            .bind_self_with_receiver(db, env, Some(receiver_type), Some(typing_self_type))
+    }
+
     pub(crate) fn has_parameters(&self) -> bool {
         self.overloads
             .iter()

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -260,9 +260,10 @@ impl<'db> SubclassOfType<'db> {
         env: &ProgramEnvironment<'db>,
         name: &str,
         policy: MemberLookupPolicy,
+        receiver: Option<Type<'db>>,
     ) -> Option<PlaceAndQualifiers<'db>> {
         if let SubclassOfInner::Protocol(protocol) = self.subclass_of
-            && let Some(member) = protocol.interface(db).meta_member(db, env, name)
+            && let Some(member) = protocol.interface(db).meta_member(db, env, name, receiver)
         {
             return Some(member);
         }
@@ -282,7 +283,7 @@ impl<'db> SubclassOfType<'db> {
             }
         };
 
-        class_like.find_name_in_mro_with_policy(db, env, name, policy)
+        class_like.find_name_in_mro_with_policy_and_receiver(db, env, name, policy, receiver)
     }
 
     pub(super) fn recursive_type_normalized_impl(


### PR DESCRIPTION
Protocol classmethods returning `Self` lose part of the receiver type when accessed through an intersection such as `type[P] & type[Mixin]`. A method declared as `make(cls: type[Self]) -> Self` should yield `() -> P & Mixin` when retrieved from that receiver.

Retain the unbound signature until the complete class receiver is available, then bind `cls` and instance `Self` using the shared signature-binding machinery. Explicit receiver annotations continue to constrain callable assignments and overload selection.

Regression coverage includes direct and extracted calls, callable assignments, intersection `Self`, explicit receiver constraints, overload filtering, and static implementations of classmethod protocols.

Fixes https://github.com/astral-sh/ty/issues/4075.

Depends on #28410.
