### PR TITLE
[ty] Preserve union alternatives during cycle normalization

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -4583,7 +4583,7 @@ class C3:
         self.x = [self.x[0].flip()]
 
 # TODO: should be `list[Sub] | list[Base]`
-reveal_type(C3(Sub()).x)  # revealed: list[Sub] | list[Divergent]
+reveal_type(C3(Sub()).x)  # revealed: list[Sub] | list[Base | Divergent] | list[Sub | Divergent]
 ```
 
 And cycles between many attributes:
@@ -4641,7 +4641,8 @@ class ManyCycles2:
         self.x3 = [1]
 
     def f1(self: "ManyCycles2"):
-        reveal_type(self.x3)  # revealed: list[int] | list[Divergent] | Unknown | list[Unknown]
+        # revealed: list[int] | list[Divergent] | Unknown | list[int | list[int] | Unknown | Divergent] | list[Unknown] | list[int | list[int] | Divergent | Unknown | list[Unknown]] | list[list[int] | Divergent | Unknown | list[Unknown] | int] | list[list[int] | Divergent | Unknown | list[Unknown]]
+        reveal_type(self.x3)
 
         self.x1 = [self.x2] + [self.x3]
         self.x2 = [self.x1] + [self.x3]
@@ -4714,7 +4715,7 @@ class NestedLists:
     def f(self: "NestedLists"):
         self.x = [self.x]
 
-reveal_type(NestedLists().x)  # revealed: int | list[Divergent]
+reveal_type(NestedLists().x)  # revealed: int | list[int | Divergent]
 
 class NestedMixed:
     def f(self: "NestedMixed"):
@@ -4760,8 +4761,8 @@ class NestedListsConcat:
         self.x = [self.x] + []
         self.y = [self.y].__add__(y)
 
-reveal_type(NestedListsConcat().x)  # revealed: list[int] | list[Divergent] | Unknown
-reveal_type(NestedListsConcat().y)  # revealed: list[int] | list[Divergent] | Unknown
+reveal_type(NestedListsConcat().x)  # revealed: list[int] | list[list[int] | Divergent | Unknown] | Unknown
+reveal_type(NestedListsConcat().y)  # revealed: list[int] | list[list[int] | Divergent | Unknown] | Unknown
 ```
 
 ### Builtin types attributes

--- a/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/basic.md
@@ -160,9 +160,9 @@ A = list["A | None"]
 
 def f(x: A):
     # TODO: should be `list[A | None]`?
-    reveal_type(x)  # revealed: list[Divergent]
+    reveal_type(x)  # revealed: list[Divergent | None]
     # TODO: should be `A | None`?
-    reveal_type(x[0])  # revealed: Divergent
+    reveal_type(x[0])  # revealed: Divergent | None
 
 JSONPrimitive = Union[str, int, float, bool, None]
 JSONValue = TypeAliasType("JSONValue", 'Union[JSONPrimitive, Sequence["JSONValue"], Mapping[str, "JSONValue"]]')

--- a/crates/ty_python_semantic/resources/mdtest/cycle/implicit_instance_attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/implicit_instance_attributes.md
@@ -530,3 +530,98 @@ class Cached:
 
 reveal_type(Cached().metadata)  # revealed: int
 ```
+
+## Growing recursive collections preserve non-recursive element types
+
+A list built from the attribute's previous value has a recursive element type. Normalization retains
+the integer elements while replacing the nested recursive list with `Divergent`, so inference
+converges.
+
+```py
+class Recursive:
+    def update(self):
+        self.values = [1, self.values]
+
+reveal_type(Recursive().values)  # revealed: list[int | Divergent]
+```
+
+## Inherited collection updates when the base is checked first
+
+Normalizing a recursive list type preserves its non-recursive element types. Reassigning the same
+attribute in a subclass does not change the inferred type on its parent. This reproduces
+<https://github.com/astral-sh/ty/issues/4221>.
+
+We still retain a `Divergent` placeholder for the recursive assignment, so the return statement
+emits an unsound-return warning. Its type is independent of which file is checked first.
+
+```toml
+[rules]
+unsound-return-statement = "warn"
+```
+
+`base.py`:
+
+```py
+class Base:
+    values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        if self.values:
+            self.values = [*self.values]
+
+    def get_values(self) -> list[str]:
+        return self.values  # error: [unsound-return-statement] "`list[str] | list[str | Divergent]`"
+
+reveal_type(Parent().values)  # revealed: list[str] | list[str | Divergent]
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        self.values = self.values + ["b"]
+
+reveal_type(Child().values)  # revealed: list[str] | list[str | Divergent]
+```
+
+## Inherited collection updates when the subclass is checked first
+
+Checking the subclass first produces the same list types and unsound-return warning.
+
+```toml
+[rules]
+unsound-return-statement = "warn"
+```
+
+`child.py`:
+
+```py
+from base import Parent
+
+class Child(Parent):
+    def __init__(self):
+        self.values = self.values + ["b"]
+
+reveal_type(Child().values)  # revealed: list[str] | list[str | Divergent]
+```
+
+`base.py`:
+
+```py
+class Base:
+    values = ["a"]
+
+class Parent(Base):
+    def __init__(self):
+        if self.values:
+            self.values = [*self.values]
+
+    def get_values(self) -> list[str]:
+        return self.values  # error: [unsound-return-statement] "`list[str] | list[str | Divergent]`"
+
+reveal_type(Parent().values)  # revealed: list[str] | list[str | Divergent]
+```

--- a/crates/ty_python_semantic/resources/mdtest/cycle/implicit_instance_attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle/implicit_instance_attributes.md
@@ -531,28 +531,11 @@ class Cached:
 reveal_type(Cached().metadata)  # revealed: int
 ```
 
-## Growing recursive collections preserve non-recursive element types
-
-A list built from the attribute's previous value has a recursive element type. Normalization retains
-the integer elements while replacing the nested recursive list with `Divergent`, so inference
-converges.
-
-```py
-class Recursive:
-    def update(self):
-        self.values = [1, self.values]
-
-reveal_type(Recursive().values)  # revealed: list[int | Divergent]
-```
-
 ## Inherited collection updates when the base is checked first
 
-Normalizing a recursive list type preserves its non-recursive element types. Reassigning the same
-attribute in a subclass does not change the inferred type on its parent. This reproduces
-<https://github.com/astral-sh/ty/issues/4221>.
-
-We still retain a `Divergent` placeholder for the recursive assignment, so the return statement
-emits an unsound-return warning. Its type is independent of which file is checked first.
+Normalizing a recursive list preserves its non-recursive element types. The unresolved recursive
+assignment still causes an unsound-return warning, whose type is independent of which file is
+checked first. This reproduces <https://github.com/astral-sh/ty/issues/4221>.
 
 ```toml
 [rules]
@@ -572,8 +555,6 @@ class Parent(Base):
 
     def get_values(self) -> list[str]:
         return self.values  # error: [unsound-return-statement] "`list[str] | list[str | Divergent]`"
-
-reveal_type(Parent().values)  # revealed: list[str] | list[str | Divergent]
 ```
 
 `child.py`:
@@ -584,13 +565,11 @@ from base import Parent
 class Child(Parent):
     def __init__(self):
         self.values = self.values + ["b"]
-
-reveal_type(Child().values)  # revealed: list[str] | list[str | Divergent]
 ```
 
 ## Inherited collection updates when the subclass is checked first
 
-Checking the subclass first produces the same list types and unsound-return warning.
+Checking the subclass first produces the same unsound-return warning.
 
 ```toml
 [rules]
@@ -605,8 +584,6 @@ from base import Parent
 class Child(Parent):
     def __init__(self):
         self.values = self.values + ["b"]
-
-reveal_type(Child().values)  # revealed: list[str] | list[str | Divergent]
 ```
 
 `base.py`:
@@ -622,6 +599,4 @@ class Parent(Base):
 
     def get_values(self) -> list[str]:
         return self.values  # error: [unsound-return-statement] "`list[str] | list[str | Divergent]`"
-
-reveal_type(Parent().values)  # revealed: list[str] | list[str | Divergent]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1699,7 +1699,7 @@ def first_recursive[T: Recursive](values: list[T], sink: Callable[[T], None]) ->
     return values[0]
 
 def _(values: list[Recursive], sink: Callable[[object], None]) -> None:
-    # revealed: None | int | set[int] | Sequence[Divergent] | Mapping[str, Divergent]
+    # revealed: None | int | set[int] | Sequence[None | int | set[int] | Divergent] | Mapping[str, None | int | set[int] | Divergent]
     reveal_type(first_recursive(values, sink))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
+++ b/crates/ty_python_semantic/resources/mdtest/ide_support/all_members.md
@@ -110,6 +110,8 @@ static_assert(has_member(C(), "static_method"))
 static_assert(not has_member(C(), "non_existent"))
 ```
 
+### Recursive instance attributes
+
 Recursive attribute inference can fall back to `Divergent`, but should still preserve members that
 were available before the cycle was introduced:
 

--- a/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/implicit_type_aliases.md
@@ -2045,7 +2045,7 @@ from typing import Union
 Recursive = list[Union["Recursive", None]]
 
 def _(r: Recursive):
-    reveal_type(r)  # revealed: list[Divergent]
+    reveal_type(r)  # revealed: list[Divergent | None]
 ```
 
 ### New union syntax
@@ -2073,10 +2073,10 @@ def _(
     recursive_dict3: RecursiveDict3,
     recursive_dict4: RecursiveDict4,
 ):
-    reveal_type(recursive_list1)  # revealed: list[Divergent]
-    reveal_type(recursive_list2)  # revealed: list[Divergent]
-    reveal_type(recursive_dict1)  # revealed: dict[str, Divergent]
-    reveal_type(recursive_dict2)  # revealed: dict[str, Divergent]
+    reveal_type(recursive_list1)  # revealed: list[Divergent | None]
+    reveal_type(recursive_list2)  # revealed: list[Divergent | None]
+    reveal_type(recursive_dict1)  # revealed: dict[str, Divergent | None]
+    reveal_type(recursive_dict2)  # revealed: dict[str, Divergent | None]
     reveal_type(recursive_dict3)  # revealed: dict[Divergent, int]
     reveal_type(recursive_dict4)  # revealed: dict[Divergent, int]
 ```
@@ -2115,8 +2115,8 @@ def _(
     nested_dict_int: NestedDict[int],
     nested_list_str: NestedList[str],
 ):
-    reveal_type(nested_dict_int)  # revealed: dict[str, Divergent]
-    reveal_type(nested_list_str)  # revealed: list[Divergent]
+    reveal_type(nested_dict_int)  # revealed: dict[str, Divergent | @Todo(specialized recursive generic type alias)]
+    reveal_type(nested_list_str)  # revealed: list[Divergent | None]
 ```
 
 ### Materialization of self-referential generic implicit type aliases

--- a/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep613_type_aliases.md
@@ -412,7 +412,8 @@ NestedDict: TypeAlias = dict[K, Union[V, "NestedDict[K, V]"]]
 
 def _(nested: NestedDict[str, int]):
     # TODO should be `dict[str, int | NestedDict[str, int]]`
-    reveal_type(nested)  # revealed: dict[@Todo(specialized recursive generic type alias), Divergent]
+    # revealed: dict[@Todo(specialized recursive generic type alias), @Todo(specialized recursive generic type alias) | Divergent]
+    reveal_type(nested)
 
 my_isinstance(1, int)
 my_isinstance(1, int | str)

--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -2529,6 +2529,7 @@ def _(
     # No error here:
     reveal_type(person[unknown_key])  # revealed: Unknown
 
+    # error: [invalid-key] "key of type `None`"
     reveal_type(movie[recursive_key[0]])  # revealed: Unknown
 
     # error: [invalid-key] "Unknown key "anything" for TypedDict `Animal`"

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1006,7 +1006,7 @@ mod tests {
                 "#
         ),
          @r#"
-        Added 4 suppressions
+        Added 5 suppressions
 
         ## Fixed source
 
@@ -1024,7 +1024,7 @@ mod tests {
             diag = get_data()
             diag["home_assistant"]["entities"] = sorted(  # ty: ignore[invalid-assignment]
                 diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty: ignore[invalid-argument-type, not-subscriptable]
-            )
+            )  # ty: ignore[no-matching-overload]
         ```
         "#);
     }
@@ -1049,7 +1049,7 @@ mod tests {
                     ); missing  # ty: ignore[unresolved-reference]
                 "#),
             @r#"
-        Added 4 suppressions
+        Added 5 suppressions
 
         ## Fixed source
 
@@ -1067,7 +1067,7 @@ mod tests {
             diag = get_data()
             diag["home_assistant"]["entities"] = sorted(  # ty: ignore[invalid-assignment]
                 diag["home_assistant"]["entities"], key=lambda ent: ent["entity_id"]  # ty: ignore[invalid-argument-type, not-subscriptable]
-            ); missing  # ty: ignore[unresolved-reference]
+            ); missing  # ty: ignore[unresolved-reference, no-matching-overload]
         ```
         "#
         );

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -36,7 +36,8 @@ use crate::types::{
     ClassLiteral, ErrorContext, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass,
     KnownInstanceType, MaterializationKind, SubclassOfInner, Type, TypeAliasType, TypeContext,
     TypeMapping, TypeRecursionContext, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance,
-    UnionAccumulator, UnionType, binding_type, infer_definition_types, inferred_declaration,
+    UnionAccumulator, UnionBuilder, UnionType, binding_type, infer_definition_types,
+    inferred_declaration,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -1533,8 +1534,26 @@ impl<'db> Specialization<'db> {
             self.types(db)
                 .iter()
                 .map(|ty| {
-                    ty.recursive_type_normalized_impl(db, env, div, true)
-                        .unwrap_or(div)
+                    let normalize = |ty: &Type<'db>| {
+                        ty.recursive_type_normalized_impl(db, env, div, true)
+                            .unwrap_or(div)
+                    };
+                    match ty {
+                        Type::Union(union) => {
+                            // Preserve non-recursive alternatives in the outermost specialization:
+                            // `list[str | Divergent]` retains `str`, while a nested recursive list
+                            // in `list[str | list[Divergent]]` still collapses to `Divergent`.
+                            let mut builder = UnionBuilder::new(db, env)
+                                .unpack_aliases(false)
+                                .cycle_recovery(true)
+                                .recursively_defined(union.recursively_defined(db));
+                            for element in union.elements(db) {
+                                builder.add_in_place(normalize(element));
+                            }
+                            builder.build()
+                        }
+                        ty => normalize(ty),
+                    }
                 })
                 .collect::<Box<[_]>>()
         };

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1534,26 +1534,24 @@ impl<'db> Specialization<'db> {
             self.types(db)
                 .iter()
                 .map(|ty| {
-                    let normalize = |ty: &Type<'db>| {
-                        ty.recursive_type_normalized_impl(db, env, div, true)
-                            .unwrap_or(div)
+                    let Type::Union(union) = ty else {
+                        return ty
+                            .recursive_type_normalized_impl(db, env, div, true)
+                            .unwrap_or(div);
                     };
-                    match ty {
-                        Type::Union(union) => {
-                            // Preserve non-recursive alternatives in the outermost specialization:
-                            // `list[str | Divergent]` retains `str`, while a nested recursive list
-                            // in `list[str | list[Divergent]]` still collapses to `Divergent`.
-                            let mut builder = UnionBuilder::new(db, env)
-                                .unpack_aliases(false)
-                                .cycle_recovery(true)
-                                .recursively_defined(union.recursively_defined(db));
-                            for element in union.elements(db) {
-                                builder.add_in_place(normalize(element));
-                            }
-                            builder.build()
-                        }
-                        ty => normalize(ty),
+                    // Preserve non-recursive alternatives without retaining recursive nesting:
+                    // `list[str | list[Divergent]]` becomes `list[str | Divergent]`.
+                    let mut builder = UnionBuilder::new(db, env)
+                        .cycle_recovery(true)
+                        .recursively_defined(union.recursively_defined(db));
+                    for element in union.elements(db) {
+                        builder.add_in_place(
+                            element
+                                .recursive_type_normalized_impl(db, env, div, true)
+                                .unwrap_or(div),
+                        );
                     }
+                    builder.build()
                 })
                 .collect::<Box<[_]>>()
         };

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -439,7 +439,7 @@ fn divergent_type() {
         normalized
             .display(db, &db.program_environment())
             .to_string(),
-        "list[Divergent]"
+        "list[Divergent | None]"
     );
 
     let recursive_tuple = Type::heterogeneous_tuple(
@@ -511,7 +511,7 @@ fn divergent_type() {
         normalized
             .display(db, &db.program_environment())
             .to_string(),
-        "dict[str, Divergent]"
+        "dict[str, int | Divergent]"
     );
 
     let union = UnionType::from_elements(db, &env, [div, KnownClass::Int.to_instance(db, &env)]);
@@ -871,16 +871,17 @@ type H[T] = G[T]
             .expand_eagerly(&db, &db.program_environment())
             .display(&db, &db.program_environment())
             .to_string(),
-        "list[Divergent]",
+        "list[T@RecursiveList | Divergent]",
     );
 
     let rec_int_list = get_type_alias(&db, "RecursiveIntList");
+    // Eager expansion follows raw alias bodies, leaving their type variables unspecialized.
     assert_eq!(
         rec_int_list
             .expand_eagerly(&db, &db.program_environment())
             .display(&db, &db.program_environment())
             .to_string(),
-        "list[Divergent]",
+        "list[T@RecursiveList | Divergent]",
     );
 
     let itself = get_type_alias(&db, "Itself");


### PR DESCRIPTION
## Summary

We now preserve non-recursive union alternatives when normalizing recursive generic arguments. Previously, normalizing `list[str | list[Divergent]]` discarded `str` along with the nested recursive list, producing `list[Divergent]`. We now normalize each alternative independently to produce `list[str | Divergent]` while still allowing recursive inference to converge.

This makes the `unsound-return-statement` diagnostic in the inherited-attribute reproducer independent of file-checking order. Both orders now consistently report `list[str] | list[str | Divergent]`; the existing warning remains.

Closes https://github.com/astral-sh/ty/issues/4221.
