### PR TITLE
Remove the "Who’s Using Ruff?" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Ruff is extremely actively developed and used in major open-source projects like
 - [Pandas](https://github.com/pandas-dev/pandas)
 - [SciPy](https://github.com/scipy/scipy)
 
-...and [many more](#whos-using-ruff).
-
 Ruff is backed by [Astral](https://astral.sh), the creators of
 [uv](https://github.com/astral-sh/uv) and [ty](https://github.com/astral-sh/ty).
 
@@ -110,7 +108,7 @@ For more, see the [documentation](https://docs.astral.sh/ruff/).
 1. [Contributing](#contributing)
 1. [Support](#support)
 1. [Acknowledgements](#acknowledgements)
-1. [Who's Using Ruff?](#whos-using-ruff)
+1. [Show Your Support](#show-your-support)
 1. [License](#license)
 
 ## Getting Started<a id="getting-started"></a>
@@ -423,110 +421,7 @@ Ruff is the beneficiary of a large number of [contributors](https://github.com/a
 
 Ruff is released under the MIT license.
 
-## Who's Using Ruff?<a id="whos-using-ruff"></a>
-
-Ruff is used by a number of major open-source projects and companies, including:
-
-- [Albumentations](https://github.com/albumentations-team/AlbumentationsX)
-- Amazon ([AWS SAM](https://github.com/aws/serverless-application-model))
-- [Anki](https://apps.ankiweb.net/)
-- Anthropic ([Python SDK](https://github.com/anthropics/anthropic-sdk-python))
-- [Apache Airflow](https://github.com/apache/airflow)
-- AstraZeneca ([Magnus](https://github.com/AstraZeneca/magnus-core))
-- [Babel](https://github.com/python-babel/babel)
-- Benchling ([Refac](https://github.com/benchling/refac))
-- [Bokeh](https://github.com/bokeh/bokeh)
-- Capital One ([datacompy](https://github.com/capitalone/datacompy))
-- CrowdCent ([NumerBlox](https://github.com/crowdcent/numerblox)) <!-- typos: ignore -->
-- [Cryptography (PyCA)](https://github.com/pyca/cryptography)
-- CERN ([Indico](https://getindico.io/))
-- [DVC](https://github.com/iterative/dvc)
-- [Dagger](https://github.com/dagger/dagger)
-- [Dagster](https://github.com/dagster-io/dagster)
-- Databricks ([MLflow](https://github.com/mlflow/mlflow))
-- [Dify](https://github.com/langgenius/dify)
-- [FastAPI](https://github.com/tiangolo/fastapi)
-- [Godot](https://github.com/godotengine/godot)
-- [Gradio](https://github.com/gradio-app/gradio)
-- [Great Expectations](https://github.com/great-expectations/great_expectations)
-- [HTTPX](https://github.com/encode/httpx)
-- [Hatch](https://github.com/pypa/hatch)
-- [Home Assistant](https://github.com/home-assistant/core)
-- Hugging Face ([Transformers](https://github.com/huggingface/transformers),
-    [Datasets](https://github.com/huggingface/datasets),
-    [Diffusers](https://github.com/huggingface/diffusers))
-- IBM ([Qiskit](https://github.com/Qiskit/qiskit))
-- ING Bank ([popmon](https://github.com/ing-bank/popmon), [probatus](https://github.com/ing-bank/probatus))
-- [Ibis](https://github.com/ibis-project/ibis)
-- [ivy](https://github.com/unifyai/ivy)
-- [JAX](https://github.com/jax-ml/jax)
-- [Jupyter](https://github.com/jupyter-server/jupyter_server)
-- [Kraken Tech](https://kraken.tech/)
-- [LangChain](https://github.com/hwchase17/langchain)
-- [Litestar](https://litestar.dev/)
-- [LlamaIndex](https://github.com/jerryjliu/llama_index)
-- Matrix ([Synapse](https://github.com/matrix-org/synapse))
-- [MegaLinter](https://github.com/oxsecurity/megalinter)
-- Meltano ([Meltano CLI](https://github.com/meltano/meltano), [Singer SDK](https://github.com/meltano/sdk))
-- Microsoft ([Semantic Kernel](https://github.com/microsoft/semantic-kernel),
-    [ONNX Runtime](https://github.com/microsoft/onnxruntime),
-    [LightGBM](https://github.com/microsoft/LightGBM))
-- Modern Treasury ([Python SDK](https://github.com/Modern-Treasury/modern-treasury-python))
-- Mozilla ([Firefox](https://github.com/mozilla-firefox/firefox))
-- [Mypy](https://github.com/python/mypy)
-- [Nautobot](https://github.com/nautobot/nautobot)
-- Netflix ([Dispatch](https://github.com/Netflix/dispatch))
-- [Neon](https://github.com/neondatabase/neon)
-- [Nokia](https://nokia.com/)
-- [NoneBot](https://github.com/nonebot/nonebot2)
-- [NumPyro](https://github.com/pyro-ppl/numpyro)
-- [ONNX](https://github.com/onnx/onnx)
-- [OpenBB](https://github.com/OpenBB-finance/OpenBBTerminal)
-- [Open Wine Components](https://github.com/Open-Wine-Components/umu-launcher)
-- [PDM](https://github.com/pdm-project/pdm)
-- [PaddlePaddle](https://github.com/PaddlePaddle/Paddle)
-- [Pandas](https://github.com/pandas-dev/pandas)
-- [Pillow](https://github.com/python-pillow/Pillow)
-- [Poetry](https://github.com/python-poetry/poetry)
-- [Polars](https://github.com/pola-rs/polars)
-- [PostHog](https://github.com/PostHog/posthog)
-- Prefect ([Python SDK](https://github.com/PrefectHQ/prefect), [Marvin](https://github.com/PrefectHQ/marvin))
-- [PyInstaller](https://github.com/pyinstaller/pyinstaller)
-- [PyMC](https://github.com/pymc-devs/pymc/)
-- [PyMC-Marketing](https://github.com/pymc-labs/pymc-marketing)
-- [pytest](https://github.com/pytest-dev/pytest)
-- [PyTorch](https://github.com/pytorch/pytorch)
-- [Pydantic](https://github.com/pydantic/pydantic)
-- [Pylint](https://github.com/PyCQA/pylint)
-- [PyScripter](https://github.com/pyscripter/pyscripter)
-- [PyVista](https://github.com/pyvista/pyvista)
-- [Reflex](https://github.com/reflex-dev/reflex)
-- [River](https://github.com/online-ml/river)
-- [Rippling](https://rippling.com)
-- [Robyn](https://github.com/sansyrox/robyn)
-- [Saleor](https://github.com/saleor/saleor)
-- Scale AI ([Launch SDK](https://github.com/scaleapi/launch-python-client))
-- [SciPy](https://github.com/scipy/scipy)
-- Snowflake ([SnowCLI](https://github.com/Snowflake-Labs/snowcli))
-- [Sphinx](https://github.com/sphinx-doc/sphinx)
-- [Stable Baselines3](https://github.com/DLR-RM/stable-baselines3)
-- [Starlette](https://github.com/encode/starlette)
-- [Streamlit](https://github.com/streamlit/streamlit)
-- [The Algorithms](https://github.com/TheAlgorithms/Python)
-- [Vega-Altair](https://github.com/altair-viz/altair)
-- [Weblate](https://weblate.org/)
-- WordPress ([Openverse](https://github.com/WordPress/openverse))
-- [ZenML](https://github.com/zenml-io/zenml)
-- [Zulip](https://github.com/zulip/zulip)
-- [build (PyPA)](https://github.com/pypa/build)
-- [cibuildwheel (PyPA)](https://github.com/pypa/cibuildwheel)
-- [delta-rs](https://github.com/delta-io/delta-rs)
-- [featuretools](https://github.com/alteryx/featuretools)
-- [meson-python](https://github.com/mesonbuild/meson-python)
-- [nox](https://github.com/wntrblm/nox)
-- [pip](https://github.com/pypa/pip)
-
-### Show Your Support
+## Show Your Support
 
 If you're using Ruff, consider adding the Ruff badge to your project's `README.md`:
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -23,7 +23,6 @@ pn = "pn"  # `import panel as pn` is a thing
 poit = "poit"
 BA = "BA" # acronym for "Bad Allowed", used in testing.
 jod = "jod" # e.g., `jod-thread`
-Numer = "Numer" # Library name 'NumerBlox' in "Who's Using Ruff?"
 CPY = "CPY"  # it's a Ruff rule category
 
 [default]

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -105,7 +105,6 @@ LINK_REWRITES: dict[str, str] = {
     "https://docs.astral.sh/ruff/rules/": "rules.md",
     "https://docs.astral.sh/ruff/default-rules/": "default-rules.md",
     "https://docs.astral.sh/ruff/settings/": "settings.md",
-    "#whos-using-ruff": "https://github.com/astral-sh/ruff#whos-using-ruff",
     "https://docs.astral.sh/ruff/preview/": "preview.md",
 }
 


### PR DESCRIPTION
## Summary

Removes the "Who's using ruff?" list. 

The section was useful when Ruff was young and not well known. Ruff is now widely used in the ecosystem, so that this list provides diminishing returns and we also lack a clear guidance on what it takes for a project to be added. 
