### PR TITLE
Remove redundant exit flag from Ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,7 +132,7 @@ repos:
     rev: 321478e58f4938179c6b86e4ddfa923d1547a49b # frozen: v0.16.6
     hooks:
       - id: ruff-check
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix]
         types_or: [python, pyi]
         exclude: crates/ty_python_semantic/resources/corpus/
         require_serial: true


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

Remove `--exit-non-zero-on-fix` from the `ruff-check` hook, keeping `--fix`. prek already fails when a hook modifies files, so the flag is redundant.

This follows the guidance in https://github.com/astral-sh/ruff-pre-commit/pull/57.

## Test Plan

<!-- How was it tested? -->
prek checks passed