### PR TITLE
[ty] Unwrap union alternatives in overload implementations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/overloads.md
@@ -1326,6 +1326,68 @@ reveal_type(union_narrowed)  # revealed: Overload[(x: int, /) -> int, (x: str, /
 reveal_type(not_callable)  # revealed: Overload[(x: int, /) -> int, (x: str, /) -> str]
 ```
 
+### Classmethod implementations returning unions of wrappers
+
+A decorator can replace an overloaded classmethod's implementation with one of several callable
+objects. Each alternative is checked before binding the class argument.
+
+```py
+from typing import TypeAlias, overload
+
+class A:
+    def __call__(self, cls: type, value: int | str) -> int | str:
+        return value
+
+class B:
+    def __call__(self, cls: type, value: int | str) -> int | str:
+        return value
+
+Choice: TypeAlias = A | B
+
+def wrap(function: object) -> Choice:
+    return A()
+
+class C:
+    @overload
+    @classmethod
+    def identity(cls, value: int) -> int: ...
+    @overload
+    @classmethod
+    def identity(cls, value: str) -> str: ...
+    @classmethod
+    @wrap
+    def identity(cls, value: int | str) -> int | str:
+        return value
+
+reveal_type(C.identity(1))  # revealed: int
+reveal_type(C.identity("x"))  # revealed: str
+```
+
+Every possible wrapper must support every overload. An alternative that only accepts `int` cannot
+implement the `str` overload, even when another alternative accepts both.
+
+```py
+class Narrow:
+    def __call__(self, cls: type, value: int) -> int:
+        return value
+
+def narrow_wrap(function: object) -> A | Narrow:
+    return Narrow()
+
+class Invalid:
+    @overload
+    @classmethod
+    def identity(cls, value: int) -> int: ...
+    @overload
+    @classmethod
+    # error: [invalid-overload] "Overload signature is not consistent with implementation"
+    def identity(cls, value: str) -> str: ...
+    @classmethod
+    @narrow_wrap
+    def identity(cls, value: int | str) -> int | str:
+        return value
+```
+
 ### Implementation consistency parameter mismatch diagnostics
 
 Non-generic implementation checks require parameter names and positional-only forms to line up with

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -620,11 +620,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if is_decorated_overload_implementation {
             // Overloads describe the exposed function. The implementation check compares the
             // unbound callable, before classmethod or staticmethod descriptor binding.
-            let implementation_ty = match inferred_ty {
+            let unwrap_method = |ty| match ty {
                 Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => {
                     wrapper.wrapped(db)
                 }
-                _ => inferred_ty,
+                _ => ty,
+            };
+            let implementation_ty = match inferred_ty {
+                Type::Union(union) => {
+                    union.map(db, self.program_environment(), |ty| unwrap_method(*ty))
+                }
+                _ => unwrap_method(inferred_ty),
             };
             let last_definition = match inferred_ty {
                 Type::FunctionLiteral(function) => Some(function.literal(db).last_definition),


### PR DESCRIPTION
## Summary

We now accept overloaded classmethod implementations whose decorators return a union of callable wrappers. Previously, we unwrapped only a single method descriptor, so a union of valid wrapped implementations was incorrectly reported as non-callable.

Unwrap each union alternative before checking implementation consistency. Every alternative must still support every declared overload; a narrower alternative continues to produce an error.

Follow-up to #28207. Addresses [this review comment](https://github.com/astral-sh/ruff/pull/28207#discussion_r3965726866).
