### PR TITLE
[ty] Fix `--force-exclude` for directories with an excluded ancestor

### DIFF
--- a/crates/ty/tests/cli/file_selection.rs
+++ b/crates/ty/tests/cli/file_selection.rs
@@ -825,7 +825,7 @@ fn explicit_path_overrides_exclude_force_exclude() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Test that `--force-exclude` respects exclude patterns even for explicitly passed files.
+/// Test that `--force-exclude` respects exclude patterns for explicitly passed files and directories.
 #[test]
 fn force_exclude_directory_exclusion() -> anyhow::Result<()> {
     let case = CliTest::with_files([
@@ -884,6 +884,14 @@ fn force_exclude_directory_exclusion() -> anyhow::Result<()> {
     ----- stderr -----
     WARN No python files found under the given path(s)
     ");
+
+    // The exclusion also applies when the passed directory is inside an excluded directory.
+    let output = case
+        .command()
+        .arg("--force-exclude")
+        .arg("out/amd64/install")
+        .output()?;
+    assert!(output.status.success(), "{output:?}");
 
     Ok(())
 }

--- a/crates/ty_project/src/walk.rs
+++ b/crates/ty_project/src/walk.rs
@@ -201,14 +201,17 @@ impl ProjectFilesWalker {
                                 return WalkState::Skip;
                             }
 
-                            // Skip excluded directories unless they were explicitly passed to the walker
-                            // (which is the case passed to `ty check <paths>`).
+                            let match_mode = if entry.depth() == 0 && force_exclude {
+                                GlobFilterCheckMode::Adhoc
+                            } else {
+                                GlobFilterCheckMode::TopDown
+                            };
+
+                            // Skip excluded directories, including explicitly passed ones with `--force-exclude`.
                             if entry.file_type().is_directory() {
                                 if entry.depth() > 0 || force_exclude {
-                                    let directory_included = filter.is_directory_included(
-                                        entry.path(),
-                                        GlobFilterCheckMode::TopDown,
-                                    );
+                                    let directory_included =
+                                        filter.is_directory_included(entry.path(), match_mode);
                                     return match directory_included {
                                         IncludeResult::Included { .. } => WalkState::Continue,
                                         IncludeResult::Excluded => {
@@ -233,11 +236,6 @@ impl ProjectFilesWalker {
                                 // For all files, except the ones that were explicitly passed to the walker (CLI),
                                 // check if they're included in the project.
                                 if entry.depth() > 0 || force_exclude {
-                                    let match_mode = if entry.depth() == 0 && force_exclude {
-                                        GlobFilterCheckMode::Adhoc
-                                    } else {
-                                        GlobFilterCheckMode::TopDown
-                                    };
                                     match filter.is_file_included(entry.path(), match_mode) {
                                         include_result @ IncludeResult::Included { .. } => {
                                             // Ignore any non python files to avoid creating too many entries in `Files`.


### PR DESCRIPTION
## Summary

When `--force-exclude` is used with a directory inside an excluded ancestor, ty still checks the directory's files. Check its ancestors before walking it, consistent with how explicitly passed files are handled.

Related to https://github.com/astral-sh/uv/issues/21551

## Test Plan

Added CLI test
