### PR TITLE
[ty] Preserve callback type context through ParamSpec forwarding

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1024,7 +1024,16 @@ def gradual(name: str, callback: Callable[[Any, int], Any]): ...
 forward(gradual, "name", lambda value, count: reveal_type((value, count)))  # revealed: tuple[Any, int]
 ```
 
-The same applies to callbacks with an unknown return type:
+A gradual parameter list gives each callback parameter the type `Any`:
+
+```py
+def gradual_list(name: str, callback: Callable[..., Any]): ...
+
+gradual_list("name", lambda first, second: reveal_type((first, second)))  # revealed: tuple[Any, Any]
+forward(gradual_list, "name", lambda first, second: reveal_type((first, second)))  # revealed: tuple[Any, Any]
+```
+
+Concrete parameter types also provide context when a callback's return type is unknown:
 
 ```py
 from ty_extensions._internal import Unknown

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -966,7 +966,7 @@ to_thread_like(
 to_thread_like(
     generic_pair_with_container,
     1,
-    reveal_type([""]),  # revealed: list[Literal[1] | str]
+    reveal_type([""]),  # revealed: list[int | str]
 )
 ```
 
@@ -988,8 +988,7 @@ def _(payload: Payload):
 
 def triple[T](first: T, second: T, third: T) -> None: ...
 def _(payload: Payload, unknown: Unknown):
-    # TODO: This should reveal `Payload`.
-    forward(triple, reveal_type({"x": 1}), payload, unknown)  # revealed: dict[str, int]
+    forward(triple, reveal_type({"x": 1}), payload, unknown)  # revealed: Payload
 ```
 
 We use a type-variable default as type context when the forwarded arguments do not otherwise
@@ -999,6 +998,76 @@ constrain it:
 def default[T = Callable[[int], int]](callback: T) -> None: ...
 
 forward(default, lambda x: reveal_type(x))  # revealed: int
+```
+
+### Forwarded callbacks with gradual types
+
+A callback forwarded through a `ParamSpec` receives its own parameter type as context, including
+when its return type is `Any`. Earlier arguments to the wrapped function do not affect the
+callback's parameter types.
+
+```py
+from typing import Any, Callable
+
+def forward[**P](function: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs): ...
+def target(name: str, callback: Callable[[int], Any]): ...
+
+forward(target, "name", lambda value: reveal_type(value))  # revealed: int
+forward(target, name="name", callback=lambda value: reveal_type(value))  # revealed: int
+```
+
+Gradual parameter types are also preserved alongside concrete parameter types:
+
+```py
+def gradual(name: str, callback: Callable[[Any, int], Any]): ...
+
+forward(gradual, "name", lambda value, count: reveal_type((value, count)))  # revealed: tuple[Any, int]
+```
+
+The same applies to callbacks with an unknown return type:
+
+```py
+from ty_extensions._internal import Unknown
+
+def unknown_return(name: str, callback: Callable[[int], Unknown]): ...
+
+forward(unknown_return, "name", lambda value: reveal_type(value))  # revealed: int
+```
+
+### Forwarded callbacks with unsolved type variables
+
+An unsolved type variable in a callback's return type does not prevent its parameter types from
+providing context.
+
+```py
+from typing import Any, Callable
+
+def forward[**P](function: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs): ...
+def target[T](name: str, callback: Callable[[int], T]): ...
+
+forward(target, "name", lambda value: reveal_type(value))  # revealed: int
+```
+
+An unsolved callback parameter remains unknown when the other arguments do not constrain it:
+
+```py
+def unsolved[T](name: str, callback: Callable[[T], Any]): ...
+
+forward(unsolved, "name", lambda value: reveal_type(value))  # revealed: Unknown
+```
+
+### Forwarded callbacks in invalid calls
+
+Omitting `name` reports a missing argument without an additional argument-type error for the
+callback.
+
+```py
+from typing import Any, Callable
+
+def forward[**P](function: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs): ...
+def target(name: str, callback: Callable[[int], Any]): ...
+
+forward(target, callback=lambda value: value)  # error: [missing-argument]
 ```
 
 ### Specializing `ParamSpec` with another `ParamSpec`

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7703,15 +7703,17 @@ impl<'db> Binding<'db> {
         let parameter_type = specialized_overload.signature.parameters()
             [specialized_parameter.index]
             .annotated_type();
-        let parameter_type = specialized_overload
-            .merged_specialization(db)
-            .map_or(parameter_type, |specialization| {
-                parameter_type.apply_specialization(db, specialization)
-            });
-
-        (!parameter_type.has_dynamic(db, env)
-            && !parameter_type.has_typevar_or_typevar_instance(db, env))
-        .then_some(parameter_type)
+        // Preserve gradual context such as `Callable[[int], Any]`, while marking unsolved
+        // type variables in the same way as for arguments to an ordinary generic call.
+        Some(parameter_type.apply_optional_specialization(
+            db,
+            specialized_overload.argument_type_context_specialization(
+                db,
+                env,
+                constraints,
+                call_expression_tcx,
+            ),
+        ))
     }
 
     /// Returns the expected tuple element for an argument matched to a `TypeVarTuple`.
@@ -7854,9 +7856,11 @@ impl<'db> Binding<'db> {
 
             // A `P.args`/`P.kwargs` parameter receives context from the `ParamSpec` specialization
             // checked during the previous fixpoint round.
-            if let Some(paramspec) = paramspec
-                && let Some(callable) = paramspec_callable(paramspec)
-                && let Some(specialized_parameter_type) =
+            if let Some(paramspec) = paramspec {
+                // Specializing `P.args` or `P.kwargs` directly yields the entire parameter list,
+                // which is not a valid type context for an individual argument.
+                let callable = paramspec_callable(paramspec)?;
+                let specialized_parameter_type =
                     self.paramspec_argument_context(&ParamSpecArgumentContext {
                         db,
                         env,
@@ -7866,8 +7870,7 @@ impl<'db> Binding<'db> {
                         arguments_types,
                         argument_index,
                         call_expression_tcx,
-                    })
-            {
+                    })?;
                 return Some(ArgumentTypeContext::paramspec(
                     original_parameter_type,
                     specialized_parameter_type,


### PR DESCRIPTION
## Summary

We now infer callbacks forwarded through a `ParamSpec` using their own parameter types, even when their annotations contain `Any` or `Unknown`. For example, `value` is inferred as `int` here:

```python
from typing import Any, Callable

def forward[**P](fn: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs): ...
def target(name: str, callback: Callable[[int], Any]): ...

forward(target, "name", lambda value: value)
```

Previously, we discarded the callback's context and could use the entire forwarded parameter list as its signature, giving `value` the earlier `str` parameter's type. We now reuse ordinary generic-call context specialization, preserving gradual types while distinguishing unsolved type variables, and avoid that fallback when we cannot resolve the forwarded parameter.

Closes https://github.com/astral-sh/ty/issues/4493.
