### PR TITLE
[ty] Preserve wrapped signatures in nominal descriptor checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -639,6 +639,59 @@ second_method = classmethod(second)
 static_assert(is_disjoint_from(TypeOf[first_method], TypeOf[second_method]))
 ```
 
+## Assigning wrappers to annotated descriptor types
+
+A `staticmethod` annotation constrains both the parameters and the return type of the wrapped
+callable. A wrapper returning `str` cannot satisfy a descriptor that promises to return `int`.
+
+```py
+def stringify(value: int) -> str:
+    return str(value)
+
+def consume(method: staticmethod[[int], int]) -> int:
+    return method(1) + 1
+
+wrapped = staticmethod(stringify)
+consume(wrapped)  # error: [invalid-argument-type]
+valid: staticmethod[[int], str] = wrapped
+wrong_parameter: staticmethod[[str], str] = wrapped  # error: [invalid-assignment]
+wider_return: staticmethod[[int], object] = wrapped
+```
+
+The class argument is part of a `classmethod` annotation's wrapped-callable contract.
+
+```py
+class Owner: ...
+class Other: ...
+
+def make(cls: type[Owner], value: int) -> str:
+    return str(value)
+
+class_wrapped = classmethod(make)
+valid_class: classmethod[Owner, [int], str] = class_wrapped
+wrong_return: classmethod[Owner, [int], int] = class_wrapped  # error: [invalid-assignment]
+wrong_owner: classmethod[Other, [int], str] = class_wrapped  # error: [invalid-assignment]
+wrong_kind: staticmethod[[type[Owner], int], str] = class_wrapped  # error: [invalid-assignment]
+```
+
+An overloaded wrapper can satisfy the signature selected by the descriptor annotation without
+combining unrelated overload return types.
+
+```py
+from typing import overload
+
+@overload
+def convert(value: int) -> str: ...
+@overload
+def convert(value: str) -> int: ...
+def convert(value: int | str) -> int | str:
+    return str(value) if isinstance(value, int) else len(value)
+
+int_to_str: staticmethod[[int], str] = staticmethod(convert)
+str_to_int: staticmethod[[str], int] = staticmethod(convert)
+invalid_overload: staticmethod[[int], int] = staticmethod(convert)  # error: [invalid-assignment]
+```
+
 ## Decorators returning a different function
 
 An inner decorator can replace a method with a function defined elsewhere. The outer `classmethod`

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1591,6 +1591,29 @@ Box.make.cache_clear()
 Box[int].make.cache_info()
 ```
 
+## Inferring a descriptor's wrapped signature
+
+A nominal `staticmethod` annotation can infer its parameter specification and return type from the
+precise callable retained by a method wrapper.
+
+```py
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def unwrap(method: staticmethod[P, R]) -> Callable[P, R]:
+    return method.__func__
+
+def stringify(value: int) -> str:
+    return str(value)
+
+function = unwrap(staticmethod(stringify))
+reveal_type(function(1))  # revealed: str
+function("wrong")  # error: [invalid-argument-type]
+```
+
 ## Metaclass descriptors shadow generic instance attributes
 
 A data descriptor on the metaclass governs class access even when instances have an attribute of the

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -1454,5 +1454,24 @@ reveal_type(C.identity(1))  # revealed: Unknown
 reveal_type(C[int].identity(1))  # revealed: int
 ```
 
+## Inferring a descriptor's wrapped signature
+
+A nominal `staticmethod` annotation can infer its parameter specification and return type from the
+precise callable retained by a method wrapper.
+
+```py
+from collections.abc import Callable
+
+def unwrap[**P, R](method: staticmethod[P, R]) -> Callable[P, R]:
+    return method.__func__
+
+def stringify(value: int) -> str:
+    return str(value)
+
+function = unwrap(staticmethod(stringify))
+reveal_type(function(1))  # revealed: str
+function("wrong")  # error: [invalid-argument-type]
+```
+
 [crtp]: https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 [f-bound]: https://en.wikipedia.org/wiki/Bounded_quantification#F-bounded_quantification

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -4355,6 +4355,19 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 );
             }
 
+            (
+                Type::NominalInstance(formal_instance),
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)),
+            ) if formal_instance
+                .class(db, self.env)
+                .is_known(db, wrapper.class(db)) =>
+            {
+                // The descriptor relation compares its wrapped callable with the nominal
+                // annotation's `__func__`, retaining parameter and return type constraints.
+                let when = self.constraint_for_relation(formal, actual, relation_polarity);
+                return self.infer_from_constraint_set(when);
+            }
+
             (formal, Type::ProtocolInstance(actual_protocol)) => {
                 if let Type::ProtocolInstance(formal_protocol) = formal
                     && let Some(actual_origin) = actual_protocol.materialized_origin(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1924,6 +1924,33 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 source_sentinel.is_same_sentinel(db, target_sentinel),
             ),
 
+            // A nominal descriptor annotation specifies the wrapped callable through `__func__`.
+            // Comparing that contract directly preserves overloads and avoids replacing the
+            // wrapped callable's parameter and return types with the default specialization.
+            (
+                Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)),
+                Type::NominalInstance(target_instance),
+            ) if target_instance
+                .class(db, env)
+                .is_known(db, wrapper.class(db)) =>
+            {
+                self.with_recursion_guard(db, source, target, || {
+                    let Some(target_function) = target
+                        .member_lookup_with_policy(
+                            db,
+                            env,
+                            "__func__",
+                            MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+                        )
+                        .place
+                        .ignore_possibly_undefined()
+                    else {
+                        return self.never();
+                    };
+                    self.check_type_pair(db, wrapper.wrapped(db), target_function)
+                })
+            }
+
             // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
             // the nominal instance with the partial's return type so the check is precise.
             (


### PR DESCRIPTION
## Summary

We now check the wrapped callable when assigning a precise method wrapper to an annotated `staticmethod` or `classmethod`. Previously, the nominal fallback discarded the wrapped signature, allowing a function returning `str` where the descriptor promised `int`:

```python
def stringify(value: int) -> str:
    return str(value)

def consume(method: staticmethod[[int], int]) -> int:
    return method(1) + 1

consume(staticmethod(stringify))  # Now rejected.
```

Compare the wrapped callable with the nominal descriptor's specialized `__func__` contract, preserving overload-specific return types. Use the same relation when inferring generic descriptor parameters.

Follow-up to #28207. Addresses [this review comment](https://github.com/astral-sh/ruff/pull/28207#discussion_r3965484630).
