### PR TITLE
[`pyupgrade`] Stop recommending deprecated `ByteString` aliases (`UP035`)

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/deprecated_import.rs
@@ -253,7 +253,6 @@ const TYPING_TO_COLLECTIONS_ABC_39: &[&str] = &[
     "AsyncIterable",
     "AsyncIterator",
     "Awaitable",
-    "ByteString",
     "Collection",
     "Container",
     "Coroutine",

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP035.py.snap
@@ -438,24 +438,6 @@ help: Import from `collections.abc`
 54 | from typing import ByteString
    |
 
-UP035 [*] Import from `collections.abc` instead: `ByteString`
-  --> UP035.py:54:1
-   |
-52 | from typing_extensions import OrderedDict
-53 | from typing import Callable
-54 | from typing import ByteString
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-55 | from typing import Container
-56 | from typing import Hashable
-   |
-help: Import from `collections.abc`
-   |
-53 | from typing import Callable
-   - from typing import ByteString
-54 + from collections.abc import ByteString
-55 | from typing import Container
-   |
-
 UP035 [*] Import from `collections.abc` instead: `Container`
   --> UP035.py:55:1
    |


### PR DESCRIPTION
Summary
--

If I had realized how small this was, I would have just bundled it with #28475, but this is another
tiny change to `UP035` to avoid replacing `typing.ByteString` with `collections.abc.ByteString`, now
that both are deprecated. The `typing` variant has been deprecated since 3.9 and the
`collections.abc` version since 3.12, and they've now been removed from their respective `__all__`s
in 3.15 in preparation for removal in 3.17.

The `collections.ByteString` to `collections.abc.ByteString` transformation is retained since
`collections.ByteString` was fully removed back in 3.10.

Test Plan
--

Updated an existing snapshot
