### PR TITLE
docs(flake8-annotations): clarify that ANN401 checks return types

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs
@@ -486,8 +486,8 @@ impl Violation for MissingReturnTypeClassMethod {
 }
 
 /// ## What it does
-/// Checks that function arguments are annotated with a more specific type than
-/// `Any`.
+/// Checks that function arguments and return values are annotated with a more
+/// specific type than `Any`.
 ///
 /// ## Why is this bad?
 /// `Any` is a special type indicating an unconstrained type. When an
@@ -503,13 +503,13 @@ impl Violation for MissingReturnTypeClassMethod {
 /// from typing import Any
 ///
 ///
-/// def foo(x: Any): ...
+/// def foo(x: Any) -> Any: ...
 /// ```
 ///
 /// Use instead:
 ///
 /// ```python
-/// def foo(x: int): ...
+/// def foo(x: int) -> int: ...
 /// ```
 ///
 /// ## Known problems


### PR DESCRIPTION
## Summary

Closes #28298.

The rule documentation for `ANN401` (`any-type`) currently states:
> *"Checks that function arguments are annotated with a more specific type than `Any`."*

However, `ANN401` also checks and flags function return annotations (`-> Any`), as implemented in `crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs:757-762`.

This PR:
1. Updates the rule explanation on `struct AnyType` to state that both function arguments and return values are checked.
2. Updates the example code to demonstrate `Any` in both parameter and return positions (`def foo(x: Any) -> Any: ...` -> `def foo(x: int) -> int: ...`).

## Test Plan

Inspected the updated doc comments on `AnyType` in `crates/ruff_linter/src/rules/flake8_annotations/rules/definition.rs` to ensure accurate markdown rendering.
