### PR TITLE
[ty] Preserve metaclass candidates after conflicts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -628,8 +628,12 @@ The metaclass of a derived class must be a (non-strict) subclass of the metaclas
 bases. ("Strict subclass" is a synonym for "proper subclass"; a non-strict subclass can be a
 subclass or the class itself.)
 
+We report the conflict and retain the candidate from the first base for attribute lookup.
+
 ```py
-class M1(type): ...
+class M1(type):
+    value: int
+
 class M2(type): ...
 class A(metaclass=M1): ...
 class B(metaclass=M2): ...
@@ -637,7 +641,8 @@ class B(metaclass=M2): ...
 # error: [conflicting-metaclass] "The metaclass of a derived class (`C`) must be a subclass of the metaclasses of all its bases, but `M1` (metaclass of base class `A`) and `M2` (metaclass of base class `B`) have no subclass relationship"
 class C(A, B): ...
 
-reveal_type(C.__class__)  # revealed: type[Unknown]
+reveal_type(C.__class__)  # revealed: <class 'M1'>
+reveal_type(C.value)  # revealed: int
 ```
 
 ## Conflict (2)
@@ -646,15 +651,21 @@ The metaclass of a derived class must be a (non-strict) subclass of the metaclas
 bases. ("Strict subclass" is a synonym for "proper subclass"; a non-strict subclass can be a
 subclass or the class itself.)
 
+An explicit metaclass is retained for attribute lookup when it conflicts with a base's metaclass.
+
 ```py
 class M1(type): ...
-class M2(type): ...
+
+class M2(type):
+    value: str
+
 class A(metaclass=M1): ...
 
 # error: [conflicting-metaclass] "The metaclass of a derived class (`B`) must be a subclass of the metaclasses of all its bases, but `M2` (metaclass of `B`) and `M1` (metaclass of base class `A`) have no subclass relationship"
 class B(A, metaclass=M2): ...
 
-reveal_type(B.__class__)  # revealed: type[Unknown]
+reveal_type(B.__class__)  # revealed: <class 'M2'>
+reveal_type(B.value)  # revealed: str
 ```
 
 ## Common metaclass
@@ -946,7 +957,7 @@ class C(metaclass=M12): ...
 # error: [conflicting-metaclass] "The metaclass of a derived class (`D`) must be a subclass of the metaclasses of all its bases, but `M1` (metaclass of base class `A`) and `M2` (metaclass of base class `B`) have no subclass relationship"
 class D(A, B, C): ...
 
-reveal_type(D.__class__)  # revealed: type[Unknown]
+reveal_type(D.__class__)  # revealed: <class 'M1'>
 ```
 
 ## Unknown
@@ -1107,6 +1118,39 @@ class Outer:
 
     class Meta(Wrapper[int], type): ...
     class Inner(Aliases, metaclass=Meta): ...
+    value: Outer.Inner.Value
+    type: Outer.Inner.Value
+```
+
+## Persistent metaclass conflict during recursive attribute inference
+
+Recursive attribute inference does not suppress a conflict between unrelated metaclasses. We retain
+the explicit candidate for member lookup and report the conflict when checking the stub.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from mod import Outer
+
+reveal_type(Outer.value)  # revealed: Unknown
+reveal_type(Outer.Inner.__class__)  # revealed: <class 'Meta'>
+```
+
+`mod.pyi`:
+
+```pyi
+class Wrapper[T](type): ...
+class OtherMeta(type): ...
+
+class Outer:
+    class Aliases(metaclass=OtherMeta):
+        Value = int
+
+    class Meta(Wrapper[int], type): ...
+    class Inner(Aliases, metaclass=Meta): ...  # error: [conflicting-metaclass]
     value: Outer.Inner.Value
     type: Outer.Inner.Value
 ```

--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -1075,6 +1075,42 @@ class C(A): ...  # error: [cyclic-class-definition]
 reveal_type(A.__class__)  # revealed: type[Unknown]
 ```
 
+## Metaclass conflicts during recursive attribute inference
+
+A stub can refer to an inherited type alias through a nested class with a custom metaclass. When an
+attribute named `type` also depends on that alias, inferring the metaclass's bases can depend on the
+metaclass being selected. Type checking completes even when temporary metaclass conflicts arise
+during this inference cycle.
+
+Regression test for [ty#4492](https://github.com/astral-sh/ty/issues/4492).
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from mod import Outer
+
+# TODO: This should be `int`.
+reveal_type(Outer.value)  # revealed: Unknown
+```
+
+`mod.pyi`:
+
+```pyi
+class Wrapper[T](type): ...
+
+class Outer:
+    class Aliases:
+        Value = int
+
+    class Meta(Wrapper[int], type): ...
+    class Inner(Aliases, metaclass=Meta): ...
+    value: Outer.Inner.Value
+    type: Outer.Inner.Value
+```
+
 ## PEP 695 generic
 
 ```toml

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1187,6 +1187,7 @@ impl<'db> StaticClassLiteral<'db> {
             cycle_initial=|_, _, _| Err(MetaclassError {
                 kind: MetaclassErrorKind::Cycle,
             }),
+            cycle_fn=try_metaclass_cycle_fn,
             heap_size=ruff_memory_usage::heap_size,
         )]
         fn try_metaclass_inner<'db>(
@@ -3538,6 +3539,32 @@ pub(crate) enum InheritanceCycle {
 impl InheritanceCycle {
     pub(crate) const fn is_participant(self) -> bool {
         matches!(self, InheritanceCycle::Participant)
+    }
+}
+
+/// Preserve a successful metaclass selection when later cycle iterations report an error.
+///
+/// A metaclass conflict can depend on an attribute whose type in turn depends on the selected
+/// metaclass. Discarding the selection on a conflict can make that conflict disappear in the next
+/// iteration, causing inference to oscillate. Once we start widening cycle results, keep the
+/// successful selection so that these transient errors cannot restart the cycle.
+fn try_metaclass_cycle_fn<'db>(
+    _db: &'db dyn Db,
+    cycle: &salsa::Cycle,
+    previous: &Result<
+        (ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>),
+        MetaclassError<'db>,
+    >,
+    current: Result<
+        (ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>),
+        MetaclassError<'db>,
+    >,
+    _class: StaticClassLiteral<'db>,
+) -> Result<(ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
+    if cycle.iteration() > crate::TAINTED_CYCLES && current.is_err() && previous.is_ok() {
+        previous.clone()
+    } else {
+        current
     }
 }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1173,7 +1173,16 @@ impl<'db> StaticClassLiteral<'db> {
     pub(in crate::types) fn inferred_metaclass(self, db: &'db dyn Db) -> ClassMetaclass<'db> {
         self.try_metaclass(db)
             .map(|(metaclass, _)| metaclass)
-            .unwrap_or_else(|_| ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()))
+            .unwrap_or_else(|error| match error.kind {
+                MetaclassErrorKind::Conflict { candidate, .. } => {
+                    // Keep the candidate for member lookup; `try_metaclass` still reports the
+                    // conflict during class validation. Falling back to `Unknown` here can change
+                    // attribute inference and make the conflict disappear on the next cycle
+                    // iteration, causing metaclass inference to oscillate.
+                    ClassMetaclass::Selected(candidate.metaclass.into())
+                }
+                _ => ClassMetaclass::Selected(SubclassOfType::subclass_of_unknown()),
+            })
     }
 
     /// Return the selected metaclass or protocol fallback, or an error if it cannot be inferred.
@@ -1187,7 +1196,6 @@ impl<'db> StaticClassLiteral<'db> {
             cycle_initial=|_, _, _| Err(MetaclassError {
                 kind: MetaclassErrorKind::Cycle,
             }),
-            cycle_fn=try_metaclass_cycle_fn,
             heap_size=ruff_memory_usage::heap_size,
         )]
         fn try_metaclass_inner<'db>(
@@ -3539,32 +3547,6 @@ pub(crate) enum InheritanceCycle {
 impl InheritanceCycle {
     pub(crate) const fn is_participant(self) -> bool {
         matches!(self, InheritanceCycle::Participant)
-    }
-}
-
-/// Preserve a successful metaclass selection when later cycle iterations report an error.
-///
-/// A metaclass conflict can depend on an attribute whose type in turn depends on the selected
-/// metaclass. Discarding the selection on a conflict can make that conflict disappear in the next
-/// iteration, causing inference to oscillate. Once we start widening cycle results, keep the
-/// successful selection so that these transient errors cannot restart the cycle.
-fn try_metaclass_cycle_fn<'db>(
-    _db: &'db dyn Db,
-    cycle: &salsa::Cycle,
-    previous: &Result<
-        (ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>),
-        MetaclassError<'db>,
-    >,
-    current: Result<
-        (ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>),
-        MetaclassError<'db>,
-    >,
-    _class: StaticClassLiteral<'db>,
-) -> Result<(ClassMetaclass<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
-    if cycle.iteration() > crate::TAINTED_CYCLES && current.is_err() && previous.is_ok() {
-        previous.clone()
-    } else {
-        current
     }
 }
 


### PR DESCRIPTION
## Summary

We now avoid a metaclass inference panic triggered by generated protobuf stubs with a field named `type`.

When metaclass selection finds a conflict, we retain the candidate for subsequent member lookup while still returning the conflict from `try_metaclass` for class validation. Previously, replacing that candidate with `type[Unknown]` changed attribute inference and could make selection alternate between success and failure.

This also preserves useful attribute types on classes with conflicting metaclasses. The tests cover both the panic and a recursive case with a genuine conflict, which still produces a diagnostic. The field in the panic regression still infers as `Unknown`; recovering its precise type remains a TODO.

Closes https://github.com/astral-sh/ty/issues/4492.
