### PR TITLE
[flake8-pyi] Fix PYI063 for __new__ methods

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.py
@@ -28,6 +28,7 @@ class Foo:
     def this_is_bad_too(__x: int) -> None: ...  # PYI063
     @classmethod
     def not_good(cls, __foo: int) -> None: ...  # PYI063
+    def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
 
     # The first non-self argument isn't positional-only, so logically the second can't be either:
     def okay1(self, x: int, __y: int) -> None: ...

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.py
@@ -30,6 +30,9 @@ class Foo:
     def not_good(cls, __foo: int) -> None: ...  # PYI063
     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
 
+    @staticmethod
+    def __new__(__cls, __name: str, __later: str) -> Self: ...  # PYI063
+
     # The first non-self argument isn't positional-only, so logically the second can't be either:
     def okay1(self, x: int, __y: int) -> None: ...
     # Same here:

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.pyi
@@ -28,6 +28,7 @@ class Foo:
     def this_is_bad_too(__x: int) -> None: ...  # PYI063
     @classmethod
     def not_good(cls, __foo: int) -> None: ...  # PYI063
+    def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
 
     # The first non-self argument isn't positional-only, so logically the second can't be either:
     def okay1(self, x: int, __y: int) -> None: ...

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI063.pyi
@@ -30,6 +30,9 @@ class Foo:
     def not_good(cls, __foo: int) -> None: ...  # PYI063
     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
 
+    @staticmethod
+    def __new__(__cls, __name: str, __later: str) -> Self: ...  # PYI063
+
     # The first non-self argument isn't positional-only, so logically the second can't be either:
     def okay1(self, x: int, __y: int) -> None: ...
     # Same here:

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
@@ -82,12 +82,15 @@ pub(crate) fn pep_484_positional_parameter(checker: &Checker, function_def: &ast
     );
 
     // If the method has a `self` or `cls` argument, skip it.
-    let skip = usize::from(matches!(
-        function_type,
-        function_type::FunctionType::Method
-            | function_type::FunctionType::ClassMethod
-            | function_type::FunctionType::NewMethod
-    ));
+    // `__new__` receives the class as its first argument even when explicitly
+    // decorated with `@staticmethod`.
+    let skip = usize::from(
+        function_def.name.as_str() == "__new__"
+            || matches!(
+                function_type,
+                function_type::FunctionType::Method | function_type::FunctionType::ClassMethod
+            ),
+    );
 
     if let Some(param) = function_def.parameters.args.get(skip) {
         if param.uses_pep_484_positional_only_convention() {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/pre_pep570_positional_argument.rs
@@ -84,7 +84,9 @@ pub(crate) fn pep_484_positional_parameter(checker: &Checker, function_def: &ast
     // If the method has a `self` or `cls` argument, skip it.
     let skip = usize::from(matches!(
         function_type,
-        function_type::FunctionType::Method | function_type::FunctionType::ClassMethod
+        function_type::FunctionType::Method
+            | function_type::FunctionType::ClassMethod
+            | function_type::FunctionType::NewMethod
     ));
 
     if let Some(param) = function_def.parameters.args.get(skip) {

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.py.snap
@@ -102,30 +102,41 @@ PYI063 Use PEP 570 syntax for positional-only parameters
 31 |     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
    |                      ^^^^^^
 32 |
-33 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+33 |     @staticmethod
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.py:53:23
+  --> PYI063.py:34:24
    |
-51 | class Metaclass(type):
-52 |     @classmethod
-53 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+33 |     @staticmethod
+34 |     def __new__(__cls, __name: str, __later: str) -> Self: ...  # PYI063
+   |                        ^^^^^^
+35 |
+36 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+   |
+help: Add `/` to function signature
+
+PYI063 Use PEP 570 syntax for positional-only parameters
+  --> PYI063.py:56:23
+   |
+54 | class Metaclass(type):
+55 |     @classmethod
+56 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                       ^^^^^^
-54 |
-55 | class Metaclass2(type):
+57 |
+58 | class Metaclass2(type):
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.py:57:26
+  --> PYI063.py:60:26
    |
-55 | class Metaclass2(type):
-56 |     @classmethod
-57 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+58 | class Metaclass2(type):
+59 |     @classmethod
+60 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                          ^^^^^^
-58 |
-59 | class GoodMetaclass(type):
+61 |
+62 | class GoodMetaclass(type):
    |
 help: Add `/` to function signature

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.py.snap
@@ -90,31 +90,42 @@ PYI063 Use PEP 570 syntax for positional-only parameters
 29 |     @classmethod
 30 |     def not_good(cls, __foo: int) -> None: ...  # PYI063
    |                       ^^^^^
-31 |
-32 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+31 |     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.py:52:23
+  --> PYI063.py:31:22
    |
-50 | class Metaclass(type):
-51 |     @classmethod
-52 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+29 |     @classmethod
+30 |     def not_good(cls, __foo: int) -> None: ...  # PYI063
+31 |     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
+   |                      ^^^^^^
+32 |
+33 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+   |
+help: Add `/` to function signature
+
+PYI063 Use PEP 570 syntax for positional-only parameters
+  --> PYI063.py:53:23
+   |
+51 | class Metaclass(type):
+52 |     @classmethod
+53 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                       ^^^^^^
-53 |
-54 | class Metaclass2(type):
+54 |
+55 | class Metaclass2(type):
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.py:56:26
+  --> PYI063.py:57:26
    |
-54 | class Metaclass2(type):
-55 |     @classmethod
-56 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+55 | class Metaclass2(type):
+56 |     @classmethod
+57 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                          ^^^^^^
-57 |
-58 | class GoodMetaclass(type):
+58 |
+59 | class GoodMetaclass(type):
    |
 help: Add `/` to function signature

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.pyi.snap
@@ -102,30 +102,41 @@ PYI063 Use PEP 570 syntax for positional-only parameters
 31 |     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
    |                      ^^^^^^
 32 |
-33 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+33 |     @staticmethod
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.pyi:53:23
+  --> PYI063.pyi:34:24
    |
-51 | class Metaclass(type):
-52 |     @classmethod
-53 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+33 |     @staticmethod
+34 |     def __new__(__cls, __name: str, __later: str) -> Self: ...  # PYI063
+   |                        ^^^^^^
+35 |
+36 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+   |
+help: Add `/` to function signature
+
+PYI063 Use PEP 570 syntax for positional-only parameters
+  --> PYI063.pyi:56:23
+   |
+54 | class Metaclass(type):
+55 |     @classmethod
+56 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                       ^^^^^^
-54 |
-55 | class Metaclass2(type):
+57 |
+58 | class Metaclass2(type):
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.pyi:57:26
+  --> PYI063.pyi:60:26
    |
-55 | class Metaclass2(type):
-56 |     @classmethod
-57 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+58 | class Metaclass2(type):
+59 |     @classmethod
+60 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                          ^^^^^^
-58 |
-59 | class GoodMetaclass(type):
+61 |
+62 | class GoodMetaclass(type):
    |
 help: Add `/` to function signature

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__pep484-style-positional-only-parameter_PYI063.pyi.snap
@@ -90,31 +90,42 @@ PYI063 Use PEP 570 syntax for positional-only parameters
 29 |     @classmethod
 30 |     def not_good(cls, __foo: int) -> None: ...  # PYI063
    |                       ^^^^^
-31 |
-32 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+31 |     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.pyi:52:23
+  --> PYI063.pyi:31:22
    |
-50 | class Metaclass(type):
-51 |     @classmethod
-52 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+29 |     @classmethod
+30 |     def not_good(cls, __foo: int) -> None: ...  # PYI063
+31 |     def __new__(cls, __name: str, __later: str) -> Self: ...  # PYI063
+   |                      ^^^^^^
+32 |
+33 |     # The first non-self argument isn't positional-only, so logically the second can't be either:
+   |
+help: Add `/` to function signature
+
+PYI063 Use PEP 570 syntax for positional-only parameters
+  --> PYI063.pyi:53:23
+   |
+51 | class Metaclass(type):
+52 |     @classmethod
+53 |     def __new__(mcls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                       ^^^^^^
-53 |
-54 | class Metaclass2(type):
+54 |
+55 | class Metaclass2(type):
    |
 help: Add `/` to function signature
 
 PYI063 Use PEP 570 syntax for positional-only parameters
-  --> PYI063.pyi:56:26
+  --> PYI063.pyi:57:26
    |
-54 | class Metaclass2(type):
-55 |     @classmethod
-56 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
+55 | class Metaclass2(type):
+56 |     @classmethod
+57 |     def __new__(metacls, __name: str, __bases: tuple[type, ...], __namespace: dict, **kwds) -> Self: ...  # PYI063
    |                          ^^^^^^
-57 |
-58 | class GoodMetaclass(type):
+58 |
+59 | class GoodMetaclass(type):
    |
 help: Add `/` to function signature


### PR DESCRIPTION
Ruff already knows that the first parameter of `__new__` is special, like `self`/`cls`, but PYI063 wasn’t accounting for that. So it was looking at the wrong parameter and not reporting the one it should. This change makes PYI063 skip the `__new__` receiver and check the next parameter instead.
Fixes #16410 