### PR TITLE
[ty] Avoid indexing the working directory for standalone files

### DIFF
--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -38,8 +38,9 @@ pub fn can_rename(
     for target in &declaration_targets {
         let target_file = target.file();
 
-        // If definition is outside the project, refuse rename
-        if !is_file_in_project(db, target_file) {
+        // A standalone file can rename its own definitions, but not definitions in other
+        // files outside the project (for example, imported library symbols).
+        if target_file != source_file && !is_file_in_project(db, target_file) {
             return None;
         }
 

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -95,10 +95,11 @@ pub struct Project {
 
     /// The paths that should be included when checking this project.
     ///
-    /// The default (when this list is empty) is to include all files in the project root
+    /// The default (when this is `None`) is to include all files in the project root
     /// (that satisfy the configured include and exclude patterns).
     /// However, it's sometimes desired to only check a subset of the project, e.g. to see
     /// the diagnostics for a single file or a folder.
+    /// An explicitly empty list leaves the project with no indexed files.
     ///
     /// This list gets initialized by the paths passed to `ty check <paths>`
     ///
@@ -114,8 +115,8 @@ pub struct Project {
     /// in an IDE when the user only wants to check the open tabs. This could be modeled
     /// with `included_paths` too but it would require an explicit walk dir step that's simply unnecessary.
     #[default]
-    #[returns(deref)]
-    included_paths_list: Vec<SystemPathBuf>,
+    #[returns(ref)]
+    included_paths_list: Option<Box<[SystemPathBuf]>>,
 
     /// Diagnostics that were generated when resolving the project settings.
     #[returns(deref)]
@@ -242,7 +243,7 @@ impl Project {
         let program_settings = self.program_settings(db).clone();
         let metadata = Box::new(self.metadata(db).clone());
         let settings = Box::new(self.settings(db).clone());
-        let included_paths = self.included_paths_list(db).to_vec();
+        let included_paths = self.included_paths_list(db).clone();
         let check_mode = self.check_mode(db);
         let verbose = self.verbose_flag(db);
         let force_exclude = self.force_exclude_flag(db);
@@ -577,10 +578,12 @@ impl Project {
         removed
     }
 
+    /// Limits indexing to these paths. An empty list disables directory indexing.
     pub fn set_included_paths(self, db: &mut dyn Db, paths: Vec<SystemPathBuf>) {
         tracing::debug!("Setting included paths: {paths}", paths = paths.len());
 
-        self.set_included_paths_list(db).to(paths);
+        self.set_included_paths_list(db)
+            .to(Some(paths.into_boxed_slice()));
         self.reload_files(db);
     }
 
@@ -615,9 +618,9 @@ impl Project {
     /// This can be useful to check arbitrary files, but it isn't something we recommend.
     /// We should try to support this use case but it's okay if there are some limitations around it.
     fn included_paths_or_root(self, db: &dyn Db) -> &[SystemPathBuf] {
-        match self.included_paths_list(db) {
-            [] => std::slice::from_ref(&self.metadata(db).root),
-            paths => paths,
+        match self.included_paths_list(db).as_deref() {
+            None => std::slice::from_ref(&self.metadata(db).root),
+            Some(paths) => paths,
         }
     }
 

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -78,7 +78,7 @@ impl ProjectWatcher {
         let included_paths = ruff_db::system::deduplicate_nested_paths(
             std::iter::once(project_path).chain(
                 db.project()
-                    .included_paths_list(db)
+                    .included_paths_or_root(db)
                     .iter()
                     .map(SystemPathBuf::as_path),
             ),

--- a/crates/ty_server/src/server.rs
+++ b/crates/ty_server/src/server.rs
@@ -7,7 +7,7 @@ use crate::session::{ClientName, InitializationOptions, Session, warn_about_unkn
 use anyhow::Context;
 use lsp_server::{Connection, ErrorCode, Message, Response};
 use lsp_types::{
-    ClientCapabilities, InitializeParams, MessageType, Uri, WorkspaceFolders,
+    ClientCapabilities, InitializeParams, MessageType, WorkspaceFolders,
     WorkspaceFoldersInitializeParams,
 };
 use ruff_db::system::System;
@@ -136,26 +136,7 @@ impl Server {
                     .map(|folder| folder.uri)
                     .collect::<Vec<_>>()
             })
-            .or_else(|| {
-                let current_dir = native_system
-                    .current_directory()
-                    .as_std_path()
-                    .to_path_buf();
-                tracing::warn!(
-                    "No workspace(s) were provided during initialization. \
-                    Using the current working directory from the fallback system as a \
-                    default workspace: {}",
-                    current_dir.display()
-                );
-                let uri = Uri::from_file_path(current_dir).ok()?;
-                Some(vec![uri])
-            })
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Failed to get the current working directory while creating a \
-                    default workspace."
-                )
-            })?;
+            .unwrap_or_default();
 
         Ok(Self {
             connection,

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -26,8 +26,8 @@ use ty_combine::Combine;
 use ty_project::metadata::Options;
 use ty_project::watch::ChangeEvent;
 use ty_project::{
-    ChangeResult, Db as _, ProjectDatabase, ProjectMetadata, ProjectReloadResult,
-    ScriptEnvironmentAvailability, UseUv, UvSyncChanges,
+    ChangeResult, CheckMode, Db as _, ProjectDatabase, ProjectMetadata, ProjectReloadResult,
+    ScriptEnvironmentAvailability, SemanticDb as _, UseUv, UvSyncChanges,
 };
 
 use index::DocumentError;
@@ -126,6 +126,9 @@ pub(crate) struct Session {
 
 /// LSP State for a Project
 pub(crate) struct ProjectState {
+    /// Whether this project handles standalone files without a client-provided workspace.
+    is_fallback: bool,
+
     /// Files that we have outstanding otherwise-untracked pushed diagnostics for.
     ///
     /// In `CheckMode::OpenFiles` we still read some files that the client hasn't
@@ -162,11 +165,25 @@ impl Session {
     ) -> crate::Result<Self> {
         let index = Arc::new(Index::new());
 
+        let is_fallback = workspace_uris.is_empty();
+        let workspace_uris = if is_fallback {
+            let current_dir = native_system.current_directory();
+            tracing::info!(
+                "No workspaces were provided during initialization. \
+                Using {current_dir} for standalone files without indexing its contents."
+            );
+            let uri = Uri::from_file_path(current_dir.as_std_path())
+                .map_err(|()| anyhow!("Failed to create a workspace URI for {current_dir}"))?;
+            vec![uri]
+        } else {
+            workspace_uris
+        };
+
         let mut workspaces = Workspaces::default();
         // Register workspaces with default settings - they'll be initialized with real settings
         // when workspace/configuration response is received
         for uri in workspace_uris {
-            workspaces.register(uri)?;
+            workspaces.register(uri, is_fallback)?;
         }
 
         let use_uv = initialization_options.use_uv(&*native_system);
@@ -683,7 +700,11 @@ impl Session {
         }
         if let Some(check_mode) = self.global_settings.diagnostic_mode().to_check_mode() {
             for project in self.projects.values_mut() {
-                project.db.set_check_mode(check_mode);
+                project.db.set_check_mode(if project.is_fallback {
+                    CheckMode::OpenFiles
+                } else {
+                    check_mode
+                });
             }
         }
 
@@ -819,8 +840,26 @@ impl Session {
             }
         };
 
-        // Carry forward diagnostic state if any exists
+        let is_fallback = workspace.is_fallback;
+        if is_fallback {
+            // The working directory may be the user's home or filesystem root. It supplies
+            // configuration for standalone files, but is not a workspace to index.
+            db.project().set_included_paths(&mut db, Vec::new());
+        }
+
+        // Preserve open documents when a real workspace replaces the fallback at the same path.
         let previous = self.projects.remove(&root);
+        let open_documents: Vec<_> = previous
+            .as_ref()
+            .into_iter()
+            .flat_map(|previous| {
+                self.file_document_handles().filter(|document| {
+                    document
+                        .notebook_or_file(&previous.db)
+                        .is_some_and(|file| previous.db.is_open_file(file))
+                })
+            })
+            .collect();
         let untracked = previous
             .map(|state| state.untracked_files_with_pushed_diagnostics)
             .unwrap_or_default();
@@ -835,10 +874,15 @@ impl Session {
         self.projects.insert(
             root.clone(),
             ProjectState {
+                is_fallback,
                 db,
                 untracked_files_with_pushed_diagnostics: untracked,
             },
         );
+
+        for document in open_documents {
+            self.open_document_in_db(client, &document, None);
+        }
 
         publish_settings_diagnostics(self, client, root);
     }
@@ -846,7 +890,7 @@ impl Session {
     /// Adds an uninitialized workspace to this session.
     ///
     /// This returns `true` when this workspace is added and `false`
-    /// when it has already been added.
+    /// when it has already been added. A real workspace replaces a fallback at the same path.
     ///
     /// If there was a problem adding the workspace folder (e.g., the
     /// path derived from the given URI is not valid UTF-8), then an
@@ -856,7 +900,7 @@ impl Session {
     /// a request for workspace folder configuration via
     /// `Session::request_uninitialized_workspace_folder_configuration`.
     pub(crate) fn register_workspace_folder(&mut self, uri: Uri) -> anyhow::Result<bool> {
-        self.workspaces.register(uri)
+        self.workspaces.register(uri, false)
     }
 
     /// Requests configuration for each registered but uninitialized
@@ -1456,14 +1500,17 @@ impl Session {
                     return;
                 }
 
-                let db = self.project_db_mut(path);
+                let project_state = self.project_state_mut(path);
+                let db = &mut project_state.db;
                 match system_path_to_file(db, system_path) {
                     Ok(file) => {
                         let project = db.project();
 
-                        // Only mark this file as open if it's part of the project.
-                        // This ensures that we don't show diagnostics for files outside the project.
-                        if project.is_file_included(db, system_path).is_included() {
+                        // Standalone files can be anywhere on disk. Explicit workspaces only
+                        // show diagnostics for files included in the project.
+                        if project_state.is_fallback
+                            || project.is_file_included(db, system_path).is_included()
+                        {
                             project.open_file(db, file);
                         }
                     }
@@ -1744,7 +1791,7 @@ impl Workspaces {
     /// to the server during the `initialize` request, but the resolved
     /// settings are only available after the client has responded to the
     /// `workspace/configuration` request.
-    fn register(&mut self, uri: Uri) -> anyhow::Result<bool> {
+    fn register(&mut self, uri: Uri, is_fallback: bool) -> anyhow::Result<bool> {
         let path = uri
             .to_file_path()
             .map_err(|()| anyhow!("Workspace URI is not a file or directory: {uri:?}"))?;
@@ -1753,7 +1800,9 @@ impl Workspaces {
         let system_path = SystemPathBuf::from_path_buf(path)
             .map_err(|_| anyhow!("Workspace URI is not valid UTF8"))?;
 
-        if self.workspaces.contains_key(&system_path) {
+        if let Some(workspace) = self.workspaces.get(&system_path)
+            && (!workspace.is_fallback || is_fallback)
+        {
             return Ok(false);
         }
 
@@ -1763,6 +1812,7 @@ impl Workspaces {
                 uri,
                 settings: Arc::new(WorkspaceSettings::default()),
                 initialized: false,
+                is_fallback,
             },
         );
         Ok(true)
@@ -1816,6 +1866,8 @@ impl<'a> IntoIterator for &'a Workspaces {
 pub(crate) struct Workspace {
     /// The workspace root URI as sent by the client during initialization.
     uri: Uri,
+    /// Whether this workspace was synthesized to handle files opened without a workspace.
+    is_fallback: bool,
     /// The settings for this workspace.
     ///
     /// The settings here have already been "combined" with the initialization

--- a/crates/ty_server/tests/e2e/call_hierarchy.rs
+++ b/crates/ty_server/tests/e2e/call_hierarchy.rs
@@ -8,6 +8,7 @@ use lsp_types::{
     CallHierarchyIncomingCallsRequest, CallHierarchyOutgoingCallsRequest,
     CallHierarchyPrepareRequest,
 };
+use ruff_db::system::SystemPath;
 
 use crate::TestServerBuilder;
 
@@ -157,6 +158,7 @@ def use_b():
 
     let mut server = TestServerBuilder::new()?
         .with_file("lib.py", lib)?
+        .with_workspace(SystemPath::new(""), None)?
         .with_file("caller_a.py", caller_a)?
         .with_file("caller_b.py", caller_b)?
         .build()

--- a/crates/ty_server/tests/e2e/initialize.rs
+++ b/crates/ty_server/tests/e2e/initialize.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use lsp_types::{
-    Code, Position, PublishDiagnosticsNotification, RegistrationRequest, ShowMessageNotification,
+    Code, DocumentDiagnosticReport, Position, PublishDiagnosticsNotification, RegistrationRequest,
+    ShowMessageNotification, WorkspaceSymbolParams, WorkspaceSymbolRequest,
 };
 use ruff_db::system::SystemPath;
 use serde_json::{Value, json};
@@ -63,6 +64,57 @@ fn empty_workspace_folders() -> Result<()> {
     let initialization_result = server.initialization_result().unwrap();
 
     insta::assert_json_snapshot!("initialization", initialization_result);
+
+    Ok(())
+}
+
+/// A fallback workspace must not index closed files in either diagnostic mode.
+/// Adding that directory as a real workspace should enable indexing normally.
+#[test]
+fn standalone_files_do_not_index_working_directory() -> Result<()> {
+    for diagnostic_mode in [DiagnosticMode::OpenFilesOnly, DiagnosticMode::Workspace] {
+        let mut server = TestServerBuilder::new()?
+            .with_file("closed.py", "class ClosedSymbol: pass\n")?
+            .with_file("open.py", "")?
+            .with_initialization_options(
+                &ClientOptions::default().with_diagnostic_mode(diagnostic_mode),
+            )
+            .build()
+            .wait_until_workspaces_are_initialized();
+
+        server.open_text_document("open.py", "missing\n", 1);
+        assert!(matches!(
+            server.document_diagnostic_request("open.py", None),
+            DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report)
+                if report.full_document_diagnostic_report.items.len() == 1
+        ));
+
+        if diagnostic_mode == DiagnosticMode::Workspace {
+            let diagnostics = server.workspace_diagnostic_request(None, None);
+            assert_eq!(diagnostics.items.len(), 1);
+        }
+
+        let symbols = server.send_request_await::<WorkspaceSymbolRequest>(WorkspaceSymbolParams {
+            query: "ClosedSymbol".to_string(),
+            ..Default::default()
+        });
+        assert!(symbols.is_none());
+
+        server.change_workspace_folders([SystemPath::new("")], []);
+        let mut server = server.wait_until_workspaces_are_initialized();
+
+        let symbols = server.send_request_await::<WorkspaceSymbolRequest>(WorkspaceSymbolParams {
+            query: "ClosedSymbol".to_string(),
+            ..Default::default()
+        });
+        assert!(symbols.is_some());
+
+        assert!(matches!(
+            server.document_diagnostic_request("open.py", None),
+            DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report)
+                if report.full_document_diagnostic_report.items.len() == 1
+        ));
+    }
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/rename.rs
+++ b/crates/ty_server/tests/e2e/rename.rs
@@ -1,6 +1,8 @@
 use crate::TestServerBuilder;
 use crate::notebook::NotebookBuilder;
+use anyhow::Context;
 use insta::assert_json_snapshot;
+use ruff_db::system::SystemPath;
 
 #[test]
 fn text_document() -> anyhow::Result<()> {
@@ -30,6 +32,64 @@ test()
         .expect("Can rename `test` function");
 
     assert_json_snapshot!(edits);
+
+    Ok(())
+}
+
+/// Standalone files outside the server's working directory support local renames.
+#[test]
+fn standalone_file_outside_working_directory() -> anyhow::Result<()> {
+    let directory = tempfile::tempdir()?;
+    let path = SystemPath::from_std_path(directory.path())
+        .context("Temporary directory path must be UTF-8")?
+        .join("standalone.py");
+    let source = "a = 1\nb = a\nmissing\n";
+    let mut server = TestServerBuilder::new()?
+        .with_file(&path, source)?
+        .build()
+        .wait_until_workspaces_are_initialized();
+    server.open_text_document(&path, source, 1);
+
+    let diagnostics = server.document_diagnostic_request(&path, None);
+    let lsp_types::DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) =
+        diagnostics
+    else {
+        panic!("Expected a full diagnostic report");
+    };
+    let diagnostics = report.full_document_diagnostic_report.items;
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(
+        diagnostics[0].code,
+        Some(lsp_types::Code::String("unresolved-reference".to_string()))
+    );
+
+    let edits = server
+        .rename(
+            &server.file_uri(&path),
+            lsp_types::Position::new(0, 0),
+            "renamed",
+        )
+        .expect("Can rename a standalone file's local variable")
+        .context("Expected rename edits")?;
+    let changes = edits.changes.context("Expected text edits")?;
+    assert_eq!(changes.len(), 1);
+    let edits = &changes[&server.file_uri(&path)];
+    assert_eq!(edits.len(), 2);
+    assert!(edits.iter().all(|edit| edit.new_text == "renamed"));
+    assert_eq!(
+        edits[0].range,
+        lsp_types::Range::new(
+            lsp_types::Position::new(0, 0),
+            lsp_types::Position::new(0, 1)
+        )
+    );
+    assert_eq!(
+        edits[1].range,
+        lsp_types::Range::new(
+            lsp_types::Position::new(1, 4),
+            lsp_types::Position::new(1, 5)
+        )
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

We now avoid indexing the server's working directory when no workspace folders are provided. This prevents opening a standalone file from scanning the home directory or filesystem root, while preserving diagnostics and local renames for files outside the working directory.

Keep the fallback project's indexed paths explicitly empty and check only open files. If the client later adds that directory as a workspace, enable normal indexing and preserve its open documents.

Closes https://github.com/astral-sh/ty/issues/2769.
