### PR TITLE
Add Numonis to "Who's Using Ruff?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Ruff is used by a number of major open-source projects and companies, including:
 - [Nokia](https://nokia.com/)
 - [NoneBot](https://github.com/nonebot/nonebot2)
 - [NumPyro](https://github.com/pyro-ppl/numpyro)
+- [Numonis](https://numonis.com)
 - [ONNX](https://github.com/onnx/onnx)
 - [OpenBB](https://github.com/OpenBB-finance/OpenBBTerminal)
 - [Open Wine Components](https://github.com/Open-Wine-Components/umu-launcher)


### PR DESCRIPTION
Numonis (https://numonis.com) is an accounting platform for SMEs in Spain and Portugal.
Our Python backend (FastAPI + Celery, Python 3.14) runs `ruff format` and `ruff check`
as the first steps of `just ci` on every commit and in CI. Ruff replaced flake8, isort
and black for us. Thanks for the tool!