### PR TITLE
[ty] Add legacy coverage for ParamSpec argument bounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Never edit snapshot files or inline snapshot bodies manually. Regenerate them by
 - Minimize regression examples to the behavior under test. When adapting real-world code or an issue reproducer, remove incidental types, methods, type parameters, imports, and domain-specific details. Preserve complexity only when necessary to reproduce the regression or distinguish the intended behavior, and reuse nearby fixtures or simple built-in types when doing so keeps the test easy to understand.
 - Prefer a minimal, purpose-built custom type over a standard-library type when a regression depends on particular attributes, methods, bounds, or constraints. Define the relevant behavior in the test so readers do not need to look up the standard-library type to understand the scenario. For commonly used standard-library types, consider adding a separate regression using the real type to protect against changes in typeshed.
 - Place each mdtest in a file for the behavior it actually tests, and assert that behavior directly. Prefer an existing file when one already covers that behavior; create a new file when no existing file is a good fit. Do not choose a file solely because its directive or helper can express the assertion.
-- When testing generic behavior supported by both legacy and PEP 695 syntax, add equivalent cases under `generics/legacy/` and `generics/pep695/`. This includes `ParamSpec` tests.
+- When testing generic behavior supported by both legacy and PEP 695 syntax, add equivalent cases under `generics/legacy/` and `generics/pep695/`.
 
 ## Running Clippy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Never edit snapshot files or inline snapshot bodies manually. Regenerate them by
 - Minimize regression examples to the behavior under test. When adapting real-world code or an issue reproducer, remove incidental types, methods, type parameters, imports, and domain-specific details. Preserve complexity only when necessary to reproduce the regression or distinguish the intended behavior, and reuse nearby fixtures or simple built-in types when doing so keeps the test easy to understand.
 - Prefer a minimal, purpose-built custom type over a standard-library type when a regression depends on particular attributes, methods, bounds, or constraints. Define the relevant behavior in the test so readers do not need to look up the standard-library type to understand the scenario. For commonly used standard-library types, consider adding a separate regression using the real type to protect against changes in typeshed.
 - Place each mdtest in a file for the behavior it actually tests, and assert that behavior directly. Prefer an existing file when one already covers that behavior; create a new file when no existing file is a good fit. Do not choose a file solely because its directive or helper can express the assertion.
+- When testing generic behavior supported by both legacy and PEP 695 syntax, add equivalent cases under `generics/legacy/` and `generics/pep695/`. This includes `ParamSpec` tests.
 
 ## Running Clippy
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -1248,9 +1248,8 @@ class ParamSpecWithDefault6(Generic[PAnother]):
 
 ## Semantics
 
-The semantics of `ParamSpec` are described in
-[the PEP 695 `ParamSpec` document](./../pep695/paramspec.md) to avoid duplication unless there are
-any behavior specific to the legacy `ParamSpec` implementation.
+See [the PEP 695 `ParamSpec` document](./../pep695/paramspec.md) for corresponding examples using
+type parameter lists.
 
 ### Binding contexts
 
@@ -1273,4 +1272,24 @@ def outer(_: Callable[P, None]):
     def inner(_: Callable[P, None]): ...
 
     reveal_type(generic_context(inner))  # revealed: None
+```
+
+### Forwarded arguments with type-variable bounds
+
+When a type variable is bounded by `LiteralString`, string literals are not promoted to `str` when
+providing context for other arguments. This applies to ordinary calls and calls forwarded through a
+`ParamSpec`.
+
+```py
+from typing import Any, Callable, ParamSpec, TypeVar
+from typing_extensions import LiteralString
+
+P = ParamSpec("P")
+T = TypeVar("T", bound=LiteralString)
+
+def forward(function: Callable[P, Any], /, *args: P.args, **kwargs: P.kwargs): ...
+def target(first: T, values: list[T]) -> None: ...
+
+target("a", ["a"])
+forward(target, "a", ["a"])
 ```


### PR DESCRIPTION
## Summary

Add the legacy `ParamSpec` equivalent of the bound-preservation regression from #28448, covering both direct and forwarded calls with a `TypeVar` bounded by `LiteralString`.

Document in `AGENTS.md` that generic behavior shared by legacy and PEP 695 syntax should have equivalent tests in both suites, including `ParamSpec`. Update the legacy test document's introduction to match that guidance.

Addresses [this review comment](https://github.com/astral-sh/ruff/pull/28448#discussion_r3968098193).
