### PR TITLE
Expose hidden lexer token metadata accessors

### DIFF
--- a/crates/ruff_python_parser/src/lexer.rs
+++ b/crates/ruff_python_parser/src/lexer.rs
@@ -119,12 +119,14 @@ impl<'src> Lexer<'src> {
     }
 
     /// Returns the range of the current token.
-    pub(crate) const fn current_range(&self) -> TextRange {
+    #[doc(hidden)]
+    pub const fn current_range(&self) -> TextRange {
         self.current_range
     }
 
     /// Returns the flags for the current token.
-    pub(crate) const fn current_flags(&self) -> TokenFlags {
+    #[doc(hidden)]
+    pub const fn current_flags(&self) -> TokenFlags {
         self.current_flags
     }
 
@@ -1617,6 +1619,7 @@ fn is_identifier_continuation(c: char, identifier_is_ascii_only: &mut bool) -> b
 }
 
 /// Create a new [`Lexer`] for the given source code and [`Mode`].
+#[doc(hidden)]
 pub fn lex(source: &str, mode: Mode) -> Lexer<'_> {
     Lexer::new(source, mode, TextSize::default())
 }

--- a/hawk.toml
+++ b/hawk.toml
@@ -136,6 +136,22 @@ reason = "preserves the public syntax-validity predicate API"
 
 [[override]]
 lint = "hawk::unnecessary_public"
+crate = "ruff_python_parser"
+item = "lexer::Lexer::<'src>::current_range"
+kind = "inherent_method"
+level = "expect"
+reason = "lets downstream lexer callers inspect the current token range"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "ruff_python_parser"
+item = "lexer::Lexer::<'src>::current_flags"
+kind = "inherent_method"
+level = "expect"
+reason = "lets downstream lexer callers inspect the current token flags"
+
+[[override]]
+lint = "hawk::unnecessary_public"
 crate = "ruff_workspace"
 item = "settings::FormatterSettings::resolve_target_version"
 kind = "inherent_method"


### PR DESCRIPTION
## Summary

Add `#[doc(hidden)]` to `lex` and make `Lexer::current_flags` and `Lexer::current_range` public with the same attribute.

Obligatory warning. This APIs are not part of Ruff's public API. They may change without notice or even be removed without a replacement. 

Closes https://github.com/astral-sh/ruff/issues/28415

## Test Plan

Testing: Parser crate tests and repository hooks passed; an external caller compiled and generated documentation omits the hidden items.
