### PR TITLE
Recognize `slice` and `frozendict` generics

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyflakes/unused-import.md
+++ b/crates/ruff_linter/resources/mdtest/pyflakes/unused-import.md
@@ -13,8 +13,8 @@ For standard-library generic types such as `slice` and `frozendict`, Ruff visits
 type expressions. Names in quoted annotations therefore mark their imports as used.
 
 ```py
-from decimal import Decimal
-from fractions import Fraction
+from decimal import Decimal  # no diagnostic
+from fractions import Fraction  # no diagnostic
 
 DecimalSlice = slice["Decimal"]
 FractionMap = frozendict[str, "Fraction"]

--- a/crates/ruff_linter/resources/mdtest/pyflakes/unused-import.md
+++ b/crates/ruff_linter/resources/mdtest/pyflakes/unused-import.md
@@ -1,0 +1,34 @@
+# `unused-import` (`F401`)
+
+```toml
+target-version = "py315"
+
+[lint]
+select = ["F401"]
+```
+
+## Standard-library generic types
+
+For standard-library generic types such as `slice` and `frozendict`, Ruff visits subscript arguments as
+type expressions. Names in quoted annotations therefore mark their imports as used.
+
+```py
+from decimal import Decimal
+from fractions import Fraction
+
+DecimalSlice = slice["Decimal"]
+FractionMap = frozendict[str, "Fraction"]
+```
+
+## Other subscription arguments
+
+For an arbitrary subscription such as `foo["Decimal"]`, the string argument is not treated as a type
+expression. The import of `Decimal` is therefore unused.
+
+```py
+from decimal import Decimal  # error: [unused-import]
+
+from somewhere import foo
+
+NotAnAlias = foo["Decimal"]
+```

--- a/crates/ruff_python_stdlib/src/typing.rs
+++ b/crates/ruff_python_stdlib/src/typing.rs
@@ -7,7 +7,7 @@ pub fn is_standard_library_generic(qualified_name: &[&str]) -> bool {
         qualified_name,
         [
             "" | "builtins",
-            "dict" | "frozenset" | "list" | "set" | "tuple" | "type"
+            "dict" | "frozendict" | "frozenset" | "list" | "set" | "slice" | "tuple" | "type"
         ] | [
             "collections" | "typing" | "typing_extensions",
             "ChainMap" | "Counter"
@@ -204,9 +204,11 @@ pub fn is_standard_library_generic_member(member: &str) -> bool {
             | "WeakValueDictionary"
             | "defaultdict"
             | "deque"
+            | "frozendict"
             | "frozenset"
             | "list"
             | "set"
+            | "slice"
             | "tuple"
             | "type"
     )


### PR DESCRIPTION
Summary
--

This PR updates our standard library generic recognition to include `frozendict` and `slice`. `F401`
is just an example of an affected rule because we visit the subscript arguments of known stdlib
generics as type expressions:

https://github.com/astral-sh/ruff/blob/275e6112e4c5d383179efaa424c8d774acf9fe58/crates/ruff_linter/src/checkers/ast/mod.rs#L2177-L2181

Test Plan
--

mdtests including `F401` to exercise the new behavior
