### PR TITLE
Recognize PEP-728 `TypedDict` class keywords

### DIFF
--- a/crates/ruff_linter/resources/mdtest/pyupgrade/convert-typed-dict-functional-to-class.md
+++ b/crates/ruff_linter/resources/mdtest/pyupgrade/convert-typed-dict-functional-to-class.md
@@ -1,0 +1,53 @@
+# `convert-typed-dict-functional-to-class` (`UP013`)
+
+```toml
+target-version = "py315"
+lint.select = ["UP013"]
+```
+
+## Class keywords
+
+The conversion preserves `closed` as a class keyword.
+
+```py
+from typing import TypedDict
+
+Closed = TypedDict("Closed", {}, closed=True)  # snapshot: convert-typed-dict-functional-to-class
+```
+
+```snapshot
+error[UP013]: Convert `Closed` from `TypedDict` functional to class syntax
+ --> src/mdtest_snippet.py:3:1
+  |
+3 | Closed = TypedDict("Closed", {}, closed=True)  # snapshot: convert-typed-dict-functional-to-class
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Convert `Closed` to class syntax
+  |
+2 |
+  - Closed = TypedDict("Closed", {}, closed=True)  # snapshot: convert-typed-dict-functional-to-class
+3 + class Closed(TypedDict, closed=True):
+4 +     pass  # snapshot: convert-typed-dict-functional-to-class
+5 | ExtraItems = TypedDict("ExtraItems", {}, extra_items=str)  # snapshot: convert-typed-dict-functional-to-class
+  |
+```
+
+The conversion also preserves `extra_items` as a class keyword.
+
+```py
+ExtraItems = TypedDict("ExtraItems", {}, extra_items=str)  # snapshot: convert-typed-dict-functional-to-class
+```
+
+```snapshot
+error[UP013]: Convert `ExtraItems` from `TypedDict` functional to class syntax
+ --> src/mdtest_snippet.py:4:1
+  |
+4 | ExtraItems = TypedDict("ExtraItems", {}, extra_items=str)  # snapshot: convert-typed-dict-functional-to-class
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: Convert `ExtraItems` to class syntax
+  |
+3 | Closed = TypedDict("Closed", {}, closed=True)  # snapshot: convert-typed-dict-functional-to-class
+  - ExtraItems = TypedDict("ExtraItems", {}, extra_items=str)  # snapshot: convert-typed-dict-functional-to-class
+4 + class ExtraItems(TypedDict, extra_items=str):
+5 +     pass  # snapshot: convert-typed-dict-functional-to-class
+  |
+```

--- a/crates/ruff_linter/resources/mdtest/typing.md
+++ b/crates/ruff_linter/resources/mdtest/typing.md
@@ -53,3 +53,85 @@ IsDecimal = TypeIs["Decimal"]
 IsFraction = typing_extensions.TypeIs["Fraction"]
 GuardsPath = typing_extensions.TypeGuard["Path"]
 ```
+
+## `TypedDict` extra items
+
+The `extra_items` argument to a `TypedDict` class is a type expression. Imports referenced only in
+this quoted argument are used.
+
+```py
+from decimal import Decimal  # no diagnostic
+from typing import TypedDict
+
+class Record(TypedDict, extra_items="Decimal"):
+    pass
+```
+
+## `TypedDict` extra items from `typing_extensions`
+
+The backported `TypedDict` also accepts quoted types in `extra_items`, including when imported under
+an alias.
+
+```py
+from decimal import Decimal  # no diagnostic
+from typing_extensions import TypedDict as TD
+
+class Record(TD, extra_items="Decimal"):
+    pass
+```
+
+## Inherited `TypedDict` extra items
+
+Subclasses can specify the type of extra items, including when their base is a generic `TypedDict`.
+
+```py
+from decimal import Decimal  # no diagnostic
+from typing import TypedDict
+
+class Base[T](TypedDict):
+    value: T
+
+class Record(Base[int], extra_items="Decimal"):
+    pass
+```
+
+## Functional `TypedDict` base
+
+A class can also inherit from a `TypedDict` defined with the functional syntax. Its `extra_items`
+argument is still a type expression.
+
+```py
+from decimal import Decimal  # no diagnostic
+from typing import TypedDict
+
+Base = TypedDict("Base", {})
+
+class Record(Base, extra_items="Decimal"):
+    pass
+```
+
+## Forward `TypedDict` base in a stub
+
+Stub files allow a base class to be defined later. Quoted extra item types still use their imports
+when the base is a `TypedDict`.
+
+```pyi
+from decimal import Decimal  # no diagnostic
+from typing import TypedDict
+
+class Record(Base, extra_items="Decimal"): ...
+
+class Base(TypedDict): ...
+```
+
+## Extra items on an unrelated class
+
+A class keyword named `extra_items` is not a type expression unless the class inherits from
+`TypedDict`.
+
+```py
+from decimal import Decimal  # error: [unused-import] "`decimal.Decimal` imported but unused"
+
+class Record(extra_items="Decimal"):
+    pass
+```

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -53,7 +53,7 @@ use ruff_python_parser::semantic_errors::{
 use ruff_python_parser::typing::{AnnotationKind, ParsedAnnotation, parse_type_annotation};
 use ruff_python_parser::{ParseError, Parsed};
 use ruff_python_semantic::all::{DunderAllDefinition, DunderAllFlags};
-use ruff_python_semantic::analyze::{imports, typing};
+use ruff_python_semantic::analyze::{class, imports, typing};
 use ruff_python_semantic::{
     BindingFlags, BindingId, BindingKind, Exceptions, Export, FromImport, GeneratorKind, Globals,
     Import, ImportLaziness, Module, ModuleKind, ModuleSource, NodeId, ScopeId, ScopeKind,
@@ -1452,7 +1452,18 @@ impl<'a> Visitor<'a> for Checker<'a> {
 
                 if let Some(arguments) = arguments {
                     self.semantic.flags |= SemanticModelFlags::CLASS_BASE;
-                    self.visit_arguments(arguments);
+                    for base in &*arguments.args {
+                        self.visit_expr(base);
+                    }
+                    for keyword in &*arguments.keywords {
+                        if keyword.arg.as_ref().is_some_and(|arg| arg == "extra_items")
+                            && self.is_typed_dict(class_def)
+                        {
+                            self.visit_type_definition(&keyword.value);
+                        } else {
+                            self.visit_keyword(keyword);
+                        }
+                    }
                     self.semantic.flags -= SemanticModelFlags::CLASS_BASE;
                 }
 
@@ -2966,6 +2977,28 @@ impl<'a> Checker<'a> {
         scope.add(id, binding_id);
     }
 
+    fn is_typed_dict(&self, class_def: &ast::StmtClassDef) -> bool {
+        class::any_base_class(class_def, &self.semantic, |base| {
+            let base = helpers::map_subscript(base);
+            if self.semantic.match_typing_expr(base, "TypedDict") {
+                return true;
+            }
+            // Handle bases defined by assignments, which `any_base_class` does not traverse:
+            // ```python
+            // Base = TypedDict("Base", {})
+            // class Record(Base, extra_items=str): ...
+            // ```
+            let Some(binding_id) = self.semantic.lookup_attribute(base) else {
+                return false;
+            };
+            matches!(
+                typing::find_binding_value(self.semantic.binding(binding_id), &self.semantic),
+                Some(Expr::Call(call))
+                    if self.semantic.match_typing_expr(&call.func, "TypedDict")
+            )
+        })
+    }
+
     /// After initial traversal of the AST, visit all class bases that were deferred.
     ///
     /// This method should only be relevant in stub files, where forward references are
@@ -2988,7 +3021,18 @@ impl<'a> Checker<'a> {
             self.semantic.restore(snapshot);
             // Set this flag to avoid infinite recursion, or we'll just defer it again:
             self.semantic.flags |= SemanticModelFlags::DEFERRED_CLASS_BASE;
-            self.visit_expr(expr);
+            // A forward base may only now identify this class as a `TypedDict`.
+            if let Stmt::ClassDef(class_def) = self.semantic.current_statement()
+                && class_def.keywords().iter().any(|keyword| {
+                    keyword.arg.as_ref().is_some_and(|arg| arg == "extra_items")
+                        && keyword.value.range() == expr.range()
+                })
+                && self.is_typed_dict(class_def)
+            {
+                self.visit_type_definition(expr);
+            } else {
+                self.visit_expr(expr);
+            }
         }
         self.semantic.restore(snapshot);
     }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/convert_typed_dict_functional_to_class.rs
@@ -97,7 +97,7 @@ pub(crate) fn convert_typed_dict_functional_to_class(
         return;
     };
 
-    let Some((body, total_keyword)) = match_fields_and_total(arguments) else {
+    let Some((body, keywords)) = match_fields_and_keywords(arguments) else {
         return;
     };
 
@@ -113,7 +113,7 @@ pub(crate) fn convert_typed_dict_functional_to_class(
             stmt,
             class_name,
             body,
-            total_keyword,
+            keywords,
             base_class,
             checker.generator(),
             checker.comment_ranges(),
@@ -171,17 +171,14 @@ fn create_field_assignment_stmt(field: &str, annotation: &Expr) -> Stmt {
 fn create_class_def_stmt(
     class_name: &str,
     body: Suite,
-    total_keyword: Option<&Keyword>,
+    keywords: &[Keyword],
     base_class: &Expr,
 ) -> Stmt {
     ast::StmtClassDef {
         name: Identifier::new(class_name.to_string(), TextRange::default()),
         arguments: Some(Box::new(Arguments {
             args: [base_class.clone()].into(),
-            keywords: match total_keyword {
-                Some(keyword) => std::iter::once(keyword.clone()).collect(),
-                None => std::iter::empty().collect(),
-            },
+            keywords: keywords.into(),
             range: TextRange::default(),
             node_index: ruff_python_ast::AtomicNodeIndex::NONE,
         })),
@@ -261,37 +258,36 @@ fn fields_from_keywords(keywords: &[Keyword]) -> Option<Suite> {
         .collect()
 }
 
-/// Match the fields and `total` keyword from a `TypedDict` call.
-fn match_fields_and_total(arguments: &Arguments) -> Option<(Suite, Option<&Keyword>)> {
+/// Match the fields and class keywords from a `TypedDict` call.
+fn match_fields_and_keywords(arguments: &Arguments) -> Option<(Suite, &[Keyword])> {
     match (&*arguments.args, &*arguments.keywords) {
         // Ex) `TypedDict("MyType", {"a": int, "b": str})`
-        ([_typename, fields], [..]) => {
-            let total = arguments.find_keyword("total");
-            match fields {
-                Expr::Dict(ast::ExprDict {
-                    items,
-                    range: _,
-                    node_index: _,
-                }) => Some((fields_from_dict_literal(items)?, total)),
-                Expr::Call(ast::ExprCall {
-                    func,
-                    arguments: Arguments { keywords, .. },
-                    range_start: _,
-                    node_index: _,
-                }) => Some((fields_from_dict_call(func, keywords)?, total)),
-                _ => None,
-            }
-        }
+        ([_typename, fields], keywords) => match fields {
+            Expr::Dict(ast::ExprDict {
+                items,
+                range: _,
+                node_index: _,
+            }) => Some((fields_from_dict_literal(items)?, keywords)),
+            Expr::Call(ast::ExprCall {
+                func,
+                arguments: Arguments {
+                    keywords: fields, ..
+                },
+                range_start: _,
+                node_index: _,
+            }) => Some((fields_from_dict_call(func, fields)?, keywords)),
+            _ => None,
+        },
         // Ex) `TypedDict("MyType")`
         ([_typename], []) => {
             let node = Stmt::Pass(ast::StmtPass {
                 range: TextRange::default(),
                 node_index: ruff_python_ast::AtomicNodeIndex::NONE,
             });
-            Some((Suite::from([node]), None))
+            Some((Suite::from([node]), &[]))
         }
         // Ex) `TypedDict("MyType", a=int, b=str)`
-        ([_typename], fields) => Some((fields_from_keywords(fields)?, None)),
+        ([_typename], fields) => Some((fields_from_keywords(fields)?, &[])),
         // Ex) `TypedDict()`
         _ => None,
     }
@@ -302,7 +298,7 @@ fn convert_to_class(
     stmt: &Stmt,
     class_name: &str,
     body: Suite,
-    total_keyword: Option<&Keyword>,
+    keywords: &[Keyword],
     base_class: &Expr,
     generator: Generator,
     comment_ranges: &CommentRanges,
@@ -310,10 +306,7 @@ fn convert_to_class(
     Fix::applicable_edit(
         Edit::range_replacement(
             generator.stmt(&create_class_def_stmt(
-                class_name,
-                body,
-                total_keyword,
-                base_class,
+                class_name, body, keywords, base_class,
             )),
             stmt.range(),
         ),


### PR DESCRIPTION
Summary
--

[PEP 728] introduced two new keyword arguments for `TypedDict`s: the boolean `closed` argument and
`extra_items`, which allows specifying the type for any additional entries in the `TypedDict`. See
this example from the PEP:

```py
class Movie(TypedDict, extra_items=bool):
    name: str

a: Movie = {"name": "Blade Runner", "novel_adaptation": True}  # OK
b: Movie = {
    "name": "Blade Runner",
    "year": 1982,  # Not OK. 'int' is not assignable to 'bool'
}
```

Like some of my previous 3.15 PRs, this PR adds support for visiting the value of the `extra_items`
keyword argument as a type expression, again using `F401` to demonstrate that such quoted
expressions mark their corresponding imports as used. This requires a little bit of special handling
when visiting class statements, which can also be deferred in stub files, but overall wasn't too bad
I think. `closed` doesn't need any special handling in the semantic model since it's just a flag,
not a type expression.

This PR also updates [`convert-typed-dict-functional-to-class` (`UP013`)] to recognize the new
keywords and carry them along in its fix.

The first commit contains the visitor changes, and the second contains the `UP013` update.

Once again, my Codex reviewers found an existing bug that this exposes in a new way. We could
sidestep this, and substantially simplify the code at the same time, by dropping the recursive base
class traversal, but it seemed more useful to me to keep the recursive traversal and fix the other
bug later if needed. Either unhandled case (multiple levels of inheritance in one file, or
inheritance + shadowing + unrelated class with `extra_items`) seems quite niche, though.

<details>
<summary>`any_base_class` bug</summary>

Ancestor lookup can misclassify an ordinary class as a TypedDict — The lookup resolves ancestor
names in the current scope, so an unrelated definition can shadow the actual base:

```py
from typing import TypedDict

class Base:
    def __init_subclass__(cls, **kwargs): pass

class Middle(Base): pass

class Namespace:
    class Base(TypedDict): pass
    class Record(Middle, extra_items="not a type"): pass
```

This valid code now produces a false F722. `Middle` inherits the module-level `Base`, but the lookup
finds `Namespace.Base`. The inheritance walk should use each base expression’s original binding.

</details>

[`convert-typed-dict-functional-to-class` (`UP013`)]: https://docs.astral.sh/ruff/rules/convert-typed-dict-functional-to-class/
[PEP 728]: https://peps.python.org/pep-0728/

Test Plan
--

New mdtests
