### PR TITLE
[ty] Give existing autofixes descriptive titles

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
+++ b/crates/ty_python_semantic/resources/mdtest/redundant_condition.md
@@ -38,6 +38,7 @@ warning[redundant-condition]: Function `func` is always truthy
   |
 3 | if func:  # snapshot: redundant-condition
   |    ^^^^ Did you mean to call this function?
+help: Replace with `func()`
   |
 2 |
   - if func:  # snapshot: redundant-condition
@@ -65,6 +66,7 @@ warning[redundant-condition]: Method `Foo.bar` is always truthy
    |
 10 |         if self.bar:  # snapshot: redundant-condition
    |            ^^^^^^^^ Did you mean to call this method?
+help: Replace with `self.bar()`
    |
 9  |     def baz(self):
    -         if self.bar:  # snapshot: redundant-condition
@@ -764,6 +766,7 @@ warning[redundant-condition]: Function `func` is always truthy
   |
 3 |     if flag and func:  # snapshot: redundant-condition
   |                 ^^^^ Did you mean to call this function?
+help: Replace with `func()`
   |
 2 | def compound_statement_conditions(flag: bool, other: bool):
   -     if flag and func:  # snapshot: redundant-condition
@@ -778,6 +781,7 @@ warning[redundant-condition]: Function `func` is always truthy
    |
 19 |     selected = True if flag and func else False  # snapshot: redundant-condition
    |                                 ^^^^ Did you mean to call this function?
+help: Replace with `func()`
    |
 18 | def compound_expression_conditions(flag: bool):
    -     selected = True if flag and func else False  # snapshot: redundant-condition
@@ -792,6 +796,7 @@ warning[redundant-condition]: Function `func` is always truthy
    |
 24 |     assert flag and func  # snapshot: redundant-condition
    |                     ^^^^ Did you mean to call this function?
+help: Replace with `func()`
    |
 23 | def compound_assertion_condition(flag: bool):
    -     assert flag and func  # snapshot: redundant-condition
@@ -976,6 +981,7 @@ warning[redundant-condition]: Function `coroutine` is always truthy
   |
 3 |     if coroutine:  # snapshot: redundant-condition
   |        ^^^^^^^^^ Did you mean to `await` and call this function?
+help: Replace with `await coroutine()`
   |
 2 | async def inspect_async_function():
   -     if coroutine:  # snapshot: redundant-condition
@@ -1014,6 +1020,7 @@ warning[redundant-condition]: Function `always_truthy` is always truthy
   |
 7 |     if always_truthy:  # snapshot: redundant-condition
   |        ^^^^^^^^^^^^^ Did you mean to call this function?
+help: Replace with `always_truthy()`
   |
 6 | def inspect_truthy_function():
   -     if always_truthy:  # snapshot: redundant-condition
@@ -1028,6 +1035,7 @@ warning[redundant-condition]: Function `always_truthy_coro` is always truthy
    |
 14 |     if always_truthy_coro:  # snapshot: redundant-condition
    |        ^^^^^^^^^^^^^^^^^^ Did you mean to `await` and call this function?
+help: Replace with `await always_truthy_coro()`
    |
 13 | async def foo():
    -     if always_truthy_coro:  # snapshot: redundant-condition
@@ -1061,6 +1069,7 @@ warning[redundant-condition]: Function `wut` is always truthy
   |
 3 | if wut:  # snapshot: redundant-condition
   |    ^^^ Did you mean to call this function?
+help: Replace with `wut(...)`
   |
 2 |
   - if wut:  # snapshot: redundant-condition
@@ -1075,6 +1084,7 @@ warning[redundant-condition]: Function `wuttt` is always truthy
   |
 8 |     if wuttt:  # snapshot: redundant-condition
   |        ^^^^^ Did you mean to `await` and call this function?
+help: Replace with `await wuttt(...)`
   |
 7 | async def bar():
   -     if wuttt:  # snapshot: redundant-condition
@@ -1110,6 +1120,7 @@ warning[redundant-condition]: Function `asynchronous` is always truthy
    |
 11 |     if asynchronous:  # snapshot: redundant-condition
    |        ^^^^^^^^^^^^ Did you mean to `await` and call this function?
+help: Replace with `await asynchronous(...)`
    |
 10 | async def inspect_asynchronous_overloads():
    -     if asynchronous:  # snapshot: redundant-condition
@@ -1141,6 +1152,7 @@ warning[redundant-condition]: Function `mixed` is always truthy
    |
 21 |     if mixed:  # snapshot: redundant-condition
    |        ^^^^^ Did you mean to call this function?
+help: Replace with `mixed(...)`
    |
 20 | async def inspect_mixed_overloads():
    -     if mixed:  # snapshot: redundant-condition
@@ -1190,6 +1202,7 @@ warning[redundant-condition]: Function `unannotated` is always truthy
    |
 18 |     if unannotated:  # snapshot: redundant-condition
    |        ^^^^^^^^^^^ Did you mean to call this function?
+help: Replace with `unannotated()`
    |
 17 | async def check_synchronous_functions():
    -     if unannotated:  # snapshot: redundant-condition
@@ -1204,6 +1217,7 @@ warning[redundant-condition]: Function `dynamic` is always truthy
    |
 20 |     if dynamic:  # snapshot: redundant-condition
    |        ^^^^^^^ Did you mean to call this function?
+help: Replace with `dynamic()`
    |
 19 |         pass
    -     if dynamic:  # snapshot: redundant-condition
@@ -1218,6 +1232,7 @@ warning[redundant-condition]: Function `terminate` is always truthy
    |
 22 |     if terminate:  # snapshot: redundant-condition
    |        ^^^^^^^^^ Did you mean to call this function?
+help: Replace with `terminate()`
    |
 21 |         pass
    -     if terminate:  # snapshot: redundant-condition
@@ -1232,6 +1247,7 @@ warning[redundant-condition]: Function `terminate_via_alias` is always truthy
    |
 24 |     if terminate_via_alias:  # snapshot: redundant-condition
    |        ^^^^^^^^^^^^^^^^^^^ Did you mean to call this function?
+help: Replace with `terminate_via_alias()`
    |
 23 |         pass
    -     if terminate_via_alias:  # snapshot: redundant-condition
@@ -1275,6 +1291,7 @@ warning[redundant-condition]: Function `make_coroutine` is always truthy
    |
 11 |     if make_coroutine:  # snapshot: redundant-condition
    |        ^^^^^^^^^^^^^^ Did you mean to `await` and call this function?
+help: Replace with `await make_coroutine()`
    |
 10 | async def check_coroutine_factory():
    -     if make_coroutine:  # snapshot: redundant-condition
@@ -2536,6 +2553,7 @@ warning[redundant-condition]: Function `func` is always truthy
    |
 28 |     selected = not func if flag else not func
    |                    ^^^^ Did you mean to call this function?
+help: Replace with `func()`
    |
 27 |     # snapshot: redundant-condition
    -     selected = not func if flag else not func
@@ -2550,6 +2568,7 @@ warning[redundant-condition]: Function `func` is always truthy
    |
 28 |     selected = not func if flag else not func
    |                                          ^^^^ Did you mean to call this function?
+help: Replace with `func()`
    |
 27 |     # snapshot: redundant-condition
    -     selected = not func if flag else not func

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Misspelled_key_for_`…_(7cf0fa634e2a2d59).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/assignment_diagnosti…_-_Subscript_assignment…_-_Misspelled_key_for_`…_(7cf0fa634e2a2d59).snap
@@ -32,6 +32,7 @@ error[invalid-key]: Unknown key "Retries" for TypedDict `Config`
   |     ------ ^^^^^^^^^ Did you mean "retries"?
   |     |
   |     TypedDict `Config`
+help: Replace with "retries"
   |
 6 | def _(config: Config) -> None:
   -     config["Retries"] = 30.0  # error: [invalid-key]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Module-literal_used_…_(652fec4fd4a6c63a).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/invalid.md_-_Tests_for_invalid_ty…_-_Diagnostics_for_comm…_-_Module-literal_used_…_(652fec4fd4a6c63a).snap
@@ -40,6 +40,7 @@ error[invalid-type-form]: Module `datetime` is not valid in a parameter annotati
   |
 3 | def f(x: datetime): ...  # error: [invalid-type-form]
   |          ^^^^^^^^ Did you mean to use the module's member `datetime.datetime`?
+help: Replace with `datetime.datetime`
   |
 2 |
   - def f(x: datetime): ...  # error: [invalid-type-form]
@@ -55,6 +56,7 @@ error[invalid-type-form]: Module `PIL.Image` is not valid in a parameter annotat
   |
 3 | def g(x: Image): ...  # error: [invalid-type-form]
   |          ^^^^^ Did you mean to use the module's member `Image.Image`?
+help: Replace with `Image.Image`
   |
 2 |
   - def g(x: Image): ...  # error: [invalid-type-form]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Diagnostics_(e5289abf5c570c29).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/typed_dict.md_-_`TypedDict`_-_Diagnostics_(e5289abf5c570c29).snap
@@ -82,6 +82,7 @@ error[invalid-key]: Unknown key "nane" for TypedDict `Person`
   |     ------ ^^^^^^ Did you mean "name"?
   |     |
   |     TypedDict `Person`
+help: Replace with "name"
   |
 7 | def access_invalid_literal_string_key(person: Person):
   -     person["nane"]  # error: [invalid-key]
@@ -137,6 +138,7 @@ error[invalid-key]: Unknown key "nane" for TypedDict `Person`
    |     ------ ^^^^^^ Did you mean "name"?
    |     |
    |     TypedDict `Person`
+help: Replace with "name"
    |
 21 | def write_to_non_existing_key(person: Person):
    -     person["nane"] = "Alice"  # error: [invalid-key]
@@ -201,6 +203,7 @@ error[invalid-key]: Unknown key "nane" for TypedDict `Person`
    |     ------ ^^^^^^ Did you mean 'name'?
    |     |
    |     TypedDict `Person`
+help: Replace with 'name'
    |
 42 |     # error: [invalid-key]
    -     person['nane'] = "Alice"  # fmt: skip

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -11026,6 +11026,9 @@ impl<'db> InvalidTypeExpression<'db> {
                 "Did you mean to use the module's member \
                 `{module_name_final_part}.{module_name_final_part}`?"
             ));
+            diagnostic.help(format_args!(
+                "Replace with `{module_name_final_part}.{module_name_final_part}`"
+            ));
             diagnostic.set_fix(Fix::unsafe_edit(Edit::insertion(
                 format!(".{module_name_final_part}"),
                 node.end(),

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -4325,6 +4325,7 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
                         diagnostic.set_primary_annotation_message(format_args!(
                             "Did you mean {quoted_suggestion}?"
                         ));
+                        diagnostic.help(format_args!("Replace with {quoted_suggestion}"));
                         diagnostic.set_fix(Fix::unsafe_edit(Edit::range_replacement(
                             quoted_suggestion,
                             key_node.range(),

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -284,6 +284,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     } else {
                         Fix::applicable_edit(call_edit, applicability)
                     };
+                    let source = source_text(db, self.file());
+                    let expression_text = &source[test.range()];
+                    let prefix = if is_awaitable_coro_function {
+                        "await "
+                    } else {
+                        ""
+                    };
+                    diagnostic.help(format_args!(
+                        "Replace with `{prefix}{expression_text}{call}`"
+                    ));
                     diagnostic.set_fix(fix);
                 }
 


### PR DESCRIPTION
## Summary

ty uses the first `help:` subdiagnostic as the title of a Quick Fix in editors and the playground. When a fix has no help text, its title falls back to `Fix <rule>`.

Add replacement-specific help for the existing fixes that correct a misspelled `TypedDict` key, replace a module used as a type with its same-named member, or call a function used as a condition. The callable title reflects the expression being fixed and includes `await` when the fix awaits a coroutine.

## Test plan

Video showing before-and-after of the fix titles in the playground:


https://github.com/user-attachments/assets/f075c970-18ac-48fc-b384-1d4eb71dd354


