### PR TITLE
[ty] Ignore divergent markers when detecting descriptors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/import/cyclic.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/cyclic.md
@@ -125,3 +125,28 @@ from module import x
 
 reveal_type(x)  # revealed: int
 ```
+
+### Attribute assignment through a circular re-export
+
+A class imported through a circular re-export is the same class as the original definition. Its
+instances can be assigned to attributes annotated with that class, including optional attributes.
+
+`models.py`:
+
+```py
+class Item: ...
+
+from reexport import Item
+
+class Container:
+    item: Item | None
+
+def set_item(container: Container):
+    container.item = Item()
+```
+
+`reexport.py`:
+
+```py
+from models import Item
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1227,10 +1227,11 @@ bitflags! {
         /// Do not call `__getattr__` during member lookup.
         const NO_GETATTR_LOOKUP = 1 << 4;
 
-        /// Ignore members that are only available through a dynamic type.
+        /// Ignore members that are only available through a dynamic type or a divergent marker.
         ///
         /// This is used when detecting descriptors. An `Any` or `Unknown` base can provide any
         /// member, but that does not mean that every subclass should be treated as a descriptor.
+        /// Likewise, a divergent marker from cyclic inference does not establish a concrete member.
         const REQUIRE_CONCRETE = 1 << 5;
     }
 }
@@ -3703,7 +3704,9 @@ impl<'db> Type<'db> {
                 }))
             }
 
-            Type::Dynamic(_) if policy.require_concrete() => Some(Place::Undefined.into()),
+            Type::Dynamic(_) | Type::Divergent(_) if policy.require_concrete() => {
+                Some(Place::Undefined.into())
+            }
 
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(Place::bound(self).into()),
 


### PR DESCRIPTION
## Summary

Fix a spurious `invalid-assignment` diagnostic when assigning an instance to an optional attribute whose class is imported through a circular re-export. The resulting `Divergent | None` annotation was incorrectly treated as a descriptor because the cycle marker appeared to provide `__set__`; checking the `None` alternative then rejected the assignment.

Closes https://github.com/astral-sh/ty/issues/4509.

## Validation

Regression test