### PR TITLE
[`pyupgrade`] Stop recommending removed `typing.no_type_check_decorator` (`UP035`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP035.py
@@ -132,3 +132,7 @@ from typing.re import Match
 
 # UP035 on py37+ only
 from typing.re import Pattern
+
+# `no_type_check_decorator` was removed from `typing` in Python 3.15.
+from typing_extensions import no_type_check_decorator
+from typing_extensions import no_type_check, no_type_check_decorator

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -193,7 +193,6 @@ const TYPING_EXTENSIONS_TO_TYPING: &[&str] = &[
     "ValuesView",
     "cast",
     "no_type_check",
-    "no_type_check_decorator",
     // Introduced in Python 3.5.2, but `typing_extensions` contains backported bugfixes and
     // optimizations,
     // "NewType",

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -1130,9 +1130,28 @@ UP035 [*] Import from `re` instead: `Pattern`
 133 | # UP035 on py37+ only
 134 | from typing.re import Pattern
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+135 |
+136 | # `no_type_check_decorator` was removed from `typing` in Python 3.15.
+    |
 help: Import from `re`
     |
 133 | # UP035 on py37+ only
     - from typing.re import Pattern
 134 + from re import Pattern
+135 |
+    |
+
+UP035 [*] Import from `typing` instead: `no_type_check`
+   --> UP035.py:138:1
+    |
+136 | # `no_type_check_decorator` was removed from `typing` in Python 3.15.
+137 | from typing_extensions import no_type_check_decorator
+138 | from typing_extensions import no_type_check, no_type_check_decorator
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Import from `typing`
+    |
+137 | from typing_extensions import no_type_check_decorator
+    - from typing_extensions import no_type_check, no_type_check_decorator
+138 + from typing_extensions import no_type_check_decorator
+139 + from typing import no_type_check
     |


### PR DESCRIPTION
Summary
--

This PR removes `typing_extensions.no_type_check_decorator` from the list of moved members in UP035. As the [docs](https://docs.python.org/3/library/typing.html#typing.no_type_check_decorator) indicate, this decorator has been deprecated since 3.13 and is removed in 3.15, so the rule should just leave it alone.

The change is not version-gated because it seemed weird to me to recommend making this change with a target version of 3.12, for example, only for the user to have to change it back when they eventually bump their Python version.

I initially thought that `typing_extensions` would continue to backport this, but it appears that they removed it as well: https://github.com/python/typing_extensions/pull/723. I don't think that actually changes how we should handle it, though.

Test Plan
--

Added a couple of tests showing no diagnostic
