### PR TITLE
[ty] Record definitions alongside place-load deferredness

### DIFF
--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2194,7 +2194,7 @@ fn is_non_exported<'db>(
 // This will first check if the definition is using the "redundant alias" pattern like `import foo
 // as foo` or `from foo import bar as bar`. If it's not, it will check whether the symbol is being
 // exported via `__all__`.
-fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
+pub(crate) fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
     // This information is computed by the semantic index builder.
     if definition.is_reexported(db) {
         return true;

--- a/crates/ty_python_semantic/src/place/definitions.rs
+++ b/crates/ty_python_semantic/src/place/definitions.rs
@@ -1,27 +1,189 @@
 use smallvec::SmallVec;
-use ty_python_core::BindingWithConstraintsIterator;
-use ty_python_core::definition::{Definition, DefinitionState};
+use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
+use ty_python_core::scope::ScopeId;
+use ty_python_core::{
+    BindingWithConstraintsIterator, BoundnessAnalysis, global_scope, place_table, use_def_map,
+};
 
 use crate::Db;
+use crate::place::{
+    Place, RequiresExplicitReExport, builtins_module_scope, class_body_implicit_symbol,
+    implicit_builtins_symbol, implicit_builtins_symbol_scope, is_reexported,
+    loop_header_reachability, module_type_implicit_global_symbol,
+};
+use crate::place_load::{ImplicitPlaceLoad, PlaceLoadSource, PlaceLoadSourceKind};
 use crate::reachability::ReachabilityConstraintsExtension;
+use crate::types::ProgramEnvironment;
 
-/// A set of definitions found by name resolution.
+/// A set of definitions found by name resolution along with facts about their availability.
+#[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "these flags describe independent facts about the resolved definitions"
+)]
 pub(crate) struct DefinitionResolution<'db> {
     definitions: SmallVec<[Definition<'db>; 2]>,
+    is_complete: bool,
+    may_be_unbound: bool,
+    may_be_deleted: bool,
+    crosses_scope_declaration: bool,
 }
 
+#[allow(
+    dead_code,
+    reason = "definition-resolution metadata is retained for IDE consumers"
+)]
 impl<'db> DefinitionResolution<'db> {
     /// Returns the definitions found by name resolution.
     pub(crate) fn definitions(&self) -> &[Definition<'db>] {
         &self.definitions
     }
 
+    /// Returns whether every possible result is represented by a definition.
+    pub(crate) fn is_complete(&self) -> bool {
+        self.is_complete
+    }
+
+    /// Returns whether the value is bound on every reachable control-flow path.
+    pub(crate) fn is_definitely_bound(&self) -> bool {
+        !self.may_be_unbound
+    }
+
+    /// Returns whether a reachable deletion may leave the value unbound.
+    pub(crate) fn may_be_deleted(&self) -> bool {
+        self.may_be_deleted
+    }
+
+    /// Returns whether resolution crosses a `global` or `nonlocal` declaration.
+    pub(crate) fn crosses_scope_declaration(&self) -> bool {
+        self.crosses_scope_declaration
+    }
+
+    fn from_place_load_source(
+        db: &'db dyn Db,
+        environment: &ProgramEnvironment<'db>,
+        scope: ScopeId<'db>,
+        source: &PlaceLoadSource<'db>,
+    ) -> Self {
+        match &source.kind {
+            PlaceLoadSourceKind::Bindings(bindings) => Self::from_bindings(db, bindings.clone()),
+            PlaceLoadSourceKind::DefinitionsFromOwningScope { scope, id } => {
+                Self::from_bindings(db, use_def_map(db, *scope).reachable_bindings(*id))
+            }
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ExplicitGlobalSymbol {
+                file,
+                name,
+            }) => {
+                let scope = global_scope(db, *file);
+                let Some(symbol) = place_table(db, scope).symbol_id(name) else {
+                    return Self {
+                        definitions: SmallVec::new(),
+                        is_complete: true,
+                        may_be_unbound: true,
+                        may_be_deleted: false,
+                        crosses_scope_declaration: false,
+                    };
+                };
+                Self::from_bindings(db, use_def_map(db, scope).reachable_symbol_bindings(symbol))
+            }
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::DunderClass(class_def)) => {
+                let mut resolution = Self {
+                    definitions: SmallVec::new(),
+                    is_complete: true,
+                    may_be_unbound: false,
+                    may_be_deleted: false,
+                    crosses_scope_declaration: false,
+                };
+                resolution.push_definition(*class_def);
+                resolution
+            }
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ClassBodySymbol(name)) => {
+                Self::from_place_without_definition(
+                    class_body_implicit_symbol(db, environment, name).place,
+                )
+            }
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::ModuleImplicitGlobal {
+                file,
+                name,
+            }) => Self::from_place_without_definition(
+                module_type_implicit_global_symbol(db, *file, name).place,
+            ),
+            PlaceLoadSourceKind::Implicit(ImplicitPlaceLoad::Builtin(name)) => {
+                Self::from_builtin(db, environment, scope, name)
+            }
+        }
+    }
+
+    fn from_builtin(
+        db: &'db dyn Db,
+        environment: &ProgramEnvironment<'db>,
+        scope: ScopeId<'db>,
+        name: &str,
+    ) -> Self {
+        if Some(scope) == builtins_module_scope(db, environment) {
+            // A missing name in `builtins` cannot fall back to the module that is currently being
+            // resolved. Treating it as undefined also avoids a recursive semantic query.
+            return Self::from_place_without_definition(Place::Undefined);
+        }
+
+        let Some(builtins_scope) = implicit_builtins_symbol_scope(db, environment, name) else {
+            // No runtime-visible builtin supplies this name.
+            return Self::from_place_without_definition(Place::Undefined);
+        };
+
+        if builtins_scope == scope {
+            // End-of-scope lookup in a project-level `__builtins__` module can select a binding
+            // that occurs after this load. Keep its inferred value unrepresented instead of
+            // exposing that later binding as the load's source definition.
+            return Self::from_place_without_definition(
+                implicit_builtins_symbol(db, environment, name).place,
+            );
+        }
+
+        let Some(symbol) = place_table(db, builtins_scope).symbol_id(name) else {
+            // The module supplies this name through a synthetic module attribute rather than an
+            // explicit symbol, so there is no source definition to expose.
+            return Self::from_place_without_definition(
+                implicit_builtins_symbol(db, environment, name).place,
+            );
+        };
+
+        let mut resolution = Self::from_bindings_with_reexport_requirement(
+            db,
+            use_def_map(db, builtins_scope).end_of_scope_symbol_bindings(symbol),
+            RequiresExplicitReExport::Yes,
+        );
+
+        // The target definitions are useful for navigation, but the implicit fallback that
+        // connects this load to them has no source representation that a refactor can safely
+        // rewrite.
+        resolution.is_complete = false;
+
+        resolution
+    }
+
     /// Resolves the reachable definitions supplied by the given bindings.
     pub(crate) fn from_bindings(
         db: &'db dyn Db,
-        mut bindings: BindingWithConstraintsIterator<'db, 'db>,
+        bindings: BindingWithConstraintsIterator<'db, 'db>,
     ) -> Self {
-        let mut definitions = SmallVec::new();
+        Self::from_bindings_with_reexport_requirement(db, bindings, RequiresExplicitReExport::No)
+    }
+
+    fn from_bindings_with_reexport_requirement(
+        db: &'db dyn Db,
+        mut bindings: BindingWithConstraintsIterator<'db, 'db>,
+        requires_explicit_reexport: RequiresExplicitReExport,
+    ) -> Self {
+        let mut resolution = Self {
+            definitions: SmallVec::new(),
+            is_complete: true,
+            may_be_unbound: false,
+            may_be_deleted: false,
+            crosses_scope_declaration: false,
+        };
+        let boundness = bindings.boundness_analysis();
+        let mut has_defined_binding = false;
 
         while let Some(binding) = bindings.next() {
             let reachability = bindings.reachability_constraints().evaluate(
@@ -33,13 +195,123 @@ impl<'db> DefinitionResolution<'db> {
                 continue;
             }
 
-            if let DefinitionState::Defined(definition) = binding.binding
-                && !definitions.contains(&definition)
-            {
-                definitions.push(definition);
+            match binding.binding {
+                DefinitionState::Defined(definition)
+                    if matches!(requires_explicit_reexport, RequiresExplicitReExport::Yes)
+                        && !is_reexported(db, definition) =>
+                {
+                    resolution.may_be_unbound |= reachability.may_be_true();
+                }
+                DefinitionState::Defined(definition) => {
+                    if matches!(definition.kind(db), DefinitionKind::LoopHeader(_)) {
+                        let deleted_reachability =
+                            loop_header_reachability(db, definition).deleted_reachability;
+                        let may_be_deleted = !deleted_reachability.is_always_false();
+                        resolution.may_be_unbound |= may_be_deleted;
+                        resolution.may_be_deleted |= may_be_deleted;
+                    }
+                    has_defined_binding = true;
+                    resolution.push_definition(definition);
+                }
+                DefinitionState::Deleted => {
+                    let may_be_deleted = reachability.may_be_true();
+                    resolution.may_be_unbound |= may_be_deleted;
+                    resolution.may_be_deleted |= may_be_deleted;
+                }
+                DefinitionState::Undefined
+                    if boundness == BoundnessAnalysis::BasedOnUnboundVisibility =>
+                {
+                    resolution.may_be_unbound |= reachability.may_be_true();
+                }
+                DefinitionState::Undefined => {}
             }
         }
 
-        Self { definitions }
+        if !has_defined_binding {
+            resolution.may_be_unbound = true;
+        }
+
+        resolution
+    }
+
+    fn push_definition(&mut self, definition: Definition<'db>) {
+        if !self.definitions.contains(&definition) {
+            self.definitions.push(definition);
+        }
+    }
+
+    fn from_place_without_definition(place: Place<'db>) -> Self {
+        Self {
+            definitions: SmallVec::new(),
+            is_complete: place.is_undefined(),
+            may_be_unbound: !place.is_definitely_bound(),
+            may_be_deleted: false,
+            crosses_scope_declaration: false,
+        }
+    }
+
+    /// Returns whether resolution found a value, including one without a source definition.
+    fn has_value(&self) -> bool {
+        !self.definitions.is_empty() || !self.is_complete
+    }
+
+    fn extend(&mut self, other: Self) {
+        for definition in other.definitions {
+            if !self.definitions.contains(&definition) {
+                self.definitions.push(definition);
+            }
+        }
+        self.is_complete &= other.is_complete;
+        self.may_be_deleted |= other.may_be_deleted;
+        self.crosses_scope_declaration |= other.crosses_scope_declaration;
+    }
+}
+
+/// Accumulates definition information while type inference resolves a place load.
+pub(crate) struct DefinitionResolutionBuilder<'db> {
+    resolution: DefinitionResolution<'db>,
+}
+
+impl<'db> DefinitionResolutionBuilder<'db> {
+    pub(crate) fn new() -> Self {
+        Self {
+            resolution: DefinitionResolution {
+                definitions: SmallVec::new(),
+                is_complete: true,
+                may_be_unbound: true,
+                may_be_deleted: false,
+                crosses_scope_declaration: false,
+            },
+        }
+    }
+
+    pub(crate) fn add_source(
+        &mut self,
+        db: &'db dyn Db,
+        environment: &ProgramEnvironment<'db>,
+        scope: ScopeId<'db>,
+        source: &PlaceLoadSource<'db>,
+    ) {
+        let mut source_resolution =
+            DefinitionResolution::from_place_load_source(db, environment, scope, source);
+        if source.is_class_body_global_fallback() && source_resolution.has_value() {
+            source_resolution.may_be_unbound = false;
+        }
+        self.resolution.extend(source_resolution);
+    }
+
+    pub(crate) fn mark_incomplete(&mut self) {
+        self.resolution.is_complete = false;
+    }
+
+    pub(crate) fn finish(
+        mut self,
+        is_definitely_bound: bool,
+        crosses_scope_declaration: bool,
+    ) -> DefinitionResolution<'db> {
+        self.resolution.may_be_unbound = !is_definitely_bound;
+        self.resolution.crosses_scope_declaration |= crosses_scope_declaration;
+        self.resolution.definitions.shrink_to_fit();
+        self.resolution
     }
 }

--- a/crates/ty_python_semantic/src/place_load.rs
+++ b/crates/ty_python_semantic/src/place_load.rs
@@ -588,6 +588,10 @@ impl<'db, 'ast> PlaceLoadResolution<'db, 'ast> {
         }
     }
 
+    pub(crate) fn crosses_scope_declaration(&self) -> bool {
+        self.crosses_scope_declaration
+    }
+
     pub(crate) fn narrowing_constraints_for(
         &self,
         source: &PlaceLoadSource<'_>,

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -44,6 +44,7 @@
 //! be considered a bug.)
 
 use crate::ProgramEnvironment;
+use crate::place::definitions::DefinitionResolution;
 use itertools::Either;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
@@ -79,9 +80,10 @@ mod tests;
 
 /// The place-load metadata produced alongside an expression's type when recording is enabled.
 #[derive(Debug, Clone, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
-struct PlaceLoadMetadata {
+struct PlaceLoadMetadata<'db> {
     range: TextRange,
     deferred_state: DeferredExpressionState,
+    resolution: DefinitionResolution<'db>,
 }
 
 bitflags::bitflags! {
@@ -262,7 +264,7 @@ pub(crate) fn function_known_decorator_flags<'db>(
 /// function-definition inference.
 #[derive(Debug, Eq, PartialEq, Default, get_size2::GetSize, salsa::SalsaValue)]
 pub(crate) struct FunctionDecoratorInference<'db> {
-    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     expression_types: FrozenMap<ExpressionNodeKey, Type<'db>>,
     bindings: Box<[(Definition<'db>, Type<'db>)]>,
     called_functions: Box<[FunctionType<'db>]>,
@@ -938,7 +940,7 @@ pub(crate) struct ScopeInference<'db> {
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct ScopeInferenceExtra<'db> {
     /// Place-load metadata retained only for files that opted into recording.
-    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
@@ -1324,7 +1326,7 @@ impl<'db> DefinitionTypes<'db> {
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 enum DefinitionInferenceExtra<'db> {
     /// Place-load metadata is the only extra data for some definitions.
-    PlaceLoadMetadata(FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>),
+    PlaceLoadMetadata(FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>),
 
     /// Type qualifiers are the only extra data for most annotated definitions.
     Qualifiers(FrozenMap<ExpressionNodeKey, TypeQualifiers>),
@@ -1363,7 +1365,7 @@ struct OtherDefinitionInferenceExtra<'db> {
     comparison_truthiness: FrozenMap<ExpressionNodeKey, Truthiness>,
 
     /// Place-load metadata retained only for files that opted into recording.
-    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
 
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
@@ -1867,7 +1869,7 @@ pub(crate) struct ExpressionInference<'db> {
 #[derive(Debug, Eq, PartialEq, get_size2::GetSize, Default, salsa::SalsaValue)]
 struct ExpressionInferenceExtra<'db> {
     /// Place-load metadata retained only for files that opted into recording.
-    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 
@@ -2115,7 +2117,7 @@ struct StatementInferenceInnerExtra<'db> {
     comparison_truthiness: FrozenMap<ExpressionNodeKey, Truthiness>,
 
     /// Place-load metadata retained only for files that opted into recording.
-    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata>>>,
+    place_load_metadata: Option<Box<FrozenMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>>>,
     /// String annotations found in this region
     string_annotations: FrozenSet<ExpressionNodeKey>,
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -35,6 +35,7 @@ use super::{
     infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
+use crate::place::definitions::DefinitionResolutionBuilder;
 use crate::place::{
     ConsideredDefinitions, DefinedPlace, Definedness, LookupError, Place, PlaceAndQualifiers,
     RequiresExplicitReExport, TypeOrigin, builtins_module_scope, class_body_implicit_symbol,
@@ -316,7 +317,7 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
 
     /// Place-load metadata retained only when this file opts into recording.
-    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata>,
+    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>,
 
     /// The scope this region is part of.
     scope: ScopeId<'db>,
@@ -10369,10 +10370,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut place = PlaceAndQualifiers::from(Place::Undefined);
         let mut failure = None;
         let mut checked_deprecated = false;
+        let mut definition_resolution = (expr_ref.is_name_expr()
+            && crate::db::should_record_place_loads(self.db(), self.file()))
+        .then(DefinitionResolutionBuilder::new);
 
         while let Some(step) = resolution.next() {
             match step {
                 PlaceLoadResolutionStep::Source(source) => {
+                    if let Some(definitions) = definition_resolution.as_mut() {
+                        definitions.add_source(self.db(), env, self.scope(), &source);
+                    }
                     if !checked_deprecated && source.is_post_lexical() {
                         // Deprecation diagnostics apply to the result of lexical name resolution,
                         // before it is combined with implicit module globals or builtins. Hence, we
@@ -10421,12 +10428,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             place
         };
 
-        if expr_ref.is_name_expr() && crate::db::should_record_place_loads(self.db(), self.file()) {
+        if let Some(mut definitions) = definition_resolution {
+            if failure == Some(PlaceLoadFailure::NotFound) {
+                definitions.mark_incomplete();
+            }
             self.place_load_metadata.insert(
                 expr_ref.into(),
                 PlaceLoadMetadata {
                     range: expr_ref.range(),
                     deferred_state: self.deferred_state,
+                    resolution: definitions.finish(
+                        place.place.is_definitely_bound(),
+                        resolution.crosses_scope_declaration(),
+                    ),
                 },
             );
         }
@@ -12418,7 +12432,7 @@ enum ExpressionCacheEntry<'db> {
 /// Unlike [`ExpressionInference`], this type is short-lived, and avoids the cost of compaction
 /// that is otherwise performed for Salsa results.
 struct FullExpressionCacheEntry<'db> {
-    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata>,
+    place_load_metadata: FxHashMap<ExpressionNodeKey, PlaceLoadMetadata<'db>>,
     expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
     comparison_truthiness: FxHashMap<ExpressionNodeKey, Truthiness>,
     type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -14,6 +14,7 @@ use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 use ruff_python_ast::visitor::{Visitor, walk_expr};
 use ruff_python_ast::{self as ast, PythonVersion};
+use ruff_text_size::Ranged;
 use salsa::Database as _;
 use salsa::plumbing::AsId;
 use ty_python_core::definition::Definition;
@@ -60,7 +61,7 @@ result = value
 }
 
 #[test]
-fn recording_retains_deferredness() {
+fn recording_retains_deferredness_and_reaching_definitions() {
     let source = r#"
 import first as value
 annotation: value.C
@@ -77,6 +78,11 @@ import second as value
     assert_eq!(&source[snapshot.metadata[0].0], "value");
     assert_eq!(&source[snapshot.metadata[1].0], "value");
     assert_ne!(snapshot.metadata[0].0, snapshot.metadata[1].0);
+    assert_eq!(
+        snapshot.metadata[0].2,
+        ["first as value", "second as value"]
+    );
+    assert_eq!(snapshot.metadata[1].2, ["first as value"]);
 }
 
 #[test]
@@ -199,6 +205,7 @@ result = value
     assert_eq!(recorded.metadata.len(), 1);
     assert_eq!(recorded.metadata[0].1, DeferredExpressionState::None);
     assert_eq!(&source[recorded.metadata[0].0], "value");
+    assert_eq!(recorded.metadata[0].2, ["first as value"]);
     assert!(recording_snapshot(&db, other, "value").metadata.is_empty());
 
     let updated_source = r#"
@@ -212,6 +219,7 @@ result = value
     assert_eq!(updated.metadata[0].1, DeferredExpressionState::None);
     assert_eq!(&updated_source[updated.metadata[0].0], "value");
     assert_ne!(updated.metadata[0].0, recorded.metadata[0].0);
+    assert_eq!(updated.metadata[0].2, ["second as value"]);
 
     db.set_place_load_recording(file, false);
     assert!(recording_snapshot(&db, file, "value").metadata.is_empty());
@@ -251,6 +259,14 @@ annotation: "tuple[first.C, second.C]"
     assert_ne!(annotation_metadata[0].range, annotation_metadata[1].range);
     assert_eq!(&source[annotation_metadata[0].range], "first");
     assert_eq!(&source[annotation_metadata[1].range], "second");
+    assert_eq!(
+        recording_definition_texts(&db, &annotation_metadata[0].resolution),
+        ["first"]
+    );
+    assert_eq!(
+        recording_definition_texts(&db, &annotation_metadata[1].resolution),
+        ["second"]
+    );
 }
 
 fn program_file(db: &TestDb, file: File) -> ProgramFile<'_> {
@@ -2122,7 +2138,7 @@ fn assert_recording_preserves_types(source: &str, name: &str) {
 #[derive(Debug, PartialEq, Eq)]
 struct RecordingSnapshot {
     types: Vec<(ExpressionNodeKey, String)>,
-    metadata: Vec<(TextRange, DeferredExpressionState)>,
+    metadata: Vec<(TextRange, DeferredExpressionState, Vec<String>)>,
 }
 
 fn recording_snapshot(db: &TestDb, file: File, name: &str) -> RecordingSnapshot {
@@ -2180,12 +2196,27 @@ fn recording_snapshot(db: &TestDb, file: File, name: &str) -> RecordingSnapshot 
                 continue;
             }
             let metadata = metadata.expect("requested place-load metadata is recorded");
-            snapshot
-                .metadata
-                .push((metadata.range, metadata.deferred_state));
+            snapshot.metadata.push((
+                metadata.range,
+                metadata.deferred_state,
+                recording_definition_texts(db, &metadata.resolution),
+            ));
         }
     }
     snapshot
+}
+
+fn recording_definition_texts(db: &TestDb, resolution: &DefinitionResolution<'_>) -> Vec<String> {
+    resolution
+        .definitions()
+        .iter()
+        .map(|definition| {
+            let file = definition.program_file(db).python_file(db);
+            let module = parsed_module(db, file).load(db);
+            let source = ruff_db::source::source_text(db, file.file(db));
+            source[definition.full_range(db, &module).range()].to_string()
+        })
+        .collect()
 }
 
 struct RecordingNameCollector<'ast, 'name> {


### PR DESCRIPTION
## Summary

This records which definitions can supply each name's value alongside the deferredness metadata from #28422. IDE operations can then use the definitions visited by type inference, including the different bindings visible to immediate reads and deferred annotations.

## Approach

[`DefinitionResolutionBuilder`](https://github.com/astral-sh/ruff/blob/4b2c5b6870134342ca25fa8945013451d9e8ebba/crates/ty_python_semantic/src/place/definitions.rs#L279) observes the sources visited during name inference and stores their reachable definitions in the existing optional metadata. Recording stops when inference finds a definitely bound value, preserving its fallback order.

The record also describes limits that matter to refactoring: whether resolution is complete, whether the name can be unbound or deleted, and whether lookup crosses a `global` or `nonlocal` declaration. Implicit builtin fallbacks retain known definitions for navigation but remain incomplete because no explicit import connects the name to those definitions.

## Test Plan

See included tests.
