### PR TITLE
[ty] Refactor "desperate" import resolution to use candidate operations that will also apply to module enumeration.

### DIFF
--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -1230,13 +1230,30 @@ fn desperately_resolve_name<'db>(
     let importing_file = ResolverFile::new(db, importing_file, resolver_environment);
     let search_paths = absolute_desperate_search_paths(db, importing_file).unwrap_or_default();
     let resolver = NameResolver::new(db, resolver_environment, name, mode);
+    let stub_packages = mode
+        .is_typing()
+        .then(|| StubPackageIndex::from_search_paths(db, search_paths.iter()));
+    let mut candidates = resolver.discover_roots(
+        name.first_component(),
+        resolver.is_non_shadowable,
+        search_paths.iter(),
+        stub_packages
+            .as_ref()
+            .map_or_else(StubPackagePaths::default, StubPackageIndex::all),
+    );
+    let mut components = name.components().skip(1).peekable();
 
-    match mode {
-        ModuleResolveMode::Typing => resolver.resolve_desperate_typing(search_paths),
-        ModuleResolveMode::Runtime | ModuleResolveMode::RuntimeSomeShadowingAllowed => {
-            resolver.resolve_runtime(search_paths.iter())
-        }
+    candidates = normalize_candidates(db, candidates, components.peek().is_some());
+    while let Some(component) = components.next() {
+        candidates = resolver.advance_candidates(
+            candidates,
+            component,
+            ComponentFileFilter::ByMode,
+            components.peek().is_some(),
+        );
     }
+
+    (!candidates.is_empty()).then_some(candidates)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1482,23 +1499,6 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         );
         candidates.extend(remaining_candidates);
 
-        self.resolve_remaining(candidates, ComponentFileFilter::ByMode)
-    }
-
-    /// Resolves the name for type checking against desperate ancestor search paths.
-    ///
-    /// These paths can contain PEP 561 stub packages, but never user-provided extra paths, so this
-    /// indexes them for stub packages without performing a separate stub-overlay pass. Runtime
-    /// resolution instead ignores stub packages and `.pyi` files entirely.
-    fn resolve_desperate_typing(&self, search_paths: &[SearchPath]) -> Option<ResolvedNames<'db>> {
-        let stub_packages =
-            StubPackageIndex::from_search_paths(self.context.db, search_paths.iter());
-        let candidates = self.discover_roots(
-            self.name.first_component(),
-            self.is_non_shadowable,
-            search_paths.iter(),
-            stub_packages.all(),
-        );
         self.resolve_remaining(candidates, ComponentFileFilter::ByMode)
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This is a small step towards the [larger refactor](https://github.com/astral-sh/ruff/pull/28199) that will allow us to share ordinary module resolution rules with the module enumeration process required to [support namespace packages for auto imports](https://github.com/astral-sh/ty/issues/2273) (please see that refactor PR for a detailed description of our motivations).  It refactors the `desperately_resolve_name` method (used for ordinary module resolution) to use methods of `NameResolver` that can be shared with module enumeration.

## Test Plan

This is a pure refactor that relies on existing tests.
<!-- How was it tested? -->
