### PR TITLE
[ty] Preserve recursive metadata in union transformations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/tuple.md
@@ -499,6 +499,21 @@ def test2(val: tuple[str, None] | list[int | float]):
     reveal_type(val[0])  # revealed: str | float
 ```
 
+## Repeated indexing with a union of indices
+
+An index can select either zero or the value from the previous iteration. Repeatedly adding one can
+produce arbitrarily large integers, so the result has type `int`.
+
+```py
+from typing import Literal
+
+def count(n: int, index: Literal[0, 1]):
+    value = 0
+    for _ in range(n):
+        value = (0, value)[index] + 1
+    reveal_type(value)  # revealed: int
+```
+
 ## Union subscript access with non-indexable type
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_qualifiers/final.md
@@ -112,6 +112,31 @@ class ScopeChain:
         self.depth: Final = 1 if parent is None else parent.depth + 1
 ```
 
+### Recursive bare `Final` class attributes
+
+A class defined in a loop can compute final attributes from the previous class. The number of
+iterations is unknown, so these growing values have types `int`, `str`, and `bytes`.
+
+```py
+from typing import Final
+
+def build_classes(n: int):
+    class C:
+        count: Final = 0
+        label: Final = ""
+        data: Final = b""
+
+    for _ in range(n):
+        class C:
+            count: Final = C.count + 1
+            label: Final = C.label + "a"
+            data: Final = C.data + b"a"
+
+    reveal_type(C.count)  # revealed: int
+    reveal_type(C.label)  # revealed: str
+    reveal_type(C.data)  # revealed: bytes
+```
+
 ## Not modifiable
 
 ### Names

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -8892,7 +8892,7 @@ impl<'db> Type<'db> {
 
                     if union.recursively_defined(db).is_yes() {
                         expanded_callables =
-                            expanded_callables.recursively_defined(RecursivelyDefined::Yes);
+                            expanded_callables.or_recursively_defined(RecursivelyDefined::Yes);
                     }
                 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2620,7 +2620,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let place = loop_header_kind.place();
         let env = self.program_environment();
-        let mut union = UnionBuilder::new(db, env).recursively_defined(RecursivelyDefined::Yes);
+        let mut union = UnionBuilder::new(db, env).or_recursively_defined(RecursivelyDefined::Yes);
 
         for reachable_binding in &loop_header.reachable_bindings {
             let binding_ty = binding_type(db, reachable_binding.definition);
@@ -2666,7 +2666,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             NestedBindingExecution::Eager => RecursivelyDefined::No,
         };
         let env = self.program_environment();
-        let mut union = UnionBuilder::new(db, env).recursively_defined(recursively_defined);
+        let mut union = UnionBuilder::new(db, env).or_recursively_defined(recursively_defined);
         for bindings in binding_sources {
             if nested_bindings_kind.execution == NestedBindingExecution::Eager {
                 // A comprehension can execute repeatedly, so a source that is unreachable in the

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1994,8 +1994,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             Type::Union(union) => {
                 let db = self.db();
-                let mut union_builder =
-                    UnionBuilder::new(db, env).recursively_defined(union.recursively_defined(db));
+                let mut union_builder = UnionBuilder::new(db, env)
+                    .or_recursively_defined(union.recursively_defined(db));
 
                 for (index, element) in union.elements(db).iter().enumerate() {
                     let mut speculative_builder = self.speculate();

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -210,7 +210,7 @@ impl<'db> UnionType<'db> {
                     builder.add_in_place(transform_fn(element));
                 }
                 return builder
-                    .recursively_defined(self.recursively_defined(db))
+                    .or_recursively_defined(self.recursively_defined(db))
                     .build();
             }
         }
@@ -255,7 +255,7 @@ impl<'db> UnionType<'db> {
                     builder.add_in_place(transform_fn(element)?);
                 }
                 return Ok(builder
-                    .recursively_defined(self.recursively_defined(db))
+                    .or_recursively_defined(self.recursively_defined(db))
                     .build());
             }
         }
@@ -358,7 +358,7 @@ impl<'db> UnionType<'db> {
         } else {
             Place::Defined(DefinedPlace {
                 ty: builder
-                    .recursively_defined(self.recursively_defined(db))
+                    .or_recursively_defined(self.recursively_defined(db))
                     .build(),
                 origin,
                 definedness: if possibly_unbound {
@@ -419,7 +419,7 @@ impl<'db> UnionType<'db> {
             } else {
                 Place::Defined(DefinedPlace {
                     ty: builder
-                        .recursively_defined(self.recursively_defined(db))
+                        .or_recursively_defined(self.recursively_defined(db))
                         .build(),
                     origin,
                     definedness: if possibly_unbound {
@@ -445,7 +445,7 @@ impl<'db> UnionType<'db> {
         let mut builder = UnionBuilder::new(db, env)
             .unpack_aliases(false)
             .cycle_recovery(true)
-            .recursively_defined(self.recursively_defined(db));
+            .or_recursively_defined(self.recursively_defined(db));
         let mut empty = true;
         for ty in self.elements(db) {
             if nested {
@@ -460,7 +460,7 @@ impl<'db> UnionType<'db> {
                 // `Divergent` in a union type does not mean true divergence, so we skip it if not nested.
                 // e.g. T | Divergent == T | (T | (T | (T | ...))) == T
                 if (*ty).same_divergent_marker(div) {
-                    builder = builder.recursively_defined(RecursivelyDefined::Yes);
+                    builder = builder.or_recursively_defined(RecursivelyDefined::Yes);
                     continue;
                 }
                 builder.add_in_place(

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -602,8 +602,9 @@ impl<'db> UnionBuilder<'db> {
         self
     }
 
-    pub(crate) fn recursively_defined(mut self, val: RecursivelyDefined) -> Self {
-        self.recursively_defined = val;
+    /// Preserve recursion from both the source union and any transformed elements already added.
+    pub(crate) fn or_recursively_defined(mut self, val: RecursivelyDefined) -> Self {
+        self.recursively_defined = self.recursively_defined.or(val);
         self
     }
 
@@ -1178,7 +1179,7 @@ impl<'db> UnionBuilder<'db> {
             let builder = UnionBuilder::new(db, &self.env)
                 .unpack_aliases(unpack_aliases)
                 .cycle_recovery(cycle_recovery)
-                .recursively_defined(recursively_defined);
+                .or_recursively_defined(recursively_defined);
             return types
                 .into_iter()
                 .fold(builder, UnionBuilder::add)
@@ -2194,7 +2195,7 @@ mod tests {
         let union = (0..=literal_limit).map(Type::int_literal).fold(
             UnionBuilder::new(db, &env)
                 .cycle_recovery(true)
-                .recursively_defined(RecursivelyDefined::Yes),
+                .or_recursively_defined(RecursivelyDefined::Yes),
             UnionBuilder::add,
         );
 

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -418,7 +418,7 @@ fn map_subscript_alternatives<'db>(
     }
 
     if let Type::Union(union) = full_object_ty {
-        builder = builder.recursively_defined(union.recursively_defined(db));
+        builder = builder.or_recursively_defined(union.recursively_defined(db));
     }
     if errors.is_empty() {
         Ok(if preserves_typevar {

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -225,7 +225,7 @@ impl<'db> Type<'db> {
 
         let mut builder = UnionBuilder::new(db, env)
             .unpack_aliases(false)
-            .recursively_defined(union.recursively_defined(db));
+            .or_recursively_defined(union.recursively_defined(db));
 
         for element in other_union_elements {
             builder = builder.add(element);


### PR DESCRIPTION
## Summary

Trying to check these codes causes a panic:

```python
from typing import Literal

def count(n: int, index: Literal[0, 1]):
    value = 0
    for _ in range(n):
        value = (0, value)[index] + 1
    reveal_type(value)  # expected: int
```

```python
from typing import Final

def build_classes(n: int):
    class C:
        count: Final = 0

    for _ in range(n):
        class C:
            count: Final = C.count + 1

    reveal_type(C.count)  # expected: int
```

Both issues are caused by the mechanism that widens literal types to guarantee convergence not working correctly. This is related to https://github.com/astral-sh/ruff/issues/23875, where the problem is that the `RecursivelyDefined` flag used to trigger widening gets reset.

While `UnionBuilder::recursively_defined(val)` currently overwrites the flag with `val` regardless of its current state, it should instead be updated using OR between the current flag and `val`.

## Test Plan

mdtest updated
