### PR TITLE
[ty] Extract module root discovery from `NameResolver`.

### DIFF
--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -1435,7 +1435,10 @@ impl<'db, 'name> NameResolver<'db, 'name> {
     /// packages as parents, but its final module must come from a stub file.
     fn resolve_typing(&self, stub_packages: &StubPackageIndex) -> Option<ResolvedNames<'db>> {
         if self.name.components().nth(1).is_none() {
-            let candidates = self.discover_roots(
+            let candidates = discover_roots(
+                &self.context,
+                self.name.first_component(),
+                self.is_non_shadowable,
                 search_paths(
                     self.context.db,
                     self.context.resolver_environment,
@@ -1450,7 +1453,10 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         // be shadowed before the resolver reaches the requested stub. Reuse those roots for the
         // normal fallback so that each extra path is probed only once.
         let (overlay_stub_packages, remaining_stub_packages) = stub_packages.split_overlay();
-        let mut candidates = self.discover_roots(
+        let mut candidates = discover_roots(
+            &self.context,
+            self.name.first_component(),
+            self.is_non_shadowable,
             search_paths(
                 self.context.db,
                 self.context.resolver_environment,
@@ -1465,7 +1471,10 @@ impl<'db, 'name> NameResolver<'db, 'name> {
             return Some(resolved);
         }
 
-        let remaining_candidates = self.discover_roots(
+        let remaining_candidates = discover_roots(
+            &self.context,
+            self.name.first_component(),
+            self.is_non_shadowable,
             search_paths(
                 self.context.db,
                 self.context.resolver_environment,
@@ -1487,7 +1496,13 @@ impl<'db, 'name> NameResolver<'db, 'name> {
     fn resolve_desperate_typing(&self, search_paths: &[SearchPath]) -> Option<ResolvedNames<'db>> {
         let stub_packages =
             StubPackageIndex::from_search_paths(self.context.db, search_paths.iter());
-        let candidates = self.discover_roots(search_paths.iter(), stub_packages.all());
+        let candidates = discover_roots(
+            &self.context,
+            self.name.first_component(),
+            self.is_non_shadowable,
+            search_paths.iter(),
+            stub_packages.all(),
+        );
         self.resolve_remaining(candidates, ComponentFileFilter::ByMode)
     }
 
@@ -1499,74 +1514,14 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         &self,
         search_paths: impl Iterator<Item = &'a SearchPath>,
     ) -> Option<ResolvedNames<'db>> {
-        let candidates = self.discover_roots(search_paths, StubPackagePaths::default());
+        let candidates = discover_roots(
+            &self.context,
+            self.name.first_component(),
+            self.is_non_shadowable,
+            search_paths,
+            StubPackagePaths::default(),
+        );
         self.resolve_remaining(candidates, ComponentFileFilter::ByMode)
-    }
-
-    fn discover_roots<'a>(
-        &self,
-        search_paths: impl Iterator<Item = &'a SearchPath>,
-        stub_paths: StubPackagePaths<'_>,
-    ) -> ResolvedNames<'db> {
-        let root_component = self.name.first_component();
-        let mut cur_candidates = Vec::new();
-        let stub_name = (!stub_paths.is_empty() && !self.is_non_shadowable)
-            .then(|| format!("{root_component}-stubs"));
-        let mut pending_stub_paths = Vec::new();
-
-        if let Some(stub_name) = &stub_name {
-            cur_candidates.extend(stub_paths.before_stdlib.iter().filter_map(|search_path| {
-                resolve_stub_package_in_search_path(&self.context, search_path, stub_name)
-            }));
-            // Defer file probes after stdlib until we know that stdlib does not win.
-            pending_stub_paths.extend(stub_paths.after_stdlib.iter().filter(|search_path| {
-                ModuleDirectory::new(&self.context, search_path.to_module_path())
-                    .may_contain_name(stub_name)
-            }));
-        }
-
-        for search_path in search_paths {
-            // When a builtin module is imported, standard module resolution is bypassed:
-            // the module name always resolves to the stdlib module,
-            // even if there's a module of the same name in the first-party root
-            // (which would normally result in the stdlib module being overridden).
-            // TODO: offer a diagnostic if there is a first-party module of the same name
-            if self.is_non_shadowable && !search_path.is_standard_library() {
-                continue;
-            }
-
-            let is_stdlib = search_path.is_standard_library();
-            // A terminal candidate can stop the search unless a matching post-stdlib stub package
-            // could still override it. A terminal stdlib candidate always stops the search.
-            let can_stop = is_stdlib || pending_stub_paths.is_empty();
-            let mut candidate = ModuleResolutionCandidate::root(&self.context, search_path);
-            let resolved = resolve_component(
-                &self.context,
-                &mut candidate,
-                root_component,
-                ComponentFileFilter::ByMode,
-            )
-            .is_ok();
-            let terminal = candidate.missing_submodule_is_terminal();
-            if resolved {
-                cur_candidates.push(candidate);
-            }
-            // A terminal candidate shadows all later search paths. Earlier candidates remain in
-            // play because they already shadow this candidate.
-            if terminal && can_stop {
-                break;
-            }
-
-            // Reaching this point for stdlib means that it did not provide a terminal candidate.
-            // The deferred post-stdlib stub packages are therefore eligible, so resolve them now.
-            if is_stdlib && let Some(stub_name) = &stub_name {
-                cur_candidates.extend(pending_stub_paths.drain(..).filter_map(|search_path| {
-                    resolve_stub_package_in_search_path(&self.context, search_path, stub_name)
-                }));
-            }
-        }
-
-        cur_candidates
     }
 
     fn resolve_remaining(
@@ -1618,6 +1573,73 @@ impl<'db, 'name> NameResolver<'db, 'name> {
             }
         }
     }
+}
+
+/// Finds candidates for a top-level name across the supplied search paths and stub packages.
+fn discover_roots<'a, 'db>(
+    context: &ResolverContext<'db>,
+    root_component: &str,
+    is_non_shadowable: bool,
+    search_paths: impl Iterator<Item = &'a SearchPath>,
+    stub_paths: StubPackagePaths<'_>,
+) -> ResolvedNames<'db> {
+    let mut cur_candidates = Vec::new();
+    let stub_name =
+        (!stub_paths.is_empty() && !is_non_shadowable).then(|| format!("{root_component}-stubs"));
+    let mut pending_stub_paths = Vec::new();
+
+    if let Some(stub_name) = &stub_name {
+        cur_candidates.extend(stub_paths.before_stdlib.iter().filter_map(|search_path| {
+            resolve_stub_package_in_search_path(context, search_path, stub_name)
+        }));
+        // Defer file probes after stdlib until we know that stdlib does not win.
+        pending_stub_paths.extend(stub_paths.after_stdlib.iter().filter(|search_path| {
+            ModuleDirectory::new(context, search_path.to_module_path()).may_contain_name(stub_name)
+        }));
+    }
+
+    for search_path in search_paths {
+        // When a builtin module is imported, standard module resolution is bypassed:
+        // the module name always resolves to the stdlib module,
+        // even if there's a module of the same name in the first-party root
+        // (which would normally result in the stdlib module being overridden).
+        // TODO: offer a diagnostic if there is a first-party module of the same name
+        if is_non_shadowable && !search_path.is_standard_library() {
+            continue;
+        }
+
+        let is_stdlib = search_path.is_standard_library();
+        // A terminal candidate can stop the search unless a matching post-stdlib stub package
+        // could still override it. A terminal stdlib candidate always stops the search.
+        let can_stop = is_stdlib || pending_stub_paths.is_empty();
+        let mut candidate = ModuleResolutionCandidate::root(context, search_path);
+        let resolved = resolve_component(
+            context,
+            &mut candidate,
+            root_component,
+            ComponentFileFilter::ByMode,
+        )
+        .is_ok();
+        let terminal = candidate.missing_submodule_is_terminal();
+        if resolved {
+            cur_candidates.push(candidate);
+        }
+        // A terminal candidate shadows all later search paths. Earlier candidates remain in
+        // play because they already shadow this candidate.
+        if terminal && can_stop {
+            break;
+        }
+
+        // Reaching this point for stdlib means that it did not provide a terminal candidate.
+        // The deferred post-stdlib stub packages are therefore eligible, so resolve them now.
+        if is_stdlib && let Some(stub_name) = &stub_name {
+            cur_candidates.extend(pending_stub_paths.drain(..).filter_map(|search_path| {
+                resolve_stub_package_in_search_path(context, search_path, stub_name)
+            }));
+        }
+    }
+
+    cur_candidates
 }
 
 fn resolve_stub_package_in_search_path<'db>(


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This is a small step towards the [larger refactor](https://github.com/astral-sh/ruff/pull/28199) that will allow us to share ordinary module resolution rules with the module enumeration process required to [support namespace packages for auto imports](https://github.com/astral-sh/ty/issues/2273) (please see that refactor PR for a detailed description of our motivations).  It refactors the previously associated `NameResolver::discover_roots` method into a free function, such that it can more easily be reused for both ordinary module resolution and module enumeration.

## Test Plan

This is a pure refactor that relies on existing tests.
<!-- How was it tested? -->
