### PR TITLE
[`flake8-type-checking`] Treat type parameter definitions as typing-only

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-type-params.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-type-params.md
@@ -94,9 +94,9 @@ note: This is an unsafe fix and may change runtime behavior
 ## Type parameter constraints are typing only
 
 ```py
-import io  # error: typing-only-standard-library-import
-from pandas import DataFrame  # error: typing-only-third-party-import
-from .anndata import AnnData  # error: typing-only-first-party-import
+import io  # error: [typing-only-standard-library-import]
+from pandas import DataFrame  # error: [typing-only-third-party-import]
+from .anndata import AnnData  # error: [typing-only-first-party-import]
 
 
 def f[T: (io.BytesIO, DataFrame, AnnData)](a: T) -> T: ...
@@ -105,9 +105,9 @@ def f[T: (io.BytesIO, DataFrame, AnnData)](a: T) -> T: ...
 ## Type parameter defaults are typing only
 
 ```py
-import io  # error: typing-only-standard-library-import
-from pandas import DataFrame  # error: typing-only-third-party-import
-from .anndata import AnnData  # error: typing-only-first-party-import
+import io  # error: [typing-only-standard-library-import]
+from pandas import DataFrame  # error: [typing-only-third-party-import]
+from .anndata import AnnData  # error: [typing-only-first-party-import]
 
 
 def foo[T: object = AnnData](a: T) -> T: ...

--- a/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-type-params.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-type-params.md
@@ -1,0 +1,116 @@
+# Treat PEP 695/696 type parameter bounds/constraints/defaults as typing-only
+
+```toml
+preview = true
+target-version = "py313"
+lint.select = [
+    "typing-only-first-party-import",
+    "typing-only-third-party-import",
+    "typing-only-standard-library-import"
+]
+```
+
+The expressions for PEP 695 type parameter bounds and constraints are never
+evaluated at runtime, unless explicitly accessed through runtime introspection.
+
+It is very rare that runtime type checkers care about the bounds/constraints of a type parameter.
+
+## Type parameter bounds are typing only
+
+```py
+from .anndata import AnnData  # snapshot: typing-only-first-party-import
+
+def foo[T: AnnData](a: T) -> T: ...
+```
+
+```snapshot
+error[TC001]: Move application import `.anndata.AnnData` into a type-checking block
+ --> src/mdtest_snippet.py:1:22
+  |
+1 | from .anndata import AnnData  # snapshot: typing-only-first-party-import
+  |                      ^^^^^^^
+help: Move into type-checking block
+  |
+  - from .anndata import AnnData  # snapshot: typing-only-first-party-import
+1 + from typing import TYPE_CHECKING
+2 +
+3 + if TYPE_CHECKING:
+4 +     from .anndata import AnnData
+5 |
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+```py
+from pandas import DataFrame  # snapshot: typing-only-third-party-import
+
+class Bar[T: DataFrame]: ...
+```
+
+```snapshot
+error[TC002]: Move third-party import `pandas.DataFrame` into a type-checking block
+ --> src/mdtest_snippet.py:4:20
+  |
+4 | from pandas import DataFrame  # snapshot: typing-only-third-party-import
+  |                    ^^^^^^^^^
+help: Move into type-checking block
+  |
+3 | def foo[T: AnnData](a: T) -> T: ...
+  - from pandas import DataFrame  # snapshot: typing-only-third-party-import
+4 + from typing import TYPE_CHECKING
+5 +
+6 + if TYPE_CHECKING:
+7 +     from pandas import DataFrame
+8 |
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+```py
+import io  # snapshot: typing-only-standard-library-import
+
+type Baz[T: io.BytesIO] = ...
+```
+
+```snapshot
+error[TC003]: Move standard library import `io` into a type-checking block
+ --> src/mdtest_snippet.py:7:8
+  |
+7 | import io  # snapshot: typing-only-standard-library-import
+  |        ^^
+help: Move into type-checking block
+   |
+6  | class Bar[T: DataFrame]: ...
+   - import io  # snapshot: typing-only-standard-library-import
+7  + from typing import TYPE_CHECKING
+8  +
+9  + if TYPE_CHECKING:
+10 +     import io
+11 |
+   |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Type parameter constraints are typing only
+
+```py
+import io  # error: typing-only-standard-library-import
+from pandas import DataFrame  # error: typing-only-third-party-import
+from .anndata import AnnData  # error: typing-only-first-party-import
+
+
+def f[T: (io.BytesIO, DataFrame, AnnData)](a: T) -> T: ...
+```
+
+## Type parameter defaults are typing only
+
+```py
+import io  # error: typing-only-standard-library-import
+from pandas import DataFrame  # error: typing-only-third-party-import
+from .anndata import AnnData  # error: typing-only-first-party-import
+
+
+def foo[T: object = AnnData](a: T) -> T: ...
+class Bar[*Ts = DataFrame]: ...
+type Baz[**P = io.BytesIO] = ...
+```

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -2447,14 +2447,10 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 node_index: _,
             }) => {
                 if let Some(expr) = bound {
-                    self.visit
-                        .type_param_definitions
-                        .push((expr, self.semantic.snapshot()));
+                    self.visit_type_param_definition(expr);
                 }
                 if let Some(expr) = default {
-                    self.visit
-                        .type_param_definitions
-                        .push((expr, self.semantic.snapshot()));
+                    self.visit_type_param_definition(expr);
                 }
             }
             ast::TypeParam::TypeVarTuple(ast::TypeParamTypeVarTuple {
@@ -2464,9 +2460,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 node_index: _,
             }) => {
                 if let Some(expr) = default {
-                    self.visit
-                        .type_param_definitions
-                        .push((expr, self.semantic.snapshot()));
+                    self.visit_type_param_definition(expr);
                 }
             }
             ast::TypeParam::ParamSpec(ast::TypeParamParamSpec {
@@ -2476,9 +2470,7 @@ impl<'a> Visitor<'a> for Checker<'a> {
                 node_index: _,
             }) => {
                 if let Some(expr) = default {
-                    self.visit
-                        .type_param_definitions
-                        .push((expr, self.semantic.snapshot()));
+                    self.visit_type_param_definition(expr);
                 }
             }
         }
@@ -2639,7 +2631,35 @@ impl<'a> Checker<'a> {
         // even though we don't visit these nodes immediately we need to
         // modify the semantic flags before we push the expression and its
         // corresponding semantic snapshot
-        self.semantic.flags |= SemanticModelFlags::DEFERRED_TYPE_ALIAS;
+        self.semantic.flags |=
+            SemanticModelFlags::DEFERRED_TYPE_ALIAS | SemanticModelFlags::TYPE_DEFINITION;
+        self.visit
+            .type_param_definitions
+            .push((expr, self.semantic.snapshot()));
+        self.semantic.flags = snapshot;
+    }
+
+    /// Visit an [`Expr`], and treat it as the bound/constraint/default of
+    /// a [type parameter definition].
+    ///
+    /// Type parameters natively support forward references,
+    /// so are always deferred during initial traversal of the source tree.
+    ///
+    /// For example:
+    /// ```python
+    /// class Foo[T: Bar]: pass  # <-- Forward reference used in definition of type parameter `T`
+    /// type X[T: Bar] = Foo[T]  # <-- Ditto
+    /// class Bar: pass
+    /// ```
+    ///
+    /// [type parameter definition]: https://docs.python.org/3/reference/executionmodel.html#annotation-scopes
+    fn visit_type_param_definition(&mut self, expr: &'a Expr) {
+        let snapshot = self.semantic.flags;
+        // even though we don't visit these nodes immediately we need to
+        // modify the semantic flags before we push the expression and its
+        // corresponding semantic snapshot
+        self.semantic.flags |=
+            SemanticModelFlags::TYPE_PARAM_DEFINITION | SemanticModelFlags::TYPE_DEFINITION;
         self.visit
             .type_param_definitions
             .push((expr, self.semantic.snapshot()));
@@ -2988,9 +3008,6 @@ impl<'a> Checker<'a> {
             let type_params = std::mem::take(&mut self.visit.type_param_definitions);
             for (type_param, snapshot) in type_params {
                 self.semantic.restore(snapshot);
-
-                self.semantic.flags |=
-                    SemanticModelFlags::TYPE_PARAM_DEFINITION | SemanticModelFlags::TYPE_DEFINITION;
                 self.visit_expr(type_param);
             }
         }

--- a/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/helpers.rs
@@ -60,7 +60,10 @@ impl TypingReference {
                 return Self::Runtime;
             }
 
-            if reference.in_typing_only_annotation() || reference.in_string_type_definition() {
+            if reference.in_typing_only_annotation()
+                || reference.in_string_type_definition()
+                || (settings.preview.is_enabled() && reference.in_type_param_definition())
+            {
                 kind = kind.combine(Self::TypingOnly);
                 continue;
             }

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -2911,7 +2911,7 @@ bitflags! {
 
         /// The context is in a typing-only context.
         const TYPING_CONTEXT = Self::TYPE_CHECKING_BLOCK.bits() | Self::TYPING_ONLY_ANNOTATION.bits() |
-            Self::STRING_TYPE_DEFINITION.bits() | Self::TYPE_PARAM_DEFINITION.bits();
+            Self::STRING_TYPE_DEFINITION.bits() | Self::TYPE_PARAM_DEFINITION.bits() | Self::DEFERRED_TYPE_ALIAS.bits();
 
         /// The context is in any type alias.
         const TYPE_ALIAS = Self::ANNOTATED_TYPE_ALIAS.bits() | Self::DEFERRED_TYPE_ALIAS.bits();

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -2906,7 +2906,8 @@ bitflags! {
         const DEFERRED_TYPE_DEFINITION = Self::SIMPLE_STRING_TYPE_DEFINITION.bits()
             | Self::COMPLEX_STRING_TYPE_DEFINITION.bits()
             | Self::FUTURE_TYPE_DEFINITION.bits()
-            | Self::TYPE_PARAM_DEFINITION.bits();
+            | Self::TYPE_PARAM_DEFINITION.bits()
+            | Self::DEFERRED_TYPE_ALIAS.bits();
 
         /// The context is in a typing-only context.
         const TYPING_CONTEXT = Self::TYPE_CHECKING_BLOCK.bits() | Self::TYPING_ONLY_ANNOTATION.bits() |

--- a/crates/ruff_python_semantic/src/reference.rs
+++ b/crates/ruff_python_semantic/src/reference.rs
@@ -87,6 +87,16 @@ impl ResolvedReference {
             .intersects(SemanticModelFlags::DUNDER_ALL_DEFINITION)
     }
 
+    /// Return `true` if the context is in a [PEP 695]/[PEP 696] type parameter
+    /// bound/constraint/default.
+    ///
+    /// [PEP 695]: https://peps.python.org/pep-0695/#type-parameter-declarations
+    /// [PEP 696]: https://peps.python.org/pep-0696/#grammar-changes
+    pub const fn in_type_param_definition(&self) -> bool {
+        self.flags
+            .intersects(SemanticModelFlags::TYPE_PARAM_DEFINITION)
+    }
+
     /// Return `true` if the context is in the r.h.s. of a [PEP 613] type alias.
     ///
     /// [PEP 613]: https://peps.python.org/pep-0613/


### PR DESCRIPTION
Fixes #27369

## Summary

PEP 695/696 type parameter bounds/constraints/defaults are deferred, just like annotations are with Python 3.14+. Both are similar to how `from __future__ import annotations` changes the runtime behavior.

We treat deferred annotations as typing-only by default, type parameter bounds/constraints/defaults arguably are introspected more rarely than annotations are, so they should be typing-only by default as well.

This change is currently only enabled in preview mode, mostly due to the fact that unlike with annotations, there is no setting yet to override this default for specific generics. It is unclear how valuable such a setting would be. It might be rare enough, that a `ruff: ignore` pragma is more ergonomic in those cases.

## Test Plan

`cargo nextest run`
