### PR TITLE
[ty] Report override conflicts introduced by new bases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1397,6 +1397,18 @@ class Grandchild(Child):
         return ""
 ```
 
+The same new conflict is reported when the first base inherits the selected method from an
+intermediate class.
+
+```py
+class Intermediate(Strings): ...
+
+class IndirectChild(Intermediate, Concrete):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+```
+
 Specializing a generic intermediate class also specializes the inherited method's return type.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -1378,6 +1378,25 @@ class PreservesInvalid(Invalid):
         return ""
 ```
 
+A parent that inherits only `Base[Any]` can validly return `str`. Adding `Concrete` introduces a new
+`int` return contract, so preserving that parent's signature is an invalid override. Further
+descendants do not repeat the violation.
+
+```py
+class Strings(Gradual):
+    def method(self) -> str:
+        return ""
+
+class Child(Strings, Concrete):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+
+class Grandchild(Child):
+    def method(self) -> str:
+        return ""
+```
+
 Specializing a generic intermediate class also specializes the inherited method's return type.
 
 ```py
@@ -1387,6 +1406,34 @@ class Specialized(GenericDiamond[int]):
     # error: [invalid-method-override]
     def method(self) -> str:
         return ""
+```
+
+## Existing method violations through gradual generic bases
+
+A parent can already have an invalid override of `Base[Any]` because its parameter is too narrow.
+Adding a `Base[int]` inheritance path does not repeat that violation on an override with the same
+signature. The parent's original `Base[Any]` specialization determines whether the violation already
+exists.
+
+```py
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+class Base(Generic[T]):
+    def method(self, value: object) -> T:
+        raise NotImplementedError
+
+class Invalid(Base[Any]):
+    # error: [invalid-method-override]
+    def method(self, value: str) -> Any:
+        return value
+
+class Concrete(Base[int]): ...
+
+class Child(Invalid, Concrete):
+    def method(self, value: str) -> Any:
+        return value
 ```
 
 ## Generic methods

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -981,6 +981,25 @@ class PreservesInvalid(Invalid):
         return ""
 ```
 
+A parent that inherits only `Base[Any]` can validly return `str`. Adding `Concrete` introduces a new
+`int` return contract, so preserving that parent's signature is an invalid override. Further
+descendants do not repeat the violation.
+
+```py
+class Strings(Gradual):
+    def method(self) -> str:
+        return ""
+
+class Child(Strings, Concrete):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+
+class Grandchild(Child):
+    def method(self) -> str:
+        return ""
+```
+
 Specializing a generic intermediate class also specializes the inherited method's return type.
 
 ```py
@@ -990,6 +1009,32 @@ class Specialized(GenericDiamond[int]):
     # error: [invalid-method-override]
     def method(self) -> str:
         return ""
+```
+
+## Existing method violations through gradual generic bases
+
+A parent can already have an invalid override of `Base[Any]` because its parameter is too narrow.
+Adding a `Base[int]` inheritance path does not repeat that violation on an override with the same
+signature. The parent's original `Base[Any]` specialization determines whether the violation already
+exists.
+
+```py
+from typing import Any
+
+class Base[T]:
+    def method(self, value: object) -> T:
+        raise NotImplementedError
+
+class Invalid(Base[Any]):
+    # error: [invalid-method-override]
+    def method(self, value: str) -> Any:
+        return value
+
+class Concrete(Base[int]): ...
+
+class Child(Invalid, Concrete):
+    def method(self, value: str) -> Any:
+        return value
 ```
 
 ## Unbound inherited methods

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -1000,6 +1000,18 @@ class Grandchild(Child):
         return ""
 ```
 
+The same new conflict is reported when the first base inherits the selected method from an
+intermediate class.
+
+```py
+class Intermediate(Strings): ...
+
+class IndirectChild(Intermediate, Concrete):
+    # error: [invalid-method-override]
+    def method(self) -> str:
+        return ""
+```
+
 Specializing a generic intermediate class also specializes the inherited method's return type.
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -979,7 +979,7 @@ class ReturnsInt:
 class Compatible(SatisfiesBoth, ReturnsStr, ReturnsInt): ...
 ```
 
-### A compatible subclass override satisfies both contracts
+### Subclass overrides must satisfy both contracts
 
 A subclass can provide an implementation that satisfies otherwise-incompatible base definitions.
 
@@ -1003,6 +1003,17 @@ class AcceptsInt:
 
 class CompatibleParameter(AcceptsStr, AcceptsInt):
     def accepts(self, value: str | int) -> None: ...
+```
+
+Matching the first base's signature does not satisfy an incompatible contract from an unrelated
+base. The conflict is introduced by the subclass, so it is reported on the override.
+
+```pyi
+class IncompatibleReturn(ReturnsStr, ReturnsInt):
+    def method(self) -> str: ...  # error: [invalid-method-override]
+
+class IncompatibleParameter(AcceptsStr, AcceptsInt):
+    def accepts(self, value: str) -> None: ...  # error: [invalid-method-override]
 ```
 
 ### An intermediate `Any` does not hide a conflict
@@ -1538,6 +1549,19 @@ Unannotated overrides of overloaded dunder methods should remain accepted.
 ```pyi
 class C(list[int]):
     def __getitem__(self, key): ...
+```
+
+An invalid override of a method inherited implicitly from `object` is also reported only on the
+parent. Preserving that signature does not produce another diagnostic on the child.
+
+`object.pyi`:
+
+```pyi
+class InvalidStr:
+    def __str__(self) -> int: ...  # error: [invalid-method-override]
+
+class PreservesInvalidStr(InvalidStr):
+    def __str__(self) -> int: ...
 ```
 
 ## Non-generic methods on generic classes work as expected

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1587,6 +1587,19 @@ class ChangesSignature(Parent):
     def method(self, right): ...
 ```
 
+A base that inherits the selected method without the conflicting contract does not make the conflict
+new. The conflict remains reported only on `Parent`, regardless of the child's base order.
+
+```pyi
+class Independent(Left): ...
+
+class IndependentFirst(Independent, Parent):
+    def method(self, left): ...
+
+class ParentFirst(Parent, Independent):
+    def method(self, left): ...
+```
+
 The existing conflict does not hide an incompatible contract introduced by another base of the
 child.
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -1564,6 +1564,95 @@ class PreservesInvalidStr(InvalidStr):
     def __str__(self) -> int: ...
 ```
 
+## Conflicts inherited through an intermediate base
+
+A parent can inherit incompatible method signatures without defining its own override. A child that
+preserves the selected signature does not repeat that conflict. An override that changes the
+selected signature still receives an error.
+
+```pyi
+class Left:
+    def method(self, left): ...
+
+class Right:
+    def method(self, right): ...
+
+class Parent(Left, Right): ...  # error: [invalid-method-override]
+
+class Child(Parent):
+    def method(self, left): ...
+
+class ChangesSignature(Parent):
+    # error: [invalid-method-override] "Definition is incompatible with `Left.method`"
+    def method(self, right): ...
+```
+
+The existing conflict does not hide an incompatible contract introduced by another base of the
+child.
+
+```pyi
+class RequiresExtra:
+    def method(self, left, extra): ...
+
+class AddsContract(Parent, RequiresExtra):
+    # error: [invalid-method-override] "Definition is incompatible with `RequiresExtra.method`"
+    def method(self, left): ...
+```
+
+The same suppression applies when one of the inherited contracts is a static method with an optional
+argument.
+
+```pyi
+class Static:
+    @staticmethod
+    def method(left=None): ...
+
+class StaticParent(Left, Static): ...  # error: [invalid-method-override]
+
+class StaticChild(StaticParent):
+    def method(self, left): ...
+```
+
+## An earlier base can be bypassed when resolving an inherited method
+
+The first direct base need not supply the selected method. Here, `Child` uses `Override.method`
+ahead of `Base.method`, even though `Inherited` on its own uses `Base.method`. The existing
+violation on `Override` does not need another diagnostic on `Child`.
+
+```pyi
+class Base:
+    def method(self, value: int): ...
+
+class Inherited(Base): ...
+
+class Override(Base):
+    def method(self, value: str): ...  # error: [invalid-method-override]
+
+class Child(Inherited, Override):
+    def method(self, value: str): ...
+```
+
+## Inherited conflicts bind `Self` to the parent
+
+An inherited method's `Self` annotation refers to the parent whose hierarchy is being checked.
+`Parent.method` only accepts `Parent` instances, conflicting with `AcceptsBase.method`, which
+accepts any `Base` instance. Preserving that signature on `Child` does not repeat the conflict.
+
+```pyi
+from typing_extensions import Self
+
+class Base:
+    def method(self, other: Self): ...
+
+class AcceptsBase:
+    def method(self, other: Base): ...
+
+class Parent(Base, AcceptsBase): ...  # error: [invalid-method-override]
+
+class Child(Parent):
+    def method(self, other: Parent): ...
+```
+
 ## Non-generic methods on generic classes work as expected
 
 ```toml

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -96,7 +96,7 @@ pub(super) fn check_class<'db>(
             .collect();
         if !generic_bases.is_empty() {
             // Overrides must respect every inherited specialization. Keep the MRO's bases first
-            // so the immediate parent used to suppress inherited violations is unchanged.
+            // so the selected inherited method is unchanged.
             let env = &context.program_environment();
             bases.extend(
                 class_specialized
@@ -650,10 +650,9 @@ fn check_class_declaration<'db>(
     let is_private_member = is_mangled_private(member.name.as_str());
     let mut subclass_variable_kind: Option<Option<VariableKind>> = None;
 
-    // Track the first superclass that defines this method (the "immediate parent" for this method).
-    // We need this to check if parent itself already has an LSP violation with an ancestor.
-    // If so, we shouldn't report the same violation for the child class.
-    let mut immediate_parent_method: Option<(ClassType<'db>, Type<'db>)> = None;
+    // Track the first superclass that defines this method so we can distinguish inherited
+    // conflicts from violations introduced by the child.
+    let mut inherited_method_owner = None;
     let mut immediate_parent_variable_kind: Option<(ClassType<'db>, VariableKind)> = None;
 
     if !is_private_member {
@@ -732,10 +731,7 @@ fn check_class_declaration<'db>(
                 ));
             }
 
-            // Record the first superclass that defines this method as the "immediate parent method"
-            if immediate_parent_method.is_none() {
-                immediate_parent_method = Some((superclass, superclass_type));
-            }
+            inherited_method_owner.get_or_insert(superclass);
 
             if (configuration.check_final_method_overridden() && overridden_final_method.is_none())
                 || (configuration.check_final_variable_overridden()
@@ -896,37 +892,19 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            // Do not repeat a violation that already exists in the immediate parent's hierarchy.
-            // Check the parent's own ancestor specializations: a valid override of `Base[Any]`
-            // can become invalid when the child also inherits `Base[int]` through another base.
-            // Include the MRO for implicit ancestors such as `object`, and explicit inheritance
-            // paths for specializations omitted from the MRO.
+            // Do not repeat a violation that already exists in the parent's hierarchy.
             // See: https://github.com/astral-sh/ty/issues/2000
-            if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method
-                && immediate_parent != superclass
-                && !is_assignable_method_override(db, env, immediate_parent_type, superclass_type)
-                && immediate_parent
-                    .iter_mro(db)
-                    .skip(1)
-                    .filter_map(ClassBase::into_class)
-                    .chain(immediate_parent.iter_explicit_ancestors(db, env).skip(1))
-                    .filter(|ancestor| ancestor.class_literal(db) == superclass.class_literal(db))
-                    .any(|ancestor| {
-                        let Place::Defined(DefinedPlace {
-                            ty: ancestor_type, ..
-                        }) = Type::instance(db, env, ancestor)
-                            .member(db, env, &member.name)
-                            .place
-                        else {
-                            return false;
-                        };
-                        !is_assignable_method_override(
-                            db,
-                            env,
-                            immediate_parent_type,
-                            ancestor_type,
-                        )
-                    })
+            if let Some(method_owner) = inherited_method_owner
+                && method_owner != superclass
+                && is_inherited_method_violation(
+                    db,
+                    env,
+                    bases,
+                    method_owner,
+                    superclass,
+                    superclass_type,
+                    &member.name,
+                )
             {
                 continue;
             }
@@ -1014,6 +992,62 @@ fn check_class_declaration<'db>(
             superclass_definition,
         );
     }
+}
+
+/// Returns whether the selected inherited method already violates this ancestor's contract.
+///
+/// The parent can inherit the method without defining an override. Its hierarchy may already
+/// combine conflicting contracts that are absent from the method-defining class's hierarchy.
+fn is_inherited_method_violation<'db>(
+    db: &'db dyn Db,
+    env: &ProgramEnvironment<'db>,
+    bases: &[ClassBase<'db>],
+    method_owner: ClassType<'db>,
+    superclass: ClassType<'db>,
+    superclass_type: Type<'db>,
+    name: &Name,
+) -> bool {
+    // An earlier MRO entry can select a different method in its own hierarchy. Find the closest
+    // ancestor that inherits the method actually selected by the child's MRO.
+    let parent = bases
+        .iter()
+        .filter_map(|base| base.into_class())
+        .find(|parent| {
+            parent
+                .iter_mro(db)
+                .any(|base| base == ClassBase::Class(method_owner))
+        })
+        .unwrap_or(method_owner);
+    let Place::Defined(DefinedPlace {
+        ty: parent_type, ..
+    }) = Type::instance(db, env, parent).member(db, env, name).place
+    else {
+        return false;
+    };
+    if is_assignable_method_override(db, env, parent_type, superclass_type) {
+        return false;
+    }
+
+    // Check the parent's own specializations: a valid override of `Base[Any]` can become invalid
+    // when the child also inherits `Base[int]`. Include implicit ancestors such as `object` and
+    // explicit inheritance paths for specializations omitted from the MRO.
+    parent
+        .iter_mro(db)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .chain(parent.iter_explicit_ancestors(db, env).skip(1))
+        .filter(|ancestor| ancestor.class_literal(db) == superclass.class_literal(db))
+        .any(|ancestor| {
+            let Place::Defined(DefinedPlace {
+                ty: ancestor_type, ..
+            }) = Type::instance(db, env, ancestor)
+                .member(db, env, name)
+                .place
+            else {
+                return false;
+            };
+            !is_assignable_method_override(db, env, parent_type, ancestor_type)
+        })
 }
 
 /// Checks whether a method override preserves its superclass method's callable domain.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -896,27 +896,39 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            // If this superclass is not the immediate parent for this method,
-            // check if the immediate parent itself already has an LSP violation with this ancestor.
-            // If so, don't report the same violation for the child class -- it would be a false positive
-            // since the child cannot fix the violation without contradicting its immediate parent's contract.
+            // Do not repeat a violation that already exists in the immediate parent's hierarchy.
+            // Check the parent's own ancestor specializations: a valid override of `Base[Any]`
+            // can become invalid when the child also inherits `Base[int]` through another base.
+            // Include the MRO for implicit ancestors such as `object`, and explicit inheritance
+            // paths for specializations omitted from the MRO.
             // See: https://github.com/astral-sh/ty/issues/2000
-            if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method {
-                if immediate_parent != superclass {
-                    // The immediate parent already defines this method and is different from the
-                    // current ancestor we're checking. Check if the immediate parent's method
-                    // is also incompatible with this ancestor.
-                    if !is_assignable_method_override(
-                        db,
-                        env,
-                        immediate_parent_type,
-                        superclass_type,
-                    ) {
-                        // The immediate parent already has an LSP violation with this ancestor.
-                        // Don't report the same violation for the child.
-                        continue;
-                    }
-                }
+            if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method
+                && immediate_parent != superclass
+                && !is_assignable_method_override(db, env, immediate_parent_type, superclass_type)
+                && immediate_parent
+                    .iter_mro(db)
+                    .skip(1)
+                    .filter_map(ClassBase::into_class)
+                    .chain(immediate_parent.iter_explicit_ancestors(db, env).skip(1))
+                    .filter(|ancestor| ancestor.class_literal(db) == superclass.class_literal(db))
+                    .any(|ancestor| {
+                        let Place::Defined(DefinedPlace {
+                            ty: ancestor_type, ..
+                        }) = Type::instance(db, env, ancestor)
+                            .member(db, env, &member.name)
+                            .place
+                        else {
+                            return false;
+                        };
+                        !is_assignable_method_override(
+                            db,
+                            env,
+                            immediate_parent_type,
+                            ancestor_type,
+                        )
+                    })
+            {
+                continue;
             }
 
             report_invalid_method_override(

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -1007,46 +1007,47 @@ fn is_inherited_method_violation<'db>(
     superclass_type: Type<'db>,
     name: &Name,
 ) -> bool {
-    // An earlier MRO entry can select a different method in its own hierarchy. Find the closest
+    // An earlier MRO entry can select a different method in its own hierarchy. Check each
     // ancestor that inherits the method actually selected by the child's MRO.
-    let parent = bases
+    bases
         .iter()
         .filter_map(|base| base.into_class())
-        .find(|parent| {
+        .filter(|parent| {
             parent
                 .iter_mro(db)
                 .any(|base| base == ClassBase::Class(method_owner))
         })
-        .unwrap_or(method_owner);
-    let Place::Defined(DefinedPlace {
-        ty: parent_type, ..
-    }) = Type::instance(db, env, parent).member(db, env, name).place
-    else {
-        return false;
-    };
-    if is_assignable_method_override(db, env, parent_type, superclass_type) {
-        return false;
-    }
-
-    // Check the parent's own specializations: a valid override of `Base[Any]` can become invalid
-    // when the child also inherits `Base[int]`. Include implicit ancestors such as `object` and
-    // explicit inheritance paths for specializations omitted from the MRO.
-    parent
-        .iter_mro(db)
-        .skip(1)
-        .filter_map(ClassBase::into_class)
-        .chain(parent.iter_explicit_ancestors(db, env).skip(1))
-        .filter(|ancestor| ancestor.class_literal(db) == superclass.class_literal(db))
-        .any(|ancestor| {
+        .any(|parent| {
             let Place::Defined(DefinedPlace {
-                ty: ancestor_type, ..
-            }) = Type::instance(db, env, ancestor)
-                .member(db, env, name)
-                .place
+                ty: parent_type, ..
+            }) = Type::instance(db, env, parent).member(db, env, name).place
             else {
                 return false;
             };
-            !is_assignable_method_override(db, env, parent_type, ancestor_type)
+            if is_assignable_method_override(db, env, parent_type, superclass_type) {
+                return false;
+            }
+
+            // Check the parent's own specializations: a valid override of `Base[Any]` can become
+            // invalid when the child also inherits `Base[int]`. Include implicit ancestors such
+            // as `object` and explicit inheritance paths for specializations omitted from the MRO.
+            parent
+                .iter_mro(db)
+                .skip(1)
+                .filter_map(ClassBase::into_class)
+                .chain(parent.iter_explicit_ancestors(db, env).skip(1))
+                .filter(|ancestor| ancestor.class_literal(db) == superclass.class_literal(db))
+                .any(|ancestor| {
+                    let Place::Defined(DefinedPlace {
+                        ty: ancestor_type, ..
+                    }) = Type::instance(db, env, ancestor)
+                        .member(db, env, name)
+                        .place
+                    else {
+                        return false;
+                    };
+                    !is_assignable_method_override(db, env, parent_type, ancestor_type)
+                })
         })
 }
 


### PR DESCRIPTION
## Summary

We now report override conflicts introduced by an additional base, even when the subclass method matches its first parent's signature:

```python
from typing import Any

class Base[T]:
    def method(self) -> T:
        raise NotImplementedError

class Strings(Base[Any]):
    def method(self) -> str:
        return ""

class Concrete(Base[int]): ...

class Child(Strings, Concrete):
    # Previously accepted; now invalid-method-override.
    def method(self) -> str:
        return ""
```

Previously, we suppressed this error as an existing violation on `Strings`, even though `Strings` only inherits `Base[Any]` and its override is valid. We now check the parent's own ancestor specializations before suppressing a diagnostic. Existing parent violations remain reported only once, including violations of methods inherited implicitly from `object`.

Follow-up to #28172. This missing diagnostic also occurs on that PR's base.
