### PR TITLE
Add accessors for comparison expressions

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1644,17 +1644,10 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 flake8_simplify::rules::double_negation(checker, expr, *op, operand);
             }
         }
-        Expr::Compare(
-            compare @ ast::ExprCompare {
-                ops,
-                operands,
-                range: _,
-                node_index: _,
-            },
-        ) => {
-            let Some((left, comparators)) = operands.split_first() else {
-                return;
-            };
+        Expr::Compare(compare) => {
+            let left = compare.first_operand();
+            let comparators = compare.comparators();
+            let ops = &*compare.ops;
             if checker.any_rule_enabled(&[Rule::NoneComparison, Rule::TrueFalseComparison]) {
                 pycodestyle::rules::literal_comparisons(checker, compare);
             }
@@ -1681,22 +1674,22 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 );
             }
             if checker.is_rule_enabled(Rule::ComparisonWithItself) {
-                pylint::rules::comparison_with_itself(checker, left, ops, comparators);
+                pylint::rules::comparison_with_itself(checker, compare);
             }
             if checker.is_rule_enabled(Rule::LiteralMembership) {
                 pylint::rules::literal_membership(checker, compare);
             }
             if checker.is_rule_enabled(Rule::ComparisonOfConstant) {
-                pylint::rules::comparison_of_constant(checker, left, ops, comparators);
+                pylint::rules::comparison_of_constant(checker, compare);
             }
             if checker.is_rule_enabled(Rule::CompareToEmptyString) {
-                pylint::rules::compare_to_empty_string(checker, left, ops, comparators);
+                pylint::rules::compare_to_empty_string(checker, compare);
             }
             if checker.is_rule_enabled(Rule::MagicValueComparison) {
-                pylint::rules::magic_value_comparison(checker, left, comparators);
+                pylint::rules::magic_value_comparison(checker, &compare.operands);
             }
             if checker.is_rule_enabled(Rule::NanComparison) {
-                pylint::rules::nan_comparison(checker, left, comparators);
+                pylint::rules::nan_comparison(checker, &compare.operands);
             }
             if checker.is_rule_enabled(Rule::InEmptyCollection) {
                 ruff::rules::in_empty_collection(checker, compare);

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -1645,14 +1645,11 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
             }
         }
         Expr::Compare(compare) => {
-            let left = compare.first_operand();
-            let comparators = compare.comparators();
-            let ops = &*compare.ops;
             if checker.any_rule_enabled(&[Rule::NoneComparison, Rule::TrueFalseComparison]) {
                 pycodestyle::rules::literal_comparisons(checker, compare);
             }
             if checker.is_rule_enabled(Rule::IsLiteral) {
-                pyflakes::rules::invalid_literal_comparison(checker, left, ops, comparators, expr);
+                pyflakes::rules::invalid_literal_comparison(checker, compare);
             }
             if checker.is_rule_enabled(Rule::TypeComparison) {
                 pycodestyle::rules::type_comparison(checker, compare);
@@ -1664,14 +1661,10 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 Rule::SysVersionInfoMinorCmpInt,
                 Rule::SysVersionCmpStr10,
             ]) {
-                flake8_2020::rules::compare(checker, left, ops, comparators);
+                flake8_2020::rules::compare(checker, compare);
             }
             if checker.is_rule_enabled(Rule::HardcodedPasswordString) {
-                flake8_bandit::rules::compare_to_hardcoded_password_string(
-                    checker,
-                    left,
-                    comparators,
-                );
+                flake8_bandit::rules::compare_to_hardcoded_password_string(checker, compare);
             }
             if checker.is_rule_enabled(Rule::ComparisonWithItself) {
                 pylint::rules::comparison_with_itself(checker, compare);
@@ -1698,25 +1691,19 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                 flake8_simplify::rules::key_in_dict_compare(checker, compare);
             }
             if checker.is_rule_enabled(Rule::YodaConditions) {
-                flake8_simplify::rules::yoda_conditions(checker, expr, left, ops, comparators);
+                flake8_simplify::rules::yoda_conditions(checker, compare);
             }
             if checker.is_rule_enabled(Rule::FloatEqualityComparison) {
                 ruff::rules::float_equality_comparison(checker, compare);
             }
             if checker.is_rule_enabled(Rule::PandasNuniqueConstantSeriesCheck) {
-                pandas_vet::rules::nunique_constant_series_check(
-                    checker,
-                    expr,
-                    left,
-                    ops,
-                    comparators,
-                );
+                pandas_vet::rules::nunique_constant_series_check(checker, compare);
             }
             if checker.is_rule_enabled(Rule::TypeNoneComparison) {
                 refurb::rules::type_none_comparison(checker, compare);
             }
             if checker.is_rule_enabled(Rule::SingleItemMembershipTest) {
-                refurb::rules::single_item_membership_test(checker, expr, left, ops, comparators);
+                refurb::rules::single_item_membership_test(checker, compare);
             }
         }
         Expr::NumberLiteral(number_literal @ ast::ExprNumberLiteral { .. }) => {

--- a/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
+++ b/crates/ruff_linter/src/rules/flake8_2020/rules/compare.rs
@@ -238,7 +238,11 @@ impl Violation for SysVersionCmpStr10 {
 }
 
 /// YTT103, YTT201, YTT203, YTT204, YTT302
-pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators: &[Expr]) {
+pub(crate) fn compare(checker: &Checker, compare: &ast::ExprCompare) {
+    let Some((left, op, right)) = compare.as_single() else {
+        return;
+    };
+
     match left {
         Expr::Subscript(ast::ExprSubscript { value, slice, .. })
             if is_sys(value, "version_info", checker.semantic()) =>
@@ -250,14 +254,12 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
             {
                 if *i == 0 {
                     if let (
-                        [operator @ (CmpOp::Eq | CmpOp::NotEq)],
-                        [
-                            Expr::NumberLiteral(ast::ExprNumberLiteral {
-                                value: ast::Number::Int(n),
-                                ..
-                            }),
-                        ],
-                    ) = (ops, comparators)
+                        operator @ (CmpOp::Eq | CmpOp::NotEq),
+                        Expr::NumberLiteral(ast::ExprNumberLiteral {
+                            value: ast::Number::Int(n),
+                            ..
+                        }),
+                    ) = (op, right)
                     {
                         if *n == 3 && checker.is_rule_enabled(Rule::SysVersionInfo0Eq3) {
                             checker.report_diagnostic(
@@ -270,14 +272,12 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
                     }
                 } else if *i == 1 {
                     if let (
-                        [CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE],
-                        [
-                            Expr::NumberLiteral(ast::ExprNumberLiteral {
-                                value: ast::Number::Int(_),
-                                ..
-                            }),
-                        ],
-                    ) = (ops, comparators)
+                        CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE,
+                        Expr::NumberLiteral(ast::ExprNumberLiteral {
+                            value: ast::Number::Int(_),
+                            ..
+                        }),
+                    ) = (op, right)
                     {
                         checker.report_diagnostic_if_enabled(SysVersionInfo1CmpInt, left.range());
                     }
@@ -289,14 +289,12 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
             if is_sys(value, "version_info", checker.semantic()) && attr == "minor" =>
         {
             if let (
-                [CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE],
-                [
-                    Expr::NumberLiteral(ast::ExprNumberLiteral {
-                        value: ast::Number::Int(_),
-                        ..
-                    }),
-                ],
-            ) = (ops, comparators)
+                CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE,
+                Expr::NumberLiteral(ast::ExprNumberLiteral {
+                    value: ast::Number::Int(_),
+                    ..
+                }),
+            ) = (op, right)
             {
                 checker.report_diagnostic_if_enabled(SysVersionInfoMinorCmpInt, left.range());
             }
@@ -307,9 +305,9 @@ pub(crate) fn compare(checker: &Checker, left: &Expr, ops: &[CmpOp], comparators
 
     if is_sys(left, "version", checker.semantic()) {
         if let (
-            [CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE],
-            [Expr::StringLiteral(ast::ExprStringLiteral { value, .. })],
-        ) = (ops, comparators)
+            CmpOp::Lt | CmpOp::LtE | CmpOp::Gt | CmpOp::GtE,
+            Expr::StringLiteral(ast::ExprStringLiteral { value, .. }),
+        ) = (op, right)
         {
             if value.len() == 1 {
                 checker.report_diagnostic_if_enabled(SysVersionCmpStr10, left.range());

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/hardcoded_password_string.rs
@@ -73,16 +73,12 @@ fn password_target(target: &Expr) -> Option<&str> {
 }
 
 /// S105
-pub(crate) fn compare_to_hardcoded_password_string(
-    checker: &Checker,
-    left: &Expr,
-    comparators: &[Expr],
-) {
-    for comp in comparators {
+pub(crate) fn compare_to_hardcoded_password_string(checker: &Checker, compare: &ast::ExprCompare) {
+    for comp in compare.comparators() {
         if string_literal(comp).is_none_or(str::is_empty) {
             continue;
         }
-        let Some(name) = password_target(left) else {
+        let Some(name) = password_target(compare.first_operand()) else {
             continue;
         };
         checker.report_diagnostic(

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/bad_version_info_comparison.rs
@@ -1,4 +1,4 @@
-use ruff_python_ast::{self as ast, CmpOp, Expr};
+use ruff_python_ast::{CmpOp, Expr};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
@@ -116,11 +116,11 @@ impl Violation for BadVersionInfoOrder {
 
 /// PYI006, PYI066
 pub(crate) fn bad_version_info_comparison(checker: &Checker, test: &Expr, has_else_clause: bool) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
+    let Expr::Compare(compare) = test else {
         return;
     };
 
-    let ([op], [left, _right]) = (&**ops, &**operands) else {
+    let Some((left, op, _right)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_platform.rs
@@ -101,11 +101,11 @@ impl Violation for UnrecognizedPlatformName {
 
 /// PYI007, PYI008
 pub(crate) fn unrecognized_platform(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
+    let Expr::Compare(compare) = test else {
         return;
     };
 
-    let ([op], [left, right]) = (&**ops, &**operands) else {
+    let Some((left, op, right)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unrecognized_version_info.rs
@@ -126,11 +126,11 @@ impl Violation for WrongTupleLengthVersionComparison {
 
 /// PYI003, PYI004, PYI005
 pub(crate) fn unrecognized_version_info(checker: &Checker, test: &Expr) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test else {
+    let Expr::Compare(compare) = test else {
         return;
     };
 
-    let ([op], [left, comparator]) = (&**ops, &**operands) else {
+    let Some((left, op, comparator)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_bool_op.rs
@@ -458,19 +458,9 @@ pub(crate) fn duplicate_isinstance_call(checker: &Checker, expr: &Expr) {
 }
 
 fn match_eq_target(expr: &Expr) -> Option<(&Name, &Expr)> {
-    let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
-        range: _,
-        node_index: _,
-    }) = expr
+    let (Expr::Name(ast::ExprName { id, .. }), CmpOp::Eq, comparator) =
+        expr.as_compare_expr()?.as_single()?
     else {
-        return None;
-    };
-    if **ops != [CmpOp::Eq] {
-        return None;
-    }
-    let [Expr::Name(ast::ExprName { id, .. }), comparator] = &**operands else {
         return None;
     };
     if !comparator.is_name_expr() {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/ast_unary_op.rs
@@ -152,16 +152,10 @@ pub(crate) fn negation_with_equal_op(checker: &Checker, expr: &Expr, op: UnaryOp
     if !matches!(op, UnaryOp::Not) {
         return;
     }
-    let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
-        range: _,
-        node_index: _,
-    }) = operand
-    else {
+    let Expr::Compare(compare) = operand else {
         return;
     };
-    if !matches!(&ops[..], [CmpOp::Eq]) {
+    if !matches!(&*compare.ops, [CmpOp::Eq]) {
         return;
     }
     if is_exception_check(checker.semantic().current_statement()) {
@@ -179,14 +173,14 @@ pub(crate) fn negation_with_equal_op(checker: &Checker, expr: &Expr, op: UnaryOp
 
     let mut diagnostic = checker.report_diagnostic(
         NegateEqualOp {
-            left: checker.generator().expr(&operands[0]),
-            right: checker.generator().expr(&operands[1]),
+            left: checker.generator().expr(compare.first_operand()),
+            right: checker.generator().expr(compare.second_operand()),
         },
         expr.range(),
     );
     let node = ast::ExprCompare {
         ops: [CmpOp::NotEq].into(),
-        operands: operands.clone(),
+        operands: compare.operands.clone(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };
@@ -206,16 +200,10 @@ pub(crate) fn negation_with_not_equal_op(
     if !matches!(op, UnaryOp::Not) {
         return;
     }
-    let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
-        range: _,
-        node_index: _,
-    }) = operand
-    else {
+    let Expr::Compare(compare) = operand else {
         return;
     };
-    if !matches!(&**ops, [CmpOp::NotEq]) {
+    if !matches!(&*compare.ops, [CmpOp::NotEq]) {
         return;
     }
     if is_exception_check(checker.semantic().current_statement()) {
@@ -233,14 +221,14 @@ pub(crate) fn negation_with_not_equal_op(
 
     let mut diagnostic = checker.report_diagnostic(
         NegateNotEqualOp {
-            left: checker.generator().expr(&operands[0]),
-            right: checker.generator().expr(&operands[1]),
+            left: checker.generator().expr(compare.first_operand()),
+            right: checker.generator().expr(compare.second_operand()),
         },
         expr.range(),
     );
     let node = ast::ExprCompare {
         ops: [CmpOp::Eq].into(),
-        operands: operands.clone(),
+        operands: compare.operands.clone(),
         range: TextRange::default(),
         node_index: ruff_python_ast::AtomicNodeIndex::NONE,
     };

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_get.rs
@@ -130,16 +130,10 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
         return;
     };
 
-    let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
-        range: _,
-        node_index: _,
-    }) = &**test
-    else {
+    let Expr::Compare(compare) = &**test else {
         return;
     };
-    let [test_key, test_dict] = &**operands else {
+    let Some((test_key, op, test_dict)) = compare.as_single() else {
         return;
     };
 
@@ -150,9 +144,9 @@ pub(crate) fn if_else_block_instead_of_dict_get(checker: &Checker, stmt_if: &ast
         return;
     }
 
-    let (expected_var, expected_value, default_var, default_value) = match ops[..] {
-        [CmpOp::In] => (body_var, body_value, orelse_var, orelse_value.as_ref()),
-        [CmpOp::NotIn] => (orelse_var, orelse_value, body_var, body_value.as_ref()),
+    let (expected_var, expected_value, default_var, default_value) = match op {
+        CmpOp::In => (body_var, body_value, orelse_var, orelse_value.as_ref()),
+        CmpOp::NotIn => (orelse_var, orelse_value, body_var, body_value.as_ref()),
         _ => {
             return;
         }
@@ -257,22 +251,16 @@ pub(crate) fn if_exp_instead_of_dict_get(
     body: &Expr,
     orelse: &Expr,
 ) {
-    let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
-        range: _,
-        node_index: _,
-    }) = test
-    else {
+    let Expr::Compare(compare) = test else {
         return;
     };
-    let [test_key, test_dict] = &**operands else {
+    let Some((test_key, op, test_dict)) = compare.as_single() else {
         return;
     };
 
-    let (body, default_value) = match &**ops {
-        [CmpOp::In] => (body, orelse),
-        [CmpOp::NotIn] => (orelse, body),
+    let (body, default_value) = match op {
+        CmpOp::In => (body, orelse),
+        CmpOp::NotIn => (orelse, body),
         _ => {
             return;
         }

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/if_else_block_instead_of_dict_lookup.rs
@@ -59,21 +59,13 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &Checker, stmt_if: &
         ..
     } = stmt_if;
 
-    let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
-        range: _,
-        node_index: _,
-    }) = test.as_ref()
+    let Expr::Compare(compare) = test.as_ref() else {
+        return;
+    };
+    let Some((Expr::Name(ast::ExprName { id: target, .. }), CmpOp::Eq, expr)) = compare.as_single()
     else {
         return;
     };
-    let [Expr::Name(ast::ExprName { id: target, .. }), expr] = &**operands else {
-        return;
-    };
-    if **ops != [CmpOp::Eq] {
-        return;
-    }
     let Some(literal_expr) = expr.as_literal_expr() else {
         return;
     };
@@ -142,16 +134,13 @@ pub(crate) fn if_else_block_instead_of_dict_lookup(checker: &Checker, stmt_if: &
                 }
             }
             // `elif`
-            Some(Expr::Compare(ast::ExprCompare {
-                ops,
-                operands,
-                range: _,
-                node_index: _,
-            })) => {
-                let [Expr::Name(ast::ExprName { id, .. }), expr] = &**operands else {
+            Some(Expr::Compare(compare)) => {
+                let Some((Expr::Name(ast::ExprName { id, .. }), CmpOp::Eq, expr)) =
+                    compare.as_single()
+                else {
                     return;
                 };
-                if id != target || **ops != [CmpOp::Eq] {
+                if id != target {
                     return;
                 }
                 let Some(literal_expr) = expr.as_literal_expr() else {

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/key_in_dict.rs
@@ -177,15 +177,7 @@ pub(crate) fn key_in_dict_comprehension(checker: &Checker, comprehension: &Compr
 
 /// SIM118 in a comparison.
 pub(crate) fn key_in_dict_compare(checker: &Checker, compare: &ast::ExprCompare) {
-    let [op] = &*compare.ops else {
-        return;
-    };
-
-    if !matches!(op, CmpOp::In | CmpOp::NotIn) {
-        return;
-    }
-
-    let [left, right] = &*compare.operands else {
+    let Some((left, op @ (CmpOp::In | CmpOp::NotIn), right)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/reimplemented_builtin.rs
@@ -2,9 +2,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::traversal;
-use ruff_python_ast::{
-    self as ast, Arguments, CmpOp, Comprehension, Expr, ExprContext, Stmt, UnaryOp,
-};
+use ruff_python_ast::{self as ast, Arguments, Comprehension, Expr, ExprContext, Stmt, UnaryOp};
 use ruff_python_codegen::Generator;
 use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextRange};
@@ -149,42 +147,16 @@ pub(crate) fn convert_for_loop_to_any_all(checker: &Checker, stmt: &Stmt) {
                 }) = &loop_.test
                 {
                     *operand.clone()
-                } else if let Expr::Compare(ast::ExprCompare {
-                    ops,
-                    operands,
-                    range: _,
-                    node_index: _,
-                }) = &loop_.test
+                } else if let Expr::Compare(compare) = &loop_.test
+                    && let Some((_, op, _)) = compare.as_single()
                 {
-                    if let ([op], [_, _]) = (&**ops, &**operands) {
-                        let op = match op {
-                            CmpOp::Eq => CmpOp::NotEq,
-                            CmpOp::NotEq => CmpOp::Eq,
-                            CmpOp::Lt => CmpOp::GtE,
-                            CmpOp::LtE => CmpOp::Gt,
-                            CmpOp::Gt => CmpOp::LtE,
-                            CmpOp::GtE => CmpOp::Lt,
-                            CmpOp::Is => CmpOp::IsNot,
-                            CmpOp::IsNot => CmpOp::Is,
-                            CmpOp::In => CmpOp::NotIn,
-                            CmpOp::NotIn => CmpOp::In,
-                        };
-                        let node = ast::ExprCompare {
-                            ops: [op].into(),
-                            operands: operands.clone(),
-                            range: TextRange::default(),
-                            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-                        };
-                        node.into()
-                    } else {
-                        let node = ast::ExprUnaryOp {
-                            op: UnaryOp::Not,
-                            operand: Box::new(loop_.test.clone()),
-                            range: TextRange::default(),
-                            node_index: ruff_python_ast::AtomicNodeIndex::NONE,
-                        };
-                        node.into()
-                    }
+                    let node = ast::ExprCompare {
+                        ops: [op.negate()].into(),
+                        operands: compare.operands.clone(),
+                        range: TextRange::default(),
+                        node_index: ruff_python_ast::AtomicNodeIndex::NONE,
+                    };
+                    node.into()
                 } else {
                     let node = ast::ExprUnaryOp {
                         op: UnaryOp::Not,

--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/yoda_conditions.rs
@@ -7,7 +7,7 @@ use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, CmpOp, Expr, UnaryOp};
 use ruff_python_codegen::Stylist;
 use ruff_python_stdlib::str::{self};
-use ruff_text_size::Ranged;
+use ruff_text_size::{Ranged, TextRange};
 
 use crate::Locator;
 use crate::checkers::ast::Checker;
@@ -137,8 +137,7 @@ impl ConstantLikelihood {
 }
 
 /// Generate a fix to reverse a comparison.
-fn reverse_comparison(expr: &Expr, locator: &Locator, stylist: &Stylist) -> Result<String> {
-    let range = expr.range();
+fn reverse_comparison(range: TextRange, locator: &Locator, stylist: &Stylist) -> Result<String> {
     let source_code = locator.slice(range);
 
     transform_expression(source_code, stylist, |mut expression| {
@@ -205,14 +204,8 @@ fn reverse_comparison(expr: &Expr, locator: &Locator, stylist: &Stylist) -> Resu
 }
 
 /// SIM300
-pub(crate) fn yoda_conditions(
-    checker: &Checker,
-    expr: &Expr,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
-    let ([op], [right]) = (ops, comparators) else {
+pub(crate) fn yoda_conditions(checker: &Checker, compare: &ast::ExprCompare) {
+    let Some((left, op, right)) = compare.as_single() else {
         return;
     };
 
@@ -227,18 +220,20 @@ pub(crate) fn yoda_conditions(
         return;
     }
 
-    if let Ok(suggestion) = reverse_comparison(expr, checker.locator(), checker.stylist()) {
+    if let Ok(suggestion) =
+        reverse_comparison(compare.range(), checker.locator(), checker.stylist())
+    {
         let mut diagnostic = checker.report_diagnostic(
             YodaConditions {
                 suggestion: Some(SourceCodeSnippet::new(suggestion.clone())),
             },
-            expr.range(),
+            compare.range(),
         );
         diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
-            pad(suggestion, expr.range(), checker.locator()),
-            expr.range(),
+            pad(suggestion, compare.range(), checker.locator()),
+            compare.range(),
         )));
     } else {
-        checker.report_diagnostic(YodaConditions { suggestion: None }, expr.range());
+        checker.report_diagnostic(YodaConditions { suggestion: None }, compare.range());
     }
 }

--- a/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/rules/nunique_constant_series_check.rs
@@ -63,18 +63,12 @@ impl Violation for PandasNuniqueConstantSeriesCheck {
 }
 
 /// PD101
-pub(crate) fn nunique_constant_series_check(
-    checker: &Checker,
-    expr: &Expr,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
+pub(crate) fn nunique_constant_series_check(checker: &Checker, compare: &ast::ExprCompare) {
     if !checker.semantic().seen_module(Modules::PANDAS) {
         return;
     }
 
-    let ([op], [right]) = (ops, comparators) else {
+    let Some((left, op, right)) = compare.as_single() else {
         return;
     };
 
@@ -116,5 +110,5 @@ pub(crate) fn nunique_constant_series_check(
         return;
     }
 
-    checker.report_diagnostic(PandasNuniqueConstantSeriesCheck, expr.range());
+    checker.report_diagnostic(PandasNuniqueConstantSeriesCheck, compare.range());
 }

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/literal_comparisons.rs
@@ -213,19 +213,14 @@ pub(crate) fn literal_comparisons(checker: &Checker, compare: &ast::ExprCompare)
     let mut diagnostics = vec![];
 
     // Check `left`.
-    let Some((left, comparators)) = compare.operands.split_first() else {
-        return;
-    };
+    let left = compare.first_operand();
+    let comparators = compare.comparators();
     let mut comparator = left;
-    let [op, ..] = &*compare.ops else {
-        return;
-    };
-    let [next, ..] = comparators else {
-        return;
-    };
+    let op = compare.first_operator();
+    let next = compare.second_operand();
 
     if !helpers::is_constant_non_singleton(next) {
-        if let Some(op) = EqCmpOp::try_from(*op) {
+        if let Some(op) = EqCmpOp::try_from(op) {
             if checker.is_rule_enabled(Rule::NoneComparison) && comparator.is_none_literal_expr() {
                 match op {
                     EqCmpOp::Eq => {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/not_tests.rs
@@ -86,21 +86,14 @@ pub(crate) fn not_tests(checker: &Checker, unary_op: &ast::ExprUnaryOp) {
         return;
     }
 
-    let Expr::Compare(ast::ExprCompare {
-        ops,
-        operands,
-        range: _,
-        node_index: _,
-    }) = unary_op.operand.as_ref()
-    else {
+    let Expr::Compare(compare) = unary_op.operand.as_ref() else {
         return;
     };
 
-    let Some((left, comparators)) = operands.split_first() else {
-        return;
-    };
+    let left = compare.first_operand();
+    let comparators = compare.comparators();
 
-    match &**ops {
+    match &*compare.ops {
         [CmpOp::In] if checker.is_rule_enabled(Rule::NotInTest) => {
             let mut diagnostic = checker.report_diagnostic(NotInTest, unary_op.operand.range());
             diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/type_comparison.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 
 use ruff_python_ast::{self as ast, CmpOp, Expr};
@@ -63,13 +62,9 @@ impl Violation for TypeComparison {
 
 /// E721
 pub(crate) fn type_comparison(checker: &Checker, compare: &ast::ExprCompare) {
-    for (left, right) in compare
-        .operands
+    for (left, _, right) in compare
         .iter()
-        .tuple_windows()
-        .zip(&compare.ops)
-        .filter(|(_, op)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
-        .map(|((left, right), _)| (left, right))
+        .filter(|(_, op, _)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
     {
         // If either expression is a type...
         if is_type(left, checker.semantic()) || is_type(right, checker.semantic()) {

--- a/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/invalid_literal_comparisons.rs
@@ -3,7 +3,7 @@ use anyhow::{Error, bail};
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::helpers;
 use ruff_python_ast::token::{TokenKind, Tokens};
-use ruff_python_ast::{CmpOp, Expr};
+use ruff_python_ast::{CmpOp, ExprCompare};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::checkers::ast::Checker;
@@ -76,16 +76,9 @@ impl AlwaysFixableViolation for IsLiteral {
 }
 
 /// F632
-pub(crate) fn invalid_literal_comparison(
-    checker: &Checker,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-    expr: &Expr,
-) {
+pub(crate) fn invalid_literal_comparison(checker: &Checker, compare: &ExprCompare) {
     let mut lazy_located = None;
-    let mut left = left;
-    for (index, (op, right)) in ops.iter().zip(comparators).enumerate() {
+    for (index, (left, op, right)) in compare.iter().enumerate() {
         if matches!(op, CmpOp::Is | CmpOp::IsNot)
             && (helpers::is_constant_non_singleton(left)
                 || helpers::is_constant_non_singleton(right)
@@ -93,9 +86,9 @@ pub(crate) fn invalid_literal_comparison(
                 || helpers::is_mutable_iterable_initializer(right))
         {
             let mut diagnostic =
-                checker.report_diagnostic(IsLiteral { cmp_op: op.into() }, expr.range());
+                checker.report_diagnostic(IsLiteral { cmp_op: op.into() }, compare.range());
             if lazy_located.is_none() {
-                lazy_located = Some(locate_cmp_ops(expr, checker.tokens()));
+                lazy_located = Some(locate_cmp_ops(compare.range(), checker.tokens()));
             }
             diagnostic.try_set_optional_fix(|| {
                 if let Some(located_op) =
@@ -121,7 +114,6 @@ pub(crate) fn invalid_literal_comparison(
                 }
             });
         }
-        left = right;
     }
 }
 
@@ -145,9 +137,9 @@ impl From<&CmpOp> for IsCmpOp {
 ///
 /// This method iterates over the token stream and re-identifies [`CmpOp`] nodes, annotating them
 /// with valid ranges.
-fn locate_cmp_ops(expr: &Expr, tokens: &Tokens) -> Vec<LocatedCmpOp> {
+fn locate_cmp_ops(range: TextRange, tokens: &Tokens) -> Vec<LocatedCmpOp> {
     let mut tok_iter = tokens
-        .in_range(expr.range())
+        .in_range(range)
         .iter()
         .filter(|token| !token.kind().is_trivia())
         .peekable();
@@ -242,13 +234,13 @@ mod tests {
 
     use ruff_python_ast::CmpOp;
     use ruff_python_parser::parse_expression;
-    use ruff_text_size::TextSize;
+    use ruff_text_size::{Ranged, TextSize};
 
     use super::{LocatedCmpOp, locate_cmp_ops};
 
     fn extract_cmp_op_locations(source: &str) -> Result<Vec<LocatedCmpOp>> {
         let parsed = parse_expression(source)?;
-        Ok(locate_cmp_ops(parsed.expr(), parsed.tokens()))
+        Ok(locate_cmp_ops(parsed.expr().range(), parsed.tokens()))
     }
 
     #[test]

--- a/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/boolean_chained_comparison.rs
@@ -82,7 +82,7 @@ pub(crate) fn boolean_chained_comparison(checker: &Checker, expr_bool_op: &ExprB
             continue;
         };
 
-        let Some(Expr::Name(right_compare_left)) = right_compare.operands.first() else {
+        let Expr::Name(right_compare_left) = right_compare.first_operand() else {
             continue;
         };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/compare_to_empty_string.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/compare_to_empty_string.rs
@@ -1,6 +1,5 @@
 use anyhow::bail;
-use itertools::Itertools;
-use ruff_python_ast::{self as ast, CmpOp, Expr};
+use ruff_python_ast::{self as ast, CmpOp, Expr, ExprCompare};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
@@ -60,12 +59,7 @@ impl Violation for CompareToEmptyString {
 }
 
 /// PLC1901
-pub(crate) fn compare_to_empty_string(
-    checker: &Checker,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
+pub(crate) fn compare_to_empty_string(checker: &Checker, compare: &ExprCompare) {
     // Omit string comparison rules within subscripts. This is mostly commonly used within
     // DataFrame and np.ndarray indexing.
     if checker
@@ -77,11 +71,7 @@ pub(crate) fn compare_to_empty_string(
     }
 
     let mut first = true;
-    for ((lhs, rhs), op) in std::iter::once(left)
-        .chain(comparators)
-        .tuple_windows::<(&Expr, &Expr)>()
-        .zip(ops)
-    {
+    for (lhs, op, rhs) in compare.iter() {
         if let Ok(op) = EmptyStringCmpOp::try_from(op) {
             if std::mem::take(&mut first) {
                 // Check the left-most expression.

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_of_constant.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_of_constant.rs
@@ -1,5 +1,4 @@
-use itertools::Itertools;
-use ruff_python_ast::{CmpOp, Expr};
+use ruff_python_ast::{CmpOp, ExprCompare};
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_text_size::Ranged;
@@ -52,17 +51,8 @@ impl Violation for ComparisonOfConstant {
 }
 
 /// PLR0133
-pub(crate) fn comparison_of_constant(
-    checker: &Checker,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
-    for ((left, right), op) in std::iter::once(left)
-        .chain(comparators)
-        .tuple_windows()
-        .zip(ops)
-    {
+pub(crate) fn comparison_of_constant(checker: &Checker, compare: &ExprCompare) {
+    for (left, op, right) in compare.iter() {
         if left.is_literal_expr() && right.is_literal_expr() {
             checker.report_diagnostic(
                 ComparisonOfConstant {

--- a/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/comparison_with_itself.rs
@@ -1,7 +1,5 @@
-use itertools::Itertools;
-
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{CmpOp, Expr};
+use ruff_python_ast::{Expr, ExprCompare};
 use ruff_text_size::Ranged;
 
 use crate::Violation;
@@ -49,17 +47,8 @@ impl Violation for ComparisonWithItself {
 }
 
 /// PLR0124
-pub(crate) fn comparison_with_itself(
-    checker: &Checker,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
-    for ((left, right), op) in std::iter::once(left)
-        .chain(comparators)
-        .tuple_windows()
-        .zip(ops)
-    {
+pub(crate) fn comparison_with_itself(checker: &Checker, compare: &ExprCompare) {
+    for (left, op, right) in compare.iter() {
         match (left, right) {
             // Ex) `foo == foo`
             (Expr::Name(left_name), Expr::Name(right_name)) if left_name.id == right_name.id => {

--- a/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/if_stmt_min_max.rs
@@ -110,15 +110,12 @@ pub(crate) fn if_stmt_min_max(checker: &Checker, stmt_if: &ast::StmtIf) {
         return;
     };
 
-    let Some(ast::ExprCompare { ops, operands, .. }) = test.as_compare_expr() else {
+    let Some(compare) = test.as_compare_expr() else {
         return;
     };
 
     // Ignore, e.g., `foo < bar < baz`.
-    let [op] = &**ops else {
-        return;
-    };
-    let [left, right] = &**operands else {
+    let Some((left, op, right)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/literal_membership.rs
@@ -51,11 +51,7 @@ impl AlwaysFixableViolation for LiteralMembership {
 
 /// PLR6201
 pub(crate) fn literal_membership(checker: &Checker, compare: &ast::ExprCompare) {
-    if !matches!(&*compare.ops, [CmpOp::In | CmpOp::NotIn]) {
-        return;
-    }
-
-    let [left, right] = &*compare.operands else {
+    let Some((left, CmpOp::In | CmpOp::NotIn, right)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/magic_value_comparison.rs
@@ -120,8 +120,8 @@ fn is_sys_version_comparand(expr: &Expr, semantic: &SemanticModel) -> bool {
 }
 
 /// PLR2004
-pub(crate) fn magic_value_comparison(checker: &Checker, left: &Expr, comparators: &[Expr]) {
-    for (left, right) in std::iter::once(left).chain(comparators).tuple_windows() {
+pub(crate) fn magic_value_comparison(checker: &Checker, operands: &[Expr]) {
+    for (left, right) in operands.iter().tuple_windows() {
         // If both of the comparators are literals, skip rule for the whole expression.
         // R0133: comparison-of-constants
         if as_literal(left).is_some() && as_literal(right).is_some() {
@@ -130,7 +130,7 @@ pub(crate) fn magic_value_comparison(checker: &Checker, left: &Expr, comparators
     }
 
     let mut previous = None;
-    let mut operands = std::iter::once(left).chain(comparators).peekable();
+    let mut operands = operands.iter().peekable();
     while let Some(comparison_expr) = operands.next() {
         if let Some(value) = as_literal(comparison_expr)
             && is_magic_value(value, &checker.settings().pylint.allow_magic_value_types)

--- a/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/nan_comparison.rs
@@ -50,8 +50,8 @@ impl Violation for NanComparison {
 }
 
 /// PLW0177
-pub(crate) fn nan_comparison(checker: &Checker, left: &Expr, comparators: &[Expr]) {
-    nan_comparison_impl(checker, std::iter::once(left).chain(comparators));
+pub(crate) fn nan_comparison(checker: &Checker, operands: &[Expr]) {
+    nan_comparison_impl(checker, operands.iter());
 }
 
 /// PLW0177

--- a/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/repeated_equality_comparison.rs
@@ -229,14 +229,8 @@ fn to_allowed_value<'a>(
     value: &'a Expr,
     semantic: &SemanticModel,
 ) -> Option<(&'a Expr, &'a Expr)> {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = value else {
-        return None;
-    };
-
     // Ignore, e.g., `foo == bar == baz`.
-    let [op] = &**ops else {
-        return None;
-    };
+    let (left, op, right) = value.as_compare_expr()?.as_single()?;
 
     if match bool_op {
         BoolOp::Or => !matches!(op, CmpOp::Eq),
@@ -246,9 +240,6 @@ fn to_allowed_value<'a>(
     }
 
     // Ignore self-comparisons, e.g., `foo == foo`.
-    let [left, right] = &**operands else {
-        return None;
-    };
     if ComparableExpr::from(left) == ComparableExpr::from(right) {
         return None;
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/outdated_version_block.rs
@@ -91,17 +91,11 @@ enum Reason {
 /// UP036
 pub(crate) fn outdated_version_block(checker: &Checker, stmt_if: &StmtIf) {
     for branch in if_elif_branches(stmt_if) {
-        let Expr::Compare(ast::ExprCompare {
-            ops,
-            operands,
-            range: _,
-            node_index: _,
-        }) = &branch.test
-        else {
+        let Expr::Compare(compare) = &branch.test else {
             continue;
         };
 
-        let ([op], [left, comparison]) = (&**ops, &**operands) else {
+        let Some((left, op, comparison)) = compare.as_single() else {
             continue;
         };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/check_and_remove_from_set.rs
@@ -132,13 +132,7 @@ fn compare(lhs: &ComparableExpr, rhs: &ComparableExpr) -> bool {
 
 /// Match `if` condition to be `expr in name`, returns a tuple of (`expr`, `name`) on success.
 fn match_check(if_stmt: &ast::StmtIf) -> Option<(&Expr, &ast::ExprName)> {
-    let ast::ExprCompare { ops, operands, .. } = if_stmt.test.as_compare_expr()?;
-
-    if **ops != [CmpOp::In] {
-        return None;
-    }
-
-    let [left, Expr::Name(right @ ast::ExprName { .. })] = &**operands else {
+    let (left, CmpOp::In, Expr::Name(right)) = if_stmt.test.as_compare_expr()?.as_single()? else {
         return None;
     };
 

--- a/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_expr_min_max.rs
@@ -87,12 +87,12 @@ impl Violation for IfExprMinMax {
 
 /// FURB136
 pub(crate) fn if_expr_min_max(checker: &Checker, if_exp: &ast::ExprIf) {
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = if_exp.test.as_ref() else {
+    let Expr::Compare(compare) = if_exp.test.as_ref() else {
         return;
     };
 
     // Ignore, e.g., `foo < bar < baz`.
-    let [op] = &**ops else {
+    let Some((left, op, right)) = compare.as_single() else {
         return;
     };
 
@@ -104,10 +104,6 @@ pub(crate) fn if_expr_min_max(checker: &Checker, if_exp: &ast::ExprIf) {
         CmpOp::Lt => (MinMax::Min, true),
         CmpOp::LtE => (MinMax::Min, false),
         _ => return,
-    };
-
-    let [left, right] = &**operands else {
-        return;
     };
 
     let body_cmp = ComparableExpr::from(if_exp.body.as_ref());

--- a/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/reimplemented_operator.rs
@@ -430,12 +430,7 @@ fn cmp_op(expr: &ast::ExprCompare, params: &Parameters) -> Option<&'static str> 
     let [arg1, arg2] = params.args.as_slice() else {
         return None;
     };
-    let [op] = &*expr.ops else {
-        return None;
-    };
-    let [left, right] = &*expr.operands else {
-        return None;
-    };
+    let (left, op, right) = expr.as_single()?;
 
     match op {
         ast::CmpOp::Eq => match_arguments(arg1, arg2, left, right).then_some("eq"),

--- a/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
@@ -66,14 +66,8 @@ impl Violation for SingleItemMembershipTest {
 }
 
 /// FURB171
-pub(crate) fn single_item_membership_test(
-    checker: &Checker,
-    expr: &Expr,
-    left: &Expr,
-    ops: &[CmpOp],
-    comparators: &[Expr],
-) {
-    let ([op], [right]) = (ops, comparators) else {
+pub(crate) fn single_item_membership_test(checker: &Checker, compare: &ast::ExprCompare) {
+    let Some((left, op, right)) = compare.as_single() else {
         return;
     };
 
@@ -95,21 +89,24 @@ pub(crate) fn single_item_membership_test(
                 left,
                 &[membership_test.replacement_op()],
                 std::slice::from_ref(item),
-                expr.into(),
+                compare.into(),
                 checker.tokens(),
                 checker.source(),
             ),
-            expr.range(),
+            compare.range(),
             checker.locator(),
         ),
-        expr.range(),
+        compare.range(),
     );
 
     // All supported cases can change runtime behavior; mark as unsafe.
     let fix = Fix::unsafe_edit(edit);
 
     checker
-        .report_diagnostic(SingleItemMembershipTest { membership_test }, expr.range())
+        .report_diagnostic(
+            SingleItemMembershipTest { membership_test },
+            compare.range(),
+        )
         .set_fix(fix);
 }
 

--- a/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/type_none_comparison.rs
@@ -54,7 +54,7 @@ impl AlwaysFixableViolation for TypeNoneComparison {
 
 /// FURB169
 pub(crate) fn type_none_comparison(checker: &Checker, compare: &ast::ExprCompare) {
-    let ([op], [left, right]) = (&*compare.ops, &*compare.operands) else {
+    let Some((left, op, right)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/float_equality_comparison.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use ruff_macros::{ViolationMetadata, derive_message_formats};
 use ruff_python_ast::{self as ast, CmpOp, Expr};
 use ruff_python_semantic::{
@@ -126,20 +125,16 @@ pub(crate) fn float_equality_comparison(checker: &Checker, compare: &ast::ExprCo
     let locator = checker.locator();
     let semantic = checker.semantic();
 
-    for (left, right, operator) in compare
-        .operands
+    for (left, operator, right) in compare
         .iter()
-        .tuple_windows()
-        .zip(&compare.ops)
-        .filter(|(_, op)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
-        .filter(|((left, right), _)| {
+        .filter(|(_, op, _)| matches!(op, CmpOp::Eq | CmpOp::NotEq))
+        .filter(|(left, _, right)| {
             if should_skip_comparison(left, semantic) || should_skip_comparison(right, semantic) {
                 return false;
             }
 
             has_float(left, semantic) || has_float(right, semantic)
         })
-        .map(|((left, right), op)| (left, right, op))
     {
         checker.report_diagnostic(
             FloatEqualityComparison {

--- a/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/in_empty_collection.rs
@@ -38,15 +38,7 @@ impl Violation for InEmptyCollection {
 
 /// RUF060
 pub(crate) fn in_empty_collection(checker: &Checker, compare: &ast::ExprCompare) {
-    let [op] = &*compare.ops else {
-        return;
-    };
-
-    if !matches!(op, CmpOp::In | CmpOp::NotIn) {
-        return;
-    }
-
-    let [_, right] = &*compare.operands else {
+    let Some((_, CmpOp::In | CmpOp::NotIn, right)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_key_check.rs
@@ -69,15 +69,11 @@ pub(crate) fn unnecessary_key_check(checker: &Checker, expr: &Expr) {
     };
 
     // Left should be, e.g., `key in dct`.
-    let Expr::Compare(ast::ExprCompare { ops, operands, .. }) = left else {
+    let Expr::Compare(compare) = left else {
         return;
     };
 
-    if !matches!(&**ops, [CmpOp::In]) {
-        return;
-    }
-
-    let [key_left, obj_left] = &**operands else {
+    let Some((key_left, CmpOp::In, obj_left)) = compare.as_single() else {
         return;
     };
 

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_regular_expression.rs
@@ -438,25 +438,14 @@ enum ComparisonToNone {
 /// If the regex call is compared to `None`, return the comparison and its range.
 ///    Example: `re.search("abc", s) is None`
 fn get_comparison_to_none(semantic: &SemanticModel) -> Option<(ComparisonToNone, TextRange)> {
-    let parent_expr = semantic.current_expression_parent()?;
-
-    let Expr::Compare(ExprCompare {
-        ops,
-        operands,
-        range,
-        ..
-    }) = parent_expr
-    else {
+    let compare = semantic.current_expression_parent()?.as_compare_expr()?;
+    let (_, op, Expr::NoneLiteral(_)) = compare.as_single()? else {
         return None;
     };
 
-    let Some(Expr::NoneLiteral(_)) = operands.get(1) else {
-        return None;
-    };
-
-    match ops.as_ref() {
-        [CmpOp::Is] => Some((ComparisonToNone::Is, *range)),
-        [CmpOp::IsNot] => Some((ComparisonToNone::IsNot, *range)),
+    match op {
+        CmpOp::Is => Some((ComparisonToNone::Is, compare.range())),
+        CmpOp::IsNot => Some((ComparisonToNone::IsNot, compare.range())),
         _ => None,
     }
 }

--- a/crates/ruff_python_ast/src/node.rs
+++ b/crates/ruff_python_ast/src/node.rs
@@ -74,19 +74,10 @@ impl ast::ExprCompare {
     where
         V: SourceOrderVisitor<'a> + ?Sized,
     {
-        let ast::ExprCompare {
-            ops,
-            operands,
-            range: _,
-            node_index: _,
-        } = self;
-
-        if let Some((left, comparators)) = operands.split_first() {
-            visitor.visit_expr(left);
-            for (op, comparator) in ops.iter().zip(comparators) {
-                visitor.visit_cmp_op(op);
-                visitor.visit_expr(comparator);
-            }
+        visitor.visit_expr(self.first_operand());
+        for (_, op, right) in self.iter() {
+            visitor.visit_cmp_op(op);
+            visitor.visit_expr(right);
         }
     }
 }

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -144,6 +144,14 @@ impl ExprCompare {
         &self.operands[1..]
     }
 
+    /// Returns `(left, operator, right)` if there is exactly one operator and two operands.
+    pub fn as_single(&self) -> Option<(&Expr, &CmpOp, &Expr)> {
+        match (&*self.operands, &*self.ops) {
+            ([left, right], [op]) => Some((left, op, right)),
+            _ => None,
+        }
+    }
+
     /// Iterates over each comparison as `(left, operator, right)`.
     ///
     /// For `a < b <= c`, yields `(a, <, b)` followed by `(b, <=, c)`.

--- a/crates/ruff_python_ast/src/nodes.rs
+++ b/crates/ruff_python_ast/src/nodes.rs
@@ -2,7 +2,7 @@
 
 use crate::AtomicNodeIndex;
 use crate::generated::{
-    ExprBytesLiteral, ExprCall, ExprDict, ExprFString, ExprList, ExprName, ExprSet,
+    ExprBytesLiteral, ExprCall, ExprCompare, ExprDict, ExprFString, ExprList, ExprName, ExprSet,
     ExprStringLiteral, ExprTString, ExprTuple, PatternMatchAs, PatternMatchOr, StmtClassDef,
 };
 use std::borrow::Cow;
@@ -99,6 +99,62 @@ impl Expr {
     /// Return the [`OperatorPrecedence`] of this expression
     pub fn precedence(&self) -> OperatorPrecedence {
         OperatorPrecedence::from(self)
+    }
+}
+
+impl ExprCompare {
+    /// Returns the initial operand (`a` in `a < b <= c`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no operands. The parser always produces at least two operands,
+    /// synthesizing an invalid name expression for a missing operand during error recovery.
+    pub fn first_operand(&self) -> &Expr {
+        self.operands
+            .first()
+            .expect("A comparison has a left operand")
+    }
+
+    /// Returns the right operand of the first comparison (`b` in `a < b <= c`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are fewer than two operands. See [`Self::first_operand`].
+    pub fn second_operand(&self) -> &Expr {
+        self.operands
+            .get(1)
+            .expect("A comparison has a right operand")
+    }
+
+    /// Returns the first comparison operator (`<` in `a < b <= c`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no operators. The parser always produces at least one operator.
+    pub fn first_operator(&self) -> CmpOp {
+        *self.ops.first().expect("A comparison has an operator")
+    }
+
+    /// Returns all operands after the initial operand (`[b, c]` in `a < b <= c`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are no operands. See [`Self::first_operand`].
+    pub fn comparators(&self) -> &[Expr] {
+        &self.operands[1..]
+    }
+
+    /// Iterates over each comparison as `(left, operator, right)`.
+    ///
+    /// For `a < b <= c`, yields `(a, <, b)` followed by `(b, <=, c)`.
+    pub fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (&Expr, &CmpOp, &Expr)> + ExactSizeIterator {
+        self.operands
+            .iter()
+            .zip(self.ops.iter())
+            .zip(self.operands.iter().skip(1))
+            .map(|((left, op), right)| (left, op, right))
     }
 }
 

--- a/crates/ruff_python_ast/src/visitor.rs
+++ b/crates/ruff_python_ast/src/visitor.rs
@@ -512,20 +512,13 @@ pub fn walk_expr<'a, V: Visitor<'a> + ?Sized>(visitor: &mut V, expr: &'a Expr) {
             range: _,
             node_index: _,
         }) => visitor.visit_expr(value),
-        Expr::Compare(ast::ExprCompare {
-            ops,
-            operands,
-            range: _,
-            node_index: _,
-        }) => {
-            if let Some((left, comparators)) = operands.split_first() {
-                visitor.visit_expr(left);
-                for cmp_op in ops {
-                    visitor.visit_cmp_op(cmp_op);
-                }
-                for expr in comparators {
-                    visitor.visit_expr(expr);
-                }
+        Expr::Compare(compare) => {
+            visitor.visit_expr(compare.first_operand());
+            for cmp_op in &compare.ops {
+                visitor.visit_cmp_op(cmp_op);
+            }
+            for expr in compare.comparators() {
+                visitor.visit_expr(expr);
             }
         }
         Expr::Call(ast::ExprCall {

--- a/crates/ruff_python_codegen/src/generator.rs
+++ b/crates/ruff_python_codegen/src/generator.rs
@@ -1166,16 +1166,11 @@ impl<'a> Generator<'a> {
                     self.unparse_expr(value, precedence::MAX);
                 });
             }
-            Expr::Compare(ast::ExprCompare {
-                ops,
-                operands,
-                range: _,
-                node_index: _,
-            }) => {
+            Expr::Compare(compare) => {
                 group_if!(precedence::CMP, {
                     let new_lvl = precedence::CMP + 1;
-                    self.unparse_expr(&operands[0], new_lvl);
-                    for (op, cmp) in ops.iter().zip(&operands[1..]) {
+                    self.unparse_expr(compare.first_operand(), new_lvl);
+                    for (_, op, cmp) in compare.iter() {
                         let op = match op {
                             CmpOp::Eq => " == ",
                             CmpOp::NotEq => " != ",

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -62,11 +62,9 @@ impl<'a> BinaryLike<'a> {
                 "Compare expression with an unbalanced number of comparators and operations."
             );
 
-            if let Some((last_expression, middle_expressions)) = compare.comparators().split_last()
-            {
-                let (last_operator, middle_operators) = compare.ops.split_last().unwrap();
-
-                for (operator, expression) in middle_operators.iter().zip(middle_expressions) {
+            let mut comparisons = compare.iter();
+            if let Some((_, last_operator, last_expression)) = comparisons.next_back() {
+                for (_, operator, expression) in comparisons {
                     parts.push(OperandOrOperator::Operator(Operator {
                         symbol: OperatorSymbol::Comparator(*operator),
                         trailing_comments: &[],

--- a/crates/ruff_python_formatter/src/expression/binary_like.rs
+++ b/crates/ruff_python_formatter/src/expression/binary_like.rs
@@ -48,7 +48,7 @@ impl<'a> BinaryLike<'a> {
 
             rec(
                 Operand::Left {
-                    expression: &compare.operands[0],
+                    expression: compare.first_operand(),
                     leading_comments,
                 },
                 comments,
@@ -62,7 +62,7 @@ impl<'a> BinaryLike<'a> {
                 "Compare expression with an unbalanced number of comparators and operations."
             );
 
-            if let Some((last_expression, middle_expressions)) = compare.operands[1..].split_last()
+            if let Some((last_expression, middle_expressions)) = compare.comparators().split_last()
             {
                 let (last_operator, middle_operators) = compare.ops.split_last().unwrap();
 

--- a/crates/ruff_python_formatter/src/expression/expr_compare.rs
+++ b/crates/ruff_python_formatter/src/expression/expr_compare.rs
@@ -26,14 +26,13 @@ impl NeedsParentheses for ExprCompare {
     ) -> OptionalParentheses {
         if parent.is_expr_await() {
             OptionalParentheses::Always
-        } else if let Ok(string) = StringLike::try_from(&self.operands[0]) {
+        } else if let Ok(string) = StringLike::try_from(self.first_operand()) {
             // Multiline strings are guaranteed to never fit, avoid adding unnecessary parentheses
             if !string.is_implicit_concatenated()
                 && string.is_multiline(context)
                 && !context.comments().has(string)
-                && self.operands.get(1).is_some_and(|right| {
-                    has_parentheses(right, context).is_some() && !context.comments().has(right)
-                })
+                && has_parentheses(self.second_operand(), context).is_some()
+                && !context.comments().has(self.second_operand())
             {
                 OptionalParentheses::Never
             } else {

--- a/crates/ruff_python_formatter/src/expression/mod.rs
+++ b/crates/ruff_python_formatter/src/expression/mod.rs
@@ -1436,7 +1436,7 @@ pub(crate) fn left_most<'expr>(expression: &'expr Expr, trivia: &TriviaRanges) -
             | Expr::Subscript(ast::ExprSubscript { value: left, .. }) => Some(&**left),
 
             Expr::BoolOp(expr_bool_op) => expr_bool_op.values.first(),
-            Expr::Compare(compare) => compare.operands.first(),
+            Expr::Compare(compare) => Some(compare.first_operand()),
 
             Expr::Generator(generator) if !generator.parenthesized => Some(&*generator.elt),
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -3633,16 +3633,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         || !Self::condition_evaluation_is_known_safe(&unary.operand),
                 );
             }
-            ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) => {
-                if let Some((left, comparators)) = operands.split_first() {
-                    self.visit_expr(left);
-                    for (op, comparator) in ops.iter().zip(comparators) {
-                        self.visit_expr(comparator);
-                        self.record_exception_checkpoint_if(!matches!(
-                            op,
-                            ast::CmpOp::Is | ast::CmpOp::IsNot
-                        ));
-                    }
+            ast::Expr::Compare(compare) => {
+                self.visit_expr(compare.first_operand());
+                for (_, op, right) in compare.iter() {
+                    self.visit_expr(right);
+                    self.record_exception_checkpoint_if(!matches!(
+                        op,
+                        ast::CmpOp::Is | ast::CmpOp::IsNot
+                    ));
                 }
             }
             ast::Expr::BoolOp(node) => self.visit_bool_expression(node, context),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -11542,16 +11542,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn infer_compare_expression(&mut self, compare: &ast::ExprCompare) -> Type<'db> {
         let db = self.db();
-        let ast::ExprCompare {
-            range: _,
-            node_index: _,
-            ops,
-            operands,
-        } = compare;
-
-        if let Some(left) = operands.first() {
-            self.infer_expression(left, TypeContext::default());
-        }
+        self.infer_expression(compare.first_operand(), TypeContext::default());
         let mut last_comparison_ty = Type::unknown();
 
         // https://docs.python.org/3/reference/expressions.html#comparisons
@@ -11567,9 +11558,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = self.infer_chained_boolean_types(
             ast::BoolOp::And,
             false,
-            operands.iter().tuple_windows::<(_, _)>().zip(ops),
+            compare.iter(),
             |_| false,
-            |builder, ((left, right), op), _peer_ty| {
+            |builder, (left, op, right), _peer_ty| {
                 let left_ty = builder.expression_type(left);
                 let right_ty = builder.infer_expression(right, TypeContext::default());
 
@@ -11608,7 +11599,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             },
         );
 
-        if ops.len() > 1 {
+        if compare.ops.len() > 1 {
             // Individual comparisons within a chain have no expression nodes whose result types
             // reachability can look up later. Retain their combined condition truthiness here;
             // `and`/`or` conditions can instead be reconstructed by walking their operand nodes.

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -978,9 +978,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let candidates = match operand {
             ast::Expr::Name(_) => [Some(operand), None],
-            ast::Expr::Compare(compare) if compare.ops.len() == 1 => {
-                [compare.operands.first(), compare.operands.get(1)]
-            }
+            ast::Expr::Compare(compare) if compare.ops.len() == 1 => [
+                Some(compare.first_operand()),
+                Some(compare.second_operand()),
+            ],
             ast::Expr::Call(call) => [call.arguments.args.first(), None],
             _ => return None,
         };

--- a/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/redundant_conditions/diagnostic.rs
@@ -122,9 +122,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ));
             }
 
-            if let ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test
-                && ops.len() == 1
-                && let [left, single_comparator] = &**operands
+            if let ast::Expr::Compare(compare) = test
+                && let Some((left, _, single_comparator)) = compare.as_single()
             {
                 if let (Type::LiteralValue(left_type), Type::LiteralValue(right_type)) = (
                     self.expression_type(left),
@@ -619,9 +618,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let db = self.db();
         let env = self.program_environment();
 
-        if let ast::Expr::Compare(ast::ExprCompare { ops, operands, .. }) = test
-            && let [single_op] = &**ops
-            && let [left, single_comparator] = &**operands
+        if let ast::Expr::Compare(compare) = test
+            && let Some((left, single_op, single_comparator)) = compare.as_single()
             && let (ast::Expr::Call(call), other) | (other, ast::Expr::Call(call)) =
                 (left, single_comparator)
             && matches!(single_op, ast::CmpOp::Eq | ast::CmpOp::NotEq)
@@ -978,10 +976,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let candidates = match operand {
             ast::Expr::Name(_) => [Some(operand), None],
-            ast::Expr::Compare(compare) if compare.ops.len() == 1 => [
-                Some(compare.first_operand()),
-                Some(compare.second_operand()),
-            ],
+            ast::Expr::Compare(compare) => {
+                let (left, _, right) = compare.as_single()?;
+                [Some(left), Some(right)]
+            }
             ast::Expr::Call(call) => [call.arguments.args.first(), None],
             _ => return None,
         };

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4055,17 +4055,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let inference = infer_expression_types(db, expression, TypeContext::default());
 
         let mut constraints = NarrowingConstraints::default();
-        let left = expr_compare.first_operand();
-        let right = expr_compare.second_operand();
 
         // Narrow unions of tuples based on element checks. For example:
         //
         //     def _(t: tuple[int, int] | tuple[None, None]):
         //         if t[0] is not None:
         //             reveal_type(t)  # tuple[int, int]
-        if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
-            && let is_positive_check =
-                is_positive == (expr_compare.first_operator() == ast::CmpOp::Is)
+        if let Some((left, op @ (ast::CmpOp::Is | ast::CmpOp::IsNot), right)) =
+            expr_compare.as_single()
+            && let is_positive_check = is_positive == (*op == ast::CmpOp::Is)
             && let ast::Expr::Subscript(subscript) = left.expression_value()
             && let Type::Union(union) = inference
                 .expression_type(&*subscript.value)
@@ -4093,7 +4091,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
-        if let [op] = &**ops
+        if let Some((left, op, right)) = expr_compare.as_single()
             && let Some(comparison) = LengthComparison::from_op(*op, is_positive)
         {
             let mut narrow_len_call =
@@ -4159,10 +4157,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //
         // Importantly, `my_typeddict_union["tag"]` isn't the place we're going to constrain.
         // Instead, we're going to constrain `my_typeddict_union` itself.
-        if matches!(&**ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq]) {
+        if let Some((left, op @ (ast::CmpOp::Eq | ast::CmpOp::NotEq), right)) =
+            expr_compare.as_single()
+        {
             // For `==`, we use equality semantics on the `if` branch (is_positive=true).
             // For `!=`, we use equality semantics on the `else` branch (is_positive=false).
-            let is_equality = is_positive == (expr_compare.first_operator() == ast::CmpOp::Eq);
+            let is_equality = is_positive == (*op == ast::CmpOp::Eq);
 
             let mut narrow_subscript = |subscript: &ast::ExprSubscript, other_type: Type<'db>| {
                 let value_type = inference.expression_type(&*subscript.value);
@@ -4196,9 +4196,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
         }
 
-        if let [
+        if let Some((
+            left,
             operator @ (ast::CmpOp::Eq | ast::CmpOp::NotEq | ast::CmpOp::Is | ast::CmpOp::IsNot),
-        ] = &**ops
+            right,
+        )) = expr_compare.as_single()
         {
             let comparison = if matches!(operator, ast::CmpOp::Is | ast::CmpOp::IsNot) {
                 NominalAttributeComparison::Identity
@@ -4249,7 +4251,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         // def _(u: Foo | Bar):
         //     if "foo" not in u:
         //         reveal_type(u)  # revealed: Bar
-        if matches!(&**ops, [ast::CmpOp::In | ast::CmpOp::NotIn])
+        if let Some((left, op @ (ast::CmpOp::In | ast::CmpOp::NotIn), right)) =
+            expr_compare.as_single()
             && let Some(key) = inference.expression_type(left).as_string_literal()
             && let rhs_expr = right.expression_value()
             && let rhs_type = inference.expression_type(right)
@@ -4274,7 +4277,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     }
                 };
 
-            if is_positive == (expr_compare.first_operator() == ast::CmpOp::In) {
+            if is_positive == (*op == ast::CmpOp::In) {
                 let narrowed = self.narrow_with_present_key(rhs_type, key);
                 if narrowed != rhs_type.resolve_type_alias(db) {
                     apply_constraint(&mut constraints, NarrowingConstraint::replacement(narrowed));

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -4054,10 +4054,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         let inference = infer_expression_types(db, expression, TypeContext::default());
 
-        let comparator_tuples = operands
-            .iter()
-            .tuple_windows::<(&ruff_python_ast::Expr, &ruff_python_ast::Expr)>();
         let mut constraints = NarrowingConstraints::default();
+        let left = expr_compare.first_operand();
+        let right = expr_compare.second_operand();
 
         // Narrow unions of tuples based on element checks. For example:
         //
@@ -4065,8 +4064,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //         if t[0] is not None:
         //             reveal_type(t)  # tuple[int, int]
         if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
-            && let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is)
-            && let ast::Expr::Subscript(subscript) = operands[0].expression_value()
+            && let is_positive_check =
+                is_positive == (expr_compare.first_operator() == ast::CmpOp::Is)
+            && let ast::Expr::Subscript(subscript) = left.expression_value()
             && let Type::Union(union) = inference
                 .expression_type(&*subscript.value)
                 .resolve_type_alias(db)
@@ -4075,7 +4075,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .expression_type(&*subscript.slice)
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
-            && let rhs_ty = inference.expression_type(&operands[1])
+            && let rhs_ty = inference.expression_type(right)
         {
             let filtered = union.filter(db, |elem| {
                 elem.tuple_instance_spec(db, &self.env)
@@ -4133,15 +4133,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
 
             // E.g., `len(items) == 2`
-            if let ast::Expr::Call(call) = operands[0].expression_value() {
-                narrow_len_call(call, inference.expression_type(&operands[1]), comparison);
+            if let ast::Expr::Call(call) = left.expression_value() {
+                narrow_len_call(call, inference.expression_type(right), comparison);
             }
 
             // E.g., `2 == len(items)`
-            if let ast::Expr::Call(call) = operands[1].expression_value() {
+            if let ast::Expr::Call(call) = right.expression_value() {
                 narrow_len_call(
                     call,
-                    inference.expression_type(&operands[0]),
+                    inference.expression_type(left),
                     comparison.reflected(),
                 );
             }
@@ -4162,7 +4162,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if matches!(&**ops, [ast::CmpOp::Eq | ast::CmpOp::NotEq]) {
             // For `==`, we use equality semantics on the `if` branch (is_positive=true).
             // For `!=`, we use equality semantics on the `else` branch (is_positive=false).
-            let is_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
+            let is_equality = is_positive == (expr_compare.first_operator() == ast::CmpOp::Eq);
 
             let mut narrow_subscript = |subscript: &ast::ExprSubscript, other_type: Type<'db>| {
                 let value_type = inference.expression_type(&*subscript.value);
@@ -4187,12 +4187,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             };
 
-            if let ast::Expr::Subscript(subscript) = operands[0].expression_value() {
-                narrow_subscript(subscript, inference.expression_type(&operands[1]));
+            if let ast::Expr::Subscript(subscript) = left.expression_value() {
+                narrow_subscript(subscript, inference.expression_type(right));
             }
 
-            if let ast::Expr::Subscript(subscript) = operands[1].expression_value() {
-                narrow_subscript(subscript, inference.expression_type(&operands[0]));
+            if let ast::Expr::Subscript(subscript) = right.expression_value() {
+                narrow_subscript(subscript, inference.expression_type(left));
             }
         }
 
@@ -4223,17 +4223,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             };
 
-            if let ast::Expr::Attribute(attribute) = &operands[0]
-                && operands[1].as_named_expr().is_none_or(|named| {
+            if let ast::Expr::Attribute(attribute) = left
+                && right.as_named_expr().is_none_or(|named| {
                     PlaceExpr::try_from_expr(&named.target)
                         != PlaceExpr::try_from_expr(&attribute.value)
                 })
             {
-                narrow_attribute(attribute, inference.expression_type(&operands[1]));
+                narrow_attribute(attribute, inference.expression_type(right));
             }
 
-            if let ast::Expr::Attribute(attribute) = &operands[1] {
-                narrow_attribute(attribute, inference.expression_type(&operands[0]));
+            if let ast::Expr::Attribute(attribute) = right {
+                narrow_attribute(attribute, inference.expression_type(left));
             }
         }
 
@@ -4250,16 +4250,16 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         //     if "foo" not in u:
         //         reveal_type(u)  # revealed: Bar
         if matches!(&**ops, [ast::CmpOp::In | ast::CmpOp::NotIn])
-            && let Some(key) = inference.expression_type(&operands[0]).as_string_literal()
-            && let rhs_expr = operands[1].expression_value()
-            && let rhs_type = inference.expression_type(&operands[1])
+            && let Some(key) = inference.expression_type(left).as_string_literal()
+            && let rhs_expr = right.expression_value()
+            && let rhs_type = inference.expression_type(right)
             && is_or_contains_typeddict(db, rhs_type)
         {
             let key = key.value(db);
             let apply_constraint =
                 |constraints: &mut NarrowingConstraints<'db>,
                  constraint: NarrowingConstraint<'db>| {
-                    let comparator_place = PlaceExpr::try_from_expr(&operands[1])
+                    let comparator_place = PlaceExpr::try_from_expr(right)
                         .and_then(|place_expr| self.places().place_id(&place_expr));
                     if let Some(place) = comparator_place {
                         constraints.insert(place, constraint.clone());
@@ -4274,7 +4274,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     }
                 };
 
-            if is_positive == (ops[0] == ast::CmpOp::In) {
+            if is_positive == (expr_compare.first_operator() == ast::CmpOp::In) {
                 let narrowed = self.narrow_with_present_key(rhs_type, key);
                 if narrowed != rhs_type.resolve_type_alias(db) {
                     apply_constraint(&mut constraints, NarrowingConstraint::replacement(narrowed));
@@ -4343,7 +4343,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         };
         let mut last_rhs_ty: Option<Type> = None;
 
-        for (op, (left, right)) in std::iter::zip(&**ops, comparator_tuples) {
+        for (left, op, right) in expr_compare.iter() {
             let lhs_ty = last_rhs_ty.unwrap_or_else(|| expression_type(left, &self.env));
             let rhs_ty = expression_type(right, &self.env);
             let lhs_narrowing_rhs_ty = if matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn) {


### PR DESCRIPTION
## Summary

We add accessors and iteration methods to `ExprCompare` and use them throughout AST visitors, formatting, lint rules, and type inference. For `a < b <= c`, `iter` yields `(a, Lt, b)` and `(b, LtE, c)`. `as_single` returns a triple only when there is exactly one operator and two operands, so callers can match an operator and both operands together while rejecting comparison chains. Rules that only inspect operands use the existing operand slice directly.

The `first_operand`, `first_operator`, and `second_operand` accessors assert the parser's existing guarantee that a comparison has at least one operator and two operands. Error recovery synthesizes missing operands; manually constructed ASTs must uphold the same invariant.
