### PR TITLE
Prebuild rendering examples for CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -404,6 +404,8 @@ jobs:
         # Ignore errors if this step fails; we want to continue to later steps in the workflow anyway.
         # This step is just to get nice GitHub annotations on the PR diff in the files-changed tab.
         run: cargo test -p ty_python_semantic --test mdtest || true
+      - name: "Build rendering examples"
+        run: uv run scripts/build_snippet_examples.py
       - name: "Run tests"
         run: uv run --locked --only-dev cargo insta test --all-features --unreferenced reject --test-runner nextest --disable-nextest-doctest
       - name: "Run doctests"
@@ -460,6 +462,8 @@ jobs:
         with:
           version: "0.12.11"
           enable-cache: "true"
+      - name: "Build rendering examples"
+        run: uv run scripts/build_snippet_examples.py --profile profiling
       - name: "Run tests"
         run: uv run --locked --only-dev cargo nextest run --cargo-profile profiling --all-features
       - name: "Run doctests"
@@ -495,6 +499,8 @@ jobs:
         with:
           version: "0.12.11"
           enable-cache: "true"
+      - name: "Build rendering examples"
+        run: uv run scripts/build_snippet_examples.py
       - name: "Run tests"
         run: |
           uv run --locked --only-dev cargo nextest run --all-features --profile ci

--- a/crates/ruff_annotate_snippets/tests/examples.rs
+++ b/crates/ruff_annotate_snippets/tests/examples.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::path::PathBuf;
 
 #[test]
 fn custom_error() {
@@ -86,7 +87,12 @@ fn struct_name_as_context() {
 
 #[track_caller]
 fn assert_example(target: &str, expected: snapbox::Data) {
-    let bin_path = snapbox::cmd::compile_example(target, ["--features=testing-colors"]).unwrap();
+    // CI builds every example with the test profile before starting the test runner.
+    let bin_path = std::env::var_os(format!("RUFF_ANNOTATE_SNIPPETS_EXAMPLE_{target}"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            snapbox::cmd::compile_example(target, ["--features=testing-colors"]).unwrap()
+        });
     snapbox::cmd::Command::new(bin_path)
         .env("CLICOLOR_FORCE", "1")
         .env_remove("NO_COLOR")

--- a/scripts/build_snippet_examples.py
+++ b/scripts/build_snippet_examples.py
@@ -1,0 +1,65 @@
+"""Build rendering examples once and export their executable paths to CI tests."""
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--profile", default="dev", help="Cargo profile used by the tests"
+    )
+    args = parser.parse_args()
+    env_file = Path(os.environ["GITHUB_ENV"])
+
+    result = subprocess.run(
+        [
+            "cargo",
+            "build",
+            "--locked",
+            "--package",
+            "ruff_annotate_snippets",
+            "--examples",
+            "--all-features",
+            "--profile",
+            args.profile,
+            "--message-format=json-render-diagnostics",
+        ],
+        cwd=Path(__file__).resolve().parent.parent,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+
+    # Use Cargo's reported paths so custom target directories and Windows executable suffixes work.
+    paths = {}
+    for line in result.stdout.splitlines():
+        message = json.loads(line)
+        if (
+            message["reason"] == "compiler-artifact"
+            and message["target"]["kind"] == ["example"]
+            and message["executable"] is not None
+        ):
+            paths[message["target"]["name"]] = message["executable"]
+
+    if not paths:
+        raise RuntimeError("Cargo did not report any rendering example executables")
+
+    with env_file.open("a", encoding="utf-8") as file:
+        for name, path in sorted(paths.items()):
+            file.write(f"RUFF_ANNOTATE_SNIPPETS_EXAMPLE_{name}={path}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_snippet_examples.py.lock
+++ b/scripts/build_snippet_examples.py.lock
@@ -1,0 +1,7 @@
+version = 1
+revision = 4
+requires-python = ">=3.11"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"


### PR DESCRIPTION
## Summary

The rendering example tests each invoke Cargo to build their executable. In the Linux release test job, the helper selects `--release` even though the test suite uses `--profile profiling`, creating a second build configuration and making twelve Cargo processes contend for the build lock.

We build all rendering examples together before running CI tests, using the same Cargo profile as the test suite. The tests receive the executable paths from Cargo's JSON output, preserving support for custom target directories and Windows executable suffixes. Local runs without prebuilt paths continue to use the existing compilation helper.
