### PR TITLE
[ty] Check captured receivers when calling wrapped classmethods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -563,6 +563,52 @@ reveal_type(Explicit.class_method.__func__)  # revealed: Wrapper
 reveal_type(Explicit.class_method.__call__(1))  # revealed: int
 ```
 
+## Checking the receiver of a wrapped classmethod
+
+Calling a classmethod passes the owner class to its wrapped callable. That implicit argument must be
+compatible with the callable's first parameter, just like an explicit argument.
+
+```py
+class Wrapper:
+    def __call__(self, cls: int) -> int:
+        return cls + 1
+
+class C:
+    method = classmethod(Wrapper())
+
+C.method()  # error: [invalid-argument-type]
+C().method()  # error: [invalid-argument-type]
+```
+
+Receiver checking also selects the appropriate overload for the class used to access the method. The
+selected overload still checks the explicit arguments.
+
+```py
+from typing import overload
+
+class OverloadedWrapper:
+    @overload
+    def __call__(self, cls: type[Base], value: int) -> int: ...
+    @overload
+    def __call__(self, cls: type[Other], value: str) -> str: ...
+    def __call__(self, cls: type[Base] | type[Other], value: int | str) -> int | str:
+        return value
+
+class Base:
+    method = classmethod(OverloadedWrapper())
+
+class Child(Base): ...
+
+class Other:
+    method = classmethod(OverloadedWrapper())
+
+reveal_type(Base.method(1))  # revealed: int
+reveal_type(Child.method(1))  # revealed: int
+reveal_type(Other.method("x"))  # revealed: str
+Base.method("x")  # error: [no-matching-overload]
+Other.method(1)  # error: [no-matching-overload]
+```
+
 ## Generic inference for method wrappers
 
 When a generic function returns a mutable container, inference can widen literal types in its

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6329,14 +6329,27 @@ impl<'db> Type<'db> {
 
             Type::BoundMethod(bound_method) => {
                 let Some(function) = bound_method.function(db) else {
-                    return bound_method.callables(db, env).map_or_else(
-                        || CallableBinding::not_callable(self).into(),
-                        |callables| {
-                            callables
-                                .into_type(db, env)
-                                .bindings_impl(db, env, recursion_guard)
-                        },
-                    );
+                    return bound_method
+                        .func(db)
+                        .try_upcast_to_callable(db, env)
+                        .map_or_else(
+                            || CallableBinding::not_callable(self).into(),
+                            |callables| {
+                                // Retain the receiver parameter so ordinary argument checking can
+                                // validate the captured class as well as the explicit arguments.
+                                Bindings::from_union(
+                                    self,
+                                    callables.iter().map(|callable| {
+                                        CallableBinding::from_overloads(
+                                            self,
+                                            callable.signatures(db).overloads.iter().cloned(),
+                                        )
+                                        .with_bound_type(bound_method.signature_receiver(db))
+                                        .into()
+                                    }),
+                                )
+                            },
+                        );
                 };
                 let signature = function.signature(db);
                 let self_instance = bound_method.self_instance(db);


### PR DESCRIPTION
## Summary

We now check the captured class argument when calling a classmethod that wraps a callable object. Previously, we removed the receiver parameter before checking arguments, accepting calls like this:

```python
class Wrapper:
    def __call__(self, cls: int) -> int:
        return cls + 1

class C:
    method = classmethod(Wrapper())

C.method()  # Now rejected: the class C is not an int.
```

Retain the wrapped signature and pass the receiver through ordinary bound-argument checking. This also selects overloads using the captured class and checks the remaining arguments against the selected signatures.

Follow-up to #28207. Addresses [this review comment](https://github.com/astral-sh/ruff/pull/28207#discussion_r3965678757).
