### PR TITLE
[ty] Extract single-component advancement on NameResolver

### DIFF
--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -1547,21 +1547,7 @@ impl<'db, 'name> NameResolver<'db, 'name> {
                 final_filter
             };
 
-            let mut remaining_are_shadowed = false;
-            cur_candidates.retain_mut(|candidate| {
-                if remaining_are_shadowed {
-                    return false;
-                }
-
-                let resolved =
-                    resolve_component(&self.context, candidate, component, file_filter).is_ok();
-
-                // A terminal candidate shadows every lower-priority candidate, even if resolving
-                // this component fails. Higher-priority candidates remain in play.
-                remaining_are_shadowed = candidate.missing_submodule_is_terminal();
-
-                resolved
-            });
+            cur_candidates = self.advance_candidates(cur_candidates, component, file_filter);
 
             if cur_candidates.is_empty() {
                 return None;
@@ -1636,6 +1622,31 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         }
 
         cur_candidates
+    }
+
+    /// Advances candidates by one component, preserving terminal shadowing even on a failed probe.
+    fn advance_candidates(
+        &self,
+        mut candidates: ResolvedNames<'db>,
+        component: &str,
+        filter: ComponentFileFilter,
+    ) -> ResolvedNames<'db> {
+        let context = &self.context;
+        let mut remaining_are_shadowed = false;
+        candidates.retain_mut(|candidate| {
+            if remaining_are_shadowed {
+                return false;
+            }
+
+            let resolved = resolve_component(context, candidate, component, filter).is_ok();
+
+            // A terminal candidate shadows every lower-priority candidate, even if resolving
+            // this component fails. Higher-priority candidates remain in play.
+            remaining_are_shadowed = candidate.missing_submodule_is_terminal();
+
+            resolved
+        });
+        candidates
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This is a small step towards the [larger refactor](https://github.com/astral-sh/ruff/pull/28199) that will allow us to share ordinary module resolution rules with the module enumeration process required to [support namespace packages for auto imports](https://github.com/astral-sh/ty/issues/2273) (please see that refactor PR for a detailed description of our motivations).  It factors out a helper method (`NameResolver::advance_candidates`) for a small part of the ordinary module resolution process such that it can more easily be reused for module enumeration in the future.

## Test Plan

This is a pure refactor that relies on existing tests.
<!-- How was it tested? -->
