### PR TITLE
[ty] Reject runtime_checkable on non-protocol classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -445,6 +445,98 @@ reveal_type(typing.Protocol is typing_extensions.Protocol)  # revealed: bool
 reveal_type(typing.Protocol is not typing_extensions.Protocol)  # revealed: bool
 ```
 
+## Applying `runtime_checkable`
+
+The `runtime_checkable` decorator can only be applied to protocol classes. Applying it to an
+ordinary class raises `TypeError` at runtime:
+
+```py
+from typing import Protocol, runtime_checkable
+from typing_extensions import runtime_checkable as runtime_checkable_extensions
+
+# snapshot: invalid-argument-type
+@runtime_checkable
+class NotAProtocol: ...
+
+# error: [invalid-argument-type] "`runtime_checkable` can only be applied to protocol classes"
+@runtime_checkable_extensions
+class AlsoNotAProtocol: ...
+```
+
+```snapshot
+error[invalid-argument-type]: `runtime_checkable` can only be applied to protocol classes
+ --> src/mdtest_snippet.py:5:1
+  |
+5 | @runtime_checkable
+  | ^^^^^^^^^^^^^^^^^^
+6 | class NotAProtocol: ...
+  |       ------------ `NotAProtocol` is not a protocol class
+info: A class is only a protocol if it directly inherits from `typing.Protocol` or `typing_extensions.Protocol`
+```
+
+A subclass of a protocol is not itself a protocol unless it explicitly inherits from `Protocol`:
+
+```py
+class Base(Protocol): ...
+
+# error: [invalid-argument-type] "`runtime_checkable` can only be applied to protocol classes"
+@runtime_checkable
+class Concrete(Base): ...
+
+@runtime_checkable
+class Subprotocol(Base, Protocol): ...
+```
+
+The same restriction applies when calling `runtime_checkable` directly:
+
+```py
+runtime_checkable(NotAProtocol)  # error: [invalid-argument-type] "`runtime_checkable` can only be applied to protocol classes"
+runtime_checkable_extensions(Concrete)  # error: [invalid-argument-type]
+runtime_checkable(Base)
+```
+
+## `runtime_checkable` with deferred bases
+
+Class bases in stub files can refer to names defined later in the file. We resolve those names
+before checking whether the decorated class is a protocol.
+
+```pyi
+from typing import runtime_checkable
+
+@runtime_checkable
+class P(ProtocolAlias): ...
+
+# error: [invalid-argument-type] "`runtime_checkable` can only be applied to protocol classes"
+@runtime_checkable
+class Concrete(P): ...
+
+from typing import Protocol as ProtocolAlias
+```
+
+## `runtime_checkable` and replacing decorators
+
+Decorators are applied from bottom to top. If an inner decorator replaces an ordinary class with a
+protocol, `runtime_checkable` accepts that protocol. Reversing their order applies
+`runtime_checkable` to the ordinary class and raises `TypeError`:
+
+```py
+from typing import Protocol, runtime_checkable
+
+class P(Protocol): ...
+
+def replace(cls: type) -> type[P]:
+    return P
+
+@runtime_checkable
+@replace
+class Replaced: ...
+
+@replace
+# error: [invalid-argument-type] "`runtime_checkable` can only be applied to protocol classes"
+@runtime_checkable
+class NotAProtocol: ...
+```
+
 ## Calls to protocol classes
 
 <!-- snapshot-diagnostics -->

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3533,6 +3533,27 @@ pub(crate) fn report_invalid_argument_number_to_special_form(
     }
 }
 
+pub(super) fn report_invalid_runtime_checkable(
+    context: &InferContext,
+    node: impl Ranged,
+    class: ClassLiteral,
+) {
+    let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, node) else {
+        return;
+    };
+    let db = context.db();
+    let mut diagnostic =
+        builder.into_diagnostic("`runtime_checkable` can only be applied to protocol classes");
+    diagnostic.annotate(
+        Annotation::secondary(class.header_span(db))
+            .message(format_args!("`{}` is not a protocol class", class.name(db))),
+    );
+    diagnostic.info(
+        "A class is only a protocol if it directly inherits from \
+        `typing.Protocol` or `typing_extensions.Protocol`",
+    );
+}
+
 pub(crate) fn report_bad_argument_to_get_protocol_members(
     context: &InferContext,
     call: &ast::ExprCall,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -75,7 +75,8 @@ use crate::types::cyclic::ActiveRecursionDetector;
 use crate::types::diagnostic::{
     ASSERT_TYPE_UNSPELLABLE_SUBTYPE, DISJOINT_CAST, INVALID_ARGUMENT_TYPE, REDUNDANT_CAST,
     STATIC_ASSERT_ERROR, TYPE_ASSERTION_FAILURE, report_bad_argument_to_get_protocol_members,
-    report_bad_argument_to_protocol_interface, report_invalid_total_ordering_call,
+    report_bad_argument_to_protocol_interface, report_invalid_runtime_checkable,
+    report_invalid_total_ordering_call,
     report_issubclass_check_against_protocol_with_non_method_members,
     report_runtime_check_against_non_runtime_checkable_protocol,
     report_runtime_check_against_typed_dict,
@@ -2798,6 +2799,14 @@ impl KnownFunction {
                     source_type
                         .disjointness_error_context(db, env, casted_type)
                         .attach_to(db, env, &mut diagnostic);
+                }
+            }
+
+            KnownFunction::RuntimeCheckable => {
+                if let [Some(Type::ClassLiteral(class))] = parameter_types
+                    && !class.is_protocol(db)
+                {
+                    report_invalid_runtime_checkable(context, call_expression, *class);
                 }
             }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1376,7 +1376,7 @@ struct OtherDefinitionInferenceExtra<'db> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
-    /// Input types for failed decorator applications that are checked after inference.
+    /// Input types for decorator applications that need validation after inference.
     deferred_decorator_calls: FrozenMap<ExpressionNodeKey, Type<'db>>,
 
     /// Whether synthesized dictionary-key assignments derived from the right-hand side should be

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -378,10 +378,10 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     /// For decorated function or class definitions, the type before applying decorators.
     undecorated_type: Option<Type<'db>>,
 
-    /// Input types for failed decorator applications, keyed by decorator expression.
+    /// Input types for decorator applications that need validation after inference.
     ///
     /// Recheck these calls after inference so formatting diagnostics cannot pull deferred
-    /// function defaults into definition inference cycles.
+    /// function defaults into definition inference cycles, and protocol bases are fully inferred.
     deferred_decorator_calls: Vec<(ExpressionNodeKey, Type<'db>)>,
 
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
@@ -5614,7 +5614,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn defer_decorator_call(&mut self, decorator: &ast::Decorator, input_ty: Type<'db>) {
-        // We replay failed decorator applications after inference only to report call errors,
+        // We validate deferred decorator applications after inference only to report call errors,
         // such as incompatible argument types or missing arguments. `@no_type_check` suppresses
         // these errors. Skip recording the calls here because the enclosing scope's post-inference
         // diagnostic context does not inherit this definition-local flag.

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -170,7 +170,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // For ordinary decorators that still apply to the original class, precompute the call so
         // the second pass can reuse it if no inner decorator has changed the binding.
         for &(decorator_ty, decorator) in decorator_types_and_nodes.iter().rev() {
-            if !metadata_applies_to_original_class {
+            if !metadata_applies_to_original_class
+                || decorator_ty
+                    .as_function_literal()
+                    .is_some_and(|function| function.is_known(db, KnownFunction::RuntimeCheckable))
+            {
                 decorators_to_apply.push((decorator_ty, decorator, None));
                 continue;
             }
@@ -225,11 +229,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             if decorator_ty.as_function_literal().is_some_and(|function| {
                 matches!(
                     function.known(db),
-                    Some(
-                        KnownFunction::Final
-                            | KnownFunction::DisjointBase
-                            | KnownFunction::RuntimeCheckable
-                    )
+                    Some(KnownFunction::Final | KnownFunction::DisjointBase)
                 )
             }) {
                 continue;
@@ -304,6 +304,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // to update the public binding. `original_class_ty` remains the class object whose body and
         // metadata were inferred above.
         for (decorator_ty, decorator_node, precomputed_result) in decorators_to_apply {
+            if decorator_ty
+                .as_function_literal()
+                .is_some_and(|function| function.is_known(db, KnownFunction::RuntimeCheckable))
+            {
+                // Protocol bases can be deferred, so validate this identity decorator after
+                // inference. Retain its actual input in case an inner decorator replaced the class.
+                self.defer_decorator_call(decorator_node, inferred_ty);
+                continue;
+            }
+
             let decorator_result = match precomputed_result {
                 // The metadata pass already called this decorator with the same input. If an inner
                 // decorator changed the binding, apply this decorator to the new public binding.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/decorator.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/decorator.rs
@@ -3,6 +3,8 @@ use ty_python_core::definition::Definition;
 
 use crate::types::call::{CallArguments, CallError};
 use crate::types::context::InferContext;
+use crate::types::diagnostic::report_invalid_runtime_checkable;
+use crate::types::function::KnownFunction;
 use crate::types::infer::infer_definition_types;
 
 pub(crate) fn check_decorator_calls<'db>(
@@ -22,6 +24,17 @@ pub(crate) fn check_decorator_calls<'db>(
             continue;
         };
         let decorator_ty = inference.expression_type(&decorator.expression);
+        if decorator_ty
+            .as_function_literal()
+            .is_some_and(|function| function.is_known(db, KnownFunction::RuntimeCheckable))
+            && let Some(class) = input_ty.as_class_literal()
+        {
+            if !class.is_protocol(db) {
+                report_invalid_runtime_checkable(context, decorator, class);
+            }
+            continue;
+        }
+
         let arguments = CallArguments::positional([input_ty]);
         if let Err(CallError(_, bindings)) = decorator_ty.try_call(db, env, &arguments) {
             bindings.report_diagnostics(context, decorator.into());


### PR DESCRIPTION
## Summary

We now report `invalid-argument-type` when `typing.runtime_checkable` or its `typing_extensions` equivalent is applied to a non-protocol class, including concrete subclasses of protocols. These applications raise `TypeError` at runtime. The check also covers direct calls to `runtime_checkable`.

We defer validation until class bases are resolved and retain the type passed to the decorator, so decorator order is respected even when another decorator replaces the class.

Closes https://github.com/astral-sh/ty/issues/4470.
