### PR TITLE
docs(flake8-annotations): clarify that ANN401 checks return types

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -486,8 +486,8 @@ impl Violation for MissingReturnTypeClassMethod {
 }
 
 /// ## What it does
-/// Checks that function arguments are annotated with a more specific type than
-/// `Any`.
+/// Checks that function arguments and return values are annotated with a more
+/// specific type than `Any`.
 ///
 /// ## Why is this bad?
 /// `Any` is a special type indicating an unconstrained type. When an
@@ -503,13 +503,13 @@ impl Violation for MissingReturnTypeClassMethod {
 /// from typing import Any
 ///
 ///
-/// def foo(x: Any): ...
+/// def foo(x: Any) -> Any: ...
 /// ```
 ///
 /// Use instead:
 ///
 /// ```python
-/// def foo(x: int): ...
+/// def foo(x: int) -> int: ...
 /// ```
 ///
 /// ## Known problems


### PR DESCRIPTION
## Summary

Clarifies the documentation for `ANN401` (`any-type`) to specify that it checks both function arguments and return values.

Also updates the example code snippet to demonstrate `-> Any:` being replaced with `-> int:`.

Closes #28298.

## Test Plan

Documentation-only comment change in `crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs` on `struct AnyType`.
