### PR TITLE
[ty] Add playground command to toggle inlay hints

### DIFF
--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -229,6 +229,18 @@ class PlaygroundServer
     private props: PlaygroundServerProps,
   ) {
     this.providerDisposables = [
+      editor.addAction({
+        id: "toggle-inlay-hints",
+        label: "Toggle Inlay Hints",
+        run(editor) {
+          const enabled =
+            editor.getOption(monaco.editor.EditorOption.inlayHints).enabled !==
+            "on";
+          editor.updateOptions({
+            inlayHints: { enabled: enabled ? "on" : "off" },
+          });
+        },
+      }),
       monaco.languages.registerTypeDefinitionProvider("python", this),
       monaco.languages.registerDeclarationProvider("python", this),
       monaco.languages.registerDefinitionProvider("python", this),


### PR DESCRIPTION
## Summary

Add a **Toggle Inlay Hints** command to the ty playground's editor command palette (F1). It toggles variable-type and argument-name hints together. I sometimes find that useful when inlay hints become too verbose.

## Screenshots

<img width="874" height="490" alt="image" src="https://github.com/user-attachments/assets/a18f7b21-aa0b-4d6d-9c25-d24a16777d9d" />

<img width="874" height="490" alt="image" src="https://github.com/user-attachments/assets/ba000e6b-fd13-44d0-97e6-edff17feefea" />


## Test Plan

Interactive, see screenshots above.