### PR TITLE
[ty] Preserve wrapped functions in precise `functools.partial` relations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/functools_partial.md
@@ -607,6 +607,32 @@ def test_union_partial(flag: bool) -> None:
     bad: Callable[[bytes, bytes], int] = p  # error: [invalid-assignment]
 ```
 
+### Union of partials with different wrapped functions
+
+The boolean-returning `partial` instance in the below example can be selected when `flag` is true.
+Its call signature is a subtype of the integer-returning `partial`'s signature, but each wraps a
+different function. Discarding `bool_partial` from the union would incorrectly make
+`selected is bool_partial` appear impossible:
+
+```py
+from functools import partial
+
+def integer() -> int:
+    return 1
+
+def boolean() -> bool:
+    return True
+
+int_partial = partial(integer)
+bool_partial = partial(boolean)
+
+def choose(flag: bool) -> None:
+    selected = bool_partial if flag else int_partial
+    reveal_type(selected)  # revealed: partial[() -> bool] | partial[() -> int]
+    reveal_type(selected.func)  # revealed: (def boolean() -> bool) | (def integer() -> int)
+    reveal_type(selected is bool_partial)  # revealed: bool
+```
+
 ### Keyword-bound overload filtering
 
 ```py

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1867,7 +1867,42 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(source_partial)),
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(target_partial)),
             ) => self.with_recursion_guard(db, source, target, || {
-                self.check_callable_pair(db, source_partial.partial(db), target_partial.partial(db))
+                // The reduced signature of `partial(boolean)` is `() -> bool`, which is a
+                // subtype of the `() -> int` signature of `partial(integer)`. The wrapped
+                // functions still differ, and `.func` exposes which one was chosen:
+                //
+                // ```py
+                // from functools import partial
+                //
+                // def integer() -> int:
+                //     return 1
+                //
+                // def boolean() -> bool:
+                //     return True
+                //
+                // int_partial = partial(integer)
+                // bool_partial = partial(boolean)
+                //
+                // def choose(flag: bool) -> bool:
+                //     selected = bool_partial if flag else int_partial
+                //     return reveal_type(selected.func is boolean)  # revealed: bool
+                // ```
+                //
+                // The comparison is true when `flag` is true. Dropping `bool_partial` from the
+                // union based only on its reduced signature would make ty reveal `Literal[False]`
+                // instead of `bool`. Check the wrapped callable as well as the reduced signature.
+                self.check_type_pair(
+                    db,
+                    source_partial.wrapped(db).inner(db),
+                    target_partial.wrapped(db).inner(db),
+                )
+                .and(db, self.constraints, || {
+                    self.check_callable_pair(
+                        db,
+                        source_partial.partial(db),
+                        target_partial.partial(db),
+                    )
+                })
             }),
 
             (


### PR DESCRIPTION
## Summary

A union of `partial(boolean)` and `partial(integer)` must retain both partials. Their reduced call signatures are related because `bool` is a subtype of `int`, but `.func` exposes two different wrapped functions. Comparing only the reduced signatures can drop the boolean-returning partial and incorrectly reveal an identity comparison as `Literal[False]`.

```py
from functools import partial

def integer() -> int:
    return 1

def boolean() -> bool:
    return True

int_partial = partial(integer)
bool_partial = partial(boolean)

def choose(flag: bool) -> None:
    selected = bool_partial if flag else int_partial
    reveal_type(selected.func)  # (def boolean() -> bool) | (def integer() -> int)
    reveal_type(selected is bool_partial)  # bool
```

Check the wrapped function type as well as the reduced call signature when relating precise partials. The regression example covers the preserved union, `.func`, and identity comparison.

This addresses https://github.com/astral-sh/ruff/pull/28409#discussion_r3968505853
