### PR TITLE
[`pyupgrade`] Make the fix for `UP040` always unsafe

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyupgrade/pep-695.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/pep-695.md
@@ -216,3 +216,69 @@ class Bounded(Generic[P]): ...  # no diagnostic
 
 def bounded(callback: Callable[P, int]): ...  # no diagnostic
 ```
+
+## Imported type variables
+
+```toml
+target-version = "py315"
+
+[lint]
+select = ["UP040"]
+```
+
+`typevars.py`:
+
+```py
+from typing import TypeVarTuple
+
+Ts = TypeVarTuple("Ts", bound=int)
+```
+
+`Ts` is imported from `typevars.py`, which Ruff can't follow. In the `TypeAlias`, we don't have
+evidence that this is actually a type variable (it could be a regular tuple being unpacked into the
+alias or something), so an unsafe fix is offered, and the suggested fix fails type checking for
+mixing old- and new-style generics in a `type` statement.
+
+`TypeAliasType` has the explicit `type_params` argument, but the fix treats imported type variables as
+unconstrained `TypeVar`s. It loses `Ts`'s bound and changes its kind, so this fix is also unsafe.
+
+`example.pyi`:
+
+```pyi
+from typing import TypeAlias, TypeAliasType
+
+from typevars import Ts
+
+Alias: TypeAlias = tuple[*Ts]  # snapshot: non-pep695-type-alias
+AliasType = TypeAliasType("AliasType", tuple[*Ts], type_params=(Ts,))  # snapshot: non-pep695-type-alias
+```
+
+```snapshot
+error[UP040]: Type alias `Alias` uses `TypeAlias` annotation instead of the `type` keyword
+ --> src/example.pyi:5:1
+  |
+5 | Alias: TypeAlias = tuple[*Ts]  # snapshot: non-pep695-type-alias
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Use the `type` keyword
+  |
+4 |
+  - Alias: TypeAlias = tuple[*Ts]  # snapshot: non-pep695-type-alias
+5 + type Alias = tuple[*Ts]  # snapshot: non-pep695-type-alias
+6 | AliasType = TypeAliasType("AliasType", tuple[*Ts], type_params=(Ts,))  # snapshot: non-pep695-type-alias
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+
+error[UP040]: Type alias `AliasType` uses `TypeAliasType` assignment instead of the `type` keyword
+ --> src/example.pyi:6:1
+  |
+6 | AliasType = TypeAliasType("AliasType", tuple[*Ts], type_params=(Ts,))  # snapshot: non-pep695-type-alias
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Use the `type` keyword
+  |
+5 | Alias: TypeAlias = tuple[*Ts]  # snapshot: non-pep695-type-alias
+  - AliasType = TypeAliasType("AliasType", tuple[*Ts], type_params=(Ts,))  # snapshot: non-pep695-type-alias
+6 + type AliasType[Ts] = tuple[*Ts]  # snapshot: non-pep695-type-alias
+  |
+note: This is an unsafe fix and may change runtime behavior
+```

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.py
@@ -94,7 +94,7 @@ PositiveList = TypeAliasType(
 T = typing.TypeVar("T", default=Any)
 AnyList = TypeAliasType("AnyList", list[T], type_params=(T,))
 
-# unsafe fix if comments within the fix
+# Comments outside the alias value are removed by the fix.
 T = TypeVar("T")
 PositiveList = TypeAliasType(  # eaten comment
     "PositiveList", list[Annotated[T, Gt(0)]], type_params=(T,)

--- a/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pyupgrade/UP040.pyi
@@ -2,7 +2,7 @@ import typing
 from typing import TypeAlias
 
 # UP040
-# Fixes in type stub files should be safe to apply unlike in regular code where runtime behavior could change
+# Fixes are unsafe even in stub files.
 x: typing.TypeAlias = int
 x: TypeAlias = int
 

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/pep695/non_pep695_type_alias.rs
@@ -5,12 +5,12 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::token::parenthesized_range;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{Expr, ExprCall, ExprName, Keyword, StmtAnnAssign, StmtAssign, StmtRef};
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
 use crate::codes::Category;
 use crate::preview::is_type_var_default_enabled;
-use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, Violation};
 use ruff_python_ast::PythonVersion;
 
 use super::{
@@ -61,10 +61,15 @@ use super::{
 ///
 /// ## Fix safety
 ///
-/// This fix is marked unsafe for `TypeAlias` assignments outside of stub files because of the
-/// runtime behavior around `isinstance()` calls noted above. The fix is also unsafe for
-/// `TypeAliasType` assignments if there are any comments in the replacement range that would be
-/// deleted.
+/// This fix is always marked unsafe because it can change runtime behavior and type-checking
+/// semantics, as described above. It may also remove comments.
+///
+/// The rule also cannot inspect type variables defined in another module. For `TypeAlias`
+/// annotations, this means the fix may fail to convert legacy type variables to type parameters,
+/// producing code that will be rejected by type checkers. For `TypeAliasType`, legacy type
+/// variables are recognized via the explicit `type_params` argument, but the type variable's
+/// definition cannot be resolved to preserve its bounds, constraints, defaults, or even kind,
+/// producing unconstrained `TypeVar`s.
 ///
 /// ## See also
 ///
@@ -278,7 +283,6 @@ fn create_diagnostic(
 
     let source = checker.source();
     let tokens = checker.tokens();
-    let comment_ranges = checker.comment_ranges();
 
     let range_with_parentheses =
         parenthesized_range(value.into(), stmt.into(), tokens).unwrap_or(value.range());
@@ -290,29 +294,6 @@ fn create_diagnostic(
     );
     let edit = Edit::range_replacement(content, stmt.range());
 
-    let applicability =
-        if type_alias_kind == TypeAliasKind::TypeAlias && !checker.source_type.is_stub() {
-            // The fix is always unsafe in non-stubs
-            // because new-style aliases have different runtime behavior.
-            // See https://github.com/astral-sh/ruff/issues/6434
-            Applicability::Unsafe
-        } else {
-            // In stub files, or in non-stub files for `TypeAliasType` assignments,
-            // the fix is only unsafe if it would delete comments.
-            //
-            // it would be easier to check for comments in the whole `stmt.range`, but because
-            // `create_diagnostic` uses the full source text of `value`, comments within `value` are
-            // actually preserved. thus, we have to check for comments in `stmt` but outside of `value`
-            let pre_value = TextRange::new(stmt.start(), range_with_parentheses.start());
-            let post_value = TextRange::new(range_with_parentheses.end(), stmt.end());
-
-            if comment_ranges.intersects(pre_value) || comment_ranges.intersects(post_value) {
-                Applicability::Unsafe
-            } else {
-                Applicability::Safe
-            }
-        };
-
     checker
         .report_diagnostic(
             NonPEP695TypeAlias {
@@ -321,5 +302,5 @@ fn create_diagnostic(
             },
             stmt.range(),
         )
-        .set_fix(Fix::applicable_edit(edit, applicability));
+        .set_fix(Fix::unsafe_edit(edit));
 }

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py.snap
@@ -245,6 +245,7 @@ help: Use the `type` keyword
 67 + type PositiveList[T] = list[Annotated[T, Gt(0)]]
 68 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `PositiveList` uses `TypeAliasType` assignment instead of the `type` keyword
   --> UP040.py:73:1
@@ -267,6 +268,7 @@ help: Use the `type` keyword
 73 + type PositiveList[T: SupportGt] = list[Annotated[T, Gt(0)]]
 74 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `Tuple3` uses `TypeAliasType` assignment instead of the `type` keyword
   --> UP040.py:81:1
@@ -285,6 +287,7 @@ help: Use the `type` keyword
 81 + type Tuple3[T1: SupportGt, T2, T3] = tuple[T1, T2, T3]
 82 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `PositiveInt` uses `TypeAliasType` assignment instead of the `type` keyword
   --> UP040.py:84:1
@@ -301,6 +304,7 @@ help: Use the `type` keyword
 84 + type PositiveInt = Annotated[int, Gt(0)]
 85 | PositiveInt = TypeAliasType("PositiveInt", Annotated[int, Gt(0)], type_params=())
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `PositiveInt` uses `TypeAliasType` assignment instead of the `type` keyword
   --> UP040.py:85:1
@@ -319,11 +323,12 @@ help: Use the `type` keyword
 85 + type PositiveInt = Annotated[int, Gt(0)]
 86 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `PositiveList` uses `TypeAliasType` assignment instead of the `type` keyword
    --> UP040.py:99:1
     |
- 97 |   # unsafe fix if comments within the fix
+ 97 |   # Comments outside the alias value are removed by the fix.
  98 |   T = TypeVar("T")
  99 | / PositiveList = TypeAliasType(  # eaten comment
 100 | |     "PositiveList", list[Annotated[T, Gt(0)]], type_params=(T,)
@@ -360,6 +365,7 @@ help: Use the `type` keyword
 104 + type PositiveList[T] = list[Annotated[T, Gt(0)]] # this comment should be okay
 105 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `PositiveList` uses `TypeAliasType` assignment instead of the `type` keyword
    --> UP040.py:111:1
@@ -387,6 +393,7 @@ help: Use the `type` keyword
 113 +     ]
 114 |
     |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `T` uses `TypeAlias` annotation instead of the `type` keyword
    --> UP040.py:117:1

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.py__preview_diff.snap
@@ -38,7 +38,7 @@ UP040 [*] Type alias `AnyList` uses `TypeAliasType` assignment instead of the `t
 95 | AnyList = TypeAliasType("AnyList", list[T], type_params=(T,))
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 96 |
-97 | # unsafe fix if comments within the fix
+97 | # Comments outside the alias value are removed by the fix.
    |
 help: Use the `type` keyword
    |
@@ -47,6 +47,7 @@ help: Use the `type` keyword
 95 + type AnyList[T = Any] = list[T]
 96 |
    |
+note: This is an unsafe fix and may change runtime behavior
 
 
 UP040 [*] Type alias `DefaultList` uses `TypeAlias` annotation instead of the `type` keyword

--- a/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.pyi.snap
+++ b/crates/ruff_linter/src/rules/pyupgrade/snapshots/ruff_linter__rules__pyupgrade__tests__UP040.pyi.snap
@@ -5,23 +5,24 @@ UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keywo
  --> UP040.pyi:6:1
   |
 4 | # UP040
-5 | # Fixes in type stub files should be safe to apply unlike in regular code where runtime behavior could change
+5 | # Fixes are unsafe even in stub files.
 6 | x: typing.TypeAlias = int
   | ^^^^^^^^^^^^^^^^^^^^^^^^^
 7 | x: TypeAlias = int
   |
 help: Use the `type` keyword
   |
-5 | # Fixes in type stub files should be safe to apply unlike in regular code where runtime behavior could change
+5 | # Fixes are unsafe even in stub files.
   - x: typing.TypeAlias = int
 6 + type x = int
 7 | x: TypeAlias = int
   |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
  --> UP040.pyi:7:1
   |
-5 | # Fixes in type stub files should be safe to apply unlike in regular code where runtime behavior could change
+5 | # Fixes are unsafe even in stub files.
 6 | x: typing.TypeAlias = int
 7 | x: TypeAlias = int
   | ^^^^^^^^^^^^^^^^^^
@@ -32,6 +33,7 @@ help: Use the `type` keyword
 7 + type x = int
 8 |
   |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `x` uses `TypeAlias` annotation instead of the `type` keyword
   --> UP040.pyi:11:1
@@ -52,6 +54,7 @@ help: Use the `type` keyword
 11 + type x = tuple[
 12 |     int,  # preserved
    |
+note: This is an unsafe fix and may change runtime behavior
 
 UP040 [*] Type alias `T` uses `TypeAlias` annotation instead of the `type` keyword
   --> UP040.pyi:16:1
@@ -75,3 +78,4 @@ help: Use the `type` keyword
 16 + type T = ( # comment0
 17 |     # comment1
    |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Summary
--

This turned into a bit of a rabbit hole, and the very short summary is that the fix for `UP040` is now always unsafe and documented as such. Read on for more details.

`UP040`, `UP046`, and `UP047` all transform code using legacy type variables (`typing.{TypeVar, TypeVarTuple, ParamSpec}`) to use PEP-695 syntax instead (`UP040` also applies to non-generic type aliases but generics are the problem here). This means transformations like this:

```diff
 from typing import Generic, TypeVar, TypeAlias, TypeAliasType

 T = TypeVar("T")

 # UP040
-Alias: TypeAlias = list[T]
+type Alias[T] = list[T]

 # UP040
-AliasType = TypeAliasType("AliasType", set[T], type_params=(T,))
+type AliasType[T] = set[T]

 # UP046
-class C(Generic[T]): ...
+class C[T]: ...

 # UP047
-def f(x: T): ...
+def f[T](x: T): ...
```

This works very well if the type variable is defined in the same file. However, if `T` is imported from another file, it could have bounds, constraints, defaults, or a different type entirely that is mishandled by the autofix.

As it turns out, `UP046` and `UP047` already handle this pretty gracefully. Their fixes are _always_ unsafe, and the limitations around imports are documented. `UP047` can't tell if an imported type is generic at all, so it simply doesn't emit a diagnostic for imported annotation types. `UP046` offers a diagnostic but not a fix. We _could_ consider an unsafe or display-only fix, perhaps, but I think we omitted the fix as being even more unsafe than the normally unsafe fix.

That leaves `UP040` as the problematic case. Its fix for `TypeAlias`es was also already unsafe in `.py` files but safe in `.pyi` files. Unfortunately, the fix can still cause problems in stub files in a case like this:

```py
from typing import TypeAlias

from somewhere import MyTypeVar

ListOfInt: TypeAlias = list[MyTypeVar]
```

The proposed safe fix is:

```diff
-ListOfInt: TypeAlias = list[MyTypeVar]
+type ListOfInt = list[MyTypeVar]
```

which is invalid: https://play.ty.dev/6385facd-2a61-4f3e-8961-9124c645643a because it mixes the old-style type variable with the new `type` statement instead of making the `type` statement itself generic:

```py
type ListOfInt[MyTypeVar] = list[MyTypeVar]
```

The example here uses `.py` files and blocks for convenience, but the same safe fix is offered for stub files. Similarly, the playground link uses a bounded type variable, but the problem occurs even without bounds or other restraints.

Second, the fix for `TypeAliasType` was also safe, even for imported type variables. The problem here is very similar to that above. For imported type variables, the safe fix could lose bounds and constraints or even the kind of type variable. For example:

```diff
 from typing import TypeAliasType

 from somewhere import Ts

 # somewhere.py
 # from typing import TypeVarTuple
 # Ts = TypeVarTuple("Ts", bound=int)

-MyAliasType = TypeAliasType("MyAliasType", tuple[*Ts], type_params=(Ts,))
+type MyAliasType[Ts] = tuple[*Ts]
```

This presents `Ts` as a regular `TypeVar` with no bound instead of a bounded `TypeVarTuple`.

I tried following `UP046` and omitting the fix for imported type variables, but it was a little bit awkward for the current structure of `UP040`. I think it's sufficient and less intrusive into the current implementation to mark it unsafe.

I also considered trying to retain safe fixes for `UP040` in stub files when no imported types are involved, but making the fix always unsafe again seemed like the more consistent and simpler approach. From what I remember, none of these rules typically has much ecosystem impact anyway.

[#28505]: https://github.com/astral-sh/ruff/pull/28505
[PEP 695]: https://peps.python.org/pep-0695/

Test Plan
--

New mdtests and also the ecosystem check here
