### PR TITLE
[ty] Respect type-variable bounds in argument context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -1000,6 +1000,22 @@ def default[T = Callable[[int], int]](callback: T) -> None: ...
 forward(default, lambda x: reveal_type(x))  # revealed: int
 ```
 
+### Forwarded arguments with type-variable bounds
+
+When a type variable is bounded by `LiteralString`, string literals are not promoted to `str` when
+providing context for other arguments. This applies to ordinary calls and calls forwarded through a
+`ParamSpec`.
+
+```py
+from typing import Any, Callable, LiteralString
+
+def forward[**P](function: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs): ...
+def target[T: LiteralString](first: T, values: list[T]) -> None: ...
+
+target("a", ["a"])
+forward(target, "a", ["a"])
+```
+
 ### Forwarded callbacks with gradual types
 
 A callback forwarded through a `ParamSpec` receives its own parameter type as context, including

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7974,7 +7974,19 @@ impl<'db> Binding<'db> {
                 let argument_constraints = argument_specialization
                     .and_then(|specialization| specialization.get(db, typevar))
                     .filter(|ty| !ty.has_provisional_marker(db, env))
-                    .map(|ty| ty.promote(db, env));
+                    .map(|ty| {
+                        let promoted = ty.promote(db, env);
+                        // Context for other arguments must still satisfy the type variable's
+                        // bound. For example, `Literal["a"]` satisfies `LiteralString`, but
+                        // promoting it to `str` would violate that bound.
+                        if let Some(bound) = typevar.typevar(db).upper_bound(db, env)
+                            && !promoted.is_assignable_to(db, env, bound)
+                        {
+                            ty
+                        } else {
+                            promoted
+                        }
+                    });
 
                 // TODO: We should similarly combine both the call expression and argument constraints
                 // here. We currently only rely on argument constraints when there is no explicit declared


### PR DESCRIPTION
## Summary

We now preserve an inferred type when promoting it for argument type context would violate its type variable's upper bound. This allows the following forwarded call, which previously rejected `"a"` after promoting it to `str`:

```python
from typing import Any, Callable, LiteralString

def forward[**P](fn: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs): ...
def target[T: LiteralString](first: T, values: list[T]) -> None: ...

forward(target, "a", ["a"])
```

Stacked on #28439. Addresses [this review comment](https://github.com/astral-sh/ruff/pull/28439#discussion_r3964666506).
