### PR TITLE
[ty] Do not bind `self` for attributes declared with a bare `TypeVar`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/dunder.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/dunder.md
@@ -168,6 +168,54 @@ def check_self(value: Child) -> None:
     result: Child = value[0]
 ```
 
+The heuristic looks at the annotation as written in the class body, not the specialized type.
+`__call__: Callable[[Args], Return]` gets a `self` bound, but `__call__: F` (where `F` is a
+`TypeVar`) does not, even after `F` is specialized to a callable. The class body says nothing about
+what the first parameter of `F` is, so we keep the full signature on instance access:
+
+```py
+from typing import TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+class WithCall(Protocol[F]):
+    __call__: F
+
+def check_call(value: WithCall[Callable[[str], None]]) -> None:
+    reveal_type(value.__call__)  # revealed: (str, /) -> None
+    reveal_type(value("value"))  # revealed: None
+```
+
+pytest 8 uses this pattern to attach an exception class to `pytest.skip` and `pytest.fail`. The
+decorated function keeps its original signature:
+
+```py
+from typing import cast
+
+ET = TypeVar("ET", bound=type[BaseException])
+
+class WithException(Protocol[F, ET]):
+    Exception: ET
+    __call__: F
+
+def with_exception(exception_type: ET) -> Callable[[F], WithException[F, ET]]:
+    def decorate(func: F) -> WithException[F, ET]:
+        func_with_exception = cast(WithException[F, ET], func)
+        func_with_exception.Exception = exception_type
+        return func_with_exception
+    return decorate
+
+class Skipped(BaseException): ...
+
+@with_exception(Skipped)
+def skip(reason: str = "", *, allow_module_level: bool = False) -> None: ...
+
+reveal_type(skip)  # revealed: WithException[(reason: str = "", *, allow_module_level: bool = False) -> None, <class 'Skipped'>]
+reveal_type(skip.Exception)  # revealed: <class 'Skipped'>
+skip("reason")
+skip("reason", allow_module_level=True)
+```
+
 And of course the same is true if we have only an implicit assignment inside a method:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1470,6 +1470,48 @@ reveal_type(DescriptorOrInt[str].value)  # revealed: int
 DescriptorOrInt[int].value = 1
 ```
 
+## Functions stored in generic instance attributes
+
+An attribute declared as `func: F` (where `F` is a type variable) is stored on each instance; the
+class itself has no value for it. So when `F` is a function, accessing the attribute on an instance
+returns that function unchanged, with no `self` bound. This matches mypy and pyright, and it matches
+the runtime, where a function in an instance's `__dict__` is not a method.
+
+```py
+from typing import Callable, Generic, TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+class Holder(Generic[F]):
+    func: F
+
+    def __init__(self, func: F) -> None:
+        self.func = func
+
+def greet(name: str) -> str:
+    return name
+
+holder = Holder(greet)
+reveal_type(holder.func)  # revealed: (name: str) -> str
+reveal_type(holder.func("world"))  # revealed: str
+holder.func(1)  # error: [invalid-argument-type]
+```
+
+The same holds when the attribute is inherited from a specialized base class, and when the type
+variable is one option in a union:
+
+```py
+class Concrete(Holder[Callable[[str], str]]): ...
+
+reveal_type(Concrete(greet).func)  # revealed: (str, /) -> str
+
+class OptionalHolder(Generic[F]):
+    func: F | None = None
+
+def check(holder: OptionalHolder[Callable[[str], str]]) -> None:
+    reveal_type(holder.func)  # revealed: ((str, /) -> str) | None
+```
+
 ## Metaclass descriptors shadow generic instance attributes
 
 A data descriptor on the metaclass governs class access even when instances have an attribute of the

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4729,6 +4729,16 @@ impl<'db> Type<'db> {
         AttributeKind,
         Option<DescriptorGetCallContext<'db>>,
     ) {
+        // A generic instance attribute such as `value: T` has no class-level value that could act
+        // as a descriptor. Its specialized type describes what each instance stores, so it is
+        // returned unchanged: a function substituted for `T` is not bound to the instance.
+        if attribute
+            .qualifiers
+            .contains(TypeQualifiers::GENERIC_INSTANCE_ATTRIBUTE)
+        {
+            return (attribute, AttributeKind::NormalOrNonDataDescriptor, None);
+        }
+
         if let PlaceAndQualifiers {
             place:
                 Place::Defined(DefinedPlace {
@@ -10610,7 +10620,7 @@ impl std::fmt::Display for DynamicType<'_> {
 bitflags! {
     /// Type qualifiers that appear in an annotation expression.
     #[derive(Copy, Clone, Debug, Eq, PartialEq, Default, Hash)]
-    pub struct TypeQualifiers: u8 {
+    pub struct TypeQualifiers: u16 {
         /// `typing.ClassVar`
         const CLASS_VAR = 1 << 0;
         /// `typing.Final`
@@ -10631,6 +10641,15 @@ bitflags! {
         /// `__getattr__` function. We need this in order to implement precedence of submodules
         /// over module-level `__getattr__`, for compatibility with other type checkers.
         const FROM_MODULE_GETATTR = 1 << 7;
+        /// A non-standard type qualifier that marks a class-body declaration whose annotation is
+        /// a bare type variable of the class, such as `value: T` in `class Box(Generic[T])`.
+        ///
+        /// Such a declaration describes storage on each instance; the class itself holds no
+        /// value for the attribute. After the class is specialized, the attribute's type is
+        /// whatever was substituted for the type variable, and that value must not be treated
+        /// as a descriptor defined in the class body. In particular, a function substituted for
+        /// the type variable is not bound to the instance on attribute access.
+        const GENERIC_INSTANCE_ATTRIBUTE = 1 << 8;
     }
 }
 
@@ -10661,10 +10680,11 @@ impl TypeQualifiers {
     /// Returns `true` if this is a non-standard qualifier.
     ///
     /// Non-standard qualifiers are internal implementation details like
-    /// `IMPLICIT_INSTANCE_ATTRIBUTE` and `FROM_MODULE_GETATTR`.
+    /// `IMPLICIT_INSTANCE_ATTRIBUTE`, `FROM_MODULE_GETATTR`, and `GENERIC_INSTANCE_ATTRIBUTE`.
     pub fn is_non_standard(self) -> bool {
-        const NON_STANDARD: TypeQualifiers =
-            TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE.union(TypeQualifiers::FROM_MODULE_GETATTR);
+        const NON_STANDARD: TypeQualifiers = TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE
+            .union(TypeQualifiers::FROM_MODULE_GETATTR)
+            .union(TypeQualifiers::GENERIC_INSTANCE_ATTRIBUTE);
         self.intersects(NON_STANDARD)
     }
 }

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -387,8 +387,8 @@ pub enum CallableTypeKind {
     /// ```
     ///
     /// As a heuristic, class-member lookup converts dunder attributes of this kind to
-    /// [`Self::FunctionLike`] if their signatures can accept parameters. See
-    /// [`Self::DunderParamSpec`] for the exception for `Callable[P, R]` attributes.
+    /// [`Self::FunctionLike`] if their signatures can accept parameters. Attributes whose
+    /// parameters come directly from a `ParamSpec` are exempt.
     ///
     /// For example, `len(Sized())` implicitly calls `__len__` on the `Sized` instance. We
     /// treat the `Callable`-typed `__len__` as a function, so accessing `Sized().__len__`
@@ -472,38 +472,6 @@ pub enum CallableTypeKind {
     ///
     /// [descriptor-protocol]: https://docs.python.org/3/howto/descriptor.html#descriptor-protocol
     FunctionLike,
-
-    /// A `Callable[P, R]`-typed dunder attribute whose parameters come from a `ParamSpec`.
-    ///
-    /// This has the runtime assumptions of [`Self::Regular`]: truthiness is ambiguous,
-    /// member lookup exposes `object` attributes, and we do not treat these callables as
-    /// descriptors. The separate kind prevents the dunder descriptor heuristic from turning
-    /// it into [`Self::FunctionLike`] after `P` is specialized: the specialized parameters
-    /// already describe the callable's arguments.
-    /// Calling [`CallableType::bind_self`] removes this marker without removing a parameter.
-    ///
-    /// In the example below, specializing `P` to `[str]` gives `callback.__call__` the signature
-    /// `(str, /) -> int`. Binding a receiver would incorrectly remove its `str` parameter:
-    ///
-    /// ```python
-    /// from collections.abc import Callable
-    ///
-    /// class Callback[**P]:
-    ///     __call__: Callable[P, int]
-    ///
-    /// class Length(Callback[[str]]):
-    ///     def __call__(self, text: str) -> int:
-    ///         return len(text)
-    ///
-    /// def invoke(callback: Callback[[str]]) -> int:
-    ///     return callback("hello")
-    ///
-    /// invoke(Length())  # Returns 5.
-    /// ```
-    ///
-    /// This variant is used to represent the callable object itself; [`Self::ParamSpecValue`]
-    /// represents the parameter list substituted for `P`.
-    DunderParamSpec,
 
     /// A callable with the descriptor behavior of `staticmethod`.
     ///
@@ -743,10 +711,6 @@ impl<'db> CallableType<'db> {
         matches!(self.kind(db), CallableTypeKind::FunctionLike)
     }
 
-    fn is_dunder_paramspec(self, db: &'db dyn Db) -> bool {
-        matches!(self.kind(db), CallableTypeKind::DunderParamSpec)
-    }
-
     pub(crate) fn is_regular(self, db: &'db dyn Db) -> bool {
         matches!(self.kind(db), CallableTypeKind::Regular)
     }
@@ -828,19 +792,11 @@ impl<'db> CallableType<'db> {
         env: &ProgramEnvironment<'db>,
         self_type: Option<Type<'db>>,
     ) -> CallableType<'db> {
-        if self.is_dunder_paramspec(db) {
-            return self.into_regular(db);
-        }
-
         self.with_signatures(db, self.signatures(db).bind_self(db, env, self_type))
     }
 
     pub(crate) fn into_function_like(self, db: &'db dyn Db) -> CallableType<'db> {
         self.with_kind(db, CallableTypeKind::FunctionLike)
-    }
-
-    pub(crate) fn into_dunder_paramspec(self, db: &'db dyn Db) -> CallableType<'db> {
-        self.with_kind(db, CallableTypeKind::DunderParamSpec)
     }
 
     pub(crate) fn apply_self(

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1918,8 +1918,21 @@ impl<'db> ClassType<'db> {
         let fallback_member_lookup = || {
             let specialization = specialization
                 .map(|specialization| specialization.tuple_runtime_element_specialization(db));
-            class_literal
-                .own_class_member(db, env, inherited_generic_context, specialization, name)
+            let mut member = class_literal.own_class_member(
+                db,
+                env,
+                inherited_generic_context,
+                specialization,
+                name,
+            );
+            // A declaration such as `value: T` is inspected before the specialization is applied,
+            // because afterwards the substituted type no longer reveals that the class body only
+            // declared storage for a value supplied from outside. See
+            // `TypeQualifiers::GENERIC_INSTANCE_ATTRIBUTE`.
+            if member.is_generic_instance_attribute(db) {
+                member.inner.qualifiers |= TypeQualifiers::GENERIC_INSTANCE_ATTRIBUTE;
+            }
+            member
                 .map_type(|ty| ty.apply_optional_owner_specialization_to_member(db, specialization))
         };
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1419,28 +1419,6 @@ impl<'db> StaticClassLiteral<'db> {
         policy: MemberLookupPolicy,
         mro_iter: impl Iterator<Item = ClassBase<'db>>,
     ) -> PlaceAndQualifiers<'db> {
-        fn into_function_like_callable<'d>(
-            db: &'d dyn Db,
-            env: &ProgramEnvironment<'d>,
-            ty: Type<'d>,
-        ) -> Type<'d> {
-            match ty {
-                Type::Callable(callable_ty)
-                    if callable_ty.is_regular(db)
-                        && callable_ty.signatures(db).has_parameters() =>
-                {
-                    Type::Callable(callable_ty.into_function_like(db))
-                }
-                Type::Union(union) => union.map(db, env, |element| {
-                    into_function_like_callable(db, env, *element)
-                }),
-                Type::Intersection(intersection) => intersection.map_positive(db, env, |element| {
-                    into_function_like_callable(db, env, *element)
-                }),
-                _ => ty,
-            }
-        }
-
         let result = MroLookup::new(db, env, mro_iter).class_member(
             name,
             policy,
@@ -1448,7 +1426,7 @@ impl<'db> StaticClassLiteral<'db> {
             self.is_known(db, KnownClass::Object),
         );
 
-        let mut member = match result {
+        match result {
             ClassMemberResult::Done(result) => result.finalize(db, env),
             ClassMemberResult::TypedDict(module) => typed_dict_class_member(
                 db,
@@ -1458,15 +1436,7 @@ impl<'db> StaticClassLiteral<'db> {
                 policy,
                 name,
             ),
-        };
-
-        // We generally treat dunder attributes with `Callable` types as function-like callables.
-        // See `callables_as_descriptors.md` for more details.
-        if name.starts_with("__") && name.ends_with("__") {
-            member = member.map_type(|ty| into_function_like_callable(db, env, ty));
         }
-
-        member
     }
 
     /// Returns the inferred type of the class member named `name`. Only bound members
@@ -1483,7 +1453,19 @@ impl<'db> StaticClassLiteral<'db> {
         specialization: Option<Specialization<'db>>,
         name: &str,
     ) -> Member<'db> {
-        fn into_dunder_paramspec_callable<'d>(
+        // We generally treat dunder attributes with `Callable` types as function-like callables,
+        // i.e. as descriptors that bind the instance to their first parameter. See
+        // `callables_as_descriptors.md` for more details.
+        //
+        // This heuristic looks at the type as written in the class body, before the class's
+        // specialization is applied. A dunder declared with a bare type variable, such as
+        // `__call__: F`, is a generic instance attribute (see
+        // `TypeQualifiers::GENERIC_INSTANCE_ATTRIBUTE`): the callable later substituted for `F`
+        // is supplied from outside the class body, so nothing identifies its first parameter as
+        // the receiver. The same reasoning excludes a callable parameterized directly by a
+        // `ParamSpec`, such as `__call__: Callable[P, int]`: after `P` is specialized, the
+        // parameter list already describes the callable's arguments.
+        fn into_function_like_callable<'d>(
             db: &'d dyn Db,
             env: &ProgramEnvironment<'d>,
             ty: Type<'d>,
@@ -1491,15 +1473,16 @@ impl<'db> StaticClassLiteral<'db> {
             match ty {
                 Type::Callable(callable_ty)
                     if callable_ty.is_regular(db)
-                        && callable_ty.signatures(db).is_single_paramspec().is_some() =>
+                        && callable_ty.signatures(db).has_parameters()
+                        && callable_ty.signatures(db).is_single_paramspec().is_none() =>
                 {
-                    Type::Callable(callable_ty.into_dunder_paramspec(db))
+                    Type::Callable(callable_ty.into_function_like(db))
                 }
                 Type::Union(union) => union.map(db, env, |element| {
-                    into_dunder_paramspec_callable(db, env, *element)
+                    into_function_like_callable(db, env, *element)
                 }),
                 Type::Intersection(intersection) => intersection.map_positive(db, env, |element| {
-                    into_dunder_paramspec_callable(db, env, *element)
+                    into_function_like_callable(db, env, *element)
                 }),
                 _ => ty,
             }
@@ -1550,7 +1533,7 @@ impl<'db> StaticClassLiteral<'db> {
         let body_scope = self.body_scope(db);
         let member = class_member(db, body_scope, name).map_type(|ty| {
             let ty = if name.starts_with("__") && name.ends_with("__") {
-                into_dunder_paramspec_callable(db, env, ty)
+                into_function_like_callable(db, env, ty)
             } else {
                 ty
             };

--- a/crates/ty_python_semantic/src/types/member.rs
+++ b/crates/ty_python_semantic/src/types/member.rs
@@ -1,9 +1,9 @@
 use crate::Db;
 use crate::place::{
     ConsideredDefinitions, DefinedPlace, Place, PlaceAndQualifiers, RequiresExplicitReExport,
-    place_by_id, place_from_bindings,
+    TypeOrigin, place_by_id, place_from_bindings,
 };
-use crate::types::{ProgramEnvironment, Type};
+use crate::types::{ProgramEnvironment, Type, TypeQualifiers};
 use ty_python_core::{place_table, scope::ScopeId, use_def_map};
 
 /// The return type of certain member-lookup operations. Contains information
@@ -28,7 +28,7 @@ impl<'db> Member<'db> {
     }
 
     /// Returns the type qualifiers of this member.
-    pub(super) fn qualifiers(&self) -> crate::types::TypeQualifiers {
+    pub(super) fn qualifiers(&self) -> TypeQualifiers {
         self.inner.qualifiers
     }
 
@@ -40,6 +40,31 @@ impl<'db> Member<'db> {
     /// Returns the inner type, unless it is definitely undefined.
     pub(super) fn ignore_possibly_undefined(&self) -> Option<Type<'db>> {
         self.inner.place.ignore_possibly_undefined()
+    }
+
+    /// Whether this member is a class-body declaration whose annotation is a bare type variable,
+    /// such as `value: T`, or a union containing one. Such a declaration only describes storage
+    /// on each instance. See [`TypeQualifiers::GENERIC_INSTANCE_ATTRIBUTE`].
+    pub(super) fn is_generic_instance_attribute(&self, db: &'db dyn Db) -> bool {
+        let Place::Defined(DefinedPlace {
+            ty,
+            origin: TypeOrigin::Declared,
+            ..
+        }) = self.inner.place
+        else {
+            return false;
+        };
+        if self.qualifiers().contains(TypeQualifiers::CLASS_VAR) {
+            return false;
+        }
+        match ty {
+            Type::TypeVar(_) => true,
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .any(|element| matches!(element, Type::TypeVar(_))),
+            _ => false,
+        }
     }
 
     /// Map a type transformation function over the type of this member.

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -3684,8 +3684,7 @@ fn proto_interface_cycle_recover<'db>(
     value.cycle_normalized(db, &env, *previous, cycle)
 }
 
-/// Bind `self` unless this is a `Callable[P, R]` dunder, and *also* discard the functionlike-ness
-/// of the callable.
+/// Bind `self`, and *also* discard the functionlike-ness of the callable.
 ///
 /// This additional upcasting is required in order for protocols with `__call__` method
 /// members to be considered assignable to `Callable` types, since the `Callable` supertype


### PR DESCRIPTION
This tightens the heuristic for when a dunder is treated as function-like. `__dunder__: Callable[[Args], Return]` is still treated that way, but `__dunder__: F` (where `F` is a `TypeVar`) is not. We now look at the annotation as written in the class body instead of the specialized type, which is the same call #26696 made for `ParamSpec`, so the `DunderParamSpec` special case is removed.

Separately, since `F` usually resolves to a function-like callable that binds `self` on its own, any bare-`TypeVar` declaration (dunder or not) no longer goes through the descriptor protocol on instance access. This matches what mypy and pyright do for declared-but-not-initialized class attributes.

This fixes `pytest.skip("reason")` with pytest 8, which declares `__call__: _F` on a protocol.

Closes https://github.com/astral-sh/ty/issues/2797
