### PR TITLE
[`flake8-pyi`] Mention stubs in the diagnostic message (`PYI002`)

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/complex_if_statement_in_stub.rs
@@ -39,7 +39,7 @@ pub(crate) struct ComplexIfStatementInStub;
 impl Violation for ComplexIfStatementInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "`if` test must be a simple comparison against `sys.platform` or `sys.version_info`"
+        "`if` test in a stub file must be a simple comparison against `sys.platform` or `sys.version_info`"
             .to_string()
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__complex-if-statement-in-stub_PYI002.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__complex-if-statement-in-stub_PYI002.pyi.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI002 `if` test must be a simple comparison against `sys.platform` or `sys.version_info`
+PYI002 `if` test in a stub file must be a simple comparison against `sys.platform` or `sys.version_info`
  --> PYI002.pyi:3:4
   |
 1 | import sys
@@ -12,7 +12,7 @@ PYI002 `if` test must be a simple comparison against `sys.platform` or `sys.vers
 5 | if hasattr(sys, 'maxint'): ...  # Y002 If test must be a simple comparison against sys.platform or sys.version_info
   |
 
-PYI002 `if` test must be a simple comparison against `sys.platform` or `sys.version_info`
+PYI002 `if` test in a stub file must be a simple comparison against `sys.platform` or `sys.version_info`
  --> PYI002.pyi:4:4
   |
 3 | if sys.version == 'Python 2.7.10': ...  # Y002 If test must be a simple comparison against sys.platform or sys.version_info
@@ -22,7 +22,7 @@ PYI002 `if` test must be a simple comparison against `sys.platform` or `sys.vers
 6 | if sys.maxsize == 42: ...  # Y002 If test must be a simple comparison against sys.platform or sys.version_info
   |
 
-PYI002 `if` test must be a simple comparison against `sys.platform` or `sys.version_info`
+PYI002 `if` test in a stub file must be a simple comparison against `sys.platform` or `sys.version_info`
  --> PYI002.pyi:5:4
   |
 3 | if sys.version == 'Python 2.7.10': ...  # Y002 If test must be a simple comparison against sys.platform or sys.version_info
@@ -32,7 +32,7 @@ PYI002 `if` test must be a simple comparison against `sys.platform` or `sys.vers
 6 | if sys.maxsize == 42: ...  # Y002 If test must be a simple comparison against sys.platform or sys.version_info
   |
 
-PYI002 `if` test must be a simple comparison against `sys.platform` or `sys.version_info`
+PYI002 `if` test in a stub file must be a simple comparison against `sys.platform` or `sys.version_info`
  --> PYI002.pyi:6:4
   |
 4 | if 'linux' == sys.platform: ...  # Y002 If test must be a simple comparison against sys.platform or sys.version_info


### PR DESCRIPTION
Fixes #27324

The PYI002 diagnostic read as a statement about the flagged test itself, which is confusing when the condition does not mention `sys.platform` or `sys.version_info` at all (the case in the issue). The rule's expectation is that `if` tests in stub files are simple comparisons, so the message now names that context:

```
PYI002 `if` test in a stub file must be a simple comparison against `sys.platform` or `sys.version_info`
```

This is a message-only change; rule behavior is unchanged. The Y002 fixtures and snapshots are untouched since that rule carries its own message, and the `PYI002.pyi.snap` output is updated to match.
