### PR TITLE
[`flake8-type-checking`] Prefer lazy imports over `TYPE_CHECKING` on 3.15+ (`TC001`, `TC002`, `TC003`)

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-runtime-import.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-type-checking/typing-only-runtime-import.md
@@ -1,0 +1,154 @@
+# Typing-only imports (`TC001`, `TC002`, `TC003`)
+
+```toml
+target-version = "py315"
+
+[lint]
+select = ["TC001", "TC002", "TC003"]
+
+[lint.isort]
+known-first-party = ["app"]
+```
+
+## Module imports
+
+On Python 3.15, a module-level import used only in annotations can become lazy. This applies to
+first-party, third-party, and standard-library imports without enabling preview.
+
+```py
+import app as local  # snapshot: typing-only-first-party-import
+from vendor import Model  # snapshot: typing-only-third-party-import
+import pathlib  # snapshot: typing-only-standard-library-import
+
+def load(value: local.Item, model: Model) -> pathlib.Path: ...
+```
+
+```snapshot
+error[TC001]: Make application import `app` lazy
+ --> src/mdtest_snippet.py:1:15
+  |
+1 | import app as local  # snapshot: typing-only-first-party-import
+  |               ^^^^^
+help: Convert to a lazy import
+  |
+  - import app as local  # snapshot: typing-only-first-party-import
+1 + lazy import app as local  # snapshot: typing-only-first-party-import
+2 | from vendor import Model  # snapshot: typing-only-third-party-import
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+
+error[TC002]: Make third-party import `vendor.Model` lazy
+ --> src/mdtest_snippet.py:2:20
+  |
+2 | from vendor import Model  # snapshot: typing-only-third-party-import
+  |                    ^^^^^
+help: Convert to a lazy import
+  |
+1 | import app as local  # snapshot: typing-only-first-party-import
+  - from vendor import Model  # snapshot: typing-only-third-party-import
+2 + lazy from vendor import Model  # snapshot: typing-only-third-party-import
+3 | import pathlib  # snapshot: typing-only-standard-library-import
+  |
+note: This is an unsafe fix and may change runtime behavior
+
+
+error[TC003]: Make standard library import `pathlib` lazy
+ --> src/mdtest_snippet.py:3:8
+  |
+3 | import pathlib  # snapshot: typing-only-standard-library-import
+  |        ^^^^^^^
+help: Convert to a lazy import
+  |
+2 | from vendor import Model  # snapshot: typing-only-third-party-import
+  - import pathlib  # snapshot: typing-only-standard-library-import
+3 + lazy import pathlib  # snapshot: typing-only-standard-library-import
+4 |
+  |
+note: This is an unsafe fix and may change runtime behavior
+```
+
+## Existing lazy imports
+
+Explicit lazy imports and imports made lazy by `__lazy_modules__` already defer import work and do
+not need to move into a type-checking block.
+
+```py
+lazy from pathlib import Path  # no diagnostic
+__lazy_modules__ = ["vendor"]
+from vendor import Model  # no diagnostic
+
+def load(value: Path) -> Model: ...
+```
+
+## Multiple imported names
+
+An import with multiple names retains the type-checking-block fix, leaving its runtime-used names
+unchanged.
+
+```py
+import pathlib, sys  # error: [typing-only-standard-library-import] "type-checking block"
+
+print(sys.version)
+def load(value: pathlib.Path): ...
+```
+
+## Invalid lazy import locations
+
+Lazy syntax is invalid inside functions and `try` statements, so these imports retain the
+type-checking-block fix.
+
+```py
+try:
+    from vendor import Model  # error: [typing-only-third-party-import] "type-checking block"
+except ImportError:
+    pass
+
+def load(value: Model):
+    from pathlib import Path  # error: [typing-only-standard-library-import] "type-checking block"
+
+    path: Path
+```
+
+## Lazy import declarations on older Python versions
+
+A `__lazy_modules__` declaration can express a preference for lazy imports while supporting older
+Python versions. Ruff does not edit these declarations, so it falls back to the type-checking-block
+fix when the target version does not support the `lazy` keyword.
+
+```toml
+target-version = "py314"
+
+[lint]
+select = ["TC003"]
+```
+
+```py
+__lazy_modules__ = ["pathlib"]
+from pathlib import Path  # error: [typing-only-standard-library-import] "type-checking block"
+
+def load(value: Path): ...
+```
+
+## Lazy import policies
+
+Imports prohibited by `ban-lazy` retain the type-checking-block fix. An excluded module can still be
+imported lazily, including with a `from` import.
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TC003", "TID254", "TID255"]
+
+[lint.flake8-tidy-imports]
+ban-lazy = { include = "all", exclude = ["pathlib"] }
+```
+
+```py
+from pathlib import Path  # error: [typing-only-standard-library-import] "lazy"
+from decimal import Decimal  # error: [typing-only-standard-library-import] "type-checking block"
+
+def load(value: Path) -> Decimal: ...
+```

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/typing_only_runtime_import.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use rustc_hash::FxHashMap;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_python_ast::{PythonVersion, Stmt};
 use ruff_python_semantic::{Binding, Imported, NodeId, Scope};
 use ruff_text_size::{Ranged, TextRange};
 
@@ -11,16 +12,17 @@ use crate::checkers::ast::{Checker, DiagnosticGuard};
 use crate::codes::{Category, Rule};
 use crate::fix;
 use crate::importer::ImportedMembers;
+use crate::rules::flake8_tidy_imports::rules::BannedModuleImportPolicies;
 use crate::rules::flake8_type_checking::helpers::{
     TypingReference, filter_contained, quote_annotation,
 };
 use crate::rules::flake8_type_checking::imports::ImportBinding;
 use crate::rules::isort::{ImportSection, ImportType, categorize};
-use crate::{Fix, FixAvailability, Violation};
+use crate::{Edit, Fix, FixAvailability, Violation};
 
 /// ## What it does
 /// Checks for first-party imports that are only used for type annotations, but
-/// aren't defined in a type-checking block.
+/// aren't imported lazily or defined in a type-checking block.
 ///
 /// ## Why is this bad?
 /// Imports that are only used for type annotations add a performance overhead
@@ -45,6 +47,11 @@ use crate::{Fix, FixAvailability, Violation};
 /// [`lint.flake8-type-checking.quote-annotations`] setting described above if
 /// both settings are enabled.
 ///
+/// On Python 3.15 and later, lazy imports are also exempt, including imports
+/// made lazy by a literal `__lazy_modules__` declaration. The fix prefers adding
+/// `lazy` to single-name import statements where the syntax is legal and
+/// [`lint.flake8-tidy-imports.ban-lazy`] allows it. This defers the import while
+/// keeping the name available for runtime annotation inspection.
 ///
 /// ## Example
 /// ```python
@@ -71,7 +78,21 @@ use crate::{Fix, FixAvailability, Violation};
 ///     return len(sized)
 /// ```
 ///
+/// On Python 3.15 and later, use instead:
+/// ```python
+/// lazy from . import local_module
+///
+///
+/// def func(sized: local_module.Container) -> int:
+///     return len(sized)
+/// ```
+///
+/// ## Fix safety
+/// This rule's fixes are unsafe because changing when a module is imported can
+/// affect runtime behavior, including import-time side effects.
+///
 /// ## Options
+/// - `lint.flake8-tidy-imports.ban-lazy`
 /// - `lint.flake8-type-checking.quote-annotations`
 /// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
 /// - `lint.flake8-type-checking.runtime-evaluated-decorators`
@@ -85,6 +106,7 @@ use crate::{Fix, FixAvailability, Violation};
 #[violation_metadata(stable_since = "0.8.0", category = Category::Pedantic)]
 pub(crate) struct TypingOnlyFirstPartyImport {
     qualified_name: String,
+    fix_style: ImportFixStyle,
 }
 
 impl Violation for TypingOnlyFirstPartyImport {
@@ -92,20 +114,25 @@ impl Violation for TypingOnlyFirstPartyImport {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Move application import `{}` into a type-checking block",
-            self.qualified_name
-        )
+        match self.fix_style {
+            ImportFixStyle::TypeCheckingBlock => format!(
+                "Move application import `{}` into a type-checking block",
+                self.qualified_name
+            ),
+            ImportFixStyle::LazyImport => {
+                format!("Make application import `{}` lazy", self.qualified_name)
+            }
+        }
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Move into type-checking block".to_string())
+        Some(self.fix_style.fix_title().to_string())
     }
 }
 
 /// ## What it does
 /// Checks for third-party imports that are only used for type annotations, but
-/// aren't defined in a type-checking block.
+/// aren't imported lazily or defined in a type-checking block.
 ///
 /// ## Why is this bad?
 /// Imports that are only used for type annotations add a performance overhead
@@ -128,6 +155,12 @@ impl Violation for TypingOnlyFirstPartyImport {
 /// moved into an `if TYPE_CHECKING:` block. This takes precedence over the
 /// [`lint.flake8-type-checking.quote-annotations`] setting described above if
 /// both settings are enabled.
+///
+/// On Python 3.15 and later, lazy imports are also exempt, including imports
+/// made lazy by a literal `__lazy_modules__` declaration. The fix prefers adding
+/// `lazy` to single-name import statements where the syntax is legal and
+/// [`lint.flake8-tidy-imports.ban-lazy`] allows it. This defers the import while
+/// keeping the name available for runtime annotation inspection.
 ///
 /// ## Example
 /// ```python
@@ -154,7 +187,21 @@ impl Violation for TypingOnlyFirstPartyImport {
 ///     return len(df)
 /// ```
 ///
+/// On Python 3.15 and later, use instead:
+/// ```python
+/// lazy import pandas as pd
+///
+///
+/// def func(df: pd.DataFrame) -> int:
+///     return len(df)
+/// ```
+///
+/// ## Fix safety
+/// This rule's fixes are unsafe because changing when a module is imported can
+/// affect runtime behavior, including import-time side effects.
+///
 /// ## Options
+/// - `lint.flake8-tidy-imports.ban-lazy`
 /// - `lint.flake8-type-checking.quote-annotations`
 /// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
 /// - `lint.flake8-type-checking.runtime-evaluated-decorators`
@@ -168,6 +215,7 @@ impl Violation for TypingOnlyFirstPartyImport {
 #[violation_metadata(stable_since = "0.8.0", category = Category::Pedantic)]
 pub(crate) struct TypingOnlyThirdPartyImport {
     qualified_name: String,
+    fix_style: ImportFixStyle,
 }
 
 impl Violation for TypingOnlyThirdPartyImport {
@@ -175,20 +223,25 @@ impl Violation for TypingOnlyThirdPartyImport {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Move third-party import `{}` into a type-checking block",
-            self.qualified_name
-        )
+        match self.fix_style {
+            ImportFixStyle::TypeCheckingBlock => format!(
+                "Move third-party import `{}` into a type-checking block",
+                self.qualified_name
+            ),
+            ImportFixStyle::LazyImport => {
+                format!("Make third-party import `{}` lazy", self.qualified_name)
+            }
+        }
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Move into type-checking block".to_string())
+        Some(self.fix_style.fix_title().to_string())
     }
 }
 
 /// ## What it does
 /// Checks for standard library imports that are only used for type
-/// annotations, but aren't defined in a type-checking block.
+/// annotations, but aren't imported lazily or defined in a type-checking block.
 ///
 /// ## Why is this bad?
 /// Imports that are only used for type annotations add a performance overhead
@@ -211,6 +264,12 @@ impl Violation for TypingOnlyThirdPartyImport {
 /// moved into an `if TYPE_CHECKING:` block. This takes precedence over the
 /// [`lint.flake8-type-checking.quote-annotations`] setting described above if
 /// both settings are enabled.
+///
+/// On Python 3.15 and later, lazy imports are also exempt, including imports
+/// made lazy by a literal `__lazy_modules__` declaration. The fix prefers adding
+/// `lazy` to single-name import statements where the syntax is legal and
+/// [`lint.flake8-tidy-imports.ban-lazy`] allows it. This defers the import while
+/// keeping the name available for runtime annotation inspection.
 ///
 /// ## Example
 /// ```python
@@ -237,7 +296,21 @@ impl Violation for TypingOnlyThirdPartyImport {
 ///     return str(path)
 /// ```
 ///
+/// On Python 3.15 and later, use instead:
+/// ```python
+/// lazy from pathlib import Path
+///
+///
+/// def func(path: Path) -> str:
+///     return str(path)
+/// ```
+///
+/// ## Fix safety
+/// This rule's fixes are unsafe because changing when a module is imported can
+/// affect runtime behavior, including import-time side effects.
+///
 /// ## Options
+/// - `lint.flake8-tidy-imports.ban-lazy`
 /// - `lint.flake8-type-checking.quote-annotations`
 /// - `lint.flake8-type-checking.runtime-evaluated-base-classes`
 /// - `lint.flake8-type-checking.runtime-evaluated-decorators`
@@ -251,6 +324,7 @@ impl Violation for TypingOnlyThirdPartyImport {
 #[violation_metadata(stable_since = "0.8.0", category = Category::Pedantic)]
 pub(crate) struct TypingOnlyStandardLibraryImport {
     qualified_name: String,
+    fix_style: ImportFixStyle,
 }
 
 impl Violation for TypingOnlyStandardLibraryImport {
@@ -258,14 +332,22 @@ impl Violation for TypingOnlyStandardLibraryImport {
 
     #[derive_message_formats]
     fn message(&self) -> String {
-        format!(
-            "Move standard library import `{}` into a type-checking block",
-            self.qualified_name
-        )
+        match self.fix_style {
+            ImportFixStyle::TypeCheckingBlock => format!(
+                "Move standard library import `{}` into a type-checking block",
+                self.qualified_name
+            ),
+            ImportFixStyle::LazyImport => {
+                format!(
+                    "Make standard library import `{}` lazy",
+                    self.qualified_name
+                )
+            }
+        }
     }
 
     fn fix_title(&self) -> Option<String> {
-        Some("Move into type-checking block".to_string())
+        Some(self.fix_style.fix_title().to_string())
     }
 }
 
@@ -302,7 +384,9 @@ pub(crate) fn typing_only_runtime_import(
             continue;
         };
 
-        if !binding.context.is_runtime() {
+        if !binding.context.is_runtime()
+            || (checker.target_version() >= PythonVersion::PY315 && binding.is_lazy())
+        {
             continue;
         }
 
@@ -401,7 +485,8 @@ pub(crate) fn typing_only_runtime_import(
         reason = "each statement group produces diagnostics and a fix independently"
     )]
     for ((node_id, import_type), imports) in errors_by_statement {
-        let fix = fix_imports(checker, node_id, &imports).ok();
+        let fix_style = ImportFixStyle::for_import(checker, scope, node_id);
+        let fix = fix_imports(checker, node_id, &imports, fix_style).ok();
 
         for ImportBinding {
             import,
@@ -414,6 +499,7 @@ pub(crate) fn typing_only_runtime_import(
                 checker,
                 import_type,
                 import.qualified_name().to_string(),
+                fix_style,
                 range,
             );
             if let Some(range) = parent_range {
@@ -431,7 +517,8 @@ pub(crate) fn typing_only_runtime_import(
         clippy::iter_over_hash_type,
         reason = "each ignored statement group produces diagnostics independently"
     )]
-    for ((_, import_type), imports) in ignores_by_statement {
+    for ((node_id, import_type), imports) in ignores_by_statement {
+        let fix_style = ImportFixStyle::for_import(checker, scope, node_id);
         for ImportBinding {
             import,
             range,
@@ -443,6 +530,7 @@ pub(crate) fn typing_only_runtime_import(
                 checker,
                 import_type,
                 import.qualified_name().to_string(),
+                fix_style,
                 range,
             );
             if let Some(range) = parent_range {
@@ -467,18 +555,31 @@ fn diagnostic_for<'a, 'b>(
     checker: &'a Checker<'b>,
     import_type: ImportType,
     qualified_name: String,
+    fix_style: ImportFixStyle,
     range: TextRange,
 ) -> DiagnosticGuard<'a, 'b> {
     match import_type {
-        ImportType::StandardLibrary => {
-            checker.report_diagnostic(TypingOnlyStandardLibraryImport { qualified_name }, range)
-        }
-        ImportType::ThirdParty => {
-            checker.report_diagnostic(TypingOnlyThirdPartyImport { qualified_name }, range)
-        }
-        ImportType::FirstParty => {
-            checker.report_diagnostic(TypingOnlyFirstPartyImport { qualified_name }, range)
-        }
+        ImportType::StandardLibrary => checker.report_diagnostic(
+            TypingOnlyStandardLibraryImport {
+                qualified_name,
+                fix_style,
+            },
+            range,
+        ),
+        ImportType::ThirdParty => checker.report_diagnostic(
+            TypingOnlyThirdPartyImport {
+                qualified_name,
+                fix_style,
+            },
+            range,
+        ),
+        ImportType::FirstParty => checker.report_diagnostic(
+            TypingOnlyFirstPartyImport {
+                qualified_name,
+                fix_style,
+            },
+            range,
+        ),
         _ => unreachable!("Unexpected import type"),
     }
 }
@@ -510,9 +611,20 @@ fn is_exempt(name: &str, exempt_modules: &[&str]) -> bool {
     }
 }
 
-/// Generate a [`Fix`] to remove typing-only imports from a runtime context.
-fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) -> Result<Fix> {
+/// Generate a [`Fix`] to defer imports used only for typing.
+fn fix_imports(
+    checker: &Checker,
+    node_id: NodeId,
+    imports: &[ImportBinding],
+    fix_style: ImportFixStyle,
+) -> Result<Fix> {
     let statement = checker.semantic().statement(node_id);
+    if matches!(fix_style, ImportFixStyle::LazyImport) {
+        return Ok(Fix::unsafe_edit(Edit::insertion(
+            "lazy ".to_string(),
+            statement.start(),
+        )));
+    }
     let parent = checker.semantic().parent_statement(node_id);
 
     let member_names: Vec<Cow<'_, str>> = imports
@@ -603,4 +715,52 @@ fn fix_imports(checker: &Checker, node_id: NodeId, imports: &[ImportBinding]) ->
     Ok(fix.isolate(Checker::isolation(
         checker.semantic().parent_statement_id(node_id),
     )))
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ImportFixStyle {
+    TypeCheckingBlock,
+    LazyImport,
+}
+
+impl ImportFixStyle {
+    fn for_import(checker: &Checker, scope: &Scope, node_id: NodeId) -> Self {
+        let semantic = checker.semantic();
+        if checker.target_version() < PythonVersion::PY315
+            || !scope.kind.is_module()
+            || semantic.statements(node_id).skip(1).any(Stmt::is_try_stmt)
+        {
+            return Self::TypeCheckingBlock;
+        }
+
+        let statement = semantic.statement(node_id);
+        let names = match statement {
+            Stmt::Import(import) => &import.names,
+            Stmt::ImportFrom(import) => &import.names,
+            _ => return Self::TypeCheckingBlock,
+        };
+        // Other members may be used at runtime, suppressed, or governed by another lazy-import policy.
+        if names.len() != 1 {
+            return Self::TypeCheckingBlock;
+        }
+
+        let ban_lazy = &checker.settings().flake8_tidy_imports.ban_lazy;
+        for (policy, node) in &BannedModuleImportPolicies::new(statement, checker) {
+            if ban_lazy.includes_all() && statement.is_import_from_stmt() && node.is_alias() {
+                continue;
+            }
+            if ban_lazy.find(&policy).is_some() {
+                return Self::TypeCheckingBlock;
+            }
+        }
+
+        Self::LazyImport
+    }
+
+    fn fix_title(self) -> &'static str {
+        match self {
+            Self::TypeCheckingBlock => "Move into type-checking block",
+            Self::LazyImport => "Convert to a lazy import",
+        }
+    }
 }


### PR DESCRIPTION
Summary
--

This PR closes #25181 by recognizing and suggesting lazy imports in the typing-only runtime imports
rules. As noted in [PEP 810], one common use for `TYPE_CHECKING` blocks is to avoid importing code
that isn't actually needed at runtime:

> Type annotations frequently require imports that are never used at runtime. The common workaround
> is to wrap them in `if TYPE_CHECKING:` blocks \[1\]. With lazy imports, annotation-only imports
> impose no runtime penalty, eliminating the need for such guards and making annotated codebases
> cleaner.

The footnote is even more relevant:

> Furthermore, there’s also external tooling, in the form of flake8-type-checking, because it is
> common for developers to mislocate imports and accidentally introduce a runtime dependency on an
> import only imported in such a block. Ironically, the static type checker is of no help in these
> circumstances.

In line with this usage, this PR exempts existing lazy imports from these rules, which otherwise
would still suggest moving them into `TYPE_CHECKING` blocks, and it also adds a new fix to all three
rules that will add `lazy` in front of an import on 3.15+.

In line with our fixes for `TID254` and `TID255`, we fall back on the existing `TYPE_CHECKING` fix
if the `lazy` addition is too complicated, i.e. when multiple names are imported on the same line or
when we'd have to edit `__lazy_modules__`.

[PEP 810]: https://peps.python.org/pep-0810/

Test Plan
--

New mdtests
