### PR TITLE
[`ruff`, `flake8-use-pathlib`] Support `parent_mode` (`RUF064`, `PTH103`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-use-pathlib/os-makedirs.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-use-pathlib/os-makedirs.md
@@ -1,0 +1,70 @@
+# `os-makedirs` (`PTH103`)
+
+## Parent directory permissions
+
+```toml
+preview = true
+target-version = "py315"
+lint.select = ["PTH103"]
+```
+
+The conversion preserves `parent_mode` alongside positional `mode` and `exist_ok` arguments,
+inserting `True` for `parents` in the position expected by `Path.mkdir`.
+
+```py
+import os
+from pathlib import Path
+
+os.makedirs("a/b", 0o700, True, parent_mode=0o755)  # snapshot: os-makedirs
+```
+
+```snapshot
+error[PTH103]: `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+ --> src/mdtest_snippet.py:4:1
+  |
+4 | os.makedirs("a/b", 0o700, True, parent_mode=0o755)  # snapshot: os-makedirs
+  | ^^^^^^^^^^^
+help: Replace with `Path(...).mkdir(parents=True)`
+  |
+3 |
+  - os.makedirs("a/b", 0o700, True, parent_mode=0o755)  # snapshot: os-makedirs
+4 + Path("a/b").mkdir(0o700, True, True, parent_mode=0o755)  # snapshot: os-makedirs
+5 | os.makedirs("a/b", parent_mode=0o755)  # snapshot: os-makedirs
+  |
+```
+
+The conversion also preserves `parent_mode` when `mode` and `exist_ok` are omitted.
+
+```py
+os.makedirs("a/b", parent_mode=0o755)  # snapshot: os-makedirs
+```
+
+```snapshot
+error[PTH103]: `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+ --> src/mdtest_snippet.py:5:1
+  |
+5 | os.makedirs("a/b", parent_mode=0o755)  # snapshot: os-makedirs
+  | ^^^^^^^^^^^
+help: Replace with `Path(...).mkdir(parents=True)`
+  |
+4 | os.makedirs("a/b", 0o700, True, parent_mode=0o755)  # snapshot: os-makedirs
+  - os.makedirs("a/b", parent_mode=0o755)  # snapshot: os-makedirs
+5 + Path("a/b").mkdir(parents=True, parent_mode=0o755)  # snapshot: os-makedirs
+6 | os.makedirs("a/b", 0o700, True, 0o755)  # snapshot: os-makedirs
+  |
+```
+
+`parent_mode` is keyword-only. Calls with a fourth positional argument receive a diagnostic without a fix.
+
+```py
+os.makedirs("a/b", 0o700, True, 0o755)  # snapshot: os-makedirs
+```
+
+```snapshot
+error[PTH103]: `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
+ --> src/mdtest_snippet.py:6:1
+  |
+6 | os.makedirs("a/b", 0o700, True, 0o755)  # snapshot: os-makedirs
+  | ^^^^^^^^^^^
+help: Replace with `Path(...).mkdir(parents=True)`
+```

--- a/crates/ruff_linter/resources/mdtest/ruff/non-octal-permissions.md
+++ b/crates/ruff_linter/resources/mdtest/ruff/non-octal-permissions.md
@@ -1,0 +1,44 @@
+# `non-octal-permissions` (`RUF064`)
+
+## Parent directory permissions
+
+```toml
+target-version = "py315"
+lint.select = ["RUF064"]
+```
+
+The `mode` and `parent_mode` arguments to `os.makedirs` are checked independently.
+
+```py
+import os
+from pathlib import Path
+
+os.makedirs(
+    "a/b",
+    mode=700,  # error: [non-octal-permissions] "Non-octal mode"
+    parent_mode=755,  # error: [non-octal-permissions] "Non-octal mode"
+)
+```
+
+`Path.mkdir` also checks `parent_mode`, even when `mode` is omitted, and offers the same octal fix.
+
+```py
+Path("a/b").mkdir(parents=True, parent_mode=755)  # snapshot: non-octal-permissions
+```
+
+```snapshot
+error[RUF064]: Non-octal mode
+ --> src/mdtest_snippet.py:9:45
+  |
+9 | Path("a/b").mkdir(parents=True, parent_mode=755)  # snapshot: non-octal-permissions
+  |                                             ^^^
+info: Current value of 755 (0o1363) sets permissions: u=-wx, g=rw-, o=-wx
+info: Suggested value of 0o755 sets permissions: u=rwx, g=r-x, o=r-x
+help: Replace with octal literal
+  |
+8 | )
+  - Path("a/b").mkdir(parents=True, parent_mode=755)  # snapshot: non-octal-permissions
+9 + Path("a/b").mkdir(parents=True, parent_mode=0o755)  # snapshot: non-octal-permissions
+  |
+note: This is an unsafe fix and may change runtime behavior
+```

--- a/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_makedirs.rs
+++ b/crates/ruff_linter/src/rules/flake8_use_pathlib/rules/os_makedirs.rs
@@ -84,19 +84,23 @@ pub(crate) fn os_makedirs(checker: &Checker, call: &ExprCall, segments: &[&str])
         return;
     }
 
-    // Signature as of Python 3.13 (https://docs.python.org/3/library/os.html#os.makedirs)
+    // Signature as of Python 3.15 (https://docs.python.org/3/library/os.html#os.makedirs)
     // ```text
     //               0      1            2
-    //  os.makedirs(name, mode=0o777, exist_ok=False)
+    //  os.makedirs(name, mode=0o777, exist_ok=False, *, parent_mode=None)
     // ```
     // We should not offer autofixes if there are more arguments
     // than in the original signature
-    if call.arguments.len() > 3 {
+    let parent_mode = call.arguments.find_keyword("parent_mode");
+    if call.arguments.len() > 3 + usize::from(parent_mode.is_some()) {
         return;
     }
     // We should not offer autofixes if there are keyword arguments
     // that don't match the original function signature
-    if has_unknown_keywords_or_starred_expr(&call.arguments, &["name", "mode", "exist_ok"]) {
+    if has_unknown_keywords_or_starred_expr(
+        &call.arguments,
+        &["name", "mode", "exist_ok", "parent_mode"],
+    ) {
         return;
     }
 
@@ -120,7 +124,7 @@ pub(crate) fn os_makedirs(checker: &Checker, call: &ExprCall, segments: &[&str])
         let mode = call.arguments.find_argument("mode", 1);
         let exist_ok = call.arguments.find_argument("exist_ok", 2);
 
-        let mkdir_args = match (mode, exist_ok) {
+        let mut mkdir_args = match (mode, exist_ok) {
             // Default to a keyword argument when alone.
             (None, None) => "parents=True".to_string(),
             // If either argument is missing, it's safe to add `parents` at the end.
@@ -138,6 +142,10 @@ pub(crate) fn os_makedirs(checker: &Checker, call: &ExprCall, segments: &[&str])
                 locator.slice(exist_ok)
             ),
         };
+        if let Some(parent_mode) = parent_mode {
+            mkdir_args.push_str(", ");
+            mkdir_args.push_str(locator.slice(parent_mode));
+        }
 
         let replacement = if is_pathlib_path_call(checker, name) {
             format!("{name_code}.mkdir({mkdir_args})")

--- a/crates/ruff_linter/src/rules/ruff/rules/non_octal_permissions.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/non_octal_permissions.rs
@@ -91,13 +91,20 @@ impl Violation for NonOctalPermissions {
 
 /// RUF064
 pub(crate) fn non_octal_permissions(checker: &Checker, call: &ExprCall) {
-    let mode_arg = find_func_mode_arg(call, checker.semantic())
-        .or_else(|| find_method_mode_arg(call, checker.semantic()));
+    if let Some(mode_arg) = find_func_mode_arg(call, checker.semantic())
+        .or_else(|| find_method_mode_arg(call, checker.semantic()))
+    {
+        check_mode(checker, mode_arg);
+    }
 
-    let Some(mode_arg) = mode_arg else {
-        return;
-    };
+    if let Some(parent_mode_arg) = find_func_parent_mode_arg(call, checker.semantic())
+        .or_else(|| find_method_parent_mode_arg(call, checker.semantic()))
+    {
+        check_mode(checker, parent_mode_arg);
+    }
+}
 
+fn check_mode(checker: &Checker, mode_arg: &Expr) {
     let Expr::NumberLiteral(ast::ExprNumberLiteral {
         value: ast::Number::Int(int),
         ..
@@ -171,6 +178,33 @@ fn find_method_mode_arg<'a>(call: &'a ExprCall, semantic: &SemanticModel) -> Opt
             ["pathlib", "Path" | "PosixPath" | "WindowsPath"],
             "chmod" | "lchmod" | "mkdir" | "touch",
         ) => call.arguments.find_argument_value("mode", 0),
+        _ => None,
+    }
+}
+
+fn find_func_parent_mode_arg<'a>(call: &'a ExprCall, semantic: &SemanticModel) -> Option<&'a Expr> {
+    let qualified_name = semantic.resolve_qualified_name(&call.func)?;
+
+    match qualified_name.segments() {
+        ["os", "makedirs"] => call
+            .arguments
+            .find_keyword("parent_mode")
+            .map(|keyword| &keyword.value),
+        _ => None,
+    }
+}
+
+fn find_method_parent_mode_arg<'a>(
+    call: &'a ExprCall,
+    semantic: &SemanticModel,
+) -> Option<&'a Expr> {
+    let (type_name, attr_name) = resolve_method_call(&call.func, semantic)?;
+
+    match (type_name.segments(), attr_name) {
+        (["pathlib", "Path" | "PosixPath" | "WindowsPath"], "mkdir") => call
+            .arguments
+            .find_keyword("parent_mode")
+            .map(|keyword| &keyword.value),
         _ => None,
     }
 }


### PR DESCRIPTION
Summary
--

Python 3.15 adds the `parent_mode` argument to both [`os.makedirs`] and [`pathlib.Path.mkdir`], which allows setting the mode for intermediate directories separately from the main `mode` argument. This PR adds support for the new argument in both [`non-octal-permissions` (`RUF064`)], which now checks this argument's permissions too, and in [`os-makedirs` (`PTH103`)], which just needs to recognize it for converting calls from the `os` to the `pathlib` versions.

As a note to head off other Codexes, my Codex keeps complaining about this fix being unsafe:

```diff
 import os
+import pathlib

 def create():
-    os.makedirs("a/b", parent_mode=(mode := 0o700), mode=mode)
+    pathlib.Path("a/b").mkdir(mode=mode, parents=True, parent_mode=(mode := 0o700))
```

because it reorders the arguments and could change the order of side effects. This is yet another preexisting issue with the way this rule and a couple of other PTH rules rewrite argument lists that hasn't been reported and isn't strictly related to the 3.15 changes. If we're really worried about that, we could just mark the fix unsafe, I guess.

[`os-makedirs` (`PTH103`)]: https://docs.astral.sh/ruff/rules/os-makedirs/
[`non-octal-permissions` (`RUF064`)]: https://docs.astral.sh/ruff/rules/non-octal-permissions/
[`pathlib.Path.mkdir`]: https://docs.python.org/3.15/library/pathlib.html#pathlib.Path.mkdir
[`os.makedirs`]: https://docs.python.org/3.15/library/os.html#os.makedirs

Test Plan
--

New mdtests for both affected rules
