### PR TITLE
[ty] Distribute len inference over unions

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6173,6 +6173,11 @@ impl<'db> Type<'db> {
             }
         }
 
+        // Eagerly distribute over unions as a fast path to avoid building a large union of bound methods.
+        if let Type::Union(union) = self {
+            return union.try_map(db, env, |element| element.len(db, env));
+        }
+
         if let Type::LiteralValue(literal) = self
             && let Some(length) = match literal.kind() {
                 LiteralValueTypeKind::String(string) => Some(string.python_len(db)),


### PR DESCRIPTION
## Summary

Inferring `len()` for a large union first creates a union of bound methods before calling them. Here, we compute each element's length first and union the results, which leads to a speedup for large unions of literals.

Context: The existing `many_string_assignments` benchmark was regressing on a PR of mine that makes changes to bound methods.