### PR TITLE
ensure prepare release changes pass prek

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -64,6 +64,16 @@ jobs:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           INPUT_VERSION: ${{ inputs.version }}
 
+      - name: "Format and check release changes"
+        shell: bash
+        run: |
+          mapfile -d '' files < <(git diff --name-only --diff-filter=ACMR -z HEAD)
+          if (( ${#files[@]} )); then
+            # Hooks can fix generated files and exit nonzero. Require a clean pass before committing.
+            uv run --only-dev --locked prek run --files "${files[@]}" ||
+              uv run --only-dev --locked prek run --files "${files[@]}"
+          fi
+
       - name: "Create release branch"
         run: |
           version="$(uv version --short)"


### PR DESCRIPTION
in release-prepare.yml, run prek to auto format and re-check before committing

observed in https://github.com/astral-sh/ruff/pull/28487, the generated changelog did not pass prek.