### PR TITLE
[flake8-bandit] Detect references to builtin exec

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S102.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_bandit/S102.py
@@ -4,6 +4,9 @@ def fn():
 
 exec('y = 3')
 
+map(exec, [])  # Error
+foo = exec  # Error
+
 
 ## https://github.com/astral-sh/ruff/issues/15442
 def _():

--- a/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/expression.rs
@@ -304,6 +304,9 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                     ]) {
                         flake8_bandit::rules::suspicious_function_reference(checker, expr);
                     }
+                    if checker.is_rule_enabled(Rule::ExecBuiltin) {
+                        flake8_bandit::rules::exec_used(checker, expr);
+                    }
 
                     // Ex) List[...]
                     if checker.any_rule_enabled(&[
@@ -426,6 +429,9 @@ pub(crate) fn expression(expr: &Expr, checker: &Checker) {
                     Rule::SuspiciousUnverifiedContextUsage,
                 ]) {
                     flake8_bandit::rules::suspicious_function_reference(checker, expr);
+                }
+                if checker.is_rule_enabled(Rule::ExecBuiltin) {
+                    flake8_bandit::rules::exec_used(checker, expr);
                 }
             }
 

--- a/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
+++ b/crates/ruff_linter/src/rules/flake8_bandit/rules/exec_used.rs
@@ -36,6 +36,12 @@ impl Violation for ExecBuiltin {
 /// S102
 pub(crate) fn exec_used(checker: &Checker, func: &Expr) {
     if checker.semantic().match_builtin_expr(func, "exec") {
+        if matches!(
+            checker.semantic().current_expression_parent(),
+            Some(Expr::Call(parent)) if parent.func.range().contains_range(func.range())
+        ) {
+            return;
+        }
         checker.report_diagnostic(ExecBuiltin, func.range());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #28011. S102 now reports references to the builtin `exec`, including passing it as a callable or assigning it to another name, while avoiding a duplicate diagnostic for direct calls.

## Test plan

- Added regression cases to the existing S102 fixture.
- `git diff --check` passed.
- Repository hooks passed all available checks; the Rust formatter could not run locally because `cargo`/`rustfmt` are not installed.

This contribution was prepared with assistance from OpenAI Codex.