### PR TITLE
[ty] Avoid rebinding extracted method calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/callables_as_descriptors.md
@@ -609,6 +609,54 @@ Base.method("x")  # error: [no-matching-overload]
 Other.method(1)  # error: [no-matching-overload]
 ```
 
+## Extracted `__call__` methods do not bind again
+
+A bound method's `__call__` retains the method's signature. Storing it on another class does not
+bind that class's instance to its first remaining parameter.
+
+```py
+from types import MethodWrapperType
+
+class A:
+    def method(self, value: int) -> int:
+        return value
+
+callback = A().method.__call__
+reveal_type(callback.__name__)  # revealed: str
+reveal_type(callback.__qualname__)  # revealed: str
+reveal_type(bool(callback))  # revealed: Literal[True]
+method_wrapper: MethodWrapperType = callback
+
+class B:
+    callback = callback
+
+reveal_type(B.callback(1))  # revealed: int
+reveal_type(B().callback(1))  # revealed: int
+B().callback("wrong")  # error: [invalid-argument-type]
+```
+
+The same applies to `__call__` extracted from a `staticmethod` descriptor: its underlying function
+still requires all its declared arguments after the extracted method is stored on a class.
+
+```py
+def stringify(value: int) -> str:
+    return str(value)
+
+wrapped = staticmethod(stringify)
+callback = wrapped.__call__
+reveal_type(callback.__name__)  # revealed: str
+reveal_type(callback.__qualname__)  # revealed: str
+reveal_type(bool(callback))  # revealed: Literal[True]
+method_wrapper: MethodWrapperType = callback
+
+class C:
+    callback = callback
+
+reveal_type(C.callback(1))  # revealed: str
+reveal_type(C().callback(1))  # revealed: str
+C().callback("wrong")  # error: [invalid-argument-type]
+```
+
 ## Generic inference for method wrappers
 
 When a generic function returns a mutable container, inference can widen literal types in its

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2187,7 +2187,11 @@ impl<'db> Type<'db> {
     fn supports_self_binding(&self, db: &'db dyn Db, env: &ProgramEnvironment<'db>) -> bool {
         match self {
             Type::FunctionLiteral(_) | Type::BoundMethod(_) | Type::KnownBoundMethod(_) => false,
-            Type::Callable(callable) if callable.is_function_like(db) => false,
+            Type::Callable(callable)
+                if callable.is_function_like(db) || callable.is_method_wrapper(db) =>
+            {
+                false
+            }
             _ => self.contains_self(db, env),
         }
     }
@@ -5729,9 +5733,12 @@ impl<'db> Type<'db> {
                 }
                 Type::KnownInstance(KnownInstanceType::MethodWrapper(wrapper)) => match name_str {
                     "__func__" | "__wrapped__" => Place::bound(wrapper.wrapped(db)).into(),
-                    "__call__" if let Some(callables) = wrapper.callables(db, env) => {
-                        Place::bound(callables.into_type(db, env)).into()
-                    }
+                    "__call__" if let Some(callables) = wrapper.callables(db, env) => Place::bound(
+                        callables
+                            .map(|callable| callable.into_method_wrapper(db))
+                            .into_type(db, env),
+                    )
+                    .into(),
                     _ => wrapper
                         .instance_fallback(db, env)
                         .member_lookup_with_policy_and_receiver(
@@ -5742,7 +5749,14 @@ impl<'db> Type<'db> {
                     "__self__" => Place::bound(bound_method.self_instance(db)).into(),
                     "__func__" => Place::bound(bound_method.func(db)).into(),
                     "__call__" if let Some(callables) = bound_method.callables(db, env) => {
-                        Place::bound(callables.into_type(db, env)).into()
+                        // The extracted method wrapper does not bind another receiver when
+                        // stored on a class, even if the underlying callable is function-like.
+                        Place::bound(
+                            callables
+                                .map(|callable| callable.into_method_wrapper(db))
+                                .into_type(db, env),
+                        )
+                        .into()
                     }
                     _ => {
                         let result = KnownClass::MethodType
@@ -5780,6 +5794,12 @@ impl<'db> Type<'db> {
 
                 Type::Callable(callable) if callable.is_function_like(db) => {
                     KnownClass::FunctionType
+                        .to_instance(db, env)
+                        .member_lookup_with_policy_and_receiver(db, env, name_str, policy, receiver)
+                }
+
+                Type::Callable(callable) if callable.is_method_wrapper(db) => {
+                    KnownClass::MethodWrapperType
                         .to_instance(db, env)
                         .member_lookup_with_policy_and_receiver(db, env, name_str, policy, receiver)
                 }
@@ -8464,6 +8484,9 @@ impl<'db> Type<'db> {
                 Type::DataclassDecorator(_) => KnownClass::FunctionType.to_class_literal(db, env),
                 Type::Callable(callable) if callable.is_function_like(db) => {
                     KnownClass::FunctionType.to_class_literal(db, env)
+                }
+                Type::Callable(callable) if callable.is_method_wrapper(db) => {
+                    KnownClass::MethodWrapperType.to_class_literal(db, env)
                 }
                 Type::Callable(_) | Type::DataclassTransformer(_) => {
                     KnownClass::Type.to_instance(db, env)

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -243,7 +243,11 @@ impl<'db> Type<'db> {
         };
 
         let truthiness = match self {
-            Type::Callable(callable) if callable.is_function_like(db) => Truthiness::AlwaysTrue,
+            Type::Callable(callable)
+                if callable.is_function_like(db) || callable.is_method_wrapper(db) =>
+            {
+                Truthiness::AlwaysTrue
+            }
 
             Type::Dynamic(_)
             | Type::Divergent(_)

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -599,6 +599,14 @@ pub enum CallableTypeKind {
     /// materializations from ordinary callable types in type-relation checks. It does not
     /// carry the runtime `typing.ParamSpec` instance behavior of a `ParamSpec` declaration.
     ParamSpecValue,
+
+    /// Callable objects modeled as instances of Python's `types.MethodWrapperType`.
+    ///
+    /// Accessing `__call__` on a bound method or method descriptor produces a method wrapper.
+    /// It retains the original callable's precise signatures, is always truthy, and exposes
+    /// method-wrapper attributes such as `__name__`, `__qualname__`, and `__self__`. Unlike a
+    /// function-like callable, it does not bind another receiver when stored on a class.
+    MethodWrapper,
 }
 
 /// A "policy" enum that describes how `type[]` types should be upcast
@@ -750,6 +758,10 @@ impl<'db> CallableType<'db> {
         matches!(self.kind(db), CallableTypeKind::FunctionLike)
     }
 
+    pub(crate) fn is_method_wrapper(self, db: &'db dyn Db) -> bool {
+        matches!(self.kind(db), CallableTypeKind::MethodWrapper)
+    }
+
     fn is_dunder_paramspec(self, db: &'db dyn Db) -> bool {
         matches!(self.kind(db), CallableTypeKind::DunderParamSpec)
     }
@@ -778,6 +790,10 @@ impl<'db> CallableType<'db> {
 
     pub(crate) fn into_regular(self, db: &'db dyn Db) -> CallableType<'db> {
         self.with_kind(db, CallableTypeKind::Regular)
+    }
+
+    pub(crate) fn into_method_wrapper(self, db: &'db dyn Db) -> CallableType<'db> {
+        self.with_kind(db, CallableTypeKind::MethodWrapper)
     }
 
     /// Retain every parameter signature and its generic context, but erase return types
@@ -1026,6 +1042,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target: CallableType<'db>,
     ) -> ConstraintSet<'db, 'c> {
         if target.is_function_like(db) && !source.is_function_like(db) {
+            return self.never();
+        }
+        if target.is_method_wrapper(db) && !source.is_method_wrapper(db) {
             return self.never();
         }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2624,6 +2624,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.check_type_pair(db, KnownClass::FunctionType.to_instance(db, env), target)
             }
 
+            // Method-wrapper callables are subtypes of `MethodWrapperType`.
+            (Type::Callable(callable), _) if callable.is_method_wrapper(db) => self
+                .check_type_pair(
+                    db,
+                    KnownClass::MethodWrapperType.to_instance(db, env),
+                    target,
+                ),
+
             (Type::Callable(_), _) => self.never(),
 
             (Type::BoundSuper(source), Type::BoundSuper(target)) => self


### PR DESCRIPTION
## Summary

We now preserve the signature of an extracted `__call__` when it is stored as a class attribute:

```python
class A:
    def method(self, value: int) -> int:
        return value

class B:
    callback = A().method.__call__

B().callback(1)  # Previously rejected as too many arguments.
```

Expose the extracted callable without function-descriptor binding behavior, so instance access does not consume another argument. Apply the same rule to `__call__` extracted from a `staticmethod` wrapper, retaining parameter and return types in both cases.

Follow-up to #28207. Addresses [this review comment](https://github.com/astral-sh/ruff/pull/28207#discussion_r3965799853). Related to the broader descriptor representation changes in #28410.
