### PR TITLE
[ty] Allow experimental intersection syntax in PEP 695 aliases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/intersection_types.md
@@ -14,6 +14,7 @@ python-version = "3.14"
 class A: ...
 class B: ...
 class C: ...
+class Box[T]: ...
 
 def _(
     a_and_b: A & B,
@@ -21,12 +22,16 @@ def _(
     i2: A | B & C,
     not_a: ~A,
     nested: A & B & C,
+    boxed: Box[A & B],
+    quoted: "A & ~B",
 ) -> None:
     reveal_type(a_and_b)  # revealed: A & B
     reveal_type(i1)  # revealed: (A & B) | C
     reveal_type(i2)  # revealed: A | (B & C)
     reveal_type(not_a)  # revealed: ~A
     reveal_type(nested)  # revealed: A & B & C
+    reveal_type(boxed)  # revealed: Box[A & B]
+    reveal_type(quoted)  # revealed: A & ~B
 ```
 
 The `&` and `~` operators cannot be used in value positions, since that would lead to a runtime
@@ -37,6 +42,8 @@ error:
 Invalid1 = A & B
 # error: [unsupported-operator] "Unary operator `~` is not supported for object of type `<class 'A'>`"
 Invalid2 = ~A
+# error: [unsupported-operator] "Operator `&` is not supported between objects of type `<class 'A'>` and `<class 'B'>`"
+Box[A & B]
 ```
 
 ## Python 3.13
@@ -90,4 +97,33 @@ Stringified annotations also defer evaluation:
 def _(a_and_b: "A & B", not_a: "~A") -> None:
     reveal_type(a_and_b)  # revealed: A & B
     reveal_type(not_a)  # revealed: ~A
+```
+
+## PEP 695 aliases
+
+PEP 695 aliases are evaluated lazily, so intersection and negation syntax can be used, even before
+Python 3.14.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class A: ...
+class B: ...
+class Box[T]: ...
+
+type AAndB = A & B
+type NotA = ~A
+type Quoted = "A & ~B"
+type Nested = Box[A & B]
+type BoxGeneric[T] = Box[A & T]
+
+def _(a_and_b: AAndB, not_a: NotA, quoted: Quoted, nested: Nested, generic: BoxGeneric[B]):
+    reveal_type(a_and_b)  # revealed: A & B
+    reveal_type(not_a)  # revealed: ~A
+    reveal_type(quoted)  # revealed: A & ~B
+    reveal_type(nested)  # revealed: Box[A & B]
+    reveal_type(generic)  # revealed: Box[A & B]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -1167,7 +1167,7 @@ An intersection of `int` and `Any` likewise retains only the compatible `int` co
 variances.
 
 ```py
-type GradualInt = Intersection[int, Any]
+type GradualInt = int & Any
 
 static_assert(is_subtype_of(ConstrainedCovariant[int], Top[ConstrainedCovariant[GradualInt]]))
 static_assert(not is_subtype_of(ConstrainedCovariant[str], Top[ConstrainedCovariant[GradualInt]]))
@@ -1255,10 +1255,10 @@ python-version = "3.12"
 
 ```py
 from typing import Any
-from ty_extensions import Bottom, Intersection, Top, static_assert
+from ty_extensions import Bottom, Top, static_assert
 from ty_extensions._internal import is_assignable_to, is_subtype_of
 
-type GradualInt = Intersection[int, Any]
+type GradualInt = int & Any
 
 class MixedConstrained[T: (int, str), U]:
     value: T

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -151,6 +151,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .inference_flags()
                     .contains(InferenceFlags::IN_PEP_613_ALIAS_FIRST_PASS)
         };
+        let ignore_experimental_runtime_errors = |builder: &Self| {
+            ignore_runtime_errors(builder)
+                || matches!(builder.scope.scope(db).kind(), ScopeKind::TypeAlias)
+        };
 
         // https://typing.python.org/en/latest/spec/annotations.html#grammar-token-expression-grammar-type_expression
         match expression {
@@ -405,7 +409,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let left_ty = self.infer_type_expression(&binary.left);
                         let right_ty = self.infer_type_expression(&binary.right);
 
-                        if !ignore_runtime_errors(self) {
+                        if !ignore_experimental_runtime_errors(self) {
                             // Infer the operands as values to report the types used by the runtime
                             // operation rather than their interpretation as type expressions.
                             let mut speculative_builder = self.speculate_without_diagnostics();
@@ -718,7 +722,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 let operand_ty = self.infer_type_expression(operand);
 
-                if !ignore_runtime_errors(self) {
+                if !ignore_experimental_runtime_errors(self) {
                     let operand_value = self
                         .speculate_without_diagnostics()
                         .infer_expression(operand, TypeContext::default());


### PR DESCRIPTION
## Summary

Allow experimental intersection and negation syntax in PEP 695 type aliases, e.g. `type Both = A & B`. These aliases are evaluated lazily, but ty previously reported an unsupported runtime operation even though it inferred the correct type.

Skip the runtime checks for `&` and `~` in PEP 695 alias scopes, and for deferred annotations.

## Test Plan

New Markdown tests