### PR TITLE
Install rustfmt before linting releases

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -64,6 +64,9 @@ jobs:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
           INPUT_VERSION: ${{ inputs.version }}
 
+      - name: "Install Rust toolchain"
+        run: rustup component add rustfmt
+
       - name: "Format and check release changes"
         shell: bash
         run: |


### PR DESCRIPTION
Summary
--

Fixes the prek step in the prepare release workflow:

https://github.com/astral-sh/ruff/actions/runs/34504504512/job/102963217706

I was surprised prek didn't handle this, but I guess that's how we defined the hook:

https://github.com/astral-sh/ruff/blob/1713a1f4325494d883a080d590a25a1946f399e8/.pre-commit-config.yaml#L47-L54

Test Plan
--

Preparing today's release
