### PR TITLE
[ty] Preserve member qualifiers on constrained class objects

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/variables.md
@@ -962,6 +962,27 @@ def constrained(f: T):
     reveal_type(f())  # revealed: int | str
 ```
 
+## Final attributes on constrained class objects
+
+Assignments through a constrained class object must respect every constraint, even when one is a
+subclass of another. `Base.value` is writable, but `Child.value` is `Final`, so assigning through
+`type[T]` is rejected:
+
+```py
+from typing import Final, TypeVar
+
+class Base:
+    value: int = 0
+
+class Child(Base):
+    value: Final[int] = 0
+
+T = TypeVar("T", Base, Child)
+
+def assign(cls: type[T]):
+    cls.value = 1  # error: [invalid-assignment] "Cannot assign to final attribute `value`"
+```
+
 ## Meta-type
 
 The meta-type of a typevar is `type[T]`.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -1074,6 +1074,25 @@ def constrained[T: (Callable[[], int], Callable[[], str])](f: T):
     reveal_type(f())  # revealed: int | str
 ```
 
+## Final attributes on constrained class objects
+
+Assignments through a constrained class object must respect every constraint, even when one is a
+subclass of another. `Base.value` is writable, but `Child.value` is `Final`, so assigning through
+`type[T]` is rejected:
+
+```py
+from typing import Final
+
+class Base:
+    value: int = 0
+
+class Child(Base):
+    value: Final[int] = 0
+
+def assign[T: (Base, Child)](cls: type[T]):
+    cls.value = 1  # error: [invalid-assignment] "Cannot assign to final attribute `value`"
+```
+
 ## Meta-type
 
 The meta-type of a typevar is `type[T]`.

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -276,7 +276,17 @@ impl<'db> SubclassOfType<'db> {
                     None => unreachable!(),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound,
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        constraints.as_type(db, env)
+                        // Preserve every constraint's qualifiers, even when one class is a
+                        // subtype of another and their union would simplify to the superclass.
+                        return Some(constraints.map_with_boundness_and_qualifiers(
+                            db,
+                            env,
+                            |constraint| {
+                                constraint
+                                    .find_name_in_mro_with_policy(db, env, name, policy)
+                                    .unwrap_or_default()
+                            },
+                        ));
                     }
                 }
             }


### PR DESCRIPTION
## Summary

We now preserve member qualifiers when looking up attributes on constrained class objects. Previously, simplifying the constraints to a union could discard a subclass and allow assignments to its `Final` attributes:

```python
from typing import Final

class Base:
    value: int = 0

class Child(Base):
    value: Final[int] = 0

def assign[T: (Base, Child)](cls: type[T]):
    # Before: no error.
    # After: error[invalid-assignment]: Cannot assign to final attribute `value`
    cls.value = 1
```

We now look up each constraint's member before combining the resulting types and qualifiers.
