### PR TITLE
[ty] fix Avoid panics for invalid incremental LSP ranges

### DIFF
--- a/crates/ty_server/src/document/range.rs
+++ b/crates/ty_server/src/document/range.rs
@@ -8,7 +8,7 @@ use ruff_db::source::{line_index, source_text};
 use ruff_db::system::SystemPathBuf;
 use ruff_source_file::LineIndex;
 use ruff_source_file::{OneIndexed, SourceLocation};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use ty_project::ProjectDatabase;
 
 /// A range in an LSP text document (cell or a regular document).
@@ -18,6 +18,20 @@ pub(crate) struct LspRange {
 
     /// The URI of this range's text document
     uri: Option<lsp_types::Uri>,
+}
+
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+pub(crate) enum PositionError {
+    #[error("line {line} is out of bounds")]
+    LineOutOfBounds { line: u32 },
+    #[error("character {character} is not a valid {encoding:?} position on line {line}")]
+    InvalidCharacter {
+        line: u32,
+        character: u32,
+        encoding: PositionEncoding,
+    },
+    #[error("range start must not be after its end")]
+    ReversedRange,
 }
 
 impl LspRange {
@@ -105,6 +119,10 @@ impl RangeExt for lsp_types::Range {
     ) -> Option<TextRange> {
         let start = self.start.to_text_size(db, file, uri, encoding)?;
         let end = self.end.to_text_size(db, file, uri, encoding)?;
+
+        if start > end {
+            return None;
+        }
 
         Some(TextRange::new(start, end))
     }
@@ -252,7 +270,6 @@ fn text_range_to_lsp_range(
 }
 
 /// Helper function to convert an LSP Position to internal `TextSize`.
-/// This is used internally by the `PositionExt` trait and other helpers.
 fn lsp_position_to_text_size(
     position: lsp_types::Position,
     text: &str,
@@ -269,6 +286,98 @@ fn lsp_position_to_text_size(
     )
 }
 
+/// Fallible position to offset conversion for raw LSP client input.
+fn try_lsp_position_to_text_size(
+    position: lsp_types::Position,
+    text: &str,
+    index: &LineIndex,
+    encoding: PositionEncoding,
+) -> Result<TextSize, PositionError> {
+    let line_index = u32_index_to_usize(position.line);
+    if line_index >= index.line_count() {
+        return Err(PositionError::LineOutOfBounds {
+            line: position.line,
+        });
+    }
+
+    let line = OneIndexed::from_zero_indexed(line_index);
+    let line_start = index.line_start(line, text);
+    let line_end = line_end_exclusive(index, line, text);
+    let text_on_line = &text[usize::from(line_start)..usize::from(line_end)];
+    let character = u32_index_to_usize(position.character);
+
+    let byte_offset = match encoding {
+        PositionEncoding::UTF8 => {
+            if character > text_on_line.len() || !text_on_line.is_char_boundary(character) {
+                return Err(PositionError::InvalidCharacter {
+                    line: position.line,
+                    character: position.character,
+                    encoding,
+                });
+            }
+            character
+        }
+        PositionEncoding::UTF16 => offset_for_encoded_character(
+            text_on_line,
+            character,
+            char::len_utf16,
+            position,
+            encoding,
+        )?,
+        PositionEncoding::UTF32 => {
+            offset_for_encoded_character(text_on_line, character, |_| 1, position, encoding)?
+        }
+    };
+
+    Ok(line_start + TextSize::try_from(byte_offset).expect("line offset fits in TextSize"))
+}
+
+fn line_end_exclusive(index: &LineIndex, line: OneIndexed, contents: &str) -> TextSize {
+    let row_index = line.to_zero_indexed();
+    let starts = index.line_starts();
+
+    if row_index.saturating_add(1) >= starts.len() {
+        contents.text_len()
+    } else {
+        let next_line_start = starts[row_index + 1].to_usize();
+        let bytes = contents.as_bytes();
+
+        let line_ending_len = if bytes[..next_line_start].ends_with(b"\r\n") {
+            2
+        } else {
+            1
+        };
+        starts[row_index + 1] - TextSize::new(line_ending_len)
+    }
+}
+
+fn offset_for_encoded_character(
+    text: &str,
+    character: usize,
+    encoded_len: impl Fn(char) -> usize,
+    position: lsp_types::Position,
+    encoding: PositionEncoding,
+) -> Result<usize, PositionError> {
+    let mut encoded_offset = 0;
+
+    for (byte_offset, current) in text.char_indices() {
+        if encoded_offset == character {
+            return Ok(byte_offset);
+        }
+        encoded_offset += encoded_len(current);
+    }
+
+    if encoded_offset == character {
+        Ok(text.len())
+    } else {
+        Err(PositionError::InvalidCharacter {
+            line: position.line,
+            character: position.character,
+            encoding,
+        })
+    }
+}
+
 /// Helper function to convert an LSP Range to internal `TextRange`.
 /// This is used internally by the `RangeExt` trait and in special cases
 /// where `db` and `file` are not available (e.g., when applying document changes).
@@ -277,11 +386,15 @@ pub(crate) fn lsp_range_to_text_range(
     text: &str,
     index: &LineIndex,
     encoding: PositionEncoding,
-) -> TextRange {
-    TextRange::new(
-        lsp_position_to_text_size(range.start, text, index, encoding),
-        lsp_position_to_text_size(range.end, text, index, encoding),
-    )
+) -> Result<TextRange, PositionError> {
+    let start = try_lsp_position_to_text_size(range.start, text, index, encoding)?;
+    let end = try_lsp_position_to_text_size(range.end, text, index, encoding)?;
+
+    if start > end {
+        return Err(PositionError::ReversedRange);
+    }
+
+    Ok(TextRange::new(start, end))
 }
 
 impl ToRangeExt for TextRange {

--- a/crates/ty_server/src/document/text_document.rs
+++ b/crates/ty_server/src/document/text_document.rs
@@ -5,7 +5,7 @@ use lsp_types::{
 use ruff_source_file::LineIndex;
 
 use crate::PositionEncoding;
-use crate::document::range::lsp_range_to_text_range;
+use crate::document::range::{PositionError, lsp_range_to_text_range};
 use crate::system::AnySystemPath;
 
 pub(crate) type DocumentVersion = i32;
@@ -95,7 +95,7 @@ impl TextDocument {
         changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
         new_version: DocumentVersion,
         encoding: PositionEncoding,
-    ) {
+    ) -> Result<(), PositionError> {
         if let [
             lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
                 TextDocumentContentChangeWholeDocument { text },
@@ -107,7 +107,7 @@ impl TextDocument {
                 contents.clone_from(text);
                 *version = new_version;
             });
-            return;
+            return Ok(());
         }
 
         let mut new_contents = self.contents().to_string();
@@ -119,7 +119,7 @@ impl TextDocument {
                     TextDocumentContentChangePartial { range, text, .. },
                 ) => {
                     let range =
-                        lsp_range_to_text_range(range, &new_contents, &active_index, encoding);
+                        lsp_range_to_text_range(range, &new_contents, &active_index, encoding)?;
 
                     new_contents
                         .replace_range(usize::from(range.start())..usize::from(range.end()), &text);
@@ -138,6 +138,8 @@ impl TextDocument {
             *contents = new_contents;
             *version = new_version;
         });
+
+        Ok(())
     }
 
     pub(crate) fn update_version(&mut self, new_version: DocumentVersion) {
@@ -183,33 +185,35 @@ def interface():
         );
 
         // Add an `s`, remove it again (back to the original code), and then re-add the `s`
-        document.apply_changes(
-            vec![
-                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
-                    TextDocumentContentChangePartial {
-                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
-                        text: "s".to_string(),
-                        ..Default::default()
-                    },
-                ),
-                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
-                    TextDocumentContentChangePartial {
-                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 8)),
-                        text: String::new(),
-                        ..Default::default()
-                    },
-                ),
-                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
-                    TextDocumentContentChangePartial {
-                        range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
-                        text: "s".to_string(),
-                        ..Default::default()
-                    },
-                ),
-            ],
-            1,
-            PositionEncoding::UTF16,
-        );
+        document
+            .apply_changes(
+                vec![
+                    TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                        TextDocumentContentChangePartial {
+                            range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                            text: "s".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                    TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                        TextDocumentContentChangePartial {
+                            range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 8)),
+                            text: String::new(),
+                            ..Default::default()
+                        },
+                    ),
+                    TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                        TextDocumentContentChangePartial {
+                            range: lsp_types::Range::new(Position::new(9, 7), Position::new(9, 7)),
+                            text: "s".to_string(),
+                            ..Default::default()
+                        },
+                    ),
+                ],
+                1,
+                PositionEncoding::UTF16,
+            )
+            .unwrap();
 
         assert_eq!(
             &document.contents,
@@ -225,5 +229,123 @@ def interface():
     pass
 "#
         );
+    }
+
+    #[test]
+    fn rejects_reversed_changes() {
+        let mut document = TextDocument::new(
+            Uri::parse("file:///test").unwrap(),
+            "abc".to_string(),
+            1,
+            LanguageKind::Python,
+        );
+
+        let result = document.apply_changes(
+            vec![
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(0, 2), Position::new(0, 1)),
+                        text: String::new(),
+                        ..Default::default()
+                    },
+                ),
+            ],
+            2,
+            PositionEncoding::UTF16,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(document.contents(), "abc");
+        assert_eq!(document.version(), 1);
+    }
+
+    #[test]
+    fn rejects_utf8_changes_inside_characters() {
+        let mut document = TextDocument::new(
+            Uri::parse("file:///test").unwrap(),
+            "é".to_string(),
+            1,
+            LanguageKind::Python,
+        );
+
+        let result = document.apply_changes(
+            vec![
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(0, 1), Position::new(0, 1)),
+                        text: "x".to_string(),
+                        ..Default::default()
+                    },
+                ),
+            ],
+            2,
+            PositionEncoding::UTF8,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(document.contents(), "é");
+        assert_eq!(document.version(), 1);
+    }
+
+    #[test]
+    fn rejects_invalid_changes_without_committing_preceding_changes() {
+        let mut document = TextDocument::new(
+            Uri::parse("file:///test").unwrap(),
+            "é".to_string(),
+            1,
+            LanguageKind::Python,
+        );
+
+        let result = document.apply_changes(
+            vec![
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(0, 0), Position::new(0, 0)),
+                        text: "x".to_string(),
+                        ..Default::default()
+                    },
+                ),
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(0, 2), Position::new(0, 2)),
+                        text: "y".to_string(),
+                        ..Default::default()
+                    },
+                ),
+            ],
+            2,
+            PositionEncoding::UTF8,
+        );
+
+        assert!(result.is_err());
+        assert_eq!(document.contents(), "é");
+        assert_eq!(document.version(), 1);
+    }
+
+    #[test]
+    fn rejects_out_of_bounds_offset_on_bare_cr_line() {
+        let mut document = TextDocument::new(
+            Uri::parse("file:///test").unwrap(),
+            "a\rb".to_string(),
+            1,
+            LanguageKind::Python,
+        );
+
+        let result = document.apply_changes(
+            vec![
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial {
+                        range: lsp_types::Range::new(Position::new(0, 1), Position::new(0, 1)),
+                        text: "X".to_string(),
+                        ..Default::default()
+                    },
+                ),
+            ],
+            2,
+            PositionEncoding::UTF8,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(document.contents(), "aX\rb");
     }
 }

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -2067,7 +2067,7 @@ impl DocumentHandle {
             if content_changes.is_empty() {
                 document.update_version(new_version);
             } else {
-                document.apply_changes(content_changes, new_version, position_encoding);
+                document.apply_changes(content_changes, new_version, position_encoding)?;
             }
 
             self.set_version(document.version());

--- a/crates/ty_server/src/session/index.rs
+++ b/crates/ty_server/src/session/index.rs
@@ -156,7 +156,7 @@ impl Index {
                     updated_cell.changes,
                     updated_cell.document.version,
                     encoding,
-                );
+                )?;
             }
         }
 


### PR DESCRIPTION
## Summary

- Validates LSP positions before converting them to text ranges in `apply_changes`
  (the `textDocument/didChange` path): rejects out-of-bounds lines, rejects offsets
  that don't land on a valid character boundary for the negotiated encoding
  (UTF-8/16/32), and rejects reversed ranges.
- `apply_changes` now returns `Result<(), PositionError>`. It builds edits into a
  local copy of the document and only commits via `self.modify(...)` after every
  edit in the batch succeeds, so an invalid range anywhere in a batch leaves the
  document's contents and version completely untouched rather than partially
  applying preceding edits
- Kept the existing clamping (non-panicking) behavior for read-only range queries
  (inlay hints, semantic tokens, code actions, hover) via `PositionExt::to_text_size`
  / `RangeExt::to_text_range`, since editors commonly send oversized end-of-range
  positions for viewport-style requests and rely on the server clamping to
  end-of-document rather than rejecting the request. Only added a reversed-range
  check there, since a backwards range is never valid regardless of clamping.

Related to #26768 

## Testing

- Added four tests to `document/text_document.rs`: `rejects_reversed_changes`,
  `rejects_utf8_changes_inside_characters`,
  `rejects_invalid_changes_without_committing_preceding_changes`, and
  `rejects_out_of_bounds_offset_on_bare_cr_line`, covering both repro cases from
  #26768, the batch-atomicity guarantee, and a bare-CR line-ending edge case.
- `cargo test -p ty_server` passes (170 tests, run single-threaded to rule out
  unrelated flakiness in two other tests, confirmed pre-existing on `main` via
  `git stash`).
- `cargo clippy -p ty_server --lib -- -D warnings` fails only on a pre-existing
  `needless_update` lint in `crates/ruff_db/src/system/os.rs:53`, confirmed via
  `git stash` to reproduce identically on `main` and unrelated to this change.