### PR TITLE
[ty] Refactor module resolution to use a `ModuleDirectory` abstraction.

### DIFF
--- a/crates/ruff_db/src/files/directory.rs
+++ b/crates/ruff_db/src/files/directory.rs
@@ -13,7 +13,7 @@ pub struct DirectoryListing(Box<[(CompactString, FileType)]>);
 
 impl DirectoryListing {
     /// Returns the type of the entry named `name`, if present.
-    fn file_type(&self, name: &str) -> Option<FileType> {
+    pub fn file_type(&self, name: &str) -> Option<FileType> {
         self.0
             .binary_search_by(|(candidate, _)| candidate.as_str().cmp(name))
             .ok()

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -1,13 +1,11 @@
 use std::borrow::Cow;
 use std::collections::btree_map::{BTreeMap, Entry};
 
-use ruff_db::files::directory_listing;
-
 use crate::ResolverEnvironment;
 use crate::db::Db;
 use crate::module::{Module, ModuleKind};
 use crate::module_name::ModuleName;
-use crate::path::{ModulePath, SearchPath, SystemOrVendoredPathRef};
+use crate::path::{ModuleDirectory, ModulePath, SearchPath, SystemOrVendoredPathRef};
 use crate::resolve::{ModuleResolveMode, ResolverContext, resolve_file_module, search_paths};
 
 /// List all available modules, including all sub-modules, sorted in lexicographic order.
@@ -98,7 +96,7 @@ fn list_modules_in<'db>(
     let mut lister = Lister::new(db, search_path.resolver_environment(db), path);
     match path.as_path() {
         SystemOrVendoredPathRef::System(system_search_path) => {
-            let Ok(listing) = directory_listing(db, system_search_path) else {
+            let Some(listing) = lister.directory.system_listing() else {
                 return vec![];
             };
             for (name, file_type) in listing.iter() {
@@ -135,7 +133,7 @@ impl get_size2::GetSize for ListedModule<'_> {}
 /// in the same directory).
 struct Lister<'db> {
     db: &'db dyn Db,
-    search_path: &'db SearchPath,
+    directory: ModuleDirectory<'db>,
     resolver_environment: ResolverEnvironment<'db>,
     modules: BTreeMap<&'db ModuleName, ListedModule<'db>>,
 }
@@ -150,7 +148,10 @@ impl<'db> Lister<'db> {
     ) -> Lister<'db> {
         Lister {
             db,
-            search_path,
+            directory: ModuleDirectory::new(
+                &ResolverContext::new(db, resolver_environment, ModuleResolveMode::Typing),
+                search_path.to_module_path(),
+            ),
             resolver_environment,
             modules: BTreeMap::new(),
         }
@@ -183,7 +184,7 @@ impl<'db> Lister<'db> {
         }
 
         let Some(name) = path.file_name() else { return };
-        let mut module_path = self.search_path.to_module_path();
+        let mut module_path = self.directory.path().search_path().to_module_path();
         module_path.push(name);
         let Some(module_name) = module_path.to_module_name() else {
             return;
@@ -191,7 +192,9 @@ impl<'db> Lister<'db> {
 
         // Some modules cannot shadow a subset of special
         // modules from the standard library.
-        if !self.search_path.is_standard_library() && self.is_non_shadowable(&module_name) {
+        if !self.directory.path().search_path().is_standard_library()
+            && self.is_non_shadowable(&module_name)
+        {
             return;
         }
 
@@ -207,7 +210,7 @@ impl<'db> Lister<'db> {
                             self.resolver_environment,
                             Cow::Owned(module_name),
                             ModuleKind::Package,
-                            self.search_path.clone(),
+                            self.directory.path().search_path().clone(),
                         ),
                     );
                     return;
@@ -245,7 +248,7 @@ impl<'db> Lister<'db> {
             let is_dir =
                 file_type.is_definitely_directory() || module_path.is_directory(&self.context());
             if is_dir {
-                if !self.search_path.is_standard_library() {
+                if !self.directory.path().search_path().is_standard_library() {
                     self.add_module(
                         &module_path,
                         Module::namespace_package(
@@ -273,7 +276,7 @@ impl<'db> Lister<'db> {
             return;
         }
 
-        let Some(file) = module_path.to_file(&self.context()) else {
+        let Some(file) = self.directory.resolve_file(&self.context(), name) else {
             return;
         };
         self.add_module(
@@ -284,7 +287,7 @@ impl<'db> Lister<'db> {
                 self.resolver_environment,
                 Cow::Owned(module_name),
                 ModuleKind::Module,
-                self.search_path.clone(),
+                self.directory.path().search_path().clone(),
             ),
         );
     }

--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use ruff_db::files::{
-    File, FilePath, directory_listing, system_path_to_file, vendored_path_to_file,
+    DirectoryListing, File, FilePath, directory_listing, system_path_to_file, vendored_path_to_file,
 };
 use ruff_db::source::source_text;
-use ruff_db::system::{System, SystemPath, SystemPathBuf};
+use ruff_db::system::{FileType, System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::{VendoredPath, VendoredPathBuf};
 
 use crate::Db;
@@ -84,6 +84,14 @@ impl ModulePath {
 
     pub(crate) fn pop(&mut self) -> bool {
         self.relative_path.pop()
+    }
+
+    /// Returns the last path component without its extension.
+    ///
+    /// For example, `acme/tools` and `acme/tools.py` yield `tools`,
+    /// while `acme/__init__.pyi` yields `__init__`.
+    pub(super) fn file_stem(&self) -> Option<&str> {
+        self.relative_path.file_stem()
     }
 
     pub(super) fn search_path(&self) -> &SearchPath {
@@ -227,44 +235,6 @@ impl ModulePath {
     }
 
     #[must_use]
-    pub(super) fn to_file(&self, resolver: &ResolverContext) -> Option<File> {
-        let db = resolver.db;
-        let ModulePath {
-            search_path,
-            relative_path,
-        } = self;
-        match &*search_path.0 {
-            SearchPathInner::Extra(search_path)
-            | SearchPathInner::FirstParty(search_path)
-            | SearchPathInner::SitePackages(search_path)
-            | SearchPathInner::Editable(search_path) => {
-                system_path_to_file_if_listed(db, &search_path.join(relative_path))
-            }
-            SearchPathInner::StandardLibraryReal(search_path) => {
-                system_path_to_file_if_listed(db, &search_path.join(relative_path))
-            }
-            SearchPathInner::StandardLibraryCustom(stdlib_root) => {
-                match query_stdlib_version(relative_path, resolver) {
-                    TypeshedVersionsQueryResult::DoesNotExist => None,
-                    TypeshedVersionsQueryResult::Exists
-                    | TypeshedVersionsQueryResult::MaybeExists => {
-                        system_path_to_file_if_listed(db, &stdlib_root.join(relative_path))
-                    }
-                }
-            }
-            SearchPathInner::StandardLibraryVendored(stdlib_root) => {
-                match query_stdlib_version(relative_path, resolver) {
-                    TypeshedVersionsQueryResult::DoesNotExist => None,
-                    TypeshedVersionsQueryResult::Exists
-                    | TypeshedVersionsQueryResult::MaybeExists => {
-                        vendored_path_to_file(db, stdlib_root.join(relative_path)).ok()
-                    }
-                }
-            }
-        }
-    }
-
-    #[must_use]
     pub(crate) fn to_module_name(&self) -> Option<ModuleName> {
         fn strip_stubs(component: &str) -> &str {
             component.strip_suffix("-stubs").unwrap_or(component)
@@ -315,33 +285,6 @@ impl ModulePath {
         }
     }
 
-    #[must_use]
-    pub(crate) fn with_pyi_extension(&self) -> Self {
-        let ModulePath {
-            search_path,
-            relative_path,
-        } = self;
-        ModulePath {
-            search_path: search_path.clone(),
-            relative_path: relative_path.with_extension("pyi"),
-        }
-    }
-
-    #[must_use]
-    pub(crate) fn with_py_extension(&self) -> Option<Self> {
-        if self.is_standard_library_stub() {
-            return None;
-        }
-        let ModulePath {
-            search_path,
-            relative_path,
-        } = self;
-        Some(ModulePath {
-            search_path: search_path.clone(),
-            relative_path: relative_path.with_extension("py"),
-        })
-    }
-
     pub(crate) fn into_search_path(self) -> SearchPath {
         self.search_path
     }
@@ -385,6 +328,116 @@ impl PartialEq<ModulePath> for VendoredPathBuf {
     }
 }
 
+/// Models a directory that participates in the module resolution process.
+#[derive(Debug, Clone)]
+pub(crate) struct ModuleDirectory<'db> {
+    // The path to the directory.
+    path: ModulePath,
+    // The contents of the directory.
+    listing: Option<&'db DirectoryListing>,
+}
+
+impl<'db> ModuleDirectory<'db> {
+    pub(crate) fn new(context: &ResolverContext<'db>, path: ModulePath) -> Self {
+        let listing = path
+            .to_system_path()
+            .and_then(|path| directory_listing(context.db, &path).ok());
+        Self { path, listing }
+    }
+
+    /// Returns an existing child directory and retrieves its listing without
+    /// changing this directory.
+    ///
+    /// `name` should be a single path component.
+    pub(crate) fn child_directory(
+        &self,
+        context: &ResolverContext<'db>,
+        name: &str,
+    ) -> Option<Self> {
+        let mut path = self.path.clone();
+        path.push(name);
+        path.is_directory(context).then(|| Self::new(context, path))
+    }
+
+    /// Returns the directory's path without permitting it to change.
+    pub(crate) fn path(&self) -> &ModulePath {
+        &self.path
+    }
+
+    /// Returns the cached listing from [`System`], or `None` for an inaccessible directory
+    /// or a path in the vendored typeshed archive.
+    pub(crate) fn system_listing(&self) -> Option<&'db DirectoryListing> {
+        self.listing
+    }
+
+    /// Returns whether or not this directory might contain the given entry.
+    pub(crate) fn may_contain_name(&self, name: &str) -> bool {
+        self.path.search_path.as_vendored_path().is_some()
+            || self
+                .listing
+                .is_some_and(|listing| listing.contains_name_with_prefix(name))
+    }
+
+    /// Resolves one exact filename in this directory, validating file status,
+    /// symlink targets, and typeshed availability for the configured Python version.
+    pub(crate) fn resolve_file(&self, context: &ResolverContext, filename: &str) -> Option<File> {
+        let path = Utf8Path::new(filename);
+
+        // Verify that the provided `filename` input identifies just the final filename
+        // component of a path (i.e., plain `tools.py` instead of, say, `pkg/tools.py`).
+        if path.file_name() != Some(filename) {
+            return None;
+        }
+
+        // Do not resolve runtime modules for standard library stubs.
+        if path.extension() == Some("py") && self.path.is_standard_library_stub() {
+            return None;
+        }
+
+        // Verify that the directory listing contains a file or symlink entry
+        // with the correct name. Symlink targets and vendored paths are
+        // validated further down.
+        if self.path.search_path.as_vendored_path().is_none()
+            && !matches!(
+                self.listing.and_then(|listing| listing.file_type(filename)),
+                Some(FileType::File | FileType::Symlink)
+            )
+        {
+            return None;
+        }
+
+        let relative_path = self.path.relative_path.join(filename);
+
+        match &*self.path.search_path.0 {
+            SearchPathInner::Extra(root)
+            | SearchPathInner::FirstParty(root)
+            | SearchPathInner::SitePackages(root)
+            | SearchPathInner::Editable(root)
+            | SearchPathInner::StandardLibraryReal(root) => {
+                system_path_to_file(context.db, root.join(&relative_path)).ok()
+            }
+            SearchPathInner::StandardLibraryCustom(root) => {
+                match query_stdlib_version(&relative_path, context) {
+                    TypeshedVersionsQueryResult::DoesNotExist => None,
+                    TypeshedVersionsQueryResult::Exists
+                    | TypeshedVersionsQueryResult::MaybeExists => {
+                        system_path_to_file(context.db, root.join(&relative_path)).ok()
+                    }
+                }
+            }
+            SearchPathInner::StandardLibraryVendored(root) => {
+                match query_stdlib_version(&relative_path, context) {
+                    TypeshedVersionsQueryResult::DoesNotExist => None,
+                    TypeshedVersionsQueryResult::Exists
+                    | TypeshedVersionsQueryResult::MaybeExists => {
+                        vendored_path_to_file(context.db, root.join(&relative_path)).ok()
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn directory_contains_file(db: &dyn Db, directory: &SystemPath, names: &[&str]) -> bool {
     let Ok(listing) = directory_listing(db, directory) else {
         return false;
@@ -393,19 +446,6 @@ fn directory_contains_file(db: &dyn Db, directory: &SystemPath, names: &[&str]) 
     names
         .iter()
         .any(|name| listing.entry_is_file(db, directory, name))
-}
-
-fn system_path_to_file_if_listed(db: &dyn Db, path: &SystemPath) -> Option<File> {
-    let Some((parent, name)) = path.parent().zip(path.file_name()) else {
-        return system_path_to_file(db, path).ok();
-    };
-
-    let listing = directory_listing(db, parent).ok()?;
-    if listing.entry_is_file(db, parent, name) {
-        system_path_to_file(db, path).ok()
-    } else {
-        None
-    }
 }
 
 fn system_path_is_directory(db: &dyn Db, path: &SystemPath) -> bool {
@@ -908,6 +948,7 @@ impl std::fmt::Display for SystemOrVendoredPathRef<'_> {
 #[cfg(test)]
 mod tests {
     use ruff_db::Db;
+    use ruff_db::system::{DbWithTestSystem as _, DbWithWritableSystem as _, OsSystem};
     use ruff_python_ast::PythonVersion;
 
     use crate::ResolverEnvironment;
@@ -933,37 +974,62 @@ mod tests {
     }
 
     #[test]
-    fn with_extension_methods() {
-        let TestCase {
-            db, src, stdlib, ..
-        } = TestCaseBuilder::new()
-            .with_mocked_typeshed(MockedTypeshed::default())
-            .build();
-
-        assert_eq!(
-            SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap())
-                .unwrap()
-                .to_module_path()
-                .with_py_extension(),
-            None
+    fn resolve_file_rejects_runtime_files_in_typeshed() {
+        const TYPESHED: MockedTypeshed = MockedTypeshed {
+            versions: "foo: 3.12-",
+            stdlib_files: &[(
+                "foo.py",
+                r#"
+value = 1
+"#,
+            )],
+        };
+        let (db, stdlib_path) = typeshed_test_case(TYPESHED, PythonVersion::PY312);
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY312, db.search_paths()),
+            ModuleResolveMode::Typing,
         );
+        let directory = ModuleDirectory::new(&resolver, stdlib_path.to_module_path());
 
-        assert_eq!(
-            &SearchPath::custom_stdlib(db.system(), stdlib.parent().unwrap())
-                .unwrap()
-                .join("foo")
-                .with_pyi_extension(),
-            &stdlib.join("foo.pyi")
-        );
+        assert_eq!(directory.resolve_file(&resolver, "foo.py"), None);
+    }
 
-        assert_eq!(
-            &SearchPath::first_party(db.system(), src.clone())
-                .unwrap()
-                .join("foo/bar")
-                .with_py_extension()
-                .unwrap(),
-            &src.join("foo/bar.py")
+    #[test]
+    fn resolve_file_requires_exact_filename_case() {
+        let temp_dir = tempfile::TempDir::new().expect("Create temporary directory");
+        let root = SystemPathBuf::from_path_buf(
+            temp_dir
+                .path()
+                .canonicalize()
+                .expect("Canonicalize temporary directory"),
+        )
+        .expect("UTF-8 temporary directory path");
+        let mut db = TestDb::new();
+        db.use_system(OsSystem::new(&root));
+        db.write_file(
+            root.join("Tools.py"),
+            r#"
+value = 1
+"#,
+        )
+        .expect("Write Tools.py");
+
+        let resolver = ResolverContext::new(
+            &db,
+            ResolverEnvironment::new(&db, PythonVersion::PY312, db.search_paths()),
+            ModuleResolveMode::Typing,
         );
+        let search_path =
+            SearchPath::first_party(db.system(), root.clone()).expect("Existing source directory");
+        let directory = ModuleDirectory::new(&resolver, search_path.to_module_path());
+
+        // Require exact filename casing even when the filesystem is case-insensitive.
+        assert_eq!(directory.resolve_file(&resolver, "tools.py"), None);
+        let file = directory
+            .resolve_file(&resolver, "Tools.py")
+            .expect("Resolve the exact filename");
+        assert_eq!(file.path(&db), &root.join("Tools.py"));
     }
 
     #[test]
@@ -1456,5 +1522,22 @@ mod tests {
         let mut mp = sp.to_module_path();
         mp.push("foo-stubs.pyi");
         assert_eq!(mp.to_module_name(), None);
+    }
+
+    impl ModulePath {
+        /// Resolves this path through the same directory validation used by the resolver.
+        fn to_file(&self, context: &ResolverContext) -> Option<File> {
+            let filename = self.relative_path.file_name()?;
+            let parent = self.relative_path.parent()?;
+            let directory = ModuleDirectory::new(
+                context,
+                ModulePath {
+                    search_path: self.search_path.clone(),
+                    relative_path: parent.to_path_buf(),
+                },
+            );
+
+            directory.resolve_file(context, filename)
+        }
     }
 }

--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -33,7 +33,7 @@ pub(crate) struct ModulePath {
 
 impl ModulePath {
     #[must_use]
-    fn is_standard_library(&self) -> bool {
+    fn is_standard_library_stub(&self) -> bool {
         matches!(
             &*self.search_path.0,
             SearchPathInner::StandardLibraryCustom(_) | SearchPathInner::StandardLibraryVendored(_)
@@ -66,7 +66,7 @@ impl ModulePath {
                 self.relative_path.extension().is_none(),
                 "Cannot push part {component} to {self:?}, which already has an extension"
             );
-            if self.is_standard_library() {
+            if self.is_standard_library_stub() {
                 assert_eq!(
                     component_extension, "pyi",
                     "Extension must be `pyi`; got `{component_extension}`"
@@ -274,7 +274,7 @@ impl ModulePath {
             search_path: _,
             relative_path,
         } = self;
-        if self.is_standard_library() {
+        if self.is_standard_library_stub() {
             stdlib_path_to_module_name(relative_path)
         } else {
             let parent = relative_path.parent()?;
@@ -329,7 +329,7 @@ impl ModulePath {
 
     #[must_use]
     pub(crate) fn with_py_extension(&self) -> Option<Self> {
-        if self.is_standard_library() {
+        if self.is_standard_library_stub() {
             return None;
         }
         let ModulePath {

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -36,6 +36,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::iter::FusedIterator;
 
+use compact_str::format_compact;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use ruff_db::PythonFile;
@@ -51,7 +52,7 @@ use ruff_python_ast::{
 use crate::db::Db;
 use crate::module::{Module, ModuleKind};
 use crate::module_name::{ImportingFile, ModuleName};
-use crate::path::{ModulePath, SearchPath, SystemOrVendoredPathRef};
+use crate::path::{ModuleDirectory, ModulePath, SearchPath, SystemOrVendoredPathRef};
 use crate::strategy::MisconfigurationStrategy;
 use crate::typeshed::{TypeshedVersions, vendored_typeshed_versions};
 use crate::{ResolverEnvironment, ResolverFile, SearchPathSettings, SearchPathSettingsError};
@@ -1507,11 +1508,8 @@ impl<'db, 'name> NameResolver<'db, 'name> {
             }));
             // Defer file probes after stdlib until we know that stdlib does not win.
             pending_stub_paths.extend(stub_paths.after_stdlib.iter().filter(|search_path| {
-                candidate_may_exist(
-                    &self.context,
-                    &ModuleResolutionCandidate::stub(search_path),
-                    stub_name,
-                )
+                ModuleDirectory::new(&self.context, search_path.to_module_path())
+                    .may_contain_name(stub_name)
             }));
         }
 
@@ -1701,87 +1699,68 @@ fn resolve_component(
         return Err(());
     }
 
-    if !candidate_may_exist(context, candidate, module_name) {
+    let module_directory = ModuleDirectory::new(context, candidate.path.clone());
+    if !module_directory.may_contain_name(module_name) {
         return Err(());
     }
 
-    let package_path = &mut candidate.path;
-    package_path.push(module_name);
+    let subdirectory = module_directory.child_directory(context, module_name);
+    let init = subdirectory
+        .as_ref()
+        .and_then(|dir| resolve_file_module_with_filter(dir, context, "__init__", file_filter));
+    candidate.path.push(module_name);
 
-    // Check for a regular package first (highest priority)
-    package_path.push("__init__");
-    if let Some(init) = resolve_file_module_with_filter(package_path, context, file_filter) {
-        // Remove the `__init__` component for any potential next step
-        package_path.pop();
-        candidate.py_typed = package_path
-            .py_typed(context)
-            .inherit_parent(candidate.py_typed);
-        if is_legacy_namespace_package(package_path, context, init) {
-            candidate.module = ResolvedModule::LegacyNamespacePackage(init);
+    if let Some(init) = init {
+        // Check for a regular package first (highest priority).
+        candidate.module = if is_legacy_namespace_package(&candidate.path, context, init) {
+            ResolvedModule::LegacyNamespacePackage(init)
         } else {
-            candidate.module = ResolvedModule::RegularPackage(init);
-        }
-        return Ok(());
-    }
-
-    // Check for a file module next
-    package_path.pop();
-
-    if let Some(file_module) = resolve_file_module_with_filter(package_path, context, file_filter) {
-        candidate.module = ResolvedModule::Module(file_module);
-        return Ok(());
-    }
-
-    // Last resort, check if a folder with the given name exists. If so,
-    // then this is a namespace package. We need to skip this check for
-    // typeshed because the `resolve_file_module` can also return `None` if the
-    // `__init__.py` exists but isn't available for the current Python version.
-    // Let's assume that the `xml` module is only available on Python 3.11+ and
-    // we're resolving for Python 3.10:
-    //
-    // * `resolve_file_module("xml/__init__.pyi")` returns `None` even though
-    //   the file exists but the module isn't available for the current Python
-    //   version.
-    // * The check here would now return `true` because the `xml` directory
-    //   exists, resulting in a false positive for a namespace package.
-    //
-    // Since typeshed doesn't use any namespace packages today (May 2025),
-    // simply skip this check which also helps performance. If typeshed
-    // ever uses namespace packages, ensure that this check also takes the
-    // `VERSIONS` file into consideration.
-    // A namespace package is not backed by a file, so it cannot satisfy a stub-only lookup.
-    if file_filter != ComponentFileFilter::StubOnly
-        && !package_path.search_path().is_standard_library()
-        && package_path.is_directory(context)
-    {
-        candidate.py_typed = package_path
+            ResolvedModule::RegularPackage(init)
+        };
+        candidate.py_typed = candidate
+            .path
             .py_typed(context)
             .inherit_parent(candidate.py_typed);
-        candidate.module = ResolvedModule::NamespacePackage;
-        return Ok(());
+        Ok(())
+    } else if let Some(file_module) =
+        resolve_file_module_with_filter(&module_directory, context, module_name, file_filter)
+    {
+        // Check for a file module next
+        candidate.module = ResolvedModule::Module(file_module);
+        Ok(())
+    } else {
+        // Last resort, check if a folder with the given name exists. If so,
+        // then this is a namespace package. We need to skip this check for
+        // typeshed because the `resolve_file_module` can also return `None` if the
+        // `__init__.py` exists but isn't available for the current Python version.
+        // Let's assume that the `xml` module is only available on Python 3.11+ and
+        // we're resolving for Python 3.10:
+        //
+        // * `resolve_file_module("xml/__init__.pyi")` returns `None` even though
+        //   the file exists but the module isn't available for the current Python
+        //   version.
+        // * The check here would now return `true` because the `xml` directory
+        //   exists, resulting in a false positive for a namespace package.
+        //
+        // Since typeshed doesn't use any namespace packages today (May 2025),
+        // simply skip this check which also helps performance. If typeshed
+        // ever uses namespace packages, ensure that this check also takes the
+        // `VERSIONS` file into consideration.
+        // A namespace package is not backed by a file, so it cannot satisfy a stub-only lookup.
+        if file_filter != ComponentFileFilter::StubOnly
+            && !candidate.path.search_path().is_standard_library()
+            && subdirectory.is_some()
+        {
+            candidate.module = ResolvedModule::NamespacePackage;
+            candidate.py_typed = candidate
+                .path
+                .py_typed(context)
+                .inherit_parent(candidate.py_typed);
+            Ok(())
+        } else {
+            Err(())
+        }
     }
-
-    Err(())
-}
-
-/// Uses the parent directory's entries to reject candidates that cannot exist without performing
-/// individual file-system probes for every supported module layout.
-fn candidate_may_exist(
-    context: &ResolverContext,
-    candidate: &ModuleResolutionCandidate,
-    module_name: &str,
-) -> bool {
-    let Some(parent) = candidate.path.to_system_path() else {
-        return true;
-    };
-
-    let Ok(listing) = directory_listing(context.db, &parent) else {
-        return false;
-    };
-
-    // Other suffixes are harmless false positives; the normal probes still determine whether the
-    // module exists.
-    listing.contains_name_with_prefix(module_name)
 }
 
 type ResolvedNames = Vec<ModuleResolutionCandidate>;
@@ -1794,28 +1773,34 @@ pub(super) fn resolve_file_module(
     module: &ModulePath,
     resolver_state: &ResolverContext,
 ) -> Option<File> {
-    resolve_file_module_with_filter(module, resolver_state, ComponentFileFilter::ByMode)
+    let mut parent = module.clone();
+    parent.pop();
+
+    resolve_file_module_with_filter(
+        &ModuleDirectory::new(resolver_state, parent),
+        resolver_state,
+        module.file_stem()?,
+        ComponentFileFilter::ByMode,
+    )
 }
 
 fn resolve_file_module_with_filter(
-    module: &ModulePath,
+    directory: &ModuleDirectory,
     resolver_state: &ResolverContext,
+    name: &str,
     filter: ComponentFileFilter,
 ) -> Option<File> {
     let stub_file = if resolver_state.mode.is_typing() {
-        module.with_pyi_extension().to_file(resolver_state)
+        directory.resolve_file(resolver_state, &format_compact!("{name}.pyi"))
     } else {
         None
     };
+
     if filter == ComponentFileFilter::StubOnly {
         return stub_file;
     }
 
-    stub_file.or_else(|| {
-        module
-            .with_py_extension()
-            .and_then(|path| path.to_file(resolver_state))
-    })
+    stub_file.or_else(|| directory.resolve_file(resolver_state, &format_compact!("{name}.py")))
 }
 
 /// Determines whether a package is a legacy namespace package.


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This refactors our module resolution code in order to introduce a `ModuleDirectory` abstraction. The purpose of that new abstraction is to make it easier to reuse a single directory listing to resolve _multiple_ modules, as is required for the symbol enumeration that will power [namespace package import completions](https://github.com/astral-sh/ty/issues/2273). For more background on this problem, please see [this document](https://gist.github.com/lerebear/399114b087d03c0860bf2cde0509e519).

Downstream, this new abstraction allows for the following improvements that continue building towards symbol enumeration that supports namespace packages:

1. A [quick performance optimization](https://github.com/astral-sh/ruff/pull/28419) that immediately benefits ordinary module resolution, and hence will also benefit symbol enumeration once it shares ordinary module resolution code.
2. The [ability to retain directory listings across resolution steps](https://github.com/astral-sh/ruff/pull/28278), so that we maintain efficiency while considering all of the directories that might contribute to a namespace package.

## Motivation

Consider trying to provide the import completion `from acme.reports import Report` for `x = Re<CURSOR>` given the following namespace package layout:

```text
/project/src/acme
└── reports.py        # defines `Report`
```
```text
/venv/site-packages/acme/
├── tools.py          # defines `Tool` and `ImplementationDetail`
└── tools.pyi         # exposes only `Tool` to type checkers
```

In order to discover the `Report` symbol, we must enumerate _all_ symbols exposed by the `acme`. That requires us to must first enumerate all of `acme`'s module names (i.e. `acme.reports` and `acme.tools`), and then to resolve each of those names to determine which file actually exposes the relevant symbols (for `acme.tools` there are two choices, but the correct one for the purposes of import suggestions is `tools.pyi`).

Enumerating `acme`'s module names requires us to retrieve directory listings for `/project/src/acme` and `/venv/site-packages/acme/`. Subsequently, resolving the name `acme.tools` requires consulting _those same directory listings_ in order to answer the following questions that determine the outcome of the module resolution process:

1. Does `/project/src/acme` contain an entry named `tools`? (No.)
2. Does `/venv/site-packages/acme/` contain an ordinary package named `tools`? (No.)
3. Does `/venv/site-packages/acme/` contain only a runtime module (`tools.py`) or does it also contain a stub (`tools.pyi`)? (Both.)

So it would be useful to be able to reuse the directory listings from the enumeration process for the module resolution process.

As a first step towards that vision, this introduces a `ModuleDirectory` struct, which encapsulates the (1) path to a directory that participates in module resolution, (2) its directory listing as retrieved from the filesystem, (3) the existing validations for resolving an exact filename within that directory.

## Approach

I defined a new [`ModuleDirectory` struct](https://github.com/astral-sh/ruff/blob/304661fb5d0a6539585b9dd75df74231a6dc9bc8/crates/ty_module_resolver/src/path.rs#L331-L338), and replaced previous calls to [`ModulePath::to_file`](https://github.com/astral-sh/ruff/blob/77f653825800ddaf3bc221ae6db49a500e1002d5/crates/ty_module_resolver/src/path.rs#L229-L230) with calls to [`ModuleDirectory::resolve_file`](https://github.com/astral-sh/ruff/blob/304661fb5d0a6539585b9dd75df74231a6dc9bc8/crates/ty_module_resolver/src/path.rs#L382-L384). That new method implements the same checks that were previously spread across several methods (please see inline comments).

`ModuleDirectory` also provides a few more convenience methods that should be self-explanatory.

## Test Plan

See included tests.
<!-- How was it tested? -->
