### PR TITLE
[ty] Extract shared abstract-method analysis

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -129,6 +129,7 @@ use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ProgramFile, Truthiness, place_table, semantic_index, use_def_map};
 
+mod abstract_methods;
 mod attribute_write;
 mod bool;
 mod bound_super;

--- a/crates/ty_python_semantic/src/types/abstract_methods.rs
+++ b/crates/ty_python_semantic/src/types/abstract_methods.rs
@@ -1,0 +1,299 @@
+//! Abstract-method discovery and diagnostics for class validation.
+
+use ruff_db::diagnostic::{Annotation, SubDiagnostic, SubDiagnosticSeverity};
+use ruff_python_ast::name::Name;
+use ty_python_core::{definition::Definition, place_table, use_def_map};
+
+use crate::{
+    Db, FxIndexMap, ProgramEnvironment, TypeQualifiers,
+    diagnostic::format_enumeration,
+    place::{DefinedPlace, Place, place_from_bindings, place_from_declarations},
+    types::{
+        ClassBase, ClassLiteral, ClassType, LintDiagnosticGuard, Parameters, Signature, Type,
+        binding_type,
+        diagnostic::{AbstractMethodAnnotationPolicy, abstract_method_span},
+        function::AbstractMethodKind,
+        infer::infer_definition_types,
+    },
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct AbstractMethods<'db> {
+    class: ClassType<'db>,
+    methods: &'db FxIndexMap<Name, AbstractMethod<'db>>,
+}
+
+impl<'db> AbstractMethods<'db> {
+    /// Find methods that remain abstract after applying overrides in MRO order.
+    pub(super) fn of_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        Self {
+            class,
+            methods: class.abstract_methods(db),
+        }
+    }
+
+    /// Annotate a diagnostic with the unimplemented methods and their declarations.
+    pub(super) fn annotate_diagnostic(
+        &self,
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        diagnostic: &mut LintDiagnosticGuard,
+    ) {
+        let Some((first_method_name, abstract_method)) = self.methods.iter().next() else {
+            return;
+        };
+        let num_abstract_methods = self.len();
+        if num_abstract_methods == 1 {
+            diagnostic.set_primary_annotation_message(format_args!(
+                "`{first_method_name}` is unimplemented"
+            ));
+        } else {
+            let formatted_methods = self.formatted_names(db);
+            if formatted_methods.truncation_occurred {
+                diagnostic.set_primary_annotation_message(format_args!(
+                    "{num_abstract_methods} abstract methods are unimplemented, including {formatted_methods}",
+                ));
+                diagnostic.info(format_args!(
+                    "Use `--verbose` to see all {num_abstract_methods} unimplemented abstract methods",
+                ));
+            } else {
+                diagnostic.set_primary_annotation_message(format_args!(
+                    "Abstract methods {formatted_methods} are unimplemented"
+                ));
+            }
+        }
+
+        let AbstractMethod {
+            defining_class,
+            definition,
+            kind,
+        } = abstract_method;
+
+        let defining_class_name = defining_class.name(db);
+
+        if let Type::FunctionLiteral(function) = binding_type(db, *definition) {
+            let policy = if kind.is_explicit() {
+                AbstractMethodAnnotationPolicy::ExcludeVerboseBody
+            } else {
+                AbstractMethodAnnotationPolicy::AlwaysIncludeBody
+            };
+            let secondary_span = abstract_method_span(db, function, policy);
+            let mut secondary_annotation = Annotation::secondary(secondary_span);
+            secondary_annotation = if defining_class.class_literal(db)
+                == self.class.class_literal(db)
+            {
+                secondary_annotation
+                    .message(format_args!("`{first_method_name}` declared as abstract"))
+            } else {
+                secondary_annotation.message(format_args!(
+                    "`{first_method_name}` declared as abstract on superclass `{defining_class_name}`",
+                ))
+            };
+            diagnostic.annotate(secondary_annotation);
+        }
+
+        if !kind.is_explicit() {
+            let mut sub = SubDiagnostic::new(
+                SubDiagnosticSeverity::Info,
+                format_args!(
+                    "`{defining_class_name}.{first_method_name}` is implicitly abstract \
+                        because `{defining_class_name}` is a `Protocol` class \
+                        and `{first_method_name}` lacks an implementation",
+                ),
+            );
+            sub.annotate(
+                Annotation::secondary(defining_class.definition_span(db))
+                    .message(format_args!("`{defining_class_name}` declared here")),
+            );
+            diagnostic.sub(sub);
+
+            // If the implicitly abstract method is defined in first-party code
+            // and the return type is assignable to `None`, they may not have intended
+            // for it to be implicitly abstract; add a clarificatory note:
+            if kind.is_implicit_due_to_stub_body() && db.should_check_file(definition.file(db)) {
+                let function_type_as_callable = infer_definition_types(db, *definition)
+                    .binding_type(*definition)
+                    .try_upcast_to_callable(db, env);
+
+                if let Some(callables) = function_type_as_callable
+                    && Type::function_like_callable(
+                        db,
+                        Signature::new(Parameters::gradual_form(), Type::none(db, env)),
+                    )
+                    .is_assignable_to(db, env, callables.into_type(db, env))
+                {
+                    diagnostic.help(format_args!(
+                        "Change the body of `{first_method_name}` to `return` \
+                            or `return None` if it was not intended to be abstract"
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Unless `--verbose` was specified on the command line,
+    /// we will only print this number of abstract methods in diagnostics
+    /// complaining about abstract class instantiation (and similar)
+    const DEFAULT_METHOD_NUMBER_TO_PRINT: usize = 3;
+
+    /// Return a string that contains a formatted subset of the abstract methods
+    /// in this collection.
+    ///
+    /// This is useful for diagnostics.
+    pub(super) fn formatted_names(&self, db: &'db dyn Db) -> FormattedAbstractMethods {
+        let len = self.methods.len();
+        let max_abstract_methods_to_print = if db.verbose() {
+            len
+        } else {
+            AbstractMethods::DEFAULT_METHOD_NUMBER_TO_PRINT
+        };
+        let truncation_occurred = max_abstract_methods_to_print < len;
+        FormattedAbstractMethods {
+            inner: format_enumeration(self.methods.keys().take(max_abstract_methods_to_print)),
+            truncation_occurred,
+        }
+    }
+
+    pub(super) fn first_name(&self) -> Option<&Name> {
+        self.methods.keys().next()
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.methods.len()
+    }
+}
+
+#[salsa::tracked]
+impl<'db> ClassType<'db> {
+    /// Returns a map of methods on this class that were defined as abstract on a superclass
+    /// and have not been overridden with a concrete implementation anywhere in the MRO
+    ///
+    /// The value of the map is a struct containing information about the abstract method.
+    #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+    pub(in crate::types) fn abstract_methods(
+        self,
+        db: &'db dyn Db,
+    ) -> FxIndexMap<Name, AbstractMethod<'db>> {
+        fn type_as_abstract_method<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            defining_class: ClassType<'db>,
+        ) -> Option<AbstractMethodKind> {
+            match ty {
+                Type::FunctionLiteral(function) => function.as_abstract_method(db, defining_class),
+                Type::BoundMethod(method) => {
+                    type_as_abstract_method(db, method.func(db), defining_class)
+                }
+                Type::PropertyInstance(property) => {
+                    // A property is abstract if any of its accessors is abstract.
+                    property
+                        .getter(db)
+                        .and_then(|getter| type_as_abstract_method(db, getter, defining_class))
+                        .or_else(|| {
+                            property.setter(db).and_then(|setter| {
+                                type_as_abstract_method(db, setter, defining_class)
+                            })
+                        })
+                        .or_else(|| {
+                            property.deleter(db).and_then(|deleter| {
+                                type_as_abstract_method(db, deleter, defining_class)
+                            })
+                        })
+                }
+                _ => None,
+            }
+        }
+
+        let mut abstract_methods: FxIndexMap<Name, _> = FxIndexMap::default();
+        let env = &ProgramEnvironment::from_file(self.class_literal(db).program_file(db));
+
+        // Iterate through the MRO in reverse order,
+        // skipping `object` (we know it doesn't define any abstract methods)
+        for supercls in self.iter_mro(db).rev().skip(1) {
+            let ClassBase::Class(class) = supercls else {
+                continue;
+            };
+
+            // Currently we do not recognize dynamic classes as being able to define abstract methods,
+            // but we do recognise them as being able to override abstract methods defined in static classes.
+            let ClassLiteral::Static(class_literal) = class.class_literal(db) else {
+                abstract_methods
+                    .retain(|name, _| class.own_class_member(db, env, None, name).is_undefined());
+                continue;
+            };
+
+            let scope = class_literal.body_scope(db);
+            let place_table = place_table(db, scope);
+            let use_def_map = use_def_map(db, class_literal.body_scope(db));
+
+            // Treat abstract methods from superclasses as having been overridden
+            // if this class has a synthesized method by that name,
+            // or this class has a `ClassVar` declaration by that name
+            abstract_methods.retain(|name, _| {
+                if class_literal
+                    .own_synthesized_member(db, env, None, None, name)
+                    .is_some()
+                {
+                    return false;
+                }
+
+                place_table.symbol_id(name).is_none_or(|symbol_id| {
+                    let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
+                    !place_from_declarations(db, env, declarations)
+                        .ignore_conflicting_declarations()
+                        .qualifiers
+                        .contains(TypeQualifiers::CLASS_VAR)
+                })
+            });
+
+            for (symbol_id, bindings_iterator) in use_def_map.all_end_of_scope_symbol_bindings() {
+                let name = place_table.symbol(symbol_id).name();
+                let place_and_definition = place_from_bindings(db, env, bindings_iterator);
+                let Place::Defined(DefinedPlace { ty, .. }) = place_and_definition.place else {
+                    continue;
+                };
+                let Some(definition) = place_and_definition.first_definition else {
+                    continue;
+                };
+                if let Some(kind) = type_as_abstract_method(db, ty, class) {
+                    let abstract_method = AbstractMethod {
+                        defining_class: class,
+                        definition,
+                        kind,
+                    };
+                    abstract_methods.insert(name.clone(), abstract_method);
+                } else {
+                    // If this method is concrete, remove it from the map of abstract methods.
+                    abstract_methods.shift_remove(name);
+                }
+            }
+        }
+
+        abstract_methods.shrink_to_fit();
+
+        abstract_methods
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+pub(super) struct AbstractMethod<'db> {
+    pub(super) defining_class: ClassType<'db>,
+    pub(super) definition: Definition<'db>,
+    pub(super) kind: AbstractMethodKind,
+}
+
+#[derive(Debug)]
+pub(super) struct FormattedAbstractMethods {
+    inner: String,
+
+    /// Boolean flag that indicates whether the wrapped string is an exhaustive
+    /// enumeration of *all* abstract methods on a class, or only an enumeration
+    /// of a truncated subset
+    pub(super) truncation_occurred: bool,
+}
+
+impl std::fmt::Display for FormattedAbstractMethods {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -31,7 +31,7 @@ use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
 };
 use crate::types::enums::enum_metadata;
-use crate::types::function::{AbstractMethodKind, DataclassTransformerParams};
+use crate::types::function::DataclassTransformerParams;
 use crate::types::generics::{GenericContext, Specialization, walk_specialization};
 use crate::types::infer::infer_definition_types;
 use crate::types::known_instance::DeprecatedInstance;
@@ -53,10 +53,7 @@ use crate::types::{
 };
 use crate::{
     Db, FxIndexMap, FxOrderSet,
-    place::{
-        Definedness, LookupError, LookupResult, Place, PlaceAndQualifiers, PublicTypePolicy,
-        place_from_bindings, place_from_declarations,
-    },
+    place::{Definedness, LookupError, LookupResult, Place, PlaceAndQualifiers, PublicTypePolicy},
     types::{MetaclassCandidate, TypeDefinition, UnionType},
 };
 use itertools::Either;
@@ -67,9 +64,9 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, NodeIndex};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
+use ty_python_core::ProgramFile;
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{ProgramFile, place_table, use_def_map};
 
 mod dynamic_literal;
 mod enum_literal;
@@ -1484,115 +1481,6 @@ impl<'db> ClassType<'db> {
         self.class_literal(db).is_final(db)
     }
 
-    /// Returns a map of methods on this class that were defined as abstract on a superclass
-    /// and have not been overridden with a concrete implementation anywhere in the MRO
-    ///
-    /// The value of the map is a struct containing information about the abstract method.
-    #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-    pub(in crate::types) fn abstract_methods(
-        self,
-        db: &'db dyn Db,
-    ) -> FxIndexMap<Name, AbstractMethod<'db>> {
-        fn type_as_abstract_method<'db>(
-            db: &'db dyn Db,
-            ty: Type<'db>,
-            defining_class: ClassType<'db>,
-        ) -> Option<AbstractMethodKind> {
-            match ty {
-                Type::FunctionLiteral(function) => function.as_abstract_method(db, defining_class),
-                Type::BoundMethod(method) => {
-                    type_as_abstract_method(db, method.func(db), defining_class)
-                }
-                Type::PropertyInstance(property) => {
-                    // A property is abstract if any of its accessors is abstract.
-                    property
-                        .getter(db)
-                        .and_then(|getter| type_as_abstract_method(db, getter, defining_class))
-                        .or_else(|| {
-                            property.setter(db).and_then(|setter| {
-                                type_as_abstract_method(db, setter, defining_class)
-                            })
-                        })
-                        .or_else(|| {
-                            property.deleter(db).and_then(|deleter| {
-                                type_as_abstract_method(db, deleter, defining_class)
-                            })
-                        })
-                }
-                _ => None,
-            }
-        }
-
-        let mut abstract_methods: FxIndexMap<Name, _> = FxIndexMap::default();
-        let env = &ProgramEnvironment::from_file(self.class_literal(db).program_file(db));
-
-        // Iterate through the MRO in reverse order,
-        // skipping `object` (we know it doesn't define any abstract methods)
-        for supercls in self.iter_mro(db).rev().skip(1) {
-            let ClassBase::Class(class) = supercls else {
-                continue;
-            };
-
-            // Currently we do not recognize dynamic classes as being able to define abstract methods,
-            // but we do recognise them as being able to override abstract methods defined in static classes.
-            let ClassLiteral::Static(class_literal) = class.class_literal(db) else {
-                abstract_methods
-                    .retain(|name, _| class.own_class_member(db, env, None, name).is_undefined());
-                continue;
-            };
-
-            let scope = class_literal.body_scope(db);
-            let place_table = place_table(db, scope);
-            let use_def_map = use_def_map(db, class_literal.body_scope(db));
-
-            // Treat abstract methods from superclasses as having been overridden
-            // if this class has a synthesized method by that name,
-            // or this class has a `ClassVar` declaration by that name
-            abstract_methods.retain(|name, _| {
-                if class_literal
-                    .own_synthesized_member(db, env, None, None, name)
-                    .is_some()
-                {
-                    return false;
-                }
-
-                place_table.symbol_id(name).is_none_or(|symbol_id| {
-                    let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
-                    !place_from_declarations(db, env, declarations)
-                        .ignore_conflicting_declarations()
-                        .qualifiers
-                        .contains(TypeQualifiers::CLASS_VAR)
-                })
-            });
-
-            for (symbol_id, bindings_iterator) in use_def_map.all_end_of_scope_symbol_bindings() {
-                let name = place_table.symbol(symbol_id).name();
-                let place_and_definition = place_from_bindings(db, env, bindings_iterator);
-                let Place::Defined(DefinedPlace { ty, .. }) = place_and_definition.place else {
-                    continue;
-                };
-                let Some(definition) = place_and_definition.first_definition else {
-                    continue;
-                };
-                if let Some(kind) = type_as_abstract_method(db, ty, class) {
-                    let abstract_method = AbstractMethod {
-                        defining_class: class,
-                        definition,
-                        kind,
-                    };
-                    abstract_methods.insert(name.clone(), abstract_method);
-                } else {
-                    // If this method is concrete, remove it from the map of abstract methods.
-                    abstract_methods.shift_remove(name);
-                }
-            }
-        }
-
-        abstract_methods.shrink_to_fit();
-
-        abstract_methods
-    }
-
     /// Returns `true` if any class in this class's MRO (excluding `object`) defines an ordering
     /// method (`__lt__`, `__le__`, `__gt__`, `__ge__`). Used by `@total_ordering` validation.
     pub(super) fn has_ordering_method_in_mro(self, db: &'db dyn Db) -> bool {
@@ -2791,13 +2679,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 })
         })
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
-pub(super) struct AbstractMethod<'db> {
-    pub(super) defining_class: ClassType<'db>,
-    pub(super) definition: Definition<'db>,
-    pub(super) kind: AbstractMethodKind,
 }
 
 /// The decorator category for a method-like function.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -1,36 +1,33 @@
 use crate::Db;
 use itertools::{Either, Itertools};
-use ruff_db::{
-    diagnostic::{Annotation, SubDiagnostic, SubDiagnosticSeverity},
-    source::source_text,
-};
+use ruff_db::{diagnostic::Annotation, source::source_text};
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::{self as ast, PythonVersion, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 
+use crate::attribute_assignments;
 use crate::{
     TypeQualifiers,
-    diagnostic::format_enumeration,
     place::{DefinedPlace, Place, TypeOrigin, place_from_bindings, place_from_declarations},
     types::{
         CallArguments, ClassBase, ClassLiteral, ClassType, DataclassFlags, DisplaySettings,
-        KnownClass, KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, Parameters,
-        Signature, SpecialFormType, StaticClassLiteral, Type, TypeVarVariance, TypingModule,
+        KnownClass, KnownInstanceType, MemberLookupPolicy, MetaclassCandidate, SpecialFormType,
+        StaticClassLiteral, Type, TypeVarVariance, TypingModule,
+        abstract_methods::AbstractMethods,
         binding_type,
         call::Argument,
         class::{
-            AbstractMethod, CodeGeneratorKind, Field, FieldKind, MetaclassErrorKind,
-            expanded_class_base_entries,
+            CodeGeneratorKind, Field, FieldKind, MetaclassErrorKind, expanded_class_base_entries,
         },
         context::InferContext,
         definition_expression_type,
         diagnostic::{
-            ABSTRACT_METHOD_IN_FINAL_CLASS, AbstractMethodAnnotationPolicy, CONFLICTING_METACLASS,
-            CYCLIC_CLASS_DEFINITION, DATACLASS_FIELD_ORDER, DUPLICATE_KW_ONLY, FINAL_WITHOUT_VALUE,
-            INCONSISTENT_MRO, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_BASE,
-            INVALID_DATACLASS, INVALID_GENERIC_CLASS, INVALID_GENERIC_ENUM, INVALID_METACLASS,
-            INVALID_NAMED_TUPLE, INVALID_PROTOCOL, INVALID_TYPED_DICT_HEADER, IncompatibleBases,
+            ABSTRACT_METHOD_IN_FINAL_CLASS, CONFLICTING_METACLASS, CYCLIC_CLASS_DEFINITION,
+            DATACLASS_FIELD_ORDER, DUPLICATE_KW_ONLY, FINAL_WITHOUT_VALUE, INCONSISTENT_MRO,
+            INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT, INVALID_BASE, INVALID_DATACLASS,
+            INVALID_GENERIC_CLASS, INVALID_GENERIC_ENUM, INVALID_METACLASS, INVALID_NAMED_TUPLE,
+            INVALID_PROTOCOL, INVALID_TYPED_DICT_HEADER, IncompatibleBases,
             SUBCLASS_OF_DATACLASS_WITH_ORDER, SUBCLASS_OF_FINAL_CLASS, UNKNOWN_ARGUMENT,
             report_bad_frozen_dataclass_inheritance, report_conflicting_metaclass_from_bases,
             report_duplicate_bases, report_inconsistent_generic_bases,
@@ -57,7 +54,6 @@ use crate::{
         visitor::find_over_type,
     },
 };
-use crate::{attribute_assignments, types::diagnostic::abstract_method_span};
 use ty_python_core::{
     SemanticIndex, attribute_scopes, definition::DefinitionKind, scope::ScopeId, semantic_index,
 };
@@ -1417,10 +1413,10 @@ fn check_final_class_abstract_methods<'db>(
     let env = context.program_environment();
 
     let class_type = class.identity_specialization(db);
-    let abstract_methods = class_type.abstract_methods(db);
+    let abstract_methods = AbstractMethods::of_class(db, class_type);
 
     // If there are no abstract methods, we're done.
-    let Some((first_method_name, abstract_method)) = abstract_methods.iter().next() else {
+    let Some(first_method_name) = abstract_methods.first_name() else {
         return;
     };
 
@@ -1452,106 +1448,23 @@ fn check_final_class_abstract_methods<'db>(
         diagnostic.annotate(context.secondary(decorator));
     }
 
+    abstract_methods.annotate_diagnostic(db, env, &mut diagnostic);
     let num_abstract_methods = abstract_methods.len();
-
     if num_abstract_methods == 1 {
         diagnostic.set_concise_message(format_args!(
-            "Final class `{class_name}` has unimplemented abstract method \
-                `{first_method_name}`",
+            "Final class `{class_name}` has unimplemented abstract method `{first_method_name}`",
         ));
-        diagnostic
-            .set_primary_annotation_message(format_args!("`{first_method_name}` is unimplemented"));
     } else {
-        let verbose = db.verbose();
-        let max_abstract_methods_to_print = if verbose { num_abstract_methods } else { 3 };
-        let formatted_methods =
-            format_enumeration(abstract_methods.keys().take(max_abstract_methods_to_print));
-
-        if num_abstract_methods > max_abstract_methods_to_print {
-            diagnostic.set_primary_annotation_message(format_args!(
-                "{num_abstract_methods} abstract methods are unimplemented, \
-                        including {formatted_methods}",
-            ));
+        let formatted_methods = abstract_methods.formatted_names(db);
+        if formatted_methods.truncation_occurred {
             diagnostic.set_concise_message(format_args!(
                 "Final class `{class_name}` has {num_abstract_methods} unimplemented \
                     abstract methods, including {formatted_methods}",
             ));
-            diagnostic.info(format_args!(
-                "Use `--verbose` to see all {num_abstract_methods} \
-                    unimplemented abstract methods",
-            ));
         } else {
             diagnostic.set_concise_message(format_args!(
-                "Final class `{class_name}` has unimplemented \
-                    abstract methods {formatted_methods}",
+                "Final class `{class_name}` has unimplemented abstract methods {formatted_methods}",
             ));
-            diagnostic.set_primary_annotation_message(format_args!(
-                "Abstract methods {formatted_methods} are unimplemented"
-            ));
-        }
-    }
-
-    let AbstractMethod {
-        defining_class,
-        definition,
-        kind,
-    } = abstract_method;
-
-    let defining_class_name = defining_class.name(db);
-
-    if let Type::FunctionLiteral(function) = binding_type(db, *definition) {
-        let policy = if kind.is_explicit() {
-            AbstractMethodAnnotationPolicy::ExcludeVerboseBody
-        } else {
-            AbstractMethodAnnotationPolicy::AlwaysIncludeBody
-        };
-        let secondary_span = abstract_method_span(db, function, policy);
-        let mut secondary_annotation = Annotation::secondary(secondary_span);
-        secondary_annotation = if defining_class.class_literal(db) == ClassLiteral::Static(class) {
-            secondary_annotation.message(format_args!("`{first_method_name}` declared as abstract"))
-        } else {
-            secondary_annotation.message(format_args!(
-                "`{first_method_name}` declared as abstract on superclass `{defining_class_name}`",
-            ))
-        };
-        diagnostic.annotate(secondary_annotation);
-    }
-
-    if !kind.is_explicit() {
-        let mut sub = SubDiagnostic::new(
-            SubDiagnosticSeverity::Info,
-            format_args!(
-                "`{defining_class_name}.{first_method_name}` is implicitly abstract \
-                    because `{defining_class_name}` is a `Protocol` class \
-                    and `{first_method_name}` lacks an implementation",
-            ),
-        );
-        sub.annotate(
-            Annotation::secondary(defining_class.definition_span(db))
-                .message(format_args!("`{defining_class_name}` declared here")),
-        );
-        diagnostic.sub(sub);
-
-        // If the implicitly abstract method is defined in first-party code
-        // and the return type is assignable to `None`, they may not have intended
-        // for it to be implicitly abstract; add a clarificatory note:
-        if kind.is_implicit_due_to_stub_body() && db.should_check_file(definition.file(db)) {
-            let function_type_as_callable = infer_definition_types(db, *definition)
-                .binding_type(*definition)
-                .try_upcast_to_callable(db, env);
-
-            if let Some(callables) = function_type_as_callable
-                && Type::function_like_callable(
-                    db,
-                    Signature::new(Parameters::gradual_form(), Type::none(db, env)),
-                )
-                .is_assignable_to(db, env, callables.into_type(db, env))
-            {
-                diagnostic.help(format_args!(
-                    "Change the body of `{first_method_name}` to `return` \
-                        or `return None` if it was not intended to be abstract"
-                ));
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

We move abstract-method discovery and the diagnostic helpers used by `@final` class validation into a shared module. This prepares the existing analysis for reuse when checking constructor calls in #28167.

The extraction preserves the cached method metadata, MRO ordering, pytest collection behavior, and existing diagnostic output.
