### PR TITLE
[ty] Fix assignability of bounded typevars to intersection types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -480,6 +480,19 @@ def two_final_bounded[T: FinalClass, U: FinalClass](t: T, u: U) -> None:
     static_assert(not is_subtype_of(U, T))
 ```
 
+A typevar bounded by a union is a subtype of that union, but not of either member individually:
+
+```py
+def _[T: int | str](t: T) -> None:
+    static_assert(is_assignable_to(T, int | str))
+    static_assert(not is_assignable_to(T, int))
+    static_assert(not is_assignable_to(T, str))
+
+    static_assert(is_subtype_of(T, int | str))
+    static_assert(not is_subtype_of(T, int))
+    static_assert(not is_subtype_of(T, str))
+```
+
 A constrained fully static typevar is assignable to the union of its constraints, but not to any of
 the constraints individually. None of the constraints are subtypes of the typevar, though the
 intersection of all of its constraints is a subtype of the typevar.
@@ -550,6 +563,19 @@ def constrained_by_gradual[T: (Base, Any)](t: T) -> None:
     static_assert(not is_subtype_of(Super | Unrelated, T))
     static_assert(not is_subtype_of(Intersection[Base, Unrelated], T))
     static_assert(not is_subtype_of(Intersection[Base, Any], T))
+```
+
+A bounded typevar is a subtype of a constrained typevar if its bound is a subtype of every target
+constraint:
+
+```py
+def _[S: Intersection[Base, Unrelated], T: (Base, Unrelated)](s: S, t: T) -> None:
+    static_assert(is_assignable_to(S, T))
+    static_assert(is_subtype_of(S, T))
+
+def _[S: Base, T: (Base, Unrelated)](s: S, t: T) -> None:
+    static_assert(not is_assignable_to(S, T))
+    static_assert(not is_subtype_of(S, T))
 ```
 
 Two distinct fully static typevars are not subtypes of each other, even if they have the same
@@ -910,6 +936,65 @@ def intersection_is_assignable[T](t: T) -> None:
 
     static_assert(is_subtype_of(Intersection[T, None], T))
     static_assert(is_subtype_of(Intersection[T, Not[None]], T))
+```
+
+A fully static typevar `T` is assignable to `T & Any`:
+
+```py
+def _[T, U](t: T) -> None:
+    static_assert(is_assignable_to(T, Intersection[T, Any]))
+    static_assert(not is_subtype_of(T, Intersection[T, Any]))
+    static_assert(not is_assignable_to(T, Intersection[U, Any]))
+
+def _[T: object, U: object](t: T) -> None:
+    static_assert(is_assignable_to(T, Intersection[T, Any]))
+    static_assert(not is_subtype_of(T, Intersection[T, Any]))
+    static_assert(not is_assignable_to(T, Intersection[U, Any]))
+
+def _[T: (int, str), U: (int, str)](t: T) -> None:
+    static_assert(is_assignable_to(T, Intersection[T, Any]))
+    static_assert(not is_subtype_of(T, Intersection[T, Any]))
+    static_assert(not is_assignable_to(T, Intersection[U, Any]))
+```
+
+The same relation holds when the intersection is nested within a union:
+
+```py
+def _[T: object, U: object](t: T, u: U) -> None:
+    static_assert(is_assignable_to(T, T | int))
+    static_assert(is_subtype_of(T, T | int))
+
+    static_assert(is_assignable_to(T, Intersection[T, Any] | int))
+    static_assert(not is_subtype_of(T, Intersection[T, Any] | int))
+    static_assert(not is_assignable_to(T, Intersection[U, Any] | int))
+
+def _[T: (int, str), U: (int, str)](t: T, u: U) -> None:
+    static_assert(is_assignable_to(T, T | int))
+    static_assert(is_subtype_of(T, T | int))
+
+    static_assert(is_assignable_to(T, Intersection[T, Any] | int))
+    static_assert(not is_subtype_of(T, Intersection[T, Any] | int))
+    static_assert(not is_assignable_to(T, Intersection[U, Any] | int))
+```
+
+But does not hold when the intersection contains a negated member within the range of the bounded
+typevar:
+
+```py
+def _[T: object](t: T) -> None:
+    static_assert(not is_assignable_to(T, Intersection[T, Any, Not[int]]))
+    static_assert(not is_subtype_of(T, Intersection[T, Not[int]]))
+
+def _[T: (int, str)](t: T) -> None:
+    static_assert(not is_assignable_to(T, Intersection[T, Any, Not[int]]))
+    static_assert(not is_subtype_of(T, Intersection[T, Not[int]]))
+```
+
+A gradually bounded typevar is not assignable to its own negation:
+
+```py
+def _[T: Any](t: T) -> None:
+    static_assert(not is_assignable_to(T, Not[T]))
 ```
 
 ## Bounded typevars remain assignable to their upper bound after narrowing

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -823,6 +823,11 @@ static_assert(is_assignable_to(LiteralString & ~Literal["", "a"], AlwaysTruthy))
 static_assert(is_assignable_to(LiteralString & ~Literal[""], ~AlwaysFalsy))
 # error: [static-assert-error]
 static_assert(is_assignable_to(LiteralString & ~Literal["", "a"], ~AlwaysFalsy))
+
+# Each member of a union must be assignable to the target intersection
+static_assert(is_assignable_to(Literal[1, 2], int & ~Literal[3]))
+static_assert(not is_assignable_to(Literal[1, 2], int & ~Literal[2]))
+static_assert(not is_assignable_to(Literal[1, "a"], int & ~Literal[3]))
 ```
 
 ## Callable types with Unknown/missing return type

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1182,6 +1182,23 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             })
     }
 
+    fn check_source_typevar_bounds(
+        &self,
+        db: &'db dyn Db,
+        bound_or_constraints: TypeVarBoundOrConstraints<'db>,
+        target: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        match bound_or_constraints {
+            TypeVarBoundOrConstraints::UpperBound(bound) => self.check_type_pair(db, bound, target),
+            TypeVarBoundOrConstraints::Constraints(constraints) => constraints
+                .elements(db)
+                .iter()
+                .when_all(db, self.constraints, |&constraint| {
+                    self.check_type_pair(db, constraint, target)
+                }),
+        }
+    }
+
     fn check_source_union(
         &self,
         db: &'db dyn Db,
@@ -1230,13 +1247,20 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             return self.check_type_pair(db, alternatives, target);
         }
 
-        let is_new_type_of_union = || {
+        let check_expanded_source = || {
             // Normally non-unions cannot directly contain unions in our model due to the fact that
             // we enforce a DNF structure on our set-theoretic types. However, it *is* possible for
             // there to be a newtype of a union, for an intersection to contain a newtype of a
             // union, or for a non-inferable typevar (possibly inside an intersection) to widen to a
             // bound or set of constraints that exposes a union; this requires special handling.
             match source {
+                Type::TypeVar(typevar)
+                    if !typevar.is_inferable(db, self.inferable)
+                        && let Some(bound_or_constraints) =
+                            typevar.typevar(db).bound_or_constraints(db, self.env) =>
+                {
+                    self.check_source_typevar_bounds(db, bound_or_constraints, target)
+                }
                 Type::Intersection(intersection)
                     if self.should_expand_intersection(db, intersection) =>
                 {
@@ -1274,7 +1298,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 }
                 result
             })
-            .or(db, self.constraints, is_new_type_of_union);
+            .or(db, self.constraints, check_expanded_source);
 
         if context_tree.is_some()
             && !elements_context.is_empty()
@@ -2047,28 +2071,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 ConstraintSet::from_bool(self.constraints, source.is_type_var() == other_is_top)
             }
 
-            // A fully static typevar is a subtype of its upper bound, and to something similar to
-            // the union of its constraints. An unbound, unconstrained, fully static typevar has an
-            // implicit upper bound of `object` (which is handled above).
-            (Type::TypeVar(bound_typevar), _)
-                if !bound_typevar.is_inferable(db, self.inferable)
-                    && let Some(bound_or_constraints) =
-                        bound_typevar.typevar(db).bound_or_constraints(db, env) =>
-            {
-                match bound_or_constraints {
-                    TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        self.check_type_pair(db, bound, target)
-                    }
-                    TypeVarBoundOrConstraints::Constraints(typevar_constraints) => {
-                        typevar_constraints.elements(db).iter().when_all(
-                            db,
-                            self.constraints,
-                            |constraint| self.check_type_pair(db, *constraint, target),
-                        )
-                    }
-                }
-            }
-
             // If the typevar is constrained, there must be multiple constraints, and the typevar
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
@@ -2135,6 +2137,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (Type::Intersection(intersection), _) => {
                 self.check_source_intersection(db, intersection, target)
+            }
+
+            // A fully static typevar is a subtype of its upper bound, and to something similar to
+            // the union of its constraints. An unbound, unconstrained, fully static typevar has an
+            // implicit upper bound of `object` (which is handled above).
+            (Type::TypeVar(bound_typevar), _)
+                if !bound_typevar.is_inferable(db, self.inferable)
+                    && let Some(bound_or_constraints) =
+                        bound_typevar.typevar(db).bound_or_constraints(db, env) =>
+            {
+                self.check_source_typevar_bounds(db, bound_or_constraints, target)
             }
 
             // `Never` is the bottom type, the empty set.


### PR DESCRIPTION
A typevar `T` should be assignable to the intersection type `T & Any`. We currently expand the bound of a bounded typevar before expanding an intersection target, meaning we lose this identity, e.g.,

```py
from typing import Any
from ty_extensions._internal import is_assignable_to
from ty_extensions import static_assert, Intersection

def _[T: object, U: object](t: T) -> None:
    static_assert(is_assignable_to(T, Intersection[T, Any])) # main: static-assert-error
```