### PR TITLE
[ty] Add runtime threat models for Ruff and ty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ request already addresses the issue, do not submit a competing one without maint
 
 ## Code Review Rules
 
+For security reviews of Ruff and ty runtime changes, use the
+[threat models](agents/references/threat-models.md) to assess trust boundaries and
+calibrate severity.
+
 When reviewing a branch or pull request, be deliberately nitpicky. Report not
 only bugs and regressions, but also architectural and maintenance risks, weak
 test coverage, unclear code, unnecessary complexity, and meaningful style or

--- a/agents/references/cli-threat-model.md
+++ b/agents/references/cli-threat-model.md
@@ -1,0 +1,51 @@
+# Ruff and ty CLI threat model
+
+## Overview
+
+Ruff checks and formats Python code. ty checks Python types. Their commands and native libraries read
+source files, configuration, and dependencies; produce diagnostics; and edit files when requested.
+They run with the user's or CI worker's permissions.
+
+A behavior is a security issue only when an independent attacker controls a concrete input, Ruff or
+ty uses it to cross a boundary defined below, and the crossing gives the attacker new power or harms
+a protected asset. Trusted-machine compromise, intended behavior, and correctness defects that give
+an attacker no new power are not security issues.
+
+Editors, playgrounds, and repository automation have [separate models](threat-models.md).
+
+## Trust boundaries and assumptions
+
+- **Attacker-controlled:** source code, stubs, notebook contents, Markdown, and project configuration.
+- **Trusted local input:** the operating system, installed programs, environment variables, `PATH`,
+    caches, user configuration, explicit command-line choices, and user-managed filesystem state that
+    the attacker cannot change.
+
+## Security invariants
+
+- **Code Execution:** Analysis must not execute user-supplied code.
+- **Configuration and file discovery:** Ruff's `--isolated` must ignore configuration files. Imports,
+    configuration extensions, and symlinks may lead outside the project; reading those files is
+    expected.
+- **Edits and cleanup:** Formatting, fixes, ignore insertion, and cache cleanup may change only the
+    targets selected by that operation. Formatting with `--check` must preserve source files.
+    Incorrect fixes are ordinarily correctness bugs.
+- **External programs:** ty's uv integration is disabled by default. When enabled, it uses the
+    executable selected by `UV` or `PATH` for workspace metadata and script environments. Script
+    synchronization may install dependencies.
+- **Output:** Diagnostics may contain source text and paths. They must be encoded for the selected
+    terminal or CI format so that attacker-controlled text cannot inject commands or active content.
+- **Availability:** An isolated parser panic or slow analysis is a correctness or performance bug.
+    A security issue requires repeatable, disproportionate resource use that materially disrupts
+    the developer's machine or CI worker beyond the failed analysis.
+
+## Severity calibration
+
+- **Critical:** With few prerequisites and safe defaults, analysis input compromises credentials
+    with broad permissions or causes widespread file damage without first compromising a trusted host.
+- **High:** A demonstrated path from analysis input to arbitrary native execution, substantial
+    disclosure of private data, or destructive filesystem access beyond the requested operation.
+- **Medium:** A limited unauthorized read or write, or bypass of an execution restriction with
+    limited effect.
+- **Low:** A narrow disclosure or safety gap across a real boundary with limited practical impact,
+    or reliable resource exhaustion affecting the developer's machine or CI worker.
+- **Informational:** A genuine security concern with negligible current impact.

--- a/agents/references/language-server-threat-model.md
+++ b/agents/references/language-server-threat-model.md
@@ -1,0 +1,41 @@
+# Ruff and ty language server threat model
+
+## Overview
+
+The [CLI threat model](cli-threat-model.md) applies to the language servers. The workspace trust rules
+below take precedence when deciding which inputs are trusted. Browser integrations have a separate
+[playground model](playground-threat-model.md).
+
+## Trust boundaries and assumptions
+
+- **Attacker-controlled:** all inputs analyzed in an untrusted workspace, including source code,
+    project configuration, and notebooks.
+- **Trusted local input:** the editor, its extensions, the local machine, including its file system,
+    and the user's configuration and trust decisions.
+
+ty treats workspaces as trusted unless `untrustedWorkspace` is true at initialization. Trust extends
+to everything in the workspace, including source code, configuration, notebooks, and the targets of
+symlinks that point outside it.
+
+## Security invariants
+
+- **Code Execution:** When `untrustedWorkspace` is true, ty must not execute code related to the
+    workspace or its dependencies, including code run during installation.
+- **Edits:** Editing operations must not change unrelated files.
+- **Output:** Diagnostics, documentation, and logs must not allow attacker-controlled text to run
+    code or invoke editor commands.
+- **Availability:** An isolated parser panic or slow analysis is a correctness or performance bug.
+    A security issue requires repeatable, disproportionate resource use that materially disrupts
+    the editor or the developer's machine beyond the failed analysis.
+
+## Severity calibration
+
+- **Critical:** With few prerequisites and safe defaults, an attacker gains broad execution
+    or credential access.
+- **High:** A demonstrated boundary crossing causes substantial confidentiality or integrity harm,
+    such as executing attacker code despite an effective untrusted-workspace restriction.
+- **Medium:** A limited unauthorized read or write, or bypass of an execution restriction with
+    limited effect.
+- **Low:** A narrow disclosure or safety gap with limited practical impact, or reliable resource
+    exhaustion affecting the editor or the developer's machine.
+- **Informational:** A genuine security concern with negligible current impact.

--- a/agents/references/playground-threat-model.md
+++ b/agents/references/playground-threat-model.md
@@ -1,0 +1,55 @@
+# Ruff and ty playground threat model
+
+## Overview
+
+This model covers browser analysis, Python execution, file exports, and the public sharing API. The
+[CLI threat model](cli-threat-model.md) defines the general criteria for security findings.
+
+Builds and publication have a separate
+[repository threat model](repository-threat-model.md).
+
+## Trust boundaries and assumptions
+
+- **Attacker-controlled:** shared URLs and workspace contents, including source code, configuration,
+    filenames, and which file is selected.
+- **Trusted environment:** the browser, operating system, local caches, HTTPS, application
+    dependencies including Pyodide, and configured Cloudflare service and KV namespace.
+- **Python execution:** Choosing Run authorizes the workspace's Python code to use the page's
+    JavaScript and browser APIs through Pyodide.
+- **API callers:** The sharing API accepts anonymous uploads, creates a random identifier, and
+    returns stored text to anyone who has that identifier.
+
+## Security invariants
+
+### Browser applications
+
+- **Code Execution:** Analysis must not execute user-supplied code. Running Python requires choosing
+    Run.
+- **Rendering:** Diagnostics, documentation, filenames, errors, and program output must not allow
+    attacker-controlled text to run code or invoke commands in the playground.
+- **Paths and exports:** Loading or editing workspace files must not overwrite unrelated application
+    state. Extracting an exported ZIP must not write outside the chosen directory.
+- **Source privacy:** Analysis must not upload source. Share and the Markdown copy actions upload the
+    selected workspace. Restoring a shared workspace must not disclose other playground data.
+- **Availability:** An isolated analysis failure or slow analysis is a correctness or performance
+    bug. A security issue requires repeatable, disproportionate resource use that materially
+    disrupts the browser or user's machine beyond the playground tab.
+
+### Sharing API
+
+- **Stored values:** Requests must not overwrite unrelated entries, reveal their identifiers or
+    contents, expose deployment credentials, or execute code in the worker.
+- **Availability:** Anonymous requests must not cause disproportionate resource use that denies
+    service to other users or exhausts shared resources.
+
+## Severity calibration
+
+- **Critical:** Service or host compromise, or loss of credentials with comparable authority,
+    with few prerequisites.
+- **High:** Substantial confidentiality or integrity harm, such as executing attacker code on
+    opening a shared link and stealing other playground data.
+- **Medium:** Limited disclosure or modification, or reliable resource exhaustion affecting the
+    shared service.
+- **Low:** A narrow safety gap with limited practical impact, or reliable resource exhaustion
+    affecting a user's browser or machine beyond the playground tab.
+- **Informational:** A genuine security concern with negligible current impact.

--- a/agents/references/threat-models.md
+++ b/agents/references/threat-models.md
@@ -1,0 +1,14 @@
+# Security threat models
+
+Use each model that covers the behavior under review.
+
+- [Ruff and ty CLI](cli-threat-model.md): command-line tools, native libraries, analysis,
+    configuration, file operations, subprocesses, and diagnostics.
+- [Language servers](language-server-threat-model.md): editor messages, workspace trust, document
+    access, edits, and logs.
+- [Playgrounds](playground-threat-model.md): browser applications, WASM, Python execution, and the
+    HTTP sharing API.
+- [GitHub repository](repository-threat-model.md):
+    CI, releases, publishing, ecosystem jobs, and maintainer automation.
+
+Development tools that build or run third-party code follow the repository model.


### PR DESCRIPTION
## Summary

The repository threat model in #28395 covers CI and release automation. Ruff and ty also need security guidance for their command-line tools, libraries, language servers, and browser playgrounds.

Add three models that define trusted inputs, security invariants, and severity for these components, including the public playground sharing API. An index linked from `AGENTS.md` points reviewers to the applicable models.

Depends on #28395.

## Test Plan

Reviewed the trust assumptions and execution paths against the CLI, language-server, and playground code.
