### PR TITLE
[ty] Bound aliased intersection expansion during inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -269,6 +269,167 @@ reveal_type(generic_context(outside_callable(int_identity)))
 outside_callable(int_identity)("string")
 ```
 
+## Union without intersection does not consider budget
+
+A single union upper bound remains precise even when it has more alternatives than the solution
+budget. Nested `TypeAliasType` aliases preserve the same result.
+
+```py
+from typing import Callable, TypeVar
+from typing_extensions import TypeAliasType
+
+T = TypeVar("T")
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+class E: ...
+
+def infer_from_consumer(consumer: Callable[[T], None]) -> T:
+    raise NotImplementedError
+
+def consume(value: A | B | C | D | E) -> None: ...
+
+reveal_type(infer_from_consumer(consume))  # revealed: A | B | C | D | E
+```
+
+The aliases retain nested union members until inference expands them:
+
+```py
+FirstTwo = TypeAliasType("FirstTwo", A | B)
+NextTwo = TypeAliasType("NextTwo", C | D)
+Options = TypeAliasType("Options", FirstTwo | NextTwo | E)
+
+def consume_alias(value: Options) -> None: ...
+
+reveal_type(infer_from_consumer(consume_alias))  # revealed: A | B | C | D | E
+```
+
+## Overlapping inferred union upper bounds with few surviving alternatives
+
+The individual union upper bounds can exceed the solution budget when only a few alternatives
+survive their intersection. Disjoint alternatives do not count toward the budget.
+
+```py
+from typing import Callable, TypeVar, final
+from typing_extensions import TypeAliasType
+
+T = TypeVar("T")
+
+def infer_from_consumers(left: Callable[[T], None], right: Callable[[T], None]) -> T:
+    raise NotImplementedError
+
+@final
+class A: ...
+
+@final
+class B: ...
+
+@final
+class C: ...
+
+@final
+class D: ...
+
+@final
+class E: ...
+
+@final
+class F: ...
+
+@final
+class G: ...
+
+@final
+class H: ...
+
+def consume_left(value: A | B | C | D | E) -> None: ...
+def consume_right(value: A | B | F | G | H) -> None: ...
+
+reveal_type(infer_from_consumers(consume_left, consume_right))  # revealed: A | B
+```
+
+Aliases for these unions also preserve the precise intersection in either argument order:
+
+```py
+Left = TypeAliasType("Left", A | B | C | D | E)
+Right = TypeAliasType("Right", A | B | F | G | H)
+
+def consume_left_alias(value: Left) -> None: ...
+def consume_right_alias(value: Right) -> None: ...
+
+reveal_type(infer_from_consumers(consume_left_alias, consume_right_alias))  # revealed: A | B
+reveal_type(infer_from_consumers(consume_right_alias, consume_left_alias))  # revealed: A | B
+```
+
+## Intersecting aliased upper bounds exceeding the solution budget
+
+Each consumer constrains `T` to a different union. The classes can share subclasses, so their
+intersection has eight distinct alternatives. Type aliases do not exempt this expansion from the
+solution budget: inference falls back to `Unknown` instead of constructing the entire intersection.
+
+```py
+from typing import Callable, TypeVar
+from typing_extensions import TypeAliasType
+
+T = TypeVar("T")
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+class E: ...
+class F: ...
+
+First = TypeAliasType("First", A | B)
+Second = TypeAliasType("Second", C | D)
+Third = TypeAliasType("Third", E | F)
+
+def infer_from_consumers(
+    first: Callable[[T], None],
+    second: Callable[[T], None],
+    third: Callable[[T], None],
+) -> T:
+    raise NotImplementedError
+
+def consume_first(value: First) -> None: ...
+def consume_second(value: Second) -> None: ...
+def consume_third(value: Third) -> None: ...
+
+reveal_type(infer_from_consumers(consume_first, consume_second, consume_third))  # revealed: Unknown
+```
+
+The same budget applies when an explicit union is intersected with aliased unions:
+
+```py
+def consume_explicit(value: E | F) -> None: ...
+
+reveal_type(infer_from_consumers(consume_first, consume_second, consume_explicit))  # revealed: Unknown
+```
+
+## Intersecting recursive inferred union upper bounds
+
+A recursive alias can contribute an upper bound without expanding its nested occurrences. Here, only
+`int` satisfies both consumers, regardless of their order.
+
+```py
+from typing import Callable, TypeVar
+from typing_extensions import TypeAliasType
+
+T = TypeVar("T")
+Recursive = TypeAliasType("Recursive", "int | list[Recursive]")
+
+def infer_from_consumers(left: Callable[[T], None], right: Callable[[T], None]) -> T:
+    raise NotImplementedError
+
+def consume_recursive(value: Recursive) -> None: ...
+def consume_int_or_str(value: int | str) -> None: ...
+
+reveal_type(infer_from_consumers(consume_recursive, consume_int_or_str))  # revealed: int
+reveal_type(infer_from_consumers(consume_int_or_str, consume_recursive))  # revealed: int
+```
+
 ## Overloaded callable as generic `Callable` argument
 
 An overloaded callable should be assignable to a non-overloaded callable type when the overload set

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -430,10 +430,22 @@ def consume(value: A | B | C | D | E) -> None: ...
 reveal_type(infer_from_consumer(consume))  # revealed: A | B | C | D | E
 ```
 
-## Overlapping inferred union upper bounds exceeding the solution budget
+The same union remains precise when it is defined through nested type aliases:
 
-Even if the precise intersection of two large union upper bounds is small, processing either union
-currently exceeds the solution budget before we can discover that intersection.
+```py
+type FirstTwo = A | B
+type NextTwo = C | D
+type Options = FirstTwo | NextTwo | E
+
+def consume_alias(value: Options) -> None: ...
+
+reveal_type(infer_from_consumer(consume_alias))  # revealed: A | B | C | D | E
+```
+
+## Overlapping inferred union upper bounds with few surviving alternatives
+
+The individual union upper bounds can exceed the solution budget when only a few alternatives
+survive their intersection. Disjoint alternatives do not count toward the budget.
 
 ```py
 from typing import Callable, final
@@ -472,6 +484,81 @@ def consume_left(value: A | B | C | D | E) -> None: ...
 def consume_right(value: A | B | F | G | H) -> None: ...
 
 reveal_type(infer_from_consumers(consume_left, consume_right))  # revealed: A | B
+```
+
+Aliases for these unions also preserve the precise intersection in either argument order:
+
+```py
+type Left = A | B | C | D | E
+type Right = A | B | F | G | H
+
+def consume_left_alias(value: Left) -> None: ...
+def consume_right_alias(value: Right) -> None: ...
+
+reveal_type(infer_from_consumers(consume_left_alias, consume_right_alias))  # revealed: A | B
+reveal_type(infer_from_consumers(consume_right_alias, consume_left_alias))  # revealed: A | B
+```
+
+## Intersecting aliased upper bounds exceeding the solution budget
+
+Each consumer constrains `T` to a different union. The classes can share subclasses, so their
+intersection has eight distinct alternatives. Type aliases do not exempt this expansion from the
+solution budget: inference falls back to `Unknown` instead of constructing the entire intersection.
+
+```py
+from typing import Callable
+
+class A: ...
+class B: ...
+class C: ...
+class D: ...
+class E: ...
+class F: ...
+
+type First = A | B
+type Second = C | D
+type Third = E | F
+
+def infer_from_consumers[T](
+    first: Callable[[T], None],
+    second: Callable[[T], None],
+    third: Callable[[T], None],
+) -> T:
+    raise NotImplementedError
+
+def consume_first(value: First) -> None: ...
+def consume_second(value: Second) -> None: ...
+def consume_third(value: Third) -> None: ...
+
+reveal_type(infer_from_consumers(consume_first, consume_second, consume_third))  # revealed: Unknown
+```
+
+The same budget applies when an explicit union is intersected with aliased unions:
+
+```py
+def consume_explicit(value: E | F) -> None: ...
+
+reveal_type(infer_from_consumers(consume_first, consume_second, consume_explicit))  # revealed: Unknown
+```
+
+## Intersecting recursive inferred union upper bounds
+
+A recursive alias can contribute an upper bound without expanding its nested occurrences. Here, only
+`int` satisfies both consumers, regardless of their order.
+
+```py
+from typing import Callable
+
+type Recursive = int | list[Recursive]
+
+def infer_from_consumers[T](left: Callable[[T], None], right: Callable[[T], None]) -> T:
+    raise NotImplementedError
+
+def consume_recursive(value: Recursive) -> None: ...
+def consume_int_or_str(value: int | str) -> None: ...
+
+reveal_type(infer_from_consumers(consume_recursive, consume_int_or_str))  # revealed: int
+reveal_type(infer_from_consumers(consume_int_or_str, consume_recursive))  # revealed: int
 ```
 
 ## Contextual generic return exceeding the solution budget

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -776,8 +776,6 @@ impl std::iter::FusedIterator for NegativeIntersectionElementsIterator<'_, '_> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for IntersectionType<'_> {}
 
-const MAX_INTERSECTION_DNF_TERMS: usize = 4;
-
 pub(crate) fn walk_intersection_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
     intersection: IntersectionType<'db>,
@@ -885,69 +883,7 @@ impl<'db> IntersectionType<'db> {
         I::IntoIter: Clone,
         Type<'db>: From<T>,
     {
-        // TODO: Consider folding this logic into IntersectionBuilder itself, and having it check
-        // an optional budget as part of its existing `add_positive` methods.
-
-        let elements = elements.into_iter().map(Type::from);
-        let union_count = elements.clone().filter(|ty| ty.is_union()).count();
-        if union_count <= 1 {
-            // If there are no unions, then all we have to do is check for redundant elements. If
-            // there is a single union, the product of all union counts should be reasonable, even
-            // if it exceeds the budget below. In both cases, just return the precise answer
-            // without considering the budget.
-            return Some(Self::from_elements(db, env, elements));
-        }
-
-        let non_union_elements = elements.clone().filter(|element| !element.is_union());
-        let initial = Self::from_elements(db, env, non_union_elements);
-        let insert_candidate = |candidates: &mut Vec<Type<'db>>,
-                                new_ty: Type<'db>,
-                                check_budget: bool|
-         -> Option<()> {
-            if new_ty.is_never()
-                || candidates
-                    .iter()
-                    .any(|old| new_ty.is_redundant_with(db, env, *old))
-            {
-                return Some(());
-            }
-
-            candidates.retain(|old| !old.is_redundant_with(db, env, new_ty));
-            if check_budget && candidates.len() >= MAX_INTERSECTION_DNF_TERMS {
-                return None;
-            }
-            candidates.push(new_ty);
-            Some(())
-        };
-
-        let mut frontier = Vec::new();
-        let mut next = Vec::new();
-        insert_candidate(&mut frontier, initial, true)?;
-
-        for (idx, clause) in elements.filter_map(Type::as_union).enumerate() {
-            // Don't check the budget for the first union clause. That ensures that we have a
-            // chance for pairs of types to "annihilate" each other without contributing to the
-            // result. For instance, this allows us to return the precise result for
-            // `(A | B | C | D | E) & (A | B | F | G | H)` (in which each class is final), since
-            // most of the pairs are disjoint.
-            let check_budget = idx > 0;
-
-            next.clear();
-            for candidate in &frontier {
-                for alternative in clause.elements(db) {
-                    let refined = Self::from_two_elements(db, env, *candidate, *alternative);
-                    insert_candidate(&mut next, refined, check_budget)?;
-                }
-            }
-
-            if next.is_empty() {
-                return Some(Type::Never);
-            }
-
-            std::mem::swap(&mut frontier, &mut next);
-        }
-
-        Some(UnionType::from_elements(db, env, frontier))
+        IntersectionBuilder::bounded_from_elements(db, env, elements)
     }
 
     /// Create an intersection type `A & B` from two elements `A` and `B`.

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -39,7 +39,9 @@
 //! shares exactly the same possible super-types, and none of them are subtypes of each other
 //! (unless exactly the same literal type), we can avoid many unnecessary redundancy checks.
 
+use std::convert::Infallible;
 use std::hint::cold_path;
+use std::ops::ControlFlow;
 
 use super::RecursivelyDefined;
 use super::generic_gradual_intersections::{GenericIntersection, generic_gradual_intersection};
@@ -1197,6 +1199,41 @@ impl<'db> UnionBuilder<'db> {
     }
 }
 
+/// Controls expansion without making ordinary intersection construction fallible.
+trait IntersectionLimits {
+    type Break;
+    const BOUNDED: bool;
+
+    fn check_terms(terms: usize) -> ControlFlow<Self::Break>;
+}
+
+struct UnboundedIntersection;
+
+impl IntersectionLimits for UnboundedIntersection {
+    type Break = Infallible;
+    const BOUNDED: bool = false;
+
+    fn check_terms(_terms: usize) -> ControlFlow<Self::Break> {
+        ControlFlow::Continue(())
+    }
+}
+
+struct BoundedIntersection;
+
+impl IntersectionLimits for BoundedIntersection {
+    type Break = ();
+    const BOUNDED: bool = true;
+
+    fn check_terms(terms: usize) -> ControlFlow<Self::Break> {
+        const MAX_INTERSECTION_DNF_TERMS: usize = 4;
+        if terms > MAX_INTERSECTION_DNF_TERMS {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct IntersectionBuilder<'db> {
     // Really this builds a union-of-intersections, because we always keep our set-theoretic types
@@ -1207,6 +1244,9 @@ pub(crate) struct IntersectionBuilder<'db> {
     intersections: Vec<InnerIntersectionBuilder<'db>>,
     db: &'db dyn Db,
     env: ProgramEnvironment<'db>,
+    // One disjunction does not multiply alternatives. Only subsequent distributions consume
+    // the bounded constructor's budget, after impossible and redundant branches are removed.
+    has_disjunction: bool,
 }
 
 impl<'db> IntersectionBuilder<'db> {
@@ -1215,6 +1255,7 @@ impl<'db> IntersectionBuilder<'db> {
             db,
             env: env.clone(),
             intersections: vec![InnerIntersectionBuilder::default()],
+            has_disjunction: false,
         }
     }
 
@@ -1223,18 +1264,89 @@ impl<'db> IntersectionBuilder<'db> {
             db,
             env: env.clone(),
             intersections: vec![],
+            has_disjunction: false,
         }
     }
 
     /// Add DNF branches, dropping those that have already collapsed to `Never` so that later
     /// union distribution does not multiply dead branches.
-    fn extend(&mut self, other: Self) {
-        self.intersections.extend(
-            other
-                .intersections
-                .into_iter()
-                .filter(|intersection| !intersection.contains_never()),
-        );
+    fn extend<L: IntersectionLimits>(
+        &mut self,
+        other: Self,
+        check_budget: bool,
+    ) -> ControlFlow<L::Break> {
+        // Retain the whole first disjunction: a later factor can eliminate all but a few of its
+        // alternatives, including alternatives that occur beyond the budget's position.
+        if !L::BOUNDED || !check_budget {
+            self.intersections.extend(
+                other
+                    .intersections
+                    .into_iter()
+                    .filter(|intersection| !intersection.contains_never()),
+            );
+            return ControlFlow::Continue(());
+        }
+
+        let db = self.db;
+        let env = &self.env;
+        for candidate in other.intersections {
+            // Some branches only collapse during `build`, for example when a constrained
+            // type variable has no remaining constraints. Those do not consume the budget.
+            let candidate_type = candidate.clone().build(db, env);
+            if candidate_type.is_never()
+                || self.intersections.iter().any(|old| {
+                    candidate_type.is_redundant_with(db, env, old.clone().build(db, env))
+                })
+            {
+                continue;
+            }
+            self.intersections.retain(|old| {
+                !old.clone()
+                    .build(db, env)
+                    .is_redundant_with(db, env, candidate_type)
+            });
+            L::check_terms(self.intersections.len() + 1)?;
+            self.intersections.push(candidate);
+        }
+        ControlFlow::Continue(())
+    }
+
+    pub(super) fn bounded_from_elements<I, T>(
+        db: &'db dyn Db,
+        env: &ProgramEnvironment<'db>,
+        elements: I,
+    ) -> Option<Type<'db>>
+    where
+        I: IntoIterator<Item = T>,
+        I::IntoIter: Clone,
+        Type<'db>: From<T>,
+    {
+        let elements = elements.into_iter().map(Type::from);
+        let mut first_elements = elements.clone();
+        let Some(first) = first_elements.next() else {
+            return Some(Type::object());
+        };
+        if first_elements.next().is_none() {
+            return Some(first);
+        }
+
+        // Before distributing multiple unions, apply narrowing factors regardless of their
+        // input order. With at most one union, retain the original intersection element order.
+        // Resolving a top-level alias only classifies the factor; the builder expands its value
+        // under the same budget and recursion guard as an explicit union.
+        let is_union = |ty: &Type<'db>| ty.resolve_type_alias(db).is_union();
+        let multiple_unions = elements.clone().filter(is_union).nth(1).is_some();
+        let mut builder = Self::new(db, env);
+        for element in elements
+            .clone()
+            .filter(|ty| !multiple_unions || !is_union(ty))
+            .chain(elements.filter(|ty| multiple_unions && is_union(ty)))
+        {
+            builder
+                .add_positive_impl::<BoundedIntersection>(element, &mut vec![])
+                .continue_value()?;
+        }
+        Some(builder.build())
     }
 
     pub(crate) fn add_positive(mut self, ty: Type<'db>) -> Self {
@@ -1243,10 +1355,15 @@ impl<'db> IntersectionBuilder<'db> {
     }
 
     pub(crate) fn add_positive_in_place(&mut self, ty: Type<'db>) {
-        self.add_positive_impl(ty, &mut vec![]);
+        let ControlFlow::Continue(()) =
+            self.add_positive_impl::<UnboundedIntersection>(ty, &mut vec![]);
     }
 
-    fn add_positive_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+    fn add_positive_impl<L: IntersectionLimits>(
+        &mut self,
+        ty: Type<'db>,
+        seen_aliases: &mut Vec<Type<'db>>,
+    ) -> ControlFlow<L::Break> {
         let db = self.db;
         match ty {
             Type::TypeAlias(alias) => {
@@ -1255,11 +1372,11 @@ impl<'db> IntersectionBuilder<'db> {
                     for inner in &mut self.intersections {
                         inner.positive.insert(ty);
                     }
-                    return;
+                    return ControlFlow::Continue(());
                 }
                 seen_aliases.push(ty);
                 let value_type = alias.value_type(db);
-                self.add_positive_impl(value_type, seen_aliases);
+                self.add_positive_impl::<L>(value_type, seen_aliases)?;
             }
             Type::Union(union) => {
                 // Distribute ourself over this union: for each union element, clone ourself and
@@ -1273,23 +1390,24 @@ impl<'db> IntersectionBuilder<'db> {
                 let mut distributed = IntersectionBuilder::empty(db, &self.env);
                 for elem in union.elements(db) {
                     let mut branch = self.clone();
-                    branch.add_positive_impl(*elem, seen_aliases);
-                    distributed.extend(branch);
+                    branch.add_positive_impl::<L>(*elem, seen_aliases)?;
+                    distributed.extend::<L>(branch, self.has_disjunction)?;
                 }
                 self.intersections = distributed.intersections;
+                self.has_disjunction = true;
             }
             // `(A & B & ~C) & (D & E & ~F)` -> `A & B & D & E & ~C & ~F`
             Type::Intersection(other) => {
                 for pos in other.positive(db) {
-                    self.add_positive_impl(*pos, seen_aliases);
+                    self.add_positive_impl::<L>(*pos, seen_aliases)?;
                 }
                 for neg in other.negative(db) {
-                    self.add_negative_impl(*neg, seen_aliases);
+                    self.add_negative_impl::<L>(*neg, seen_aliases)?;
                 }
             }
             Type::EnumComplement(complement) => {
                 let intersection = complement.to_intersection(db, &self.env);
-                self.add_positive_impl(intersection, seen_aliases);
+                self.add_positive_impl::<L>(intersection, seen_aliases)?;
             }
             _ => {
                 // If we are already a union-of-intersections, distribute the new intersected element
@@ -1299,6 +1417,7 @@ impl<'db> IntersectionBuilder<'db> {
                 }
             }
         }
+        ControlFlow::Continue(())
     }
 
     pub(crate) fn add_negative(mut self, ty: Type<'db>) -> Self {
@@ -1307,10 +1426,15 @@ impl<'db> IntersectionBuilder<'db> {
     }
 
     pub(crate) fn add_negative_in_place(&mut self, ty: Type<'db>) {
-        self.add_negative_impl(ty, &mut vec![]);
+        let ControlFlow::Continue(()) =
+            self.add_negative_impl::<UnboundedIntersection>(ty, &mut vec![]);
     }
 
-    fn add_negative_impl(&mut self, ty: Type<'db>, seen_aliases: &mut Vec<Type<'db>>) {
+    fn add_negative_impl<L: IntersectionLimits>(
+        &mut self,
+        ty: Type<'db>,
+        seen_aliases: &mut Vec<Type<'db>>,
+    ) -> ControlFlow<L::Break> {
         let db = self.db;
         // See comments above in `add_positive`; this is just the negated version.
         match ty {
@@ -1320,15 +1444,15 @@ impl<'db> IntersectionBuilder<'db> {
                     for inner in &mut self.intersections {
                         inner.negative.insert(ty);
                     }
-                    return;
+                    return ControlFlow::Continue(());
                 }
                 seen_aliases.push(ty);
                 let value_type = alias.value_type(db);
-                self.add_negative_impl(value_type, seen_aliases);
+                self.add_negative_impl::<L>(value_type, seen_aliases)?;
             }
             Type::Union(union) => {
                 for elem in union.elements(db) {
-                    self.add_negative_impl(*elem, seen_aliases);
+                    self.add_negative_impl::<L>(*elem, seen_aliases)?;
                 }
             }
             Type::Intersection(intersection) => {
@@ -1340,23 +1464,31 @@ impl<'db> IntersectionBuilder<'db> {
                 // is (existing & ~C) | (existing & D)
 
                 let mut distributed = IntersectionBuilder::empty(db, &self.env);
+                // A single negative element can encode double negation. It only introduces a
+                // disjunction if expanding that element does, for example `~~Alias` for a union.
+                let branches = intersection.positive(db).len() + intersection.negative(db).len();
+                let check_budget = self.has_disjunction && branches > 1;
+                let mut has_disjunction = self.has_disjunction || branches > 1;
                 // We negate all the positive constraints while distributing.
                 for elem in intersection.positive(db) {
                     let mut branch = self.clone();
-                    branch.add_negative_impl(*elem, &mut seen_aliases.clone());
-                    distributed.extend(branch);
+                    branch.add_negative_impl::<L>(*elem, &mut seen_aliases.clone())?;
+                    has_disjunction |= branch.has_disjunction;
+                    distributed.extend::<L>(branch, check_budget)?;
                 }
                 // All negative constraints end up becoming positive constraints.
                 for elem in intersection.negative(db) {
                     let mut branch = self.clone();
-                    branch.add_positive_impl(*elem, &mut seen_aliases.clone());
-                    distributed.extend(branch);
+                    branch.add_positive_impl::<L>(*elem, &mut seen_aliases.clone())?;
+                    has_disjunction |= branch.has_disjunction;
+                    distributed.extend::<L>(branch, check_budget)?;
                 }
                 self.intersections = distributed.intersections;
+                self.has_disjunction = has_disjunction;
             }
             Type::EnumComplement(complement) => {
                 let intersection = complement.to_intersection(db, &self.env);
-                self.add_negative_impl(intersection, seen_aliases);
+                self.add_negative_impl::<L>(intersection, seen_aliases)?;
             }
             _ => {
                 for inner in &mut self.intersections {
@@ -1364,6 +1496,7 @@ impl<'db> IntersectionBuilder<'db> {
                 }
             }
         }
+        ControlFlow::Continue(())
     }
 
     pub(crate) fn positive_elements<I, T>(mut self, elements: I) -> Self

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -96,6 +96,19 @@ fn bounded_intersection_preserves_late_union_elements() {
             Some(expected)
         );
     }
+
+    // A narrowing factor applies before union distribution even when it appears last.
+    let literal = Type::int_literal(5);
+    for elements in [
+        [wide, narrow, literal],
+        [narrow, wide, literal],
+        [literal, wide, narrow],
+    ] {
+        assert_eq!(
+            IntersectionType::bounded_from_elements(db, &env, elements),
+            Some(literal)
+        );
+    }
 }
 
 #[test]
@@ -115,6 +128,60 @@ fn bounded_intersection_returns_none_when_budget_exhausted() {
         IntersectionType::bounded_from_elements(db, &env, [wide, wide]),
         None
     );
+}
+
+#[test]
+fn bounded_intersection_limits_negated_alias_expansion() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/aliases.py",
+        r#"
+        from ty_extensions import Intersection, Not
+
+        class A: ...
+        class B: ...
+        class C: ...
+        class D: ...
+        class E: ...
+        class F: ...
+
+        type First = Intersection[A, B]
+        type Second = Intersection[C, D]
+        type Third = Intersection[E, F]
+        type Excluded = Not[int]
+        "#,
+    )?;
+    let db = &db;
+    let env = db.program_environment();
+    let file = system_path_to_file(db, "/src/aliases.py")?;
+    let file = ProgramFile::new(db, file, env.program(db));
+    let mut exclusions = Vec::new();
+    for name in ["First", "Second", "Third"] {
+        let ty = global_symbol(db, file, name).place.expect_type();
+        let Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) = ty else {
+            anyhow::bail!("expected `{name}` to be a type alias");
+        };
+        exclusions.push(Type::TypeAlias(alias).negate(db, &env));
+    }
+
+    // De Morgan's law expands these negated intersections into a product of unions.
+    assert!(IntersectionType::bounded_from_elements(db, &env, &exclusions[..2]).is_some());
+    assert!(IntersectionType::bounded_from_elements(db, &env, exclusions).is_none());
+
+    // A double negation introduces no alternatives and must not consume the first-union exemption.
+    let excluded = global_symbol(db, file, "Excluded").place.expect_type();
+    let Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) = excluded else {
+        anyhow::bail!("expected `Excluded` to be a type alias");
+    };
+    let integer = Type::TypeAlias(alias).negate(db, &env);
+    let wide = UnionType::from_elements(db, &env, (1..=6).map(Type::int_literal));
+    for elements in [[integer, wide], [wide, integer]] {
+        assert_eq!(
+            IntersectionType::bounded_from_elements(db, &env, elements),
+            Some(wide)
+        );
+    }
+    Ok(())
 }
 
 /// Explicitly test for Python version <3.13 and >=3.13, to ensure that


### PR DESCRIPTION
Aliased union upper bounds could bypass the intersection budget during generic inference, causing exponential expansion and apparent hangs. Apply the budget inside `IntersectionBuilder`, where aliases and negated intersections are expanded, so inference falls back to `Unknown` when the surviving alternatives exceed the limit.

Preserve precise results for a single wide union and for intersections whose impossible or redundant alternatives reduce them below the budget. Apply narrowing factors before distributing multiple disjunctions, including aliased unions and negated intersection aliases.

Addresses the pandas/NumPy alias case discussed in astral-sh/ty#4147.

## Test plan

Extend legacy and PEP 695 callable-inference mdtests with nested aliases, overlapping aliased unions in either argument order, aliased and mixed explicit/aliased unions that exceed the budget, and recursive aliases. Cover negated intersection aliases with a narrowing literal upper bound in either argument order. Add unit coverage for narrowing factors in every position, negated alias expansion, and double negation.
