### PR TITLE
Recognize quoted types in `typing.TypeForm`

### DIFF
--- a/crates/ruff_linter/resources/mdtest/typeform.md
+++ b/crates/ruff_linter/resources/mdtest/typeform.md
@@ -1,0 +1,38 @@
+# `typing.TypeForm`
+
+These examples use `unused-import` (`F401`) to check whether quoted type expressions mark their imports
+as used.
+
+```toml
+target-version = "py315"
+
+[lint]
+select = ["F401"]
+```
+
+## Subscription and call
+
+Both `TypeForm[...]` and `TypeForm(...)` accept type expressions, so quoted types in either form mark
+their imports as used even outside an annotation.
+
+```py
+from decimal import Decimal  # no diagnostic
+from fractions import Fraction  # no diagnostic
+from typing import TypeForm
+
+DecimalForm = TypeForm["Decimal"]
+form = TypeForm("Fraction")
+```
+
+## `typing_extensions`
+
+Both forms also work with the backport, including when imported under an alias.
+
+```py
+from decimal import Decimal  # no diagnostic
+from pathlib import Path  # no diagnostic
+from typing_extensions import TypeForm as TF
+
+DecimalForm = TF["Decimal"]
+form = TF("Path")
+```

--- a/crates/ruff_linter/resources/mdtest/typing.md
+++ b/crates/ruff_linter/resources/mdtest/typing.md
@@ -1,4 +1,4 @@
-# `typing.TypeForm`
+# Typing constructs
 
 These examples use `unused-import` (`F401`) to check whether quoted type expressions mark their imports
 as used.
@@ -10,7 +10,7 @@ target-version = "py315"
 select = ["F401"]
 ```
 
-## Subscription and call
+## `TypeForm` subscription and call
 
 Both `TypeForm[...]` and `TypeForm(...)` accept type expressions, so quoted types in either form mark
 their imports as used even outside an annotation.
@@ -24,7 +24,7 @@ DecimalForm = TypeForm["Decimal"]
 form = TypeForm("Fraction")
 ```
 
-## `typing_extensions`
+## `TypeForm` backport
 
 Both forms also work with the backport, including when imported under an alias.
 
@@ -35,4 +35,21 @@ from typing_extensions import TypeForm as TF
 
 DecimalForm = TF["Decimal"]
 form = TF("Path")
+```
+
+## `TypeIs` and `TypeGuard`
+
+Quoted types in `TypeIs` and `TypeGuard` subscriptions also mark their imports as used, even outside
+annotations. This includes the backports in `typing_extensions`.
+
+```py
+from decimal import Decimal  # no diagnostic
+from fractions import Fraction  # no diagnostic
+from pathlib import Path  # no diagnostic
+from typing import TypeIs
+import typing_extensions
+
+IsDecimal = TypeIs["Decimal"]
+IsFraction = typing_extensions.TypeIs["Fraction"]
+GuardsPath = typing_extensions.TypeGuard["Path"]
 ```

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1880,6 +1880,11 @@ impl<'a> Visitor<'a> for Checker<'a> {
                                 Some(typing::Callable::Cast)
                             } else if self
                                 .semantic
+                                .match_typing_qualified_name(&qualified_name, "TypeForm")
+                            {
+                                Some(typing::Callable::TypeForm)
+                            } else if self
+                                .semantic
                                 .match_typing_qualified_name(&qualified_name, "NewType")
                             {
                                 Some(typing::Callable::NewType)
@@ -1948,6 +1953,18 @@ impl<'a> Visitor<'a> for Checker<'a> {
                                     }
                                 }
                             }
+                        }
+                    }
+                    Some(typing::Callable::TypeForm) => {
+                        let mut args = arguments.args.iter();
+                        if let Some(arg) = args.next() {
+                            self.visit_type_definition(arg);
+                        }
+                        for arg in args {
+                            self.visit_non_type_definition(arg);
+                        }
+                        for keyword in &*arguments.keywords {
+                            self.visit_non_type_definition(&keyword.value);
                         }
                     }
                     Some(typing::Callable::NewType) => {

--- a/crates/ruff_python_semantic/src/analyze/typing.rs
+++ b/crates/ruff_python_semantic/src/analyze/typing.rs
@@ -24,6 +24,7 @@ use crate::{Binding, BindingKind, Modules};
 pub enum Callable {
     Bool,
     Cast,
+    TypeForm,
     NewType,
     TypeVar,
     NamedTuple,

--- a/crates/ruff_python_stdlib/src/typing.rs
+++ b/crates/ruff_python_stdlib/src/typing.rs
@@ -85,7 +85,9 @@ pub fn is_standard_library_generic(qualified_name: &[&str]) -> bool {
                     | "TextIO"
                     | "Tuple"
                     | "Type"
+                    | "TypeForm"
                     | "TypeGuard"
+                    | "TypeIs"
                     | "Union"
                     | "Unpack"
                     | "ValuesView"
@@ -106,6 +108,9 @@ pub fn is_standard_library_generic(qualified_name: &[&str]) -> bool {
                     | "DefaultDict"
                     | "Deque"
                     | "Type"
+                    | "TypeForm"
+                    | "TypeGuard"
+                    | "TypeIs"
             ]
             | [
                 "weakref",
@@ -195,7 +200,9 @@ pub fn is_standard_library_generic_member(member: &str) -> bool {
             | "TextIO"
             | "Tuple"
             | "Type"
+            | "TypeForm"
             | "TypeGuard"
+            | "TypeIs"
             | "Union"
             | "Unpack"
             | "ValuesView"


### PR DESCRIPTION
Summary
--

`typing.TypeForm` was introduced in Python 3.15 and [PEP 747](https://peps.python.org/pep-0747/) as
a way to annotate the passing of type objects like `int | str`, `list[int]`, or `MyTypeAlias`. It
can be used either as a subscripted generic, as in this example from the PEP:

```py
from typing import TypeForm

def trycast[T](typx: TypeForm[T], value: object) -> T | None: ...
```

or as a callable, which returns its argument unchanged:

```py
from typing import TypeForm

TypeForm("list[int]")
```

This PR recognizes `typing.TypeForm` as a standard-library generic and as a known `typing` callable
and visits its argument or subscript as a type definition.

While I was reading the [typing docs], I realized that a couple of nearby types were also not
listed, so I've attempted to sneak them in here but could split them off if needed. We already had
coverage for `typing.TypeGuard` but not `typing_extensions.TypeGuard` (added in 3.10), and we were
missing both variants of `TypeIs` (added in 3.13). These are only valid in the subscript form, so
they don't need new `Callable` entries.

[typing docs]: https://docs.python.org/3.15/library/typing.html#typing.TypeForm

Test Plan
--

New mdtests, using `unused-import` (`F401`) to demonstrate that visiting these arguments as type
definitions marks them as used, but other rules will be affected as well.
