### PR TITLE
[ty] Optionally record place-load deferredness as an "extra" output from type inference.

### DIFF
--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -21,7 +21,9 @@ use ty_python_core::ProgramFile;
 use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};
 use ty_python_semantic::dependency::DependencyMetadata;
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
-use ty_python_semantic::{AnalysisSettings, Db as SemanticDb, PythonVersionWithSource};
+use ty_python_semantic::{
+    AnalysisSettings, Db as SemanticDb, PlaceLoadRecordingMode, PythonVersionWithSource,
+};
 
 mod changes;
 
@@ -110,7 +112,12 @@ impl ProjectDatabase {
     where
         S: System + 'static + Send + Sync + RefUnwindSafe,
     {
-        Self::new(project_metadata, system, &FallibleStrategy)
+        Self::new(
+            project_metadata,
+            system,
+            PlaceLoadRecordingMode::default(),
+            &FallibleStrategy,
+        )
     }
 
     /// Creates a new database, substituting default values for any misconfigured settings.
@@ -118,7 +125,12 @@ impl ProjectDatabase {
     where
         S: System + 'static + Send + Sync + RefUnwindSafe,
     {
-        let Ok(db) = Self::new(project_metadata, system, &UseDefaultStrategy);
+        let Ok(db) = Self::new(
+            project_metadata,
+            system,
+            PlaceLoadRecordingMode::default(),
+            &UseDefaultStrategy,
+        );
         db
     }
 
@@ -144,6 +156,7 @@ impl ProjectDatabase {
     fn new<S, Strategy: MisconfigurationStrategy>(
         project_metadata: ProjectMetadata,
         system: S,
+        recording_mode: PlaceLoadRecordingMode,
         strategy: &Strategy,
     ) -> Result<Self, Strategy::Error<anyhow::Error>>
     where
@@ -181,6 +194,8 @@ impl ProjectDatabase {
 
         let (program_settings, program_settings_diagnostics) = strategy
             .to_anyhow(merged_options.to_program_settings(db.system(), db.vendored(), strategy))?;
+
+        ty_python_semantic::initialize_place_load_recording(&db, recording_mode);
 
         // This must be called before `from_metadata`, or the `SearchPath` root
         // will take precedence over the `Project` root, resulting in
@@ -714,7 +729,7 @@ pub(crate) mod testing {
     use ty_python_semantic::ProgramEnvironment;
     use ty_python_semantic::dependency::DependencyMetadata;
     use ty_python_semantic::lint::{LintRegistry, RuleSelection};
-    use ty_python_semantic::{AnalysisSettings, PythonVersionWithSource};
+    use ty_python_semantic::{AnalysisSettings, PlaceLoadRecordingMode, PythonVersionWithSource};
 
     use crate::db::Db;
     use crate::metadata::settings::file_settings;
@@ -738,6 +753,14 @@ pub(crate) mod testing {
 
     impl TestDb {
         pub fn new(project: ProjectMetadata) -> Self {
+            Self::with_place_load_recording_mode(project, PlaceLoadRecordingMode::default())
+        }
+
+        /// Creates a test database with the given recording policy.
+        fn with_place_load_recording_mode(
+            project: ProjectMetadata,
+            recording_mode: PlaceLoadRecordingMode,
+        ) -> Self {
             let events = Events::default();
             let uv_environments = UvEnvironments::new(project.use_uv());
             let mut db = Self {
@@ -755,6 +778,8 @@ pub(crate) mod testing {
                 events,
                 project: None,
             };
+
+            ty_python_semantic::initialize_place_load_recording(&db, recording_mode);
 
             let (settings, settings_diagnostics) = project
                 .to_merged_options()
@@ -938,6 +963,27 @@ mod tests {
     use crate::db::testing::TestDb;
     use crate::watch::ChangeEvent;
     use crate::{Db, ProjectDatabase, ProjectMetadata, UseUv};
+
+    #[test]
+    fn place_load_recording_defaults_to_disabled() {
+        let system = TestSystem::default();
+        system
+            .memory_file_system()
+            .write_file_all(
+                "/project/test.py",
+                r#"
+value = 1
+result = value
+"#,
+            )
+            .expect("write recording fixture");
+        let metadata = ProjectMetadata::new("recording", SystemPathBuf::from("/project"));
+        let mut db = ProjectDatabase::fallible(metadata, system).expect("valid test project");
+        let file = system_path_to_file(&db, "/project/test.py").expect("fixture exists");
+        ty_python_semantic::enable_place_load_recording(&mut db, [file]);
+        assert!(!ty_python_semantic::should_record_place_loads(&db, file));
+        assert!(db.check_file(file).is_empty());
+    }
 
     #[test]
     fn checks_use_available_script_environment_without_running_uv() -> anyhow::Result<()> {

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -3,6 +3,8 @@ use crate::lint::{LintRegistry, RuleSelection};
 use crate::{AnalysisSettings, PythonVersionWithSource};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
+use rustc_hash::FxHashSet;
+use salsa::Setter;
 use ty_python_core::{Db as PythonCoreDb, ProgramFile};
 
 /// Database giving access to semantic information about a Python program.
@@ -35,6 +37,77 @@ pub trait Db: PythonCoreDb {
     fn is_open_file(&self, file: File) -> bool;
 
     fn dyn_clone(&self) -> Box<dyn Db>;
+}
+
+/// Initializes the database's permanent recording policy, with no files selected.
+///
+/// Call once when constructing a database, before running inference or creating snapshots.
+/// The input must exist even while recording is disabled: Salsa does not track the absence
+/// of a singleton, so creating it on first opt-in would not invalidate earlier inference.
+pub fn initialize_place_load_recording(db: &dyn Db, mode: PlaceLoadRecordingMode) {
+    let _ = PlaceLoadRecording::builder(mode, FxHashSet::default())
+        .mode_durability(salsa::Durability::NEVER_CHANGE)
+        .new(db);
+}
+
+/// Whether a database can retain place-load metadata alongside inferred types.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, get_size2::GetSize)]
+pub enum PlaceLoadRecordingMode {
+    /// Never record place loads, even if a caller requests them.
+    #[default]
+    Disabled,
+    /// Allow callers to enable recording for individual files.
+    OnDemand,
+}
+
+/// Enables cached place-load records for the selected files without running inference.
+///
+/// Recording persists across requests and source edits. Newly enabled files invalidate their
+/// unrecorded inference; enabling an already-enabled file does not change the database.
+/// Has no effect when the database was constructed with [`PlaceLoadRecordingMode::Disabled`].
+pub fn enable_place_load_recording(db: &mut dyn Db, files: impl IntoIterator<Item = File>) {
+    let recording = PlaceLoadRecording::get(db);
+    if recording.mode(db) == PlaceLoadRecordingMode::Disabled {
+        return;
+    }
+
+    let enabled = recording.files(db);
+
+    let additions: FxHashSet<_> = files
+        .into_iter()
+        .filter(|file| !enabled.contains(file))
+        .collect();
+    if additions.is_empty() {
+        return;
+    }
+
+    let mut enabled = enabled.clone();
+    enabled.extend(additions);
+    enabled.shrink_to_fit();
+
+    recording.set_files(db).to(enabled);
+}
+
+#[salsa::input(singleton, heap_size=ruff_memory_usage::heap_size)]
+struct PlaceLoadRecording {
+    #[returns(copy)]
+    mode: PlaceLoadRecordingMode,
+    #[returns(ref)]
+    files: FxHashSet<File>,
+}
+
+/// Returns whether inference retains place-load metadata for `file`.
+///
+/// Permanently disabled databases neither cache per-file flags nor depend on the selected files.
+pub fn should_record_place_loads(db: &dyn Db, file: File) -> bool {
+    PlaceLoadRecording::get(db).mode(db) == PlaceLoadRecordingMode::OnDemand
+        && should_record_place_loads_impl(db, file)
+}
+
+/// Isolates recording changes so inference for other files can retain its cached result.
+#[salsa::tracked(heap_size=ruff_memory_usage::heap_size, returns(copy))]
+fn should_record_place_loads_impl(db: &dyn Db, file: File) -> bool {
+    PlaceLoadRecording::get(db).files(db).contains(&file)
 }
 
 #[cfg(test)]
@@ -76,11 +149,11 @@ pub(crate) mod tests {
     }
 
     impl TestDb {
-        fn new() -> Self {
+        fn new(recording_mode: PlaceLoadRecordingMode) -> Self {
             let events = Events::default();
             let vendored = ty_vendored::file_system().clone();
             let program_settings = ProgramSettings::empty(&vendored);
-            Self {
+            let db = Self {
                 storage: salsa::Storage::new(Some(Box::new({
                     let events = events.clone();
                     move |event| {
@@ -97,7 +170,9 @@ pub(crate) mod tests {
                 analysis_settings: AnalysisSettings::default().into(),
                 open_files: rustc_hash::FxHashSet::default(),
                 program_settings,
-            }
+            };
+            initialize_place_load_recording(&db, recording_mode);
+            db
         }
 
         pub(crate) fn python_version(&self) -> PythonVersion {
@@ -113,6 +188,24 @@ pub(crate) mod tests {
         /// This is untracked state: open a file before running any queries.
         pub(crate) fn open_file(&mut self, file: File) {
             self.open_files.insert(file);
+        }
+
+        pub(crate) fn enable_place_load_recording(&mut self, file: File) {
+            super::enable_place_load_recording(self, [file]);
+        }
+
+        pub(crate) fn set_place_load_recording(&mut self, file: File, enabled: bool) {
+            let recording = PlaceLoadRecording::get(self);
+            let mut files = recording.files(self).clone();
+            let changed = if enabled {
+                files.insert(file)
+            } else {
+                files.remove(&file)
+            };
+            if changed {
+                files.shrink_to_fit();
+                recording.set_files(self).to(files);
+            }
         }
 
         /// Takes the salsa events.
@@ -235,6 +328,7 @@ pub(crate) mod tests {
         /// Whether module resolution should include packages from the synthetic virtual environment.
         third_party_packages: bool,
         rule_selection: Option<RuleSelection>,
+        recording_mode: PlaceLoadRecordingMode,
     }
 
     impl<'a> TestDbBuilder<'a> {
@@ -246,11 +340,20 @@ pub(crate) mod tests {
                 files: vec![],
                 third_party_packages: false,
                 rule_selection: None,
+                recording_mode: PlaceLoadRecordingMode::default(),
             }
         }
 
         pub(crate) fn with_python_version(mut self, version: PythonVersion) -> Self {
             self.python_version = version;
+            self
+        }
+
+        pub(crate) fn with_place_load_recording_mode(
+            mut self,
+            mode: PlaceLoadRecordingMode,
+        ) -> Self {
+            self.recording_mode = mode;
             self
         }
 
@@ -288,7 +391,7 @@ pub(crate) mod tests {
         }
 
         pub(crate) fn build(self) -> anyhow::Result<TestDb> {
-            let mut db = TestDb::new();
+            let mut db = TestDb::new(self.recording_mode);
 
             if let Some(selection) = self.rule_selection {
                 db.rule_selection = Arc::new(selection);

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -8,7 +8,11 @@ use crate::suppression::{
     UNUSED_TYPE_IGNORE_COMMENT,
 };
 use crate::types::check_types;
-pub use db::Db;
+#[allow(dead_code)]
+pub use db::{
+    Db, PlaceLoadRecordingMode, enable_place_load_recording, initialize_place_load_recording,
+    should_record_place_loads,
+};
 pub(crate) use diagnostic::add_inferred_python_version_hint_to_diagnostic;
 pub use diagnostic::inferred_python_version_source_annotation;
 pub use fixes::{fix_all_diagnostics, suppress_all_diagnostics};

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -63,7 +63,7 @@ use crate::types::{
 };
 use crate::{Db, FxIndexSet};
 
-use builder::TypeInferenceBuilder;
+use builder::{DeferredExpressionState, TypeInferenceBuilder};
 pub(super) use comparisons::UnsupportedComparisonError;
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::expression::Expression;
@@ -76,6 +76,13 @@ mod builder;
 mod comparisons;
 #[cfg(test)]
 mod tests;
+
+/// The place-load metadata produced alongside an expression's type when recording is enabled.
+#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+struct PlaceLoadMetadata {
+    range: TextRange,
+    deferred_state: DeferredExpressionState,
+}
 
 bitflags::bitflags! {
     /// Metadata for expressions inferred as type expressions.
@@ -255,6 +262,7 @@ pub(crate) fn function_known_decorator_flags<'db>(
 /// function-definition inference.
 #[derive(Debug, Eq, PartialEq, Default, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct FunctionDecoratorInference<'db> {
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
     expression_types: FrozenMap<ExpressionNodeKey, Type<'db>>,
     bindings: Box<[(Definition<'db>, Type<'db>)]>,
     called_functions: Box<[FunctionType<'db>]>,
@@ -929,6 +937,8 @@ pub(crate) struct ScopeInference<'db> {
 
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct ScopeInferenceExtra<'db> {
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
@@ -1313,6 +1323,9 @@ impl<'db> DefinitionTypes<'db> {
 /// `Other` stores uncommon combinations that require multiple fields.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 enum DefinitionInferenceExtra<'db> {
+    /// Place-load metadata is the only extra data for some definitions.
+    PlaceLoadMetadata(FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>),
+
     /// Type qualifiers are the only extra data for most annotated definitions.
     Qualifiers(FrozenMap<ExpressionNodeKey, TypeQualifiers>),
 
@@ -1348,6 +1361,9 @@ struct OtherDefinitionInferenceExtra<'db> {
     /// Condition truthiness retained for checks of enclosing conditions containing walrus expressions.
     /// See [`ExpressionInferenceExtra::comparison_truthiness`] for the distinction from value types.
     comparison_truthiness: FrozenMap<ExpressionNodeKey, Truthiness>,
+
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
 
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
@@ -1391,6 +1407,10 @@ struct OtherDefinitionInferenceExtra<'db> {
 impl<'db> DefinitionInferenceExtra<'db> {
     fn into_other(self) -> OtherDefinitionInferenceExtra<'db> {
         match self {
+            Self::PlaceLoadMetadata(place_load_metadata) => OtherDefinitionInferenceExtra {
+                place_load_metadata: Some(Box::new(place_load_metadata)),
+                ..OtherDefinitionInferenceExtra::default()
+            },
             Self::Qualifiers(qualifiers) => OtherDefinitionInferenceExtra {
                 qualifiers,
                 ..OtherDefinitionInferenceExtra::default()
@@ -1846,6 +1866,8 @@ pub(crate) struct ExpressionInference<'db> {
 /// Extra data that only exists for few inferred expression regions.
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct ExpressionInferenceExtra<'db> {
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
@@ -2092,6 +2114,8 @@ struct StatementInferenceInnerExtra<'db> {
     /// See [`ExpressionInferenceExtra::comparison_truthiness`] for the distinction from value types.
     comparison_truthiness: FrozenMap<ExpressionNodeKey, Truthiness>,
 
+    /// Place-load metadata retained only for files that opted into recording.
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -25,6 +25,7 @@ use ty_module_resolver::{ImportingFile, ModuleName, resolve_module};
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
+use super::PlaceLoadMetadata;
 use super::{
     CollectionUseConstraints, DeferredAndUndecorated, DefinitionInference,
     DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
@@ -314,6 +315,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// Expected types for expression nodes tracked for IDE completion.
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
+    /// Place-load metadata retained only when this file opts into recording.
+    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata>,
+
     /// The scope this region is part of.
     scope: ScopeId<'db>,
 
@@ -514,6 +518,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             collection_use_constraints: FxHashMap::default(),
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
+            place_load_metadata: FxHashMap::default(),
             bindings: VecMap::default(),
             declarations: VecMap::default(),
             typevar_binding_context: None,
@@ -600,6 +605,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(extra) = &inference.extra {
             match extra.as_ref() {
+                DefinitionInferenceExtra::PlaceLoadMetadata(metadata) => {
+                    self.place_load_metadata.extend(metadata.iter().cloned());
+                }
                 DefinitionInferenceExtra::Qualifiers(qualifiers) => {
                     self.qualifiers.extend(qualifiers.iter().copied());
                 }
@@ -628,6 +636,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 DefinitionInferenceExtra::Other(extra) => {
                     self.comparison_truthiness
                         .extend(extra.comparison_truthiness.iter().copied());
+                    if let Some(place_load_metadata) = &extra.place_load_metadata {
+                        self.place_load_metadata
+                            .extend(place_load_metadata.iter().cloned());
+                    }
                     self.called_functions
                         .extend(extra.called_functions.iter().copied());
                     self.extend_cycle_recovery(extra.cycle_recovery);
@@ -679,6 +691,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(extra) = &inference.extra {
             self.comparison_truthiness
                 .extend(extra.comparison_truthiness.iter().copied());
+            if let Some(place_load_metadata) = &extra.place_load_metadata {
+                self.place_load_metadata
+                    .extend(place_load_metadata.iter().cloned());
+            }
             self.called_functions
                 .extend(extra.called_functions.iter().copied());
             self.return_types_and_ranges
@@ -734,6 +750,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.extend_expression_types(inference.expressions.iter().copied());
 
         if let Some(extra) = &inference.extra {
+            if let Some(place_load_metadata) = &extra.place_load_metadata {
+                self.place_load_metadata
+                    .extend(place_load_metadata.iter().cloned());
+            }
             self.comparison_truthiness
                 .extend(extra.comparison_truthiness.iter().copied());
             self.context.extend(&extra.diagnostics);
@@ -761,6 +781,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_expression_cache_entry(&mut self, inference: &FullExpressionCacheEntry<'db>) {
+        self.place_load_metadata.extend(
+            inference
+                .place_load_metadata
+                .iter()
+                .map(|(key, metadata)| (*key, metadata.clone())),
+        );
         #[cfg(debug_assertions)]
         assert_eq!(self.scope, inference.scope);
 
@@ -811,6 +837,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.extend_expression_types(inference.expressions.iter());
 
         if let Some(extra) = &inference.extra {
+            if let Some(place_load_metadata) = &extra.place_load_metadata {
+                self.place_load_metadata
+                    .extend(place_load_metadata.iter().cloned());
+            }
             self.context.extend(&extra.diagnostics);
             self.extend_cycle_recovery(extra.cycle_recovery);
             self.string_annotations
@@ -10322,7 +10352,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ///
     /// This also returns the [`ConstraintKey`]s used by expression-level narrowing.
     fn infer_place_load(
-        &self,
+        &mut self,
         place_expr: PlaceExpr,
         expr_ref: ast::ExprRef,
     ) -> (PlaceAndQualifiers<'db>, Vec<(FileScopeId, ConstraintKey)>) {
@@ -10390,6 +10420,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } else {
             place
         };
+
+        if expr_ref.is_name_expr() && crate::db::should_record_place_loads(self.db(), self.file()) {
+            self.place_load_metadata.insert(
+                expr_ref.into(),
+                PlaceLoadMetadata {
+                    range: expr_ref.range(),
+                    deferred_state: self.deferred_state,
+                },
+            );
+        }
 
         let constraint_keys = resolution.into_constraints();
 
@@ -11671,6 +11711,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -11708,6 +11749,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         FullExpressionCacheEntry {
+            place_load_metadata,
             expressions,
             comparison_truthiness,
             type_expression_flags,
@@ -11734,6 +11776,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             mut collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -11763,6 +11806,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let extra = (!diagnostics.is_empty()
             || !comparison_truthiness.is_empty()
+            || !place_load_metadata.is_empty()
             || !string_annotations.is_empty()
             || cycle_recovery.is_some()
             || !expected_types.is_empty()
@@ -11777,6 +11821,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return_types_and_ranges.shrink_to_fit();
             Box::new(StatementInferenceInnerExtra {
                 comparison_truthiness: FrozenMap::from(comparison_truthiness),
+                place_load_metadata: (!place_load_metadata.is_empty())
+                    .then(|| Box::new(FrozenMap::from(place_load_metadata))),
                 string_annotations: FrozenSet::from(string_annotations),
                 expected_types: FrozenMap::from(expected_types),
                 called_functions: called_functions
@@ -11855,6 +11901,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred: _,
             scope: _,
             string_annotations: _,
+            place_load_metadata,
             expected_types: _,
             return_types_and_ranges: _,
             collection_use_constraints: _,
@@ -11873,6 +11920,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         FunctionDecoratorInference {
+            place_load_metadata: (!place_load_metadata.is_empty())
+                .then(|| Box::new(FrozenMap::from(place_load_metadata))),
             expression_types: FrozenMap::from(expressions),
             bindings: bindings.into_boxed_slice(),
             called_functions: called_functions
@@ -11901,6 +11950,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             mut collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -11928,6 +11978,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let non_undecorated_extra_field_count = usize::from(!string_annotations.is_empty())
             + usize::from(!comparison_truthiness.is_empty())
+            + usize::from(!place_load_metadata.is_empty())
             + usize::from(!expected_types.is_empty())
             + usize::from(!collection_use_constraints.is_empty())
             + usize::from(!called_functions.is_empty())
@@ -11941,6 +11992,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let extra = match (non_undecorated_extra_field_count, undecorated_type) {
             (0, None) => None,
+            (1, None) if !place_load_metadata.is_empty() => Some(Box::new(
+                DefinitionInferenceExtra::PlaceLoadMetadata(FrozenMap::from(place_load_metadata)),
+            )),
             (1, None) if !qualifiers.is_empty() => Some(Box::new(
                 DefinitionInferenceExtra::Qualifiers(FrozenMap::from(qualifiers)),
             )),
@@ -11982,6 +12036,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 collection_use_constraints.shrink_to_fit();
                 let extra = OtherDefinitionInferenceExtra {
                     comparison_truthiness: FrozenMap::from(comparison_truthiness),
+                    place_load_metadata: (!place_load_metadata.is_empty())
+                        .then(|| Box::new(FrozenMap::from(place_load_metadata))),
                     string_annotations: FrozenSet::from(string_annotations),
                     expected_types: FrozenMap::from(expected_types),
                     collection_use_constraints,
@@ -12039,6 +12095,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Self {
             context,
             string_annotations,
+            place_load_metadata,
             expected_types,
             type_expression_flags,
             mut collection_use_constraints,
@@ -12074,6 +12131,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let diagnostics = context.finish();
 
         let extra = (!string_annotations.is_empty()
+            || !place_load_metadata.is_empty()
             || !expected_types.is_empty()
             || !diagnostics.is_empty()
             || cycle_recovery.is_some()
@@ -12083,6 +12141,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         .then(|| {
             collection_use_constraints.shrink_to_fit();
             Box::new(ScopeInferenceExtra {
+                place_load_metadata: (!place_load_metadata.is_empty())
+                    .then(|| Box::new(FrozenMap::from(place_load_metadata))),
                 string_annotations: FrozenSet::from(string_annotations),
                 qualifiers: FrozenMap::from(qualifiers),
                 expected_types: FrozenMap::from(expected_types),
@@ -12128,6 +12188,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions: _,
             comparison_truthiness: _,
             string_annotations: _,
+            place_load_metadata: _,
             expected_types: _,
             scope: _,
             bindings: _,
@@ -12191,6 +12252,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             type_expression_flags,
             collection_use_constraints,
             string_annotations,
+            place_load_metadata,
             expected_types,
             scope,
             bindings,
@@ -12229,6 +12291,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         self.extend_expression_types(expressions);
+        self.place_load_metadata.extend(place_load_metadata);
         self.comparison_truthiness.extend(comparison_truthiness);
         self.context.extend(&diagnostics);
         self.extend_cycle_recovery(cycle_recovery);
@@ -12355,6 +12418,7 @@ enum ExpressionCacheEntry<'db> {
 /// Unlike [`ExpressionInference`], this type is short-lived, and avoids the cost of compaction
 /// that is otherwise performed for Salsa results.
 struct FullExpressionCacheEntry<'db> {
+    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata>,
     expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
     comparison_truthiness: FxHashMap<ExpressionNodeKey, Truthiness>,
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
@@ -12380,6 +12444,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
 
     fn is_single_expression(&self, expression: ExpressionNodeKey, ty: Type<'db>) -> bool {
         self.expressions.len() == 1
+            && self.place_load_metadata.is_empty()
             && self.expressions.get(&expression) == Some(&ty)
             && self.comparison_truthiness.is_empty()
             && self.type_expression_flags.is_empty()
@@ -12397,6 +12462,7 @@ impl<'db> FullExpressionCacheEntry<'db> {
         region: InferenceRegion<'db>,
     ) -> ExpressionInference<'db> {
         let extra = (!self.string_annotations.is_empty()
+            || !self.place_load_metadata.is_empty()
             || !self.comparison_truthiness.is_empty()
             || !self.type_expression_flags.is_empty()
             || !self.collection_use_constraints.is_empty()
@@ -12418,6 +12484,8 @@ impl<'db> FullExpressionCacheEntry<'db> {
             self.collection_use_constraints.shrink_to_fit();
             self.diagnostics.shrink_to_fit();
             Box::new(ExpressionInferenceExtra {
+                place_load_metadata: (!self.place_load_metadata.is_empty())
+                    .then(|| Box::new(FrozenMap::from(self.place_load_metadata))),
                 string_annotations: FrozenSet::from(self.string_annotations),
                 comparison_truthiness: FrozenMap::from(self.comparison_truthiness),
                 expected_types: FrozenMap::from(self.expected_types),
@@ -12587,8 +12655,8 @@ impl<'a> Iterator for ArgumentsIter<'a> {
 }
 
 /// The deferred state of a specific expression in an inference region.
-#[derive(Default, Debug, Clone, Copy)]
-enum DeferredExpressionState {
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+pub(super) enum DeferredExpressionState {
     /// The expression is not deferred.
     #[default]
     None,

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -427,6 +427,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let decorator_inference =
             (!decorator_list.is_empty()).then(|| function_known_decorators(self.db(), definition));
         if let Some(decorator_inference) = decorator_inference.as_ref() {
+            if let Some(metadata) = &decorator_inference.place_load_metadata {
+                self.place_load_metadata.extend(metadata.iter().cloned());
+            }
             self.context.extend(decorator_inference.diagnostics());
             self.expressions
                 .extend(decorator_inference.expression_types());

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -2,6 +2,7 @@ use std::assert_matches;
 use std::fmt::Write;
 
 use super::builder::TypeInferenceBuilder;
+use crate::db::PlaceLoadRecordingMode;
 use crate::db::tests::{TestDb, TestDbBuilder, setup_db};
 use crate::lint::{LintSource, RuleSelection};
 use crate::place::symbol;
@@ -11,7 +12,8 @@ use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
-use ruff_python_ast::PythonVersion;
+use ruff_python_ast::visitor::{Visitor, walk_expr};
+use ruff_python_ast::{self as ast, PythonVersion};
 use salsa::Database as _;
 use salsa::plumbing::AsId;
 use ty_python_core::definition::Definition;
@@ -23,6 +25,233 @@ use ty_python_core::{
 use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
 use super::*;
+
+#[test]
+fn recording_is_disabled_by_default() {
+    let mut db = TestDbBuilder::new()
+        .with_file(
+            "/src/test.py",
+            r#"
+value = 1
+result = value
+"#,
+        )
+        .build()
+        .expect("valid recording fixture");
+    let file = system_path_to_file(&db, "/src/test.py").expect("fixture file exists");
+    let original = recording_snapshot(&db, file, "value");
+    assert!(original.metadata.is_empty());
+
+    db.enable_place_load_recording(file);
+    assert_eq!(recording_snapshot(&db.clone(), file, "value"), original);
+
+    db.write_file(
+        "/src/test.py",
+        r#"
+value = "updated"
+result = value
+"#,
+    )
+    .expect("replace source in permanently disabled database");
+    db.enable_place_load_recording(file);
+    let updated = recording_snapshot(&db, file, "value");
+    assert!(updated.metadata.is_empty());
+    assert_ne!(updated.types, original.types);
+}
+
+#[test]
+fn recording_retains_deferredness() {
+    let source = r#"
+import first as value
+annotation: value.C
+runtime = [value]
+import second as value
+"#;
+    let mut db = recording_db("/src/test.pyi", source);
+    let file = system_path_to_file(&db, "/src/test.pyi").expect("fixture file exists");
+    db.enable_place_load_recording(file);
+    let snapshot = recording_snapshot(&db, file, "value");
+    assert_eq!(snapshot.metadata.len(), 2);
+    assert_eq!(snapshot.metadata[0].1, DeferredExpressionState::Deferred);
+    assert_eq!(snapshot.metadata[1].1, DeferredExpressionState::None);
+    assert_eq!(&source[snapshot.metadata[0].0], "value");
+    assert_eq!(&source[snapshot.metadata[1].0], "value");
+    assert_ne!(snapshot.metadata[0].0, snapshot.metadata[1].0);
+}
+
+#[test]
+fn recording_follows_nested_and_cached_regions() {
+    assert_recording_preserves_types(
+        r#"
+import package as value
+
+def identity[T](item: T) -> T:
+    return item
+
+module_value = [value]
+generic_value = identity(value)
+for item in [value]:
+    pass
+
+@value.decorator
+def function(default=value):
+    statement = value
+    named = (alias := value)
+    closure = lambda: value
+    comprehension = [value for _ in value]
+"#,
+        "value",
+    );
+}
+
+#[test]
+fn recording_preserves_recursive_module_members() {
+    assert_recording_preserves_types(
+        r#"
+import test
+f = lambda: test.f
+"#,
+        "test",
+    );
+}
+
+#[test]
+fn recording_preserves_recursive_unpack_targets() {
+    assert_recording_preserves_types(
+        r#"
+x, = (lambda: x,)
+"#,
+        "x",
+    );
+}
+
+#[test]
+fn recording_preserves_recursive_lambdas_and_collections() {
+    for source in [
+        r#"
+x = lambda: x
+"#,
+        r#"
+x = lambda: y
+y = lambda: x
+"#,
+        r#"
+x = []
+x.append(x)
+"#,
+        r#"
+x = {}
+x["self"] = x
+"#,
+        r#"
+x = [lambda: x]
+"#,
+        r#"
+while True:
+    x = (*x, x)
+"#,
+        r#"
+def f(flag: bool):
+    x = ()
+    while flag:
+        x = (x,)
+    return x
+"#,
+    ] {
+        assert_recording_preserves_types(source, "x");
+    }
+}
+
+#[test]
+fn recording_preserves_recursive_annotations_and_context() {
+    for source in [
+        r#"
+from __future__ import annotations
+def f(x: f):
+    pass
+"#,
+        r#"
+from collections.abc import Callable
+f: Callable[[int], int] = lambda x: f(x)
+"#,
+    ] {
+        assert_recording_preserves_types(source, "f");
+    }
+}
+
+#[test]
+fn recording_tracks_file_selection_and_source_edits() {
+    let source = r#"
+import first as value
+result = value
+"#;
+    let mut db = recording_db("/src/test.py", source);
+    db.write_file("/src/other.py", source)
+        .expect("write second fixture");
+    let file = system_path_to_file(&db, "/src/test.py").expect("fixture file exists");
+    let other = system_path_to_file(&db, "/src/other.py").expect("second fixture file exists");
+    let original = recording_snapshot(&db, file, "value");
+    assert!(original.metadata.is_empty());
+
+    db.enable_place_load_recording(file);
+    let recorded = recording_snapshot(&db, file, "value");
+    assert_eq!(recorded.types, original.types);
+    assert_eq!(recorded.metadata.len(), 1);
+    assert_eq!(recorded.metadata[0].1, DeferredExpressionState::None);
+    assert_eq!(&source[recorded.metadata[0].0], "value");
+    assert!(recording_snapshot(&db, other, "value").metadata.is_empty());
+
+    let updated_source = r#"
+import second as value
+result = value
+"#;
+    db.write_file("/src/test.py", updated_source)
+        .expect("replace recorded source");
+    let updated = recording_snapshot(&db, file, "value");
+    assert_eq!(updated.metadata.len(), 1);
+    assert_eq!(updated.metadata[0].1, DeferredExpressionState::None);
+    assert_eq!(&updated_source[updated.metadata[0].0], "value");
+    assert_ne!(updated.metadata[0].0, recorded.metadata[0].0);
+
+    db.set_place_load_recording(file, false);
+    assert!(recording_snapshot(&db, file, "value").metadata.is_empty());
+    db.enable_place_load_recording(file);
+    assert_eq!(recording_snapshot(&db, file, "value"), updated);
+}
+
+#[test]
+fn recording_keeps_string_annotation_names_distinct() {
+    let source = r#"
+import first
+import second
+annotation: "tuple[first.C, second.C]"
+"#;
+    let mut db = recording_db("/src/test.py", source);
+    let file = system_path_to_file(&db, "/src/test.py").expect("fixture file exists");
+    db.enable_place_load_recording(file);
+    let file = program_file(&db, file);
+    let inference = infer_complete_scope_types(&db, global_scope(&db, file));
+    let metadata = inference
+        .extra
+        .as_ref()
+        .expect("recorded scope has extra data")
+        .place_load_metadata
+        .as_deref()
+        .expect("recorded scope has place-load metadata");
+    let annotation_metadata: Vec<_> = metadata
+        .iter()
+        .map(|(_, metadata)| metadata)
+        .filter(|metadata| matches!(&source[metadata.range], "first" | "second"))
+        .collect();
+    assert_eq!(annotation_metadata.len(), 2);
+    assert!(annotation_metadata.iter().all(|metadata| matches!(
+        metadata.deferred_state,
+        DeferredExpressionState::InStringAnnotation(_)
+    )));
+    assert_ne!(annotation_metadata[0].range, annotation_metadata[1].range);
+    assert_eq!(&source[annotation_metadata[0].range], "first");
+    assert_eq!(&source[annotation_metadata[1].range], "second");
+}
 
 fn program_file(db: &TestDb, file: File) -> ProgramFile<'_> {
     ProgramFile::new(db, file, db.program_environment().program(db))
@@ -1841,4 +2070,137 @@ fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
     );
 
     Ok(())
+}
+
+fn recording_db(path: &str, source: &str) -> TestDb {
+    TestDbBuilder::new()
+        .with_place_load_recording_mode(PlaceLoadRecordingMode::OnDemand)
+        .with_python_version(PythonVersion::PY314)
+        .with_file(path, source)
+        .build()
+        .expect("valid recording fixture")
+}
+
+#[track_caller]
+fn assert_recording_preserves_types(source: &str, name: &str) {
+    let baseline = recording_db("/src/test.py", source);
+    let file = system_path_to_file(&baseline, "/src/test.py").expect("fixture file exists");
+    check_types(&baseline, program_file(&baseline, file));
+    let expected = recording_snapshot(&baseline, file, name);
+    assert!(expected.metadata.is_empty());
+
+    let mut cold_metadata = None;
+    for warm_first in [false, true] {
+        let mut db = recording_db("/src/test.py", source);
+        let file = system_path_to_file(&db, "/src/test.py").expect("fixture file exists");
+        if warm_first {
+            check_types(&db, program_file(&db, file));
+            assert_eq!(recording_snapshot(&db, file, name), expected);
+        }
+        db.enable_place_load_recording(file);
+        let actual = recording_snapshot(&db, file, name);
+        assert_eq!(
+            actual.types, expected.types,
+            "warm={warm_first}; source={source}"
+        );
+        assert!(
+            !actual.metadata.is_empty(),
+            "fixture must record place-load metadata"
+        );
+        assert_eq!(actual, recording_snapshot(&db, file, name));
+        if let Some(cold_metadata) = &cold_metadata {
+            assert_eq!(
+                &actual.metadata, cold_metadata,
+                "records differ after warming: {source}"
+            );
+        } else {
+            cold_metadata = Some(actual.metadata);
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RecordingSnapshot {
+    types: Vec<(ExpressionNodeKey, String)>,
+    metadata: Vec<(TextRange, DeferredExpressionState)>,
+}
+
+fn recording_snapshot(db: &TestDb, file: File, name: &str) -> RecordingSnapshot {
+    let file = program_file(db, file);
+    let env = ProgramEnvironment::from_file(file);
+    let index = semantic_index(db, file);
+    let model = crate::SemanticModel::new(db, file);
+    let module = parsed_module(db, file.python_file(db)).load(db);
+    let mut collector = RecordingNameCollector {
+        name,
+        names: Vec::new(),
+    };
+    collector.visit_body(&module.syntax().body);
+    assert!(
+        !collector.names.is_empty(),
+        "fixture must contain a requested name"
+    );
+
+    let mut by_scope = crate::FxIndexMap::<ScopeId<'_>, Vec<&ast::ExprName>>::default();
+    for name in collector.names {
+        let mut scope = model
+            .scope(name.into())
+            .expect("name scope")
+            .to_scope_id(db, file);
+        while scope.accepts_type_context(db) {
+            scope = index
+                .parent_scope_id(scope.file_scope_id(db))
+                .expect("context-dependent scope has a parent")
+                .to_scope_id(db, file);
+        }
+        by_scope.entry(scope).or_default().push(name);
+    }
+
+    let mut snapshot = RecordingSnapshot {
+        types: Vec::new(),
+        metadata: Vec::new(),
+    };
+    for (scope, names) in by_scope {
+        let inference = infer_complete_scope_types(db, scope);
+        snapshot.types.extend(
+            inference
+                .expressions
+                .iter()
+                .map(|(expression, ty)| (expression, ty.display(db, &env).to_string())),
+        );
+        let metadata = inference
+            .extra
+            .as_deref()
+            .and_then(|extra| extra.place_load_metadata.as_deref());
+        for name in names {
+            let metadata =
+                metadata.and_then(|metadata| metadata.get(&ast::ExprRef::Name(name).into()));
+            if !crate::db::should_record_place_loads(db, file.file(db)) {
+                assert!(metadata.is_none());
+                continue;
+            }
+            let metadata = metadata.expect("requested place-load metadata is recorded");
+            snapshot
+                .metadata
+                .push((metadata.range, metadata.deferred_state));
+        }
+    }
+    snapshot
+}
+
+struct RecordingNameCollector<'ast, 'name> {
+    name: &'name str,
+    names: Vec<&'ast ast::ExprName>,
+}
+
+impl<'ast> Visitor<'ast> for RecordingNameCollector<'ast, '_> {
+    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+        if let ast::Expr::Name(name) = expression
+            && name.ctx.is_load()
+            && name.id == self.name
+        {
+            self.names.push(name);
+        }
+        walk_expr(self, expression);
+    }
 }

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -155,7 +155,7 @@ impl CorpusDb {
     pub fn new() -> Self {
         let vendored = ty_vendored::file_system().clone();
         let program_settings = ProgramSettings::empty(&vendored);
-        Self {
+        let db = Self {
             storage: salsa::Storage::new(None),
             system: TestSystem::default(),
             vendored,
@@ -163,7 +163,12 @@ impl CorpusDb {
             files: Files::default(),
             analysis_settings: Arc::new(AnalysisSettings::default()),
             program_settings,
-        }
+        };
+        ty_python_semantic::initialize_place_load_recording(
+            &db,
+            ty_python_semantic::PlaceLoadRecordingMode::default(),
+        );
+        db
     }
 }
 

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -184,6 +184,7 @@ Memory report:
 `FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `File`                                             metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `ModuleResolveModeIngredient`                      metadata=[X.XXMB]   fields=[X.XXMB]   count=1
+`PlaceLoadRecording`                               metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Project`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `ResolverEnvironment`                              metadata=[X.XXMB]   fields=[X.XXMB]   count=1

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -51,6 +51,10 @@ impl Db {
         };
 
         db.settings = Some(Settings::new(&db, program_settings));
+        ty_python_semantic::initialize_place_load_recording(
+            &db,
+            ty_python_semantic::PlaceLoadRecordingMode::default(),
+        );
         db
     }
 

--- a/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
@@ -74,6 +74,10 @@ impl TestDb {
         };
         program_settings.search_paths.try_register_static_roots(&db);
         db.program_settings = program_settings;
+        ty_python_semantic::initialize_place_load_recording(
+            &db,
+            ty_python_semantic::PlaceLoadRecordingMode::default(),
+        );
 
         db
     }


### PR DESCRIPTION
## Summary

This lets type inference retain how a name was looked up, including whether its lookup was deferred. That distinction lets later IDE operations use the same name-resolution rules as inference, including when annotations can refer to definitions that appear later in a file.

## Approach

Databases choose whether recording is disabled permanently or available on demand. In the latter mode, callers select files before inference runs. The resulting metadata travels with cached inference results, including nested expressions and decorators.

Selecting a file invalidates its earlier inference results so they can be recomputed with metadata. A per-file query keeps changes to the selection from rerunning inference in unrelated files. Recording remains disabled by default.

## Test Plan

See included tests.
