### PR TITLE
[ty] Infer tuple variance more precisely

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variance.md
@@ -1089,6 +1089,68 @@ static_assert(is_subtype_of(D[B], D[A]))
 static_assert(not is_subtype_of(D[A], D[B]))
 ```
 
+## Tuple elements
+
+Tuples are covariant in each element type. A class that accepts `tuple[T, object]` is therefore
+contravariant in `T`.
+
+```py
+from ty_extensions import static_assert
+from ty_extensions._internal import is_subtype_of
+
+class Covariant[T]:
+    def produce(self) -> tuple[T, object]:
+        raise NotImplementedError
+
+static_assert(not is_subtype_of(Covariant[int], Covariant[bool]))
+static_assert(is_subtype_of(Covariant[bool], Covariant[int]))
+
+class Contravariant[T]:
+    def consume(self, value: tuple[T, object]) -> None: ...
+
+static_assert(is_subtype_of(Contravariant[int], Contravariant[bool]))
+static_assert(not is_subtype_of(Contravariant[bool], Contravariant[int]))
+
+class Invariant[T]:
+    def produce(self) -> tuple[list[T], object]:
+        raise NotImplementedError
+
+static_assert(not is_subtype_of(Invariant[int], Invariant[bool]))
+static_assert(not is_subtype_of(Invariant[bool], Invariant[int]))
+```
+
+The same applies to all elements of a variable-length tuple.
+
+```py
+class PrefixConsumer[T]:
+    def consume(self, value: tuple[T, *tuple[object, ...]]) -> None: ...
+
+static_assert(is_subtype_of(PrefixConsumer[int], PrefixConsumer[bool]))
+static_assert(not is_subtype_of(PrefixConsumer[bool], PrefixConsumer[int]))
+
+class SuffixConsumer[T]:
+    def consume(self, value: tuple[*tuple[object, ...], T]) -> None: ...
+
+static_assert(is_subtype_of(SuffixConsumer[int], SuffixConsumer[bool]))
+static_assert(not is_subtype_of(SuffixConsumer[bool], SuffixConsumer[int]))
+
+class RepeatedConsumer[T]:
+    def consume(self, value: tuple[object, *tuple[T, ...]]) -> None: ...
+
+static_assert(is_subtype_of(RepeatedConsumer[int], RepeatedConsumer[bool]))
+static_assert(not is_subtype_of(RepeatedConsumer[bool], RepeatedConsumer[int]))
+```
+
+An unpacked type variable tuple also contributes to variance.
+
+```py
+class VariadicConsumer[*Ts]:
+    def consume(self, value: tuple[object, *Ts]) -> None: ...
+
+static_assert(is_subtype_of(VariadicConsumer[int], VariadicConsumer[bool]))
+static_assert(not is_subtype_of(VariadicConsumer[bool], VariadicConsumer[int]))
+```
+
 ## Union Types
 
 Union types are covariant in all their members. If `A <: B`, then `A | C <: B | C` and

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -1281,7 +1281,14 @@ impl<'db> VarianceInferable<'db> for NominalInstanceType<'db> {
         env: &ProgramEnvironment<'db>,
         typevar: BoundTypeVarIdentity<'db>,
     ) -> VarianceTerm<'db> {
-        self.class(db, env).variance_of(db, env, typevar)
+        match self.0 {
+            NominalInstanceInner::ExactTuple(tuple) => tuple.variance_of(db, env, typevar),
+            NominalInstanceInner::Object
+            | NominalInstanceInner::NonTuple(_)
+            | NominalInstanceInner::SysVersionInfo => {
+                self.class(db, env).variance_of(db, env, typevar)
+            }
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -28,10 +28,11 @@ use crate::types::class::{ClassType, KnownClass};
 use crate::types::constraints::{ConstraintSet, IteratorConstraintsExtension};
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker, TypeVarEvaluation};
 use crate::types::set_theoretic::RecursivelyDefined;
+use crate::types::variance::{VarianceInferable, VarianceTerm};
 use crate::types::visitor::any_over_type_expanding_aliases;
 use crate::types::{
-    ApplyTypeMappingVisitor, BoundTypeVarInstance, ErrorContext, FindLegacyTypeVarsVisitor,
-    IntersectionType, Type, TypeContext, TypeMapping, UnionType,
+    ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, ErrorContext,
+    FindLegacyTypeVarsVisitor, IntersectionType, Type, TypeContext, TypeMapping, UnionType,
 };
 use crate::{Db, FxOrderSet};
 use ty_python_core::Truthiness;
@@ -167,6 +168,27 @@ pub(super) fn walk_tuple_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for TupleType<'_> {}
+
+impl<'db> VarianceInferable<'db> for TupleType<'db> {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> VarianceTerm<'db> {
+        let elements = match self.tuple(db) {
+            Tuple::Fixed(tuple) => Either::Left(tuple.iter_all_elements()),
+            Tuple::Variable(tuple) => Either::Right(
+                tuple
+                    .iter_prefix_elements()
+                    .chain(std::iter::once(tuple.variable().tuple_class_type()))
+                    .chain(tuple.iter_suffix_elements()),
+            ),
+        };
+
+        VarianceTerm::join(db, elements.map(|ty| ty.variance_of(db, env, typevar)))
+    }
+}
 
 #[salsa::tracked]
 impl<'db> TupleType<'db> {


### PR DESCRIPTION
When inferring the variance of a tuple type, we currently go through the `Tuple::tuple_class_type` helper, which unions all elements of the tuple. This can lead to type variables getting simplified out of the target type, e.g., in the case of `tuple[T, object]`, leading to incorrect variance results. This PR adds a separate path that infers variance from the elements of the tuple directly.